### PR TITLE
DO NOT MERGE - Removed repositories from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -897,34 +897,6 @@
     </dependencies>
   </dependencyManagement>
 
-  <repositories>
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <name>JBoss Public Repository Group</name>
-      <url>http://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>jboss-public-repository-group</id>
-      <name>JBoss Public Repository Group</name>
-      <url>http://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
-
   <modules>
     <!-- misc -->
     <module>tools</module>


### PR DESCRIPTION
DO NOT MERGE THIS YET! 

This Pull-request removes the repositories set in the parent pom.xml. The build should not rely on specific JBoss.org artifacts (as illustrated in https://issues.jboss.org/browse/SWARM-336)
