### PR TITLE
Adds Hibernate Search fraction

### DIFF
--- a/hibernate-search/README.md
+++ b/hibernate-search/README.md
@@ -1,0 +1,12 @@
+# WildFly Swarm - Hibernate Search
+
+Support for Hibernate Search.
+
+## Enable Hibernate Search
+
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>hibernate-search</artifactId>
+    </dependency>
+
+

--- a/hibernate-search/api/pom.xml
+++ b/hibernate-search/api/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>hibernate-search-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <artifactId>hibernate-search-api</artifactId>
+
+  <name>WildFly Swarm: Hibernate Search API</name>
+  <description>WildFly Swarm: Hibernate Search API</description>
+
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>spi-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>hibernate-search-modules</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/hibernate-search/api/src/main/java/org/wildfly/swarm/hibernate/search/HibernateSearchFraction.java
+++ b/hibernate-search/api/src/main/java/org/wildfly/swarm/hibernate/search/HibernateSearchFraction.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.hibernate.search;
+
+import org.wildfly.swarm.spi.api.Fraction;
+
+/**
+ * @author George Gastaldi
+ */
+public class HibernateSearchFraction implements Fraction {
+
+    public static HibernateSearchFraction createDefaultFraction() {
+        return new HibernateSearchFraction();
+    }
+
+}

--- a/hibernate-search/api/src/main/resources/wildfly-swarm-bootstrap.conf
+++ b/hibernate-search/api/src/main/resources/wildfly-swarm-bootstrap.conf
@@ -1,0 +1,1 @@
+org.wildfly.swarm.hibernate.search

--- a/hibernate-search/hibernate-search/pom.xml
+++ b/hibernate-search/hibernate-search/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>hibernate-search-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <artifactId>hibernate-search</artifactId>
+
+  <name>WildFly Swarm: Hibernate Search</name>
+  <description>WildFly Swarm: Hibernate Search</description>
+
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>hibernate-search-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>hibernate-search-modules</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>hibernate-search-runtime</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/hibernate-search/modules/pom.xml
+++ b/hibernate-search/modules/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>hibernate-search-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <artifactId>hibernate-search-modules</artifactId>
+
+  <name>WildFly Swarm: Hibernate Search Modules</name>
+  <description>WildFly Swarm: Hibernate Search Modules</description>
+
+  <packaging>jar</packaging>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>wildfly-swarm-fraction-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>bootstrap</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>container-modules</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>transactions-modules</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-search-orm</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>dom4j</groupId>
+          <artifactId>dom4j</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.core</groupId>
+      <artifactId>wildfly-core-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/hibernate-search/modules/src/main/resources/modules/org/wildfly/swarm/hibernate/search/api/module.xml
+++ b/hibernate-search/modules/src/main/resources/modules/org/wildfly/swarm/hibernate/search/api/module.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.swarm.hibernate.search" slot="api">
+  <resources>
+    <artifact name="org.wildfly.swarm:hibernate-search-api:${project.version}"/>
+  </resources>
+  <dependencies>
+    <module name="org.wildfly.swarm.container"/>
+    <module name="org.wildfly.swarm.configuration"/>
+    <module name="org.jboss.shrinkwrap"/>
+  </dependencies>
+</module>

--- a/hibernate-search/modules/src/main/resources/modules/org/wildfly/swarm/hibernate/search/main/module.xml
+++ b/hibernate-search/modules/src/main/resources/modules/org/wildfly/swarm/hibernate/search/main/module.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.swarm.hibernate.search">
+  <dependencies>
+    <system export="true">
+      <paths>
+        <path name="org/wildfly/swarm/hibernate/search"/>
+      </paths>
+    </system>
+
+    <module name="org.wildfly.swarm.hibernate.search" slot="api" export="true" services="export"/>
+
+  </dependencies>
+</module>

--- a/hibernate-search/modules/src/main/resources/modules/org/wildfly/swarm/hibernate/search/runtime/module.xml
+++ b/hibernate-search/modules/src/main/resources/modules/org/wildfly/swarm/hibernate/search/runtime/module.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.swarm.hibernate.search" slot="runtime">
+  <resources>
+    <artifact name="org.wildfly.swarm:hibernate-search-runtime:${project.version}"/>
+  </resources>
+
+  <dependencies>
+    <module name="org.jboss.shrinkwrap"/>
+    <module name="org.wildfly.swarm.hibernate.search"/>
+    <module name="org.wildfly.swarm.container"/>
+    <module name="org.wildfly.swarm.container" slot="runtime"/>
+    <module name="org.wildfly.swarm.configuration"/>
+
+    <module name="org.hibernate.search.orm"/>
+    <module name="org.hibernate.search.engine"/>
+    <module name="org.hibernate.search.serialization-avro"/>
+  </dependencies>
+
+</module>

--- a/hibernate-search/modules/src/main/resources/provided-dependencies.txt
+++ b/hibernate-search/modules/src/main/resources/provided-dependencies.txt
@@ -1,0 +1,1 @@
+org.hibernate:hibernate-search-orm

--- a/hibernate-search/pom.xml
+++ b/hibernate-search/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>core</artifactId>
+    <version>1.0.0.Beta5-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <artifactId>hibernate-search-parent</artifactId>
+
+  <name>WildFly Swarm: Hibernate Search</name>
+  <description>WildFly Swarm: Hibernate Search</description>
+
+  <packaging>pom</packaging>
+
+  <properties>
+    <!-- Must be the same as bundled in Wildfly-->
+    <version.hibernate.search>5.5.2.Final</version.hibernate.search>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.hibernate</groupId>
+        <artifactId>hibernate-search-orm</artifactId>
+        <version>${version.hibernate.search}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <modules>
+    <module>hibernate-search</module>
+
+    <module>api</module>
+    <module>runtime</module>
+    <module>modules</module>
+    <module>test</module>
+  </modules>
+
+</project>

--- a/hibernate-search/runtime/pom.xml
+++ b/hibernate-search/runtime/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>hibernate-search-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <artifactId>hibernate-search-runtime</artifactId>
+
+  <name>WildFly Swarm: Hibernate Search Runtime</name>
+  <description>WildFly Swarm: Hibernate Search Runtime</description>
+
+  <packaging>jar</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>wildfly-swarm-fraction-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>hibernate-search-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>spi-runtime</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/hibernate-search/runtime/src/main/java/org/wildfly/swarm/hibernate/search/runtime/HibernateSearchConfiguration.java
+++ b/hibernate-search/runtime/src/main/java/org/wildfly/swarm/hibernate/search/runtime/HibernateSearchConfiguration.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.hibernate.search.runtime;
+
+import org.wildfly.swarm.hibernate.search.HibernateSearchFraction;
+import org.wildfly.swarm.spi.runtime.AbstractServerConfiguration;
+
+/**
+ * @author George Gastaldi
+ */
+public class HibernateSearchConfiguration extends AbstractServerConfiguration<HibernateSearchFraction> {
+
+    public HibernateSearchConfiguration() {
+        super(HibernateSearchFraction.class);
+    }
+
+    @Override
+    public HibernateSearchFraction defaultFraction() {
+        return new HibernateSearchFraction();
+    }
+}

--- a/hibernate-search/test/pom.xml
+++ b/hibernate-search/test/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>hibernate-search-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <artifactId>hibernate-search-test</artifactId>
+
+  <name>WildFly Swarm: Hibernate Search Test</name>
+  <description>WildFly Swarm: Hibernate Search Test</description>
+
+  <packaging>jar</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>hibernate-search</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-search-orm</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>arquillian</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.junit</groupId>
+      <artifactId>arquillian-junit-container</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/hibernate-search/test/src/test/java/org/wildfly/swarm/hibernate/search/HibernateSearchArquillianTest.java
+++ b/hibernate-search/test/src/test/java/org/wildfly/swarm/hibernate/search/HibernateSearchArquillianTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.hibernate.search;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.ContainerFactory;
+import org.wildfly.swarm.container.Container;
+import org.wildfly.swarm.spi.api.JARArchive;
+
+@RunWith(Arquillian.class)
+public class HibernateSearchArquillianTest implements ContainerFactory {
+    @Deployment(testable = false)
+    public static Archive createDeployment() {
+        JARArchive deployment = ShrinkWrap.create(JARArchive.class);
+        deployment.add(EmptyAsset.INSTANCE, "nothing");
+        return deployment;
+    }
+
+    @Override
+    public Container newContainer(String... args) throws Exception {
+        return new Container().fraction(HibernateSearchFraction.createDefaultFraction());
+    }
+
+    @Test
+    @RunAsClient
+    public void testNothing() {
+    }
+}

--- a/hibernate-search/test/src/test/java/org/wildfly/swarm/hibernate/search/HibernateSearchInVmTest.java
+++ b/hibernate-search/test/src/test/java/org/wildfly/swarm/hibernate/search/HibernateSearchInVmTest.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.hibernate.search;
+
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.arquillian.adapter.InVM;
+import org.wildfly.swarm.container.Container;
+
+public class HibernateSearchInVmTest {
+
+    @Test
+    public void testBasic() throws Exception {
+        Container container = new Container();
+        container.fraction(HibernateSearchFraction.createDefaultFraction());
+        container.start().stop();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -489,6 +489,27 @@
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
+        <artifactId>hibernate-search</artifactId>
+        <version>1.0.0.Beta5-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>hibernate-search-api</artifactId>
+        <version>1.0.0.Beta5-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>hibernate-search-modules</artifactId>
+        <version>1.0.0.Beta5-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>hibernate-search-runtime</artifactId>
+        <version>1.0.0.Beta5-SNAPSHOT</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.wildfly.swarm</groupId>
         <artifactId>hibernate-validator</artifactId>
         <version>1.0.0.Beta5-SNAPSHOT</version>
       </dependency>
@@ -1042,6 +1063,7 @@
     <module>ee</module>
     <module>ejb</module>
     <module>ejb-remote</module>
+    <module>hibernate-search</module>
     <module>hibernate-validator</module>
     <module>infinispan</module>
     <module>io</module>


### PR DESCRIPTION
Motivation:
Hibernate Search is already added as part of the Wildfly core modules. Fixes SWARM-328

Modifications:
Adds a Hibernate Search fraction that allows users to use Hibernate Search in their projects.
