### PR TITLE
SWARM-328: Adds Hibernate Search fraction

### DIFF
--- a/hibernate-search/pom.xml
+++ b/hibernate-search/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>core</artifactId>
+    <version>1.0.0.Beta5-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <artifactId>hibernate-search</artifactId>
+
+  <name>WildFly Swarm: Hibernate Search</name>
+  <description>WildFly Swarm: Hibernate Search</description>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>wildfly-swarm-fraction-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>bootstrap</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>container-modules</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>transactions-modules</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- Provided APIs -->
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-search-orm</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-search-engine</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-search-serialization-avro</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/hibernate-search/src/main/resources/modules/org/wildfly/swarm/hibernate/search/main/module.xml
+++ b/hibernate-search/src/main/resources/modules/org/wildfly/swarm/hibernate/search/main/module.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.swarm.hibernate.search">
+  <dependencies>
+    <module name="org.hibernate.search.orm" services="import"/>
+    <module name="org.hibernate.search.engine" services="import"/>
+    <module name="org.hibernate.search.serialization-avro" services="import"/>
+  </dependencies>
+</module>

--- a/hibernate-search/src/main/resources/provided-dependencies.txt
+++ b/hibernate-search/src/main/resources/provided-dependencies.txt
@@ -1,0 +1,3 @@
+org.hibernate:hibernate-search-orm
+org.hibernate:hibernate-search-engine
+org.hibernate:hibernate-search-serialization-avro

--- a/pom.xml
+++ b/pom.xml
@@ -489,6 +489,12 @@
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
+        <artifactId>hibernate-search</artifactId>
+        <version>1.0.0.Beta5-SNAPSHOT</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.wildfly.swarm</groupId>
         <artifactId>hibernate-validator</artifactId>
         <version>1.0.0.Beta5-SNAPSHOT</version>
       </dependency>
@@ -1042,6 +1048,7 @@
     <module>ee</module>
     <module>ejb</module>
     <module>ejb-remote</module>
+    <module>hibernate-search</module>
     <module>hibernate-validator</module>
     <module>infinispan</module>
     <module>io</module>


### PR DESCRIPTION
Motivation:
Hibernate Search is already added as part of the Wildfly core modules. Fixes SWARM-328

Modifications:
Adds a Hibernate Search fraction that allows users to use Hibernate Search in their projects.
