### PR TITLE
Add utility methods for enabling AJP

### DIFF
--- a/undertow/api/src/main/java/org/wildfly/swarm/undertow/UndertowFraction.java
+++ b/undertow/api/src/main/java/org/wildfly/swarm/undertow/UndertowFraction.java
@@ -172,9 +172,6 @@ public class UndertowFraction extends Undertow<UndertowFraction> implements Frac
         initContext.socketBinding(
                 new SocketBinding("https")
                         .port(SwarmProperties.propertyVar(UndertowProperties.HTTPS_PORT, "8443")));
-        initContext.socketBinding(
-                new SocketBinding("ajp")
-                        .port(SwarmProperties.propertyVar(UndertowProperties.AJP_PORT, "8009")));
     }
 
     @Override
@@ -208,6 +205,10 @@ public class UndertowFraction extends Undertow<UndertowFraction> implements Frac
         }
 
         if (this.enableAJP) {
+            initContext.socketBinding(
+                new SocketBinding("ajp")
+                    .port(SwarmProperties.propertyVar(UndertowProperties.AJP_PORT, "8009")));
+
             subresources().servers().stream()
                     .filter(server -> server.subresources().ajpListeners().isEmpty())
                     .forEach(server -> server.ajpListener("ajp", listener -> listener.socketBinding("ajp")));

--- a/undertow/api/src/main/java/org/wildfly/swarm/undertow/UndertowProperties.java
+++ b/undertow/api/src/main/java/org/wildfly/swarm/undertow/UndertowProperties.java
@@ -23,6 +23,9 @@ public class UndertowProperties {
     public static final String HTTPS_PORT = "swarm.https.port";
 
     //public
+    public static final String AJP_PORT = "swarm.ajp.port";
+
+    //public
     public static final String CONTEXT_PATH = "swarm.context.path";
 
 }


### PR DESCRIPTION
## Motivation

For enabling AJP, some boilerplate codes(adding ajp socket-binding, listener) is needed.
## Modifications

Added utility methods enabling AJP.
## Result

More easily enabling AJP.
