### PR TITLE
SWARM-447: Expose StageConfig in CDI context through @ConfigValue

### DIFF
--- a/cdi/api/src/main/java/org/wildfly/swarm/cdi/CDIFraction.java
+++ b/cdi/api/src/main/java/org/wildfly/swarm/cdi/CDIFraction.java
@@ -22,11 +22,6 @@ import org.wildfly.swarm.spi.api.annotations.Configuration;
 /**
  * @author Bob McWhirter
  */
-@Configuration(
-        marshal = true,
-        extension = "org.jboss.as.weld",
-        parserFactoryClassName = "org.wildfly.swarm.cdi.runtime.ParserFactory"
-)
 public class CDIFraction extends Weld<CDIFraction> implements Fraction {
 
     public CDIFraction() {

--- a/cdi/api/src/main/resources/cdi-fraction.properties
+++ b/cdi/api/src/main/resources/cdi-fraction.properties
@@ -1,0 +1,1 @@
+version: ${project.version}

--- a/cdi/ext/pom.xml
+++ b/cdi/ext/pom.xml
@@ -15,33 +15,20 @@
   </parent>
 
   <groupId>org.wildfly.swarm</groupId>
-  <artifactId>cdi-api</artifactId>
+  <artifactId>cdi-ext</artifactId>
 
-  <name>WildFly Swarm: CDI API</name>
-  <description>WildFly Swarm: CDI API</description>
+  <name>WildFly Swarm: CDI Extensions</name>
+  <description>WildFly Swarm: CDI Extensions</description>
 
   <packaging>jar</packaging>
 
   <dependencies>
+
+    <!-- Provided APIs -->
+
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>spi-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.wildfly.swarm</groupId>
-      <artifactId>cdi-modules</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.wildfly.swarm</groupId>
-      <artifactId>cdi-ext</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
-    <!-- Provided APIs -->
-    <dependency>
-      <groupId>javax.enterprise</groupId>
-      <artifactId>cdi-api</artifactId>
     </dependency>
 
     <dependency>
@@ -49,15 +36,11 @@
       <artifactId>javax.inject</artifactId>
     </dependency>
 
-  </dependencies>
+    <dependency>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
+    </dependency>
 
-  <build>
-    <resources>
-      <resource>
-        <directory>${project.basedir}/src/main/resources</directory>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
-  </build>
+  </dependencies>
 
 </project>

--- a/cdi/ext/src/main/java/org/wildfly/swarm/cdi/ConfigExtension.java
+++ b/cdi/ext/src/main/java/org/wildfly/swarm/cdi/ConfigExtension.java
@@ -1,0 +1,114 @@
+package org.wildfly.swarm.cdi;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.InjectionException;
+import javax.enterprise.inject.spi.AnnotatedField;
+import javax.enterprise.inject.spi.AnnotatedType;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.enterprise.inject.spi.InjectionTarget;
+import javax.enterprise.inject.spi.ProcessInjectionTarget;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.wildfly.swarm.spi.api.StageConfig;
+
+/**
+ * @author Gavin King
+ * @author Adam Warski
+ * @author Heiko Braun
+ */
+public class ConfigExtension implements Extension {
+
+    public <X> void processInjectionTarget(@Observes ProcessInjectionTarget<X> pit) {
+
+        final InjectionTarget<X> it = pit.getInjectionTarget();
+        final Map<Field, String> configFieldKeys = new HashMap<>();
+
+        AnnotatedType<X> at = pit.getAnnotatedType();
+        Annotation annotation = at.getAnnotation(Configured.class);
+        if(annotation == null){
+            //don't process classes not marked with @Configured annotation
+            return;
+        }
+
+        for (AnnotatedField<? super X> aField : at.getFields()) {
+            if(aField.isAnnotationPresent(ConfigValue.class)) {
+
+                Field field = aField.getJavaMember();
+                field.setAccessible(true);
+                configFieldKeys.put(field, aField.getAnnotation(ConfigValue.class).value());
+            }
+        }
+
+        InjectionTarget<X> wrapped = new InjectionTarget<X>() {
+
+            @Override
+            public void inject(X instance, CreationalContext<X> ctx) {
+                it.inject(instance, ctx);
+
+                try {
+                    StageConfig stageConfig = lookup();
+
+                    for (Map.Entry<Field, String> fieldKey: configFieldKeys.entrySet()) {
+                        try {
+                            String key = fieldKey.getValue();
+                            Class<?> type = fieldKey.getKey().getType();
+
+                            fieldKey.getKey().set(
+                                    instance, stageConfig.resolve(key).as(type).getValue()
+                            );
+                        }
+                        catch (Exception e) {
+                            throw new InjectionException(e);
+                        }
+                    }
+                } catch (NamingException e) {
+                    throw new InjectionException(e);
+                }
+            }
+
+            @Override
+            public void postConstruct(X instance) {
+                it.postConstruct(instance);
+            }
+
+            @Override
+            public void preDestroy(X instance) {
+                it.dispose(instance);
+            }
+
+            @Override
+            public void dispose(X instance) {
+                it.dispose(instance);
+            }
+
+            @Override
+            public Set<InjectionPoint> getInjectionPoints() {
+                return it.getInjectionPoints();
+            }
+
+            @Override
+            public X produce(CreationalContext<X> ctx) {
+                return it.produce(ctx);
+            }
+
+        };
+
+        pit.setInjectionTarget(wrapped);
+
+    }
+
+
+    static StageConfig lookup() throws NamingException {
+        InitialContext context = new InitialContext();
+        return (StageConfig) context.lookup("jboss/swarm/stage-config");
+    }
+}

--- a/cdi/ext/src/main/java/org/wildfly/swarm/cdi/ConfigValue.java
+++ b/cdi/ext/src/main/java/org/wildfly/swarm/cdi/ConfigValue.java
@@ -1,0 +1,20 @@
+package org.wildfly.swarm.cdi;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.enterprise.util.Nonbinding;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * @author Heiko Braun
+ */
+@Retention(RUNTIME)
+@Target({FIELD})
+public @interface ConfigValue {
+
+    @Nonbinding
+    String value();
+}

--- a/cdi/ext/src/main/java/org/wildfly/swarm/cdi/Configured.java
+++ b/cdi/ext/src/main/java/org/wildfly/swarm/cdi/Configured.java
@@ -1,0 +1,16 @@
+package org.wildfly.swarm.cdi;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * @author Heiko Braun
+ */
+@Retention(RUNTIME)
+@Target({TYPE})
+public @interface Configured {
+
+}

--- a/cdi/ext/src/main/resources/META-INF/beans.xml
+++ b/cdi/ext/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   The contents of this file is permitted to be empty.
+   The schema definition is provided for your convenience.
+-->
+<beans xmlns="http://java.sun.com/xml/ns/javaee"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="
+      http://java.sun.com/xml/ns/javaee
+      http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+</beans>

--- a/cdi/ext/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
+++ b/cdi/ext/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
@@ -1,0 +1,1 @@
+org.wildfly.swarm.cdi.ConfigExtension

--- a/cdi/modules/pom.xml
+++ b/cdi/modules/pom.xml
@@ -52,6 +52,12 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>ee-modules</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>undertow-modules</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.wildfly.core</groupId>
       <artifactId>wildfly-core-feature-pack</artifactId>

--- a/cdi/modules/src/main/resources/modules/org/wildfly/swarm/cdi/api/module.xml
+++ b/cdi/modules/src/main/resources/modules/org/wildfly/swarm/cdi/api/module.xml
@@ -1,6 +1,7 @@
 <module xmlns="urn:jboss:module:1.3" name="org.wildfly.swarm.cdi" slot="api">
   <resources>
     <artifact name="org.wildfly.swarm:cdi-api:${project.version}"/>
+    <artifact name="org.wildfly.swarm:cdi-ext:${project.version}"/>
   </resources>
 
   <dependencies>

--- a/cdi/modules/src/main/resources/modules/org/wildfly/swarm/cdi/runtime/module.xml
+++ b/cdi/modules/src/main/resources/modules/org/wildfly/swarm/cdi/runtime/module.xml
@@ -9,6 +9,9 @@
     <module name="org.wildfly.swarm.container" slot="runtime"/>
     <module name="org.wildfly.swarm.configuration"/>
 
+    <module name="org.jboss.shrinkwrap"/>
+    <module name="org.wildfly.swarm.undertow"/>
+
     <module name="org.jboss.as.weld"/>
   </dependencies>
 </module>

--- a/cdi/pom.xml
+++ b/cdi/pom.xml
@@ -28,6 +28,7 @@
     <module>api</module>
     <module>runtime</module>
     <module>modules</module>
+    <module>ext</module>
     <module>test</module>
   </modules>
 

--- a/cdi/runtime/pom.xml
+++ b/cdi/runtime/pom.xml
@@ -23,6 +23,12 @@
   <packaging>jar</packaging>
 
   <dependencies>
+
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>container-api</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>cdi-api</artifactId>
@@ -35,6 +41,11 @@
     <dependency>
       <groupId>org.wildfly</groupId>
       <artifactId>wildfly-weld</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>undertow-api</artifactId>
     </dependency>
   </dependencies>
 

--- a/cdi/runtime/src/main/java/org/wildfly/swarm/cdi/runtime/CDIConfiguration.java
+++ b/cdi/runtime/src/main/java/org/wildfly/swarm/cdi/runtime/CDIConfiguration.java
@@ -1,0 +1,65 @@
+package org.wildfly.swarm.cdi.runtime;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+
+import javax.xml.namespace.QName;
+
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.staxmapper.XMLElementReader;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.cdi.CDIFraction;
+import org.wildfly.swarm.spi.runtime.AbstractParserFactory;
+import org.wildfly.swarm.spi.runtime.MarshallingServerConfiguration;
+import org.wildfly.swarm.undertow.WARArchive;
+
+/**
+ * @author Heiko Braun
+ * @since 21/04/16
+ */
+public class CDIConfiguration extends MarshallingServerConfiguration<CDIFraction> {
+
+    public CDIConfiguration() {
+        super(CDIFraction.class, "org.jboss.as.weld");
+    }
+
+    @Override
+    public void prepareArchive(Archive<?> a) {
+
+        if(a.getName().endsWith(".war")) { // TODO: fix this
+            try {
+                WARArchive warArchive = a.as(WARArchive.class);
+                warArchive.addModule("org.wildfly.swarm.spi");
+                warArchive.addAsLibraries(Swarm.artifact("org.wildfly.swarm:cdi-ext:jar:"+VERSION));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+    }
+
+    @Override
+    public Optional<Map<QName, XMLElementReader<List<ModelNode>>>> getSubsystemParsers() throws Exception {
+        return AbstractParserFactory.mapParserNamespaces(new ParserFactory());
+    }
+
+    public static final String VERSION;
+
+    static {
+        InputStream in = CDIFraction.class.getClassLoader().getResourceAsStream("cdi-fraction.properties");
+        Properties props = new Properties();
+        try {
+            props.load(in);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        VERSION = props.getProperty("version", "unknown");
+    }
+
+}

--- a/container/api/src/main/resources/provided-dependencies.txt
+++ b/container/api/src/main/resources/provided-dependencies.txt
@@ -12,3 +12,4 @@ org.jboss.shrinkwrap.descriptors:shrinkwrap-descriptors-impl-base
 org.jboss.shrinkwrap.descriptors:shrinkwrap-descriptors-impl-jboss
 org.jboss.shrinkwrap.descriptors:shrinkwrap-descriptors-impl-javaee
 org.yaml:snakeyaml
+org.wildfly:wildfly-naming

--- a/container/modules/pom.xml
+++ b/container/modules/pom.xml
@@ -49,6 +49,18 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-servlet-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>config-api</artifactId>
     </dependency>
@@ -56,6 +68,7 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>config-api-modules</artifactId>
     </dependency>
+
   </dependencies>
 
 </project>

--- a/container/modules/src/main/resources/modules/org/wildfly/swarm/container/runtime/module.xml
+++ b/container/modules/src/main/resources/modules/org/wildfly/swarm/container/runtime/module.xml
@@ -32,5 +32,8 @@
     <module name="javax.api" export="true"/>
     <module name="org.jboss.staxmapper" export="true"/>
     <module name="org.jboss.as.logging" export="true"/>
+
+    <!-- to support service activators that expose container components through JNDI -->
+    <module name="org.jboss.as.naming"/>
   </dependencies>
 </module>

--- a/container/runtime/pom.xml
+++ b/container/runtime/pom.xml
@@ -36,7 +36,11 @@
       <artifactId>wildfly-server</artifactId>
       <scope>provided</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-naming</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.wildfly.core</groupId>
       <artifactId>wildfly-logging</artifactId>


### PR DESCRIPTION
Motivation:
Allow people to use stage configuration values within application level code (CDI)

Modification:
- RuntimeServer exposes StageConfig through JNDI
- CDI fraction attaches Config extension to war deployments
- CDI API extended by `@Configured` and `@ConfigValue`

Result:
- `project-stages.yml` value can now be referenced from CDI contexts.
