### PR TITLE
SWARM-485 - Example of how to recreate java.lang.NoClassDefFoundError Link Error when extending a Jackson Provider

### DIFF
--- a/jaxrs/test/pom.xml
+++ b/jaxrs/test/pom.xml
@@ -69,6 +69,12 @@
     	<version>4.5.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
+      <version>2.5.4</version>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
     	<groupId>commons-logging</groupId>

--- a/jaxrs/test/src/test/java/org/wildfly/swarm/jaxrs/CustomJsonProvider.java
+++ b/jaxrs/test/src/test/java/org/wildfly/swarm/jaxrs/CustomJsonProvider.java
@@ -1,0 +1,34 @@
+package org.wildfly.swarm.jaxrs;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * @author Richard Lucas
+ */
+@Provider
+@Consumes(MediaType.WILDCARD)
+@Produces(MediaType.WILDCARD)
+public class CustomJsonProvider extends JacksonJaxbJsonProvider{
+
+    public CustomJsonProvider() {
+        super();
+        super.setAnnotationsToUse(DEFAULT_ANNOTATIONS);
+        super.setMapper(getObjectMapper());
+    }
+
+    private ObjectMapper getObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        mapper.setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES);
+        return mapper;
+    }
+
+}

--- a/jaxrs/test/src/test/java/org/wildfly/swarm/jaxrs/JAXRSArquillianTest.java
+++ b/jaxrs/test/src/test/java/org/wildfly/swarm/jaxrs/JAXRSArquillianTest.java
@@ -41,6 +41,7 @@ public class JAXRSArquillianTest implements ContainerFactory {
     public static Archive createDeployment() {
         JAXRSArchive deployment = ShrinkWrap.create(JAXRSArchive.class, "myapp.war");
         deployment.addClass(HealthCheckResource.class);
+        deployment.addClass(CustomJsonProvider.class);
         return deployment;
     }
 


### PR DESCRIPTION
The following PR alters the org.wildfly.swarm.jaxrs.JAXRSArquillianTest to demonstrate the  java.lang.NoClassDefFoundError Link Error

It adds a custom JAX-RS provider that extends JacksonJaxbJsonProvider. Running the test results in the exception being thrown.

This only started occurring in the 1.0.0.CR1 release
