### PR TITLE
Add a handy method for Form Login

### DIFF
--- a/undertow/api/src/main/java/org/wildfly/swarm/undertow/descriptors/WebXmlAsset.java
+++ b/undertow/api/src/main/java/org/wildfly/swarm/undertow/descriptors/WebXmlAsset.java
@@ -92,6 +92,15 @@ public class WebXmlAsset implements NamedAsset {
                 .realmName(realmName);
     }
 
+    public void setFormLoginConfig(String realmName, String loginPage, String errorPage) {
+        this.descriptor.createLoginConfig()
+                .authMethod("FORM")
+                .realmName(realmName)
+                .getOrCreateFormLoginConfig()
+                .formLoginPage(loginPage)
+                .formErrorPage(errorPage);
+    }
+
     public String getLoginRealm(String authMethod) {
         if (authMethod == null || authMethod.length() == 0) {
             return null;

--- a/undertow/api/src/test/java/org/wildfly/swarm/undertow/WebXmlAssetTest.java
+++ b/undertow/api/src/test/java/org/wildfly/swarm/undertow/WebXmlAssetTest.java
@@ -95,4 +95,12 @@ public class WebXmlAssetTest {
         assertThat(realm).isNotEmpty();
         assertThat(realm).isEqualTo("myRealm");
     }
+
+    @Test
+    public void testFormLoginConfig() throws Exception {
+        WebXmlAsset asset = new WebXmlAsset();
+
+        asset.setFormLoginConfig("myRealm", "/login", "/error");
+        assertThat(asset.getLoginRealm("FORM")).isEqualTo("myRealm");
+    }
 }


### PR DESCRIPTION
related: https://groups.google.com/forum/#!topic/wildfly-swarm/zhGHImhWaUY
## Motivation

Because there is no handy programmatic method for Form Login for now, it would be useful for users.
## Modifications

Add org.wildfly.swarm.undertow#setFormLoginConfig
## Result

More easily enabling Form Login with programmatic way
