### PR TITLE
Add gradle support to ArtifactManager

### DIFF
--- a/container/api/src/test/java/org/wildfly/swarm/internal/ArtifactManagerTest.java
+++ b/container/api/src/test/java/org/wildfly/swarm/internal/ArtifactManagerTest.java
@@ -15,6 +15,7 @@
  */
 package org.wildfly.swarm.internal;
 
+import java.nio.file.Paths;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -136,6 +137,21 @@ public class ArtifactManagerTest {
     public void noDependenciesExcluded() throws Exception {
         List<JavaArchive> archives = manager.allArtifacts();
         assertThat(archives.size()).isEqualTo(5);
+    }
+
+    @Test
+    public void testArchiveNameForGradleClassesOutputDir() {
+        assertThat(manager.archiveNameForClassesDir(Paths.get("/test/projectname/build/resources/main"))).isEqualTo("projectname.jar");
+    }
+
+    @Test
+    public void testArchiveNameForGradleResourcesOutputDir() {
+        assertThat(manager.archiveNameForClassesDir(Paths.get("/test/projectname/build/classes/main"))).isEqualTo("projectname.jar");
+    }
+
+    @Test
+    public void testArchiveNameForMavenOutputDir() {
+        assertThat(manager.archiveNameForClassesDir(Paths.get("/test/projectname/target/classes"))).isEqualTo("projectname.jar");
     }
 
     private static WildFlySwarmDependenciesConf conf = new WildFlySwarmDependenciesConf();


### PR DESCRIPTION
Creating a org.wildfly.swarm.undertow.WARArchive with ShrinkWrap and trying to add all dependencies with "addAllDependencies" results in multiple problems if you are using gradle as your buildtool, having multiple projects (gradle multip-project-build) and starting the Main-Class from the IDE.
- The exclusion for all org.wildfly.swarm artifacts doesn't work: The filter for the local maven repository and the local gradle-cache are using a different approach for storing the artifacts in the filesystem. Maven creates a hierarchical folder-structure for the group of the maven artifact whereas gradle creates one folder for the group.
- Creating an on-the-fly-JavaArchive for directories in the classpath creates multiple JavaArchives for one "javaproject": Gradle separates the outputfolder for resources and classes. But they have to be packed into the same JavaArchive - otherwise CDI doesn't work, when the beans.xml is placed in a different JAR then the classes.
- The filter for not including classpath-elements which are placed under "user.dir" included to many elements when there when one projectname is the "prefix" of another projectname. 
