### PR TITLE
Add a mod_cluster fraction

### DIFF
--- a/modcluster/api/pom.xml
+++ b/modcluster/api/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>mod_cluster-parent</artifactId>
+    <version>1.0.2.Final-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>mod_cluster-api</artifactId>
+
+  <name>WildFly Swarm: Modcluster API</name>
+  <description>WildFly Swarm: Modcluster API</description>
+
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>spi-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>mod_cluster-modules</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>undertow-api</artifactId>
+    </dependency>
+
+    <!-- MOVE TO A MODULE? -->
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-all</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-mod_cluster-extension</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-mod_cluster-undertow</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/modcluster/api/src/main/java/org/wildfly/swarm/mod_cluster/ModclusterFraction.java
+++ b/modcluster/api/src/main/java/org/wildfly/swarm/mod_cluster/ModclusterFraction.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.mod_cluster;
+
+import org.wildfly.swarm.config.Modcluster;
+import org.wildfly.swarm.config.modcluster.ConfigurationModClusterConfig;
+import org.wildfly.swarm.spi.api.Fraction;
+import org.wildfly.swarm.spi.api.SocketBinding;
+import org.wildfly.swarm.spi.api.annotations.Configuration;
+import org.wildfly.swarm.spi.api.annotations.Default;
+
+/**
+ * @author Stuart Douglas
+ */
+@Configuration(
+        extension = "org.wildfly.extension.mod_cluster",
+        marshal = true
+)
+public class ModclusterFraction extends Modcluster<ModclusterFraction> implements Fraction {
+
+    public ModclusterFraction() {
+    }
+
+    @Default
+    public static ModclusterFraction createDefaultFraction() {
+        ModclusterFraction fraction = new ModclusterFraction();
+        fraction.configurationModClusterConfig(new ConfigurationModClusterConfig()
+                .advertiseSocket("modcluster")
+                .advertise(true)
+                .connector("default"));
+        return fraction;
+    }
+    @Override
+    public void postInitialize(Fraction.PostInitContext initContext) {
+        //TODO: this should probably not be hard coded
+        initContext.socketBinding(
+                new SocketBinding("modcluster")
+                        .port(0)
+                        .multicastAddress("224.0.1.105")
+                        .multicastPort("23364"));
+    }
+
+}

--- a/modcluster/mod_cluster/pom.xml
+++ b/modcluster/mod_cluster/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>mod_cluster-parent</artifactId>
+    <version>1.0.2.Final-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>mod_cluster</artifactId>
+
+  <name>Modcluster</name>
+  <description>Modcluster support</description>
+
+  <packaging>jar</packaging>
+
+  <properties>
+    <swarm.fraction.tags>Web</swarm.fraction.tags>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>container</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>mod_cluster-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>mod_cluster-modules</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>mod_cluster-runtime</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>undertow</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>security</artifactId>
+    </dependency>
+
+
+  </dependencies>
+
+</project>

--- a/modcluster/modules/pom.xml
+++ b/modcluster/modules/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>mod_cluster-parent</artifactId>
+    <version>1.0.2.Final-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>mod_cluster-modules</artifactId>
+
+  <name>WildFly Swarm: Modcluster Modules</name>
+  <description>WildFly Swarm: Modcluster Modules</description>
+
+  <packaging>jar</packaging>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>bootstrap</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>container-modules</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>undertow-modules</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>naming-modules</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>security-modules</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.core</groupId>
+      <artifactId>wildfly-core-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-servlet-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/modcluster/modules/src/main/resources/modules/org/wildfly/swarm/mod_cluster/api/module.xml
+++ b/modcluster/modules/src/main/resources/modules/org/wildfly/swarm/mod_cluster/api/module.xml
@@ -1,0 +1,14 @@
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.swarm.mod_cluster" slot="api">
+  <resources>
+    <artifact name="org.wildfly.swarm:mod_cluster-api:${project.version}"/>
+  </resources>
+
+  <dependencies>
+    <module name="org.wildfly.swarm.container"/>
+    <module name="org.wildfly.swarm.undertow"/>
+    <module name="org.wildfly.swarm.configuration"/>
+    <module name="org.jboss.shrinkwrap"/>
+    <module name="org.ow2.asm"/>
+    <module name="javax.ws.rs.api"/>
+  </dependencies>
+</module>

--- a/modcluster/modules/src/main/resources/modules/org/wildfly/swarm/mod_cluster/main/module.xml
+++ b/modcluster/modules/src/main/resources/modules/org/wildfly/swarm/mod_cluster/main/module.xml
@@ -1,0 +1,13 @@
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.swarm.mod_cluster">
+  <dependencies>
+    <system export="true">
+      <paths>
+        <path name="org/wildfly/swarm/mod_cluster"/>
+        <path name="org/wildfly/swarm/mod_cluster/internal"/>
+      </paths>
+    </system>
+
+    <module name="org.wildfly.swarm.mod_cluster" slot="api" export="true" services="export"/>
+
+  </dependencies>
+</module>

--- a/modcluster/modules/src/main/resources/modules/org/wildfly/swarm/mod_cluster/runtime/module.xml
+++ b/modcluster/modules/src/main/resources/modules/org/wildfly/swarm/mod_cluster/runtime/module.xml
@@ -1,0 +1,15 @@
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.swarm.mod_cluster" slot="runtime">
+  <resources>
+    <artifact name="org.wildfly.swarm:mod_cluster-runtime:${project.version}"/>
+  </resources>
+
+  <dependencies>
+    <module name="org.wildfly.swarm.mod_cluster"/>
+    <module name="org.wildfly.swarm.container"/>
+    <module name="org.wildfly.swarm.container" slot="runtime"/>
+    <module name="org.wildfly.swarm.configuration"/>
+
+    <module name="org.wildfly.extension.mod_cluster"/>
+    <module name="org.wildfly.mod_cluster.undertow"/>
+  </dependencies>
+</module>

--- a/modcluster/pom.xml
+++ b/modcluster/pom.xml
@@ -14,19 +14,21 @@
     <relativePath>../</relativePath>
   </parent>
 
-  <artifactId>jpa-postgresql-parent</artifactId>
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>mod_cluster-parent</artifactId>
 
-  <name>WildFly Swarm: JPA PostgreSQL Parent</name>
-  <description>WildFly Swarm: JPA PostgreSQL Parent</description>
+  <name>WildFly Swarm: Modcluster Parent</name>
+  <description>WildFly Swarm: Modcluster Parent</description>
 
   <packaging>pom</packaging>
 
   <modules>
-    <module>jpa-postgresql</module>
+    <module>mod_cluster</module>
 
     <module>api</module>
     <module>runtime</module>
     <module>modules</module>
     <module>test</module>
   </modules>
+
 </project>

--- a/modcluster/runtime/pom.xml
+++ b/modcluster/runtime/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>mod_cluster-parent</artifactId>
+    <version>1.0.2.Final-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>mod_cluster-runtime</artifactId>
+
+  <name>WildFly Swarm: Modcluster Runtime</name>
+  <description>WildFly Swarm: Modcluster Runtime</description>
+
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>mod_cluster-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>spi-runtime</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-mod_cluster-extension</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/modcluster/test/pom.xml
+++ b/modcluster/test/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>mod_cluster-parent</artifactId>
+    <version>1.0.2.Final-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>mod_cluster-test</artifactId>
+
+  <name>WildFly Swarm: Modcluster Test</name>
+  <description>WildFly Swarm: Modcluster Test</description>
+
+  <packaging>jar</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>mod_cluster</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>monitor</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>mod_cluster-modules</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>arquillian</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.junit</groupId>
+      <artifactId>arquillian-junit-container</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+    	<groupId>org.apache.httpcomponents</groupId>
+    	<artifactId>httpclient</artifactId>
+    	<version>4.5.2</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+    	<groupId>commons-logging</groupId>
+    	<artifactId>commons-logging</artifactId>
+    	<version>1.2</version>
+      <scope>test</scope>
+    </dependency>
+
+
+
+  </dependencies>
+
+</project>

--- a/modcluster/test/src/test/java/org/wildfly/swarm/mod_cluster/ModclusterInVmSimpleTest.java
+++ b/modcluster/test/src/test/java/org/wildfly/swarm/mod_cluster/ModclusterInVmSimpleTest.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.mod_cluster;
+
+import org.junit.Test;
+import org.wildfly.swarm.container.Container;
+/**
+ * @author Stuart Douglas
+ */
+public class ModclusterInVmSimpleTest {
+
+    @Test
+    public void testSimple() throws Exception {
+
+        Container container = new Container();
+        container.fraction(new ModclusterFraction());
+        container.start();
+        container.stop();
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -789,6 +789,28 @@
         <version>1.0.2.Final-SNAPSHOT</version>
       </dependency>
 
+
+      <dependency>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>mod_cluster</artifactId>
+        <version>1.0.2.Final-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>mod_cluster-api</artifactId>
+        <version>1.0.2.Final-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>mod_cluster-modules</artifactId>
+        <version>1.0.2.Final-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>mod_cluster-runtime</artifactId>
+        <version>1.0.2.Final-SNAPSHOT</version>
+      </dependency>
+
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>monitor</artifactId>
@@ -1151,6 +1173,7 @@
     <module>messaging</module>
     <module>msc</module>
     <module>monitor</module>
+    <module>modcluster</module>
     <module>naming</module>
     <module>remoting</module>
     <module>request-controller</module>


### PR DESCRIPTION
This allows swarm backends to register themselves with mod_proxy based load balancers.

This needs review, as I am not 100% sure how the config should work (especially with regard to the mod_cluster socket binding).
