### PR TITLE
Simplified management-console

### DIFF
--- a/management-console/pom.xml
+++ b/management-console/pom.xml
@@ -10,7 +10,6 @@
   </parent>
 
   <artifactId>management-console</artifactId>
-
   <name>Management Console</name>
   <description>UI to manage a running WildFly/Swarm server</description>
 
@@ -38,6 +37,10 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>management</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>spi-runtime</artifactId>
     </dependency>
     <dependency>
@@ -53,6 +56,4 @@
       </exclusions>
     </dependency>
   </dependencies>
-
-
 </project>

--- a/management-console/src/main/java/org/wildfly/swarm/management/console/ManagementConsoleFraction.java
+++ b/management-console/src/main/java/org/wildfly/swarm/management/console/ManagementConsoleFraction.java
@@ -4,11 +4,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
+import org.wildfly.swarm.management.ManagementFraction;
 import org.wildfly.swarm.spi.api.Fraction;
+import org.wildfly.swarm.spi.api.annotations.Configuration;
 
 /**
  * Created by ggastald on 02/06/16.
  */
+@Configuration
 public class ManagementConsoleFraction implements Fraction {
 
     public ManagementConsoleFraction() {
@@ -19,6 +22,22 @@ public class ManagementConsoleFraction implements Fraction {
         return this;
     }
 
+    public ManagementConsoleFraction inhibitStandaloneDeployment() {
+        this.inhibitStandaloneDeployment = true;
+    }
+
+    public boolean isInhibitStandaloneDeployment() {
+        return inhibitStandaloneDeployment;
+    }
+
+    @Override
+    public void postInitialize(PostInitContext initContext) {
+        ManagementFraction fraction = (ManagementFraction) initContext.fraction("Management");
+        if (fraction != null) {
+            fraction.httpInterfaceManagementInterface(iface -> iface.allowedOrigin("*").consoleEnabled(true));
+        }
+    }
+
     public String getContextRoot() {
         return context;
     }
@@ -26,4 +45,5 @@ public class ManagementConsoleFraction implements Fraction {
     private final String DEFAULT_CONTEXT = "/console";
 
     private String context = DEFAULT_CONTEXT;
+    private boolean inhibitStandaloneDeployment;
 }

--- a/management-console/src/main/java/org/wildfly/swarm/management/console/runtime/ManagementConsoleConfiguration.java
+++ b/management-console/src/main/java/org/wildfly/swarm/management/console/runtime/ManagementConsoleConfiguration.java
@@ -15,15 +15,10 @@
  */
 package org.wildfly.swarm.management.console.runtime;
 
-import java.net.URL;
 import java.util.Collections;
-import java.util.Enumeration;
 import java.util.List;
 
-import org.jboss.modules.Module;
-import org.jboss.modules.ModuleLoader;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.wildfly.swarm.management.console.ManagementConsoleFraction;
 import org.wildfly.swarm.spi.api.ArtifactLookup;
 import org.wildfly.swarm.spi.runtime.AbstractServerConfiguration;
@@ -40,11 +35,15 @@ public class ManagementConsoleConfiguration extends AbstractServerConfiguration<
 
     @Override
     public List<Archive> getImplicitDeployments(ManagementConsoleFraction fraction) throws Exception {
-        WARArchive war = ArtifactLookup.get()
-                .artifact("org.jboss.as:jboss-as-console:jar:2.8.25.Final:resources", "management-console-ui.war")
-                .as(WARArchive.class)
-                .setContextRoot(fraction.getContextRoot());
-        return Collections.singletonList(war);
+        if (!fraction.isInhibitStandaloneDeployment()) {
+            WARArchive war = ArtifactLookup.get()
+                    .artifact("org.jboss.as:jboss-as-console:jar:2.8.25.Final:resources", "management-console-ui.war")
+                    .as(WARArchive.class)
+                    .setContextRoot(fraction.getContextRoot());
+            return Collections.singletonList(war);
+        } else {
+            return Collections.emptyList();
+        }
     }
 
     @Override

--- a/management-console/src/main/resources/modules/org/jboss/as/console/main/module.xml
+++ b/management-console/src/main/resources/modules/org/jboss/as/console/main/module.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.console">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="org.jboss.hal:release-stream:2.8.19.Final:resources"/>
+    </resources>
+
+    <dependencies>
+        <!-- Do not add dependencies to the console as resources in any
+             dependencies could be served up through the HTTP interface. -->
+    </dependencies>
+</module>

--- a/management-console/src/main/resources/modules/org/wildfly/swarm/management/console/runtime/module.xml
+++ b/management-console/src/main/resources/modules/org/wildfly/swarm/management/console/runtime/module.xml
@@ -3,13 +3,13 @@
     <artifact name="org.wildfly.swarm:management-console:${project.version}"/>
     <artifact name="org.jboss.as:jboss-as-console:2.8.25.Final:resources"/>
   </resources>
-
   <dependencies>
     <module name="org.wildfly.swarm.management.console"/>
     <module name="org.wildfly.swarm.container"/>
     <module name="org.wildfly.swarm.container" slot="runtime"/>
     <module name="org.wildfly.swarm.undertow"/>
+    <module name="org.wildfly.swarm.management"/>
+    <module name="org.wildfly.swarm.management" slot="runtime"/>
     <module name="javax.servlet.api"/>
-    <module name="org.jboss.shrinkwrap"/>
   </dependencies>
 </module>


### PR DESCRIPTION
This PR depends on https://github.com/wildfly/wildfly-core/pull/1645 to be available
as the existing code throws a NPE in WildFly Core (See WFCORE-1629). 

At last but not least, -Dswarm.http.eager=true should be true to enable it
