### PR TITLE
The fixed the pattern for the default color formatter

### DIFF
--- a/logging/src/main/java/org/wildfly/swarm/logging/LoggingFraction.java
+++ b/logging/src/main/java/org/wildfly/swarm/logging/LoggingFraction.java
@@ -113,7 +113,7 @@ public class LoggingFraction extends Logging<LoggingFraction> implements Fractio
      * @return This fraction.
      */
     public LoggingFraction defaultColorFormatter() {
-        return formatter(COLOR_PATTERN, "%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n");
+        return formatter(COLOR_PATTERN, "%K{level}%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n");
     }
 
 


### PR DESCRIPTION
The pattern for the default color formatter in the logging fraction didn't include colors, so I updated the pattern
