### PR TITLE
Default module-dir in the gradle-plugin

### DIFF
--- a/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/PackagePlugin.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/PackagePlugin.java
@@ -27,7 +27,7 @@ public class PackagePlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
-        project.getExtensions().create("swarm", SwarmExtension.class);
+        project.getExtensions().create("swarm", SwarmExtension.class, project);
         project.afterEvaluate(__ -> {
             final TaskContainer tasks = project.getTasks();
             final PackageTask packageTask = tasks.create("wildfly-swarm-package", PackageTask.class);

--- a/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/PackageTask.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/PackageTask.java
@@ -82,6 +82,7 @@ public class PackageTask extends DefaultTask {
                 .fractionList(FractionList.get())
                 .fractionDetectionMode(BuildTool.FractionDetectionMode.when_missing)
                 .additionalModules(ext.getModuleDirs().stream()
+                                           .filter(f -> f.exists())
                                            .map(File::getAbsolutePath)
                                            .collect(Collectors.toList()))
                 .logger(new BuildTool.SimpleLogger() {

--- a/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/SwarmExtension.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/SwarmExtension.java
@@ -22,11 +22,15 @@ import java.util.Properties;
 
 import groovy.lang.Closure;
 import groovy.util.ConfigObject;
+import org.gradle.api.Project;
 
 /**
  * @author Bob McWhirter
  */
 public class SwarmExtension {
+
+    private Project project;
+
     private String mainClass;
 
     private Boolean bundleDependencies = true;
@@ -41,8 +45,9 @@ public class SwarmExtension {
 
     private List<File> moduleDirs = new ArrayList<>();
 
-    public SwarmExtension() {
-
+    public SwarmExtension(Project project) {
+        this.project = project;
+        this.moduleDirs.add(new File(this.project.getBuildDir(), "resources/main/modules"));
     }
 
     public void properties(Closure<Properties> closure) {


### PR DESCRIPTION
With the change, gradle now has the same behaviour like maven. It scans for module.xml which are placed in src/main/resources/modules (which results in build/resources/main/modules)
