### PR TITLE
Changed the logic which gradle archive-task gets wrapped in the swarm…

### DIFF
--- a/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/SwarmExtension.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/SwarmExtension.java
@@ -22,6 +22,7 @@ import java.util.Properties;
 
 import groovy.lang.Closure;
 import groovy.util.ConfigObject;
+import org.gradle.api.tasks.bundling.Jar;
 
 /**
  * @author Bob McWhirter
@@ -40,6 +41,8 @@ public class SwarmExtension {
     private File propertiesFile;
 
     private List<File> moduleDirs = new ArrayList<>();
+
+    private Jar archiveTask;
 
     public SwarmExtension() {
 
@@ -104,5 +107,13 @@ public class SwarmExtension {
     public void setModuleDirs(final List<File> moduleDirs) {
         this.moduleDirs.clear();
         this.moduleDirs.addAll(moduleDirs);
+    }
+
+    public Jar getArchiveTask() {
+        return archiveTask;
+    }
+
+    public void setArchiveTask(Jar archiveTask) {
+        this.archiveTask = archiveTask;
     }
 }


### PR DESCRIPTION
Changed the logic which gradle archive-task gets wrapped in the swarm-jar to a more controlled one.

With the current logic the latest added task with type 'Jar' wins. That's fine in the following scenarios:
- jar-packaging: just the task Jar with the name 'jar' from the java-plugin ==> Task 'jar' gets wrapped
- war-packaging: task with the 'jar' from the java-plugin and 'war' from the war-plugin ==> war-Tasks gets wrapped

In the following scenario the latest added jar-tasks results in an wrong swarm-jar.
- jar-packaging with a custom archive-task from type "Jar" e.g. source-jar ==> source-jar gets wrapped.

With the new logic the 'war' task wins over the 'jar' task. If the user likes to wrap another archive-task he has to add this explicitly in the swarmextension.

The following snipped illustrates how a source-jar from the type Jar is added to a project - which results in an wrong swarm-jar.
`task sourcesJar(type: Jar, dependsOn: classes) {
    classifier = 'sources'
    from sourceSets.main.allSource
}`
