### PR TITLE
SWARM-594 - Make DefaultDeploymentFactory into CDI components.

### DIFF
--- a/container/src/main/java/org/wildfly/swarm/container/runtime/deployments/DefaultDeploymentCreator.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/deployments/DefaultDeploymentCreator.java
@@ -1,0 +1,93 @@
+package org.wildfly.swarm.container.runtime.deployments;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.wildfly.swarm.spi.api.DefaultDeploymentFactory;
+import org.wildfly.swarm.spi.api.JARArchive;
+
+/**
+ * @author Bob McWhirter
+ */
+@ApplicationScoped
+public class DefaultDeploymentCreator {
+
+    private Map<String,DefaultDeploymentFactory> factories = new HashMap<>();
+
+    @Inject
+    public DefaultDeploymentCreator(@Any Instance<DefaultDeploymentFactory> factories) {
+        this( (Iterable<DefaultDeploymentFactory>) factories );
+    }
+
+    public DefaultDeploymentCreator(DefaultDeploymentFactory...factories) {
+        this(Arrays.asList( factories ) );
+    }
+
+    public DefaultDeploymentCreator(Iterable<DefaultDeploymentFactory> factories) {
+        for (DefaultDeploymentFactory factory : factories) {
+            final DefaultDeploymentFactory current = this.factories.get(factory.getType());
+            if (current == null) {
+                this.factories.put(factory.getType(), factory);
+            } else {
+                // if this one is high priority than the previously-seen factory, replace it.
+                if (factory.getPriority() > current.getPriority()) {
+                    this.factories.put(factory.getType(), factory);
+                }
+            }
+        }
+    }
+
+    public Archive<?> createDefaultDeployment(String type) {
+        try {
+            return getFactory(type).create();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    DefaultDeploymentFactory getFactory(String type) {
+        DefaultDeploymentFactory factory = this.factories.get(type);
+        if ( factory != null ) {
+            return factory;
+        }
+        return new EmptyJARArchiveDeploymentFactory(type);
+    }
+
+    private static class EmptyJARArchiveDeploymentFactory extends DefaultDeploymentFactory {
+        private final String type;
+
+        public EmptyJARArchiveDeploymentFactory(String type) {
+            this.type = type;
+        }
+
+        @Override
+        public int getPriority() {
+            return 0;
+        }
+
+        @Override
+        public String getType() {
+            return this.type;
+        }
+
+        @Override
+        public Archive create() throws Exception {
+            return ShrinkWrap.create(JARArchive.class, UUID.randomUUID().toString() + "." + this.type );
+        }
+
+        @Override
+        protected boolean setupUsingMaven(Archive<?> archive) throws Exception {
+            return false;
+        }
+    }
+
+}

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/deployments/DefaultJarDeploymentFactory.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/deployments/DefaultJarDeploymentFactory.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.swarm.container.internal;
+package org.wildfly.swarm.container.runtime.deployments;
 
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
@@ -22,7 +22,7 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 
-import javax.enterprise.inject.Vetoed;
+import javax.enterprise.context.ApplicationScoped;
 
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -35,7 +35,7 @@ import org.wildfly.swarm.spi.api.JARArchive;
  * @author Bob McWhirter
  * @author Heiko Braun
  */
-@Vetoed
+@ApplicationScoped
 public class DefaultJarDeploymentFactory extends DefaultDeploymentFactory {
 
     @Override

--- a/container/src/main/resources/META-INF/services/org.wildfly.swarm.spi.api.DefaultDeploymentFactory
+++ b/container/src/main/resources/META-INF/services/org.wildfly.swarm.spi.api.DefaultDeploymentFactory
@@ -1,1 +1,0 @@
-org.wildfly.swarm.container.internal.DefaultJarDeploymentFactory

--- a/container/src/test/java/org/wildfly/swarm/container/runtime/deployments/DefaultDeploymentCreatorTest.java
+++ b/container/src/test/java/org/wildfly/swarm/container/runtime/deployments/DefaultDeploymentCreatorTest.java
@@ -1,0 +1,57 @@
+package org.wildfly.swarm.container.runtime.deployments;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.wildfly.swarm.spi.api.DefaultDeploymentFactory;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Bob McWhirter
+ */
+public class DefaultDeploymentCreatorTest {
+
+    @Test
+    public void testNoDeploymentFactories() throws Exception {
+        DefaultDeploymentCreator creator = new DefaultDeploymentCreator();
+        DefaultDeploymentFactory factory = creator.getFactory("foo");
+        assertThat(factory).isNotNull();
+        assertThat(factory.getType()).isEqualTo("foo");
+
+        Archive archive = factory.create();
+        assertThat(archive).isNotNull();
+        assertThat(archive.getName()).endsWith(".foo");
+    }
+
+    @Test
+    public void testDistinctFactories() throws Exception {
+        DefaultDeploymentCreator creator = new DefaultDeploymentCreator(
+                new MockDefaultDeploymentFactory("war", 0),
+                new MockDefaultDeploymentFactory("jar", 0)
+        );
+
+        DefaultDeploymentFactory jarFactory = creator.getFactory("jar");
+        assertThat(jarFactory).isNotNull();
+        assertThat(jarFactory.getType()).isEqualTo("jar");
+
+        DefaultDeploymentFactory warFactory = creator.getFactory("war");
+        assertThat(warFactory).isNotNull();
+        assertThat(warFactory.getType()).isEqualTo("war");
+    }
+
+    @Test
+    public void testConflictingFactories() throws Exception {
+        MockDefaultDeploymentFactory lowPrio = new MockDefaultDeploymentFactory("war", 0);
+        MockDefaultDeploymentFactory highPrio = new MockDefaultDeploymentFactory("war", 1000);
+
+        DefaultDeploymentCreator creator = new DefaultDeploymentCreator( lowPrio, highPrio );
+        DefaultDeploymentFactory factory = creator.getFactory( "war" );
+        assertThat( factory ).isSameAs( highPrio );
+
+        // try reverse registration
+
+        creator = new DefaultDeploymentCreator( highPrio, lowPrio );
+        factory = creator.getFactory( "war" );
+        assertThat( factory ).isSameAs( highPrio );
+    }
+}

--- a/container/src/test/java/org/wildfly/swarm/container/runtime/deployments/MockDefaultDeploymentFactory.java
+++ b/container/src/test/java/org/wildfly/swarm/container/runtime/deployments/MockDefaultDeploymentFactory.java
@@ -1,0 +1,37 @@
+package org.wildfly.swarm.container.runtime.deployments;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.wildfly.swarm.spi.api.DefaultDeploymentFactory;
+
+/**
+ * @author Bob McWhirter
+ */
+public class MockDefaultDeploymentFactory extends DefaultDeploymentFactory {
+    private final String type;
+
+    private final int prio;
+
+    public MockDefaultDeploymentFactory(String type, int prio) {
+        this.type = type;
+        this.prio = prio;
+    }
+    @Override
+    public int getPriority() {
+        return this.prio;
+    }
+
+    @Override
+    public String getType() {
+        return this.type;
+    }
+
+    @Override
+    public Archive create() throws Exception {
+        return null;
+    }
+
+    @Override
+    protected boolean setupUsingMaven(Archive<?> archive) throws Exception {
+        return false;
+    }
+}

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -50,6 +50,17 @@
       <artifactId>security</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- MOVE TO A MODULE? -->
     <dependency>
       <groupId>org.ow2.asm</groupId>

--- a/jaxrs/src/main/java/org/wildfly/swarm/jaxrs/internal/DefaultJAXRSWarDeploymentFactory.java
+++ b/jaxrs/src/main/java/org/wildfly/swarm/jaxrs/internal/DefaultJAXRSWarDeploymentFactory.java
@@ -15,6 +15,8 @@
  */
 package org.wildfly.swarm.jaxrs.internal;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.wildfly.swarm.jaxrs.JAXRSArchive;
@@ -23,6 +25,7 @@ import org.wildfly.swarm.undertow.internal.DefaultWarDeploymentFactory;
 /**
  * @author Bob McWhirter
  */
+@ApplicationScoped
 public class DefaultJAXRSWarDeploymentFactory extends DefaultWarDeploymentFactory {
 
     @Override

--- a/jaxrs/src/main/resources/META-INF/services/org.wildfly.swarm.spi.api.DefaultDeploymentFactory
+++ b/jaxrs/src/main/resources/META-INF/services/org.wildfly.swarm.spi.api.DefaultDeploymentFactory
@@ -1,1 +1,0 @@
-org.wildfly.swarm.jaxrs.internal.DefaultJAXRSWarDeploymentFactory

--- a/resource-adapters/pom.xml
+++ b/resource-adapters/pom.xml
@@ -55,6 +55,18 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>security</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.wildfly.core</groupId>
       <artifactId>wildfly-core-feature-pack</artifactId>

--- a/resource-adapters/src/main/java/org/wildfly/swarm/resource/adapters/internal/DefaultRarDeploymentFactory.java
+++ b/resource-adapters/src/main/java/org/wildfly/swarm/resource/adapters/internal/DefaultRarDeploymentFactory.java
@@ -22,6 +22,8 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.FileAsset;
@@ -33,6 +35,7 @@ import org.wildfly.swarm.spi.api.DependenciesContainer;
 /**
  * @author Ralf Battenfeld
  */
+@ApplicationScoped
 public class DefaultRarDeploymentFactory extends DefaultDeploymentFactory {
 
     public static RARArchive archiveFromCurrentApp() throws Exception {

--- a/resource-adapters/src/main/resources/META-INF/services/org.wildfly.swarm.spi.api.DefaultDeploymentFactory
+++ b/resource-adapters/src/main/resources/META-INF/services/org.wildfly.swarm.spi.api.DefaultDeploymentFactory
@@ -1,1 +1,0 @@
-org.wildfly.swarm.resource.adapters.internal.DefaultRarDeploymentFactory

--- a/undertow/src/main/java/org/wildfly/swarm/undertow/internal/DefaultWarDeploymentFactory.java
+++ b/undertow/src/main/java/org/wildfly/swarm/undertow/internal/DefaultWarDeploymentFactory.java
@@ -22,6 +22,8 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.FileAsset;
@@ -34,6 +36,7 @@ import org.wildfly.swarm.undertow.WARArchive;
  * @author Bob McWhirter
  * @author Heiko Braun
  */
+@ApplicationScoped
 public class DefaultWarDeploymentFactory extends DefaultDeploymentFactory {
 
     public static WARArchive archiveFromCurrentApp() throws Exception {

--- a/undertow/src/main/resources/META-INF/services/org.wildfly.swarm.spi.api.DefaultDeploymentFactory
+++ b/undertow/src/main/resources/META-INF/services/org.wildfly.swarm.spi.api.DefaultDeploymentFactory
@@ -1,1 +1,0 @@
-org.wildfly.swarm.undertow.internal.DefaultWarDeploymentFactory


### PR DESCRIPTION
Since we're registering most runtime side components via CDI now
might as well remove another instance of ServiceLoader'ing.
Allows for removal/forgetting the related META-INF/services/
file.  Also may open up cross-injecting FSLayout bits as necessary
in order to build an archive from maven/gradle/whatever layout.
