### PR TITLE
SWARM-599: Remote JMX not working.

### DIFF
--- a/jmx/module.conf
+++ b/jmx/module.conf
@@ -1,1 +1,2 @@
 org.jboss.as.jmx
+org.jboss.remoting-jmx

--- a/jmx/pom.xml
+++ b/jmx/pom.xml
@@ -41,6 +41,14 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>container</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>remoting</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>management</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.wildfly.core</groupId>

--- a/testsuite/testsuite-jmx/pom.xml
+++ b/testsuite/testsuite-jmx/pom.xml
@@ -37,6 +37,11 @@
       <artifactId>arquillian-junit-container</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.remotingjmx</groupId>
+      <artifactId>remoting-jmx</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/testsuite/testsuite-jmx/src/test/java/org/wildfly/swarm/jmx/JMXRemoteArquillianTest.java
+++ b/testsuite/testsuite-jmx/src/test/java/org/wildfly/swarm/jmx/JMXRemoteArquillianTest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.jmx;
+
+import java.util.ArrayList;
+
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanServer;
+import javax.management.MBeanServerConnection;
+import javax.management.MBeanServerFactory;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.arquillian.CreateSwarm;
+import org.wildfly.swarm.spi.api.JARArchive;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Bob McWhirter
+ */
+@RunWith(Arquillian.class)
+public class JMXRemoteArquillianTest {
+
+    @Deployment(testable = false)
+    public static Archive createDeployment() {
+        JARArchive deployment = ShrinkWrap.create(JARArchive.class);
+        deployment.add(EmptyAsset.INSTANCE, "nothing");
+        return deployment;
+    }
+
+    @CreateSwarm
+    public static Swarm newSwarm() throws Exception {
+        return new Swarm().fraction(
+                new JMXFraction()
+                        .expressionExposeModel()
+                        .resolvedExposeModel()
+                        .jmxRemotingConnector()
+        );
+    }
+
+    @Test
+    @RunAsClient
+    public void testRemoteConnection() throws Exception {
+        String urlString = "service:jmx:remote+http://localhost:9990";
+        
+        JMXServiceURL serviceURL = new JMXServiceURL(urlString);
+        JMXConnector jmxConnector = JMXConnectorFactory.connect(serviceURL, null);
+        MBeanServerConnection connection = jmxConnector.getMBeanServerConnection();
+
+        int count = connection.getMBeanCount();
+        assertThat( count ).isGreaterThan( 1 );
+
+        jmxConnector.close();
+    }
+
+}


### PR DESCRIPTION
Add dependencies to jmx fraction to include both
remoting and management, as that's what's required in order
for remote JMX to function.

Additionally, ensure that the correct remotingjmx module is
included into the solution of the module tree.

Add a test to verify that a remote client can indeed contact
and use the remote JMX interface.
