### PR TITLE
SWARM-600 and SWARM-599 - Remote JMX over (management/http/remoting)

### DIFF
--- a/jmx/module.conf
+++ b/jmx/module.conf
@@ -1,2 +1,4 @@
 org.jboss.as.jmx
 org.jboss.remoting-jmx
+org.jboss.logging
+org.wildfly.swarm.remoting

--- a/jmx/pom.xml
+++ b/jmx/pom.xml
@@ -43,11 +43,21 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
-      <artifactId>remoting</artifactId>
+      <artifactId>logging</artifactId>
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
-      <artifactId>management</artifactId>
+      <artifactId>remoting</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/jmx/src/main/java/org/wildfly/swarm/jmx/runtime/JMXRemotingConnectorEndpointSelector.java
+++ b/jmx/src/main/java/org/wildfly/swarm/jmx/runtime/JMXRemotingConnectorEndpointSelector.java
@@ -1,0 +1,87 @@
+package org.wildfly.swarm.jmx.runtime;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.jboss.logging.Logger;
+import org.wildfly.swarm.config.ManagementCoreService;
+import org.wildfly.swarm.config.Undertow;
+import org.wildfly.swarm.config.jmx.JMXRemotingConnector;
+import org.wildfly.swarm.jmx.JMXFraction;
+import org.wildfly.swarm.remoting.RemotingFraction;
+import org.wildfly.swarm.spi.api.Customizer;
+import org.wildfly.swarm.spi.runtime.annotations.Pre;
+
+/** Picks and/or verifies the remote JMX connector to use.
+ *
+ * <p>If a user has not specified <b>any</b> {@link JMXFraction#jmxRemotingConnector(JMXRemotingConnector)},
+ * then nothing is done as JMX remains purely available only inside the process.</p>
+ *
+ * <p>If a user has specified a generic, unconfigured {@link JMXRemotingConnector}, then his selector
+ * will pick the "best" connector available, given the following priority:</p>
+ *
+ * <ul>
+ *     <li>Management Interface (typically port 9990) if <code>org.wildfly.swarm:management</code> is present</li>
+ *     <li>Remoting over HTTP (typically normal web-port, 8080) if <code>org.wildfly.swarm:undertow</code> is present</li>
+ *     <li>Else, the legacy remoting port (typically port 4777)</li>
+ * </ul>
+ *
+ * <p>In the event a user has specifically {@link JMXRemotingConnector#useManagementEndpoint(Boolean)} to
+ * <code>true<</code>, then in the event <code>org.wildfly.swarm:management</code> is not present,
+ * then the remote connector for JMX will be <b>completely disabled</b>.</p>
+ *
+ * @author Bob McWhirter
+ */
+@Pre
+@Singleton
+public class JMXRemotingConnectorEndpointSelector implements Customizer {
+
+    private static Logger LOG = Logger.getLogger("org.wildfly.swarm.jmx");
+
+    @Inject
+    private JMXFraction jmx;
+
+    @Inject
+    private Instance<ManagementCoreService> management;
+
+    @Inject
+    private Instance<Undertow> undertow;
+
+    @Inject
+    private RemotingFraction remoting;
+
+    @Override
+    public void customize() {
+        JMXRemotingConnector remotingConnector = this.jmx.subresources().jmxRemotingConnector();
+        if (remotingConnector == null) {
+            LOG.info("JMX not configured for remote access");
+            return;
+        }
+
+        boolean requiresLegacyRemoting = false;
+
+        if (remotingConnector.useManagementEndpoint() == null) {
+            if (!this.management.isUnsatisfied()) {
+                LOG.info("JMX configured for remote connector: implicitly using management interface");
+                remotingConnector.useManagementEndpoint(true);
+            } else if (!this.undertow.isUnsatisfied()) {
+                LOG.info("JMX configured for remote connector: implicitly using standard interface");
+                remotingConnector.useManagementEndpoint(false);
+            } else {
+                requiresLegacyRemoting = true;
+            }
+        } else if (remotingConnector.useManagementEndpoint() && this.management.isUnsatisfied()) {
+            LOG.warn("JMX configured to use management endpoint, but org.wildfly.swarm:management not available. Disabling");
+            this.jmx.jmxRemotingConnector(() -> null);
+        } else if (this.undertow.isUnsatisfied()) {
+            requiresLegacyRemoting = true;
+        }
+
+        if (requiresLegacyRemoting) {
+            remotingConnector.useManagementEndpoint(false);
+            LOG.info("JMX configured for remote connector but neither management nor http interfaces available. Using legacy remoting.");
+            this.remoting.requireLegacyConnector(true);
+        }
+    }
+}

--- a/remoting/module.conf
+++ b/remoting/module.conf
@@ -1,1 +1,2 @@
 org.jboss.as.remoting
+org.jboss.logging

--- a/remoting/pom.xml
+++ b/remoting/pom.xml
@@ -38,6 +38,10 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>io</artifactId>
     </dependency>
     <dependency>

--- a/remoting/src/main/java/org/wildfly/swarm/remoting/RemotingFraction.java
+++ b/remoting/src/main/java/org/wildfly/swarm/remoting/RemotingFraction.java
@@ -31,9 +31,15 @@ import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
 @MarshalDMR
 public class RemotingFraction extends Remoting<RemotingFraction> implements Fraction<RemotingFraction> {
 
-    @PostConstruct
-    public void postConstruct() {
-        applyDefaults();
+    private boolean required;
+
+    public RemotingFraction requireLegacyConnector(boolean required) {
+        this.required = required;
+        return this;
+    }
+
+    public boolean isRequireLegacyConnector() {
+        return this.required;
     }
 
     public static RemotingFraction defaultFraction() {

--- a/remoting/src/main/java/org/wildfly/swarm/remoting/RemotingProperties.java
+++ b/remoting/src/main/java/org/wildfly/swarm/remoting/RemotingProperties.java
@@ -1,0 +1,10 @@
+package org.wildfly.swarm.remoting;
+
+/** Properties for configuration of the remoting fraction.
+ *
+ * @author Bob McWhirter
+ */
+public class RemotingProperties {
+    /** Port upon standard-stockets for remoting binding. */
+    public static final String REMOTING_PORT = "swarm.remoting.port";
+}

--- a/remoting/src/main/java/org/wildfly/swarm/remoting/runtime/RemotingLegacyConnectorCustomizer.java
+++ b/remoting/src/main/java/org/wildfly/swarm/remoting/runtime/RemotingLegacyConnectorCustomizer.java
@@ -1,0 +1,61 @@
+package org.wildfly.swarm.remoting.runtime;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.jboss.logging.Logger;
+import org.wildfly.swarm.container.runtime.config.DefaultSocketBindingGroupProducer;
+import org.wildfly.swarm.remoting.RemotingFraction;
+import org.wildfly.swarm.remoting.RemotingProperties;
+import org.wildfly.swarm.spi.api.Customizer;
+import org.wildfly.swarm.spi.api.SocketBinding;
+import org.wildfly.swarm.spi.api.SocketBindingGroup;
+import org.wildfly.swarm.spi.runtime.annotations.ConfigurationValue;
+import org.wildfly.swarm.spi.runtime.annotations.Post;
+
+/** Configures the legacy remoting socketing binding and connector if required.
+ *
+ * <p>In the event {@link RemotingFraction#requireLegacyConnector(boolean)}</p> has been
+ * set to <code>true</code> or if configuration property <code>swarm.remoting.port</code>
+ * is set to any value, this customizer will install a socket-binding named
+ * <code>legacy-remoting</code> for port <code>4777</code> or whatever value
+ * configuration property <code>swarm.remoting.port</code> is set to.</p>
+ *
+ * @author Bob McWhirter
+ */
+@Post
+@Singleton
+public class RemotingLegacyConnectorCustomizer implements Customizer {
+
+    private static Logger LOG = Logger.getLogger("org.wildfly.swarm.remoting");
+
+    /** Default legacy remoting port. */
+    public static final int DEFAULT_LEGACY_REMOTING_PORT = 4777;
+
+    @Inject
+    private RemotingFraction remoting;
+
+    @Inject
+    @ConfigurationValue(RemotingProperties.REMOTING_PORT)
+    private Integer port;
+
+    @Inject
+    @Named(DefaultSocketBindingGroupProducer.STANDARD_SOCKETS)
+    private SocketBindingGroup group;
+
+    @Override
+    public void customize() {
+        if (this.remoting.isRequireLegacyConnector() || this.port != null ) {
+            LOG.info("Remoting installed but Undertnow not available. Enabled legacy connector on port 4777.");
+            this.remoting.connector("legacy", (connector) -> {
+                connector.socketBinding("legacy-remoting");
+            });
+            if ( this.port == null ) {
+                this.port = DEFAULT_LEGACY_REMOTING_PORT;
+
+            }
+            group.socketBinding(new SocketBinding("legacy-remoting").port(this.port));
+        }
+    }
+}

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -91,6 +91,9 @@
     <module>testsuite-jdr</module>
     <module>testsuite-jgroups</module>
     <module>testsuite-jmx</module>
+    <module>testsuite-jmx-remote-remoting</module>
+    <module>testsuite-jmx-remote-management</module>
+    <module>testsuite-jmx-remote-undertow</module>
     <module>testsuite-jolokia</module>
     <module>testsuite-jpa</module>
     <module>testsuite-jpa-mysql</module>

--- a/testsuite/testsuite-jmx-remote-management/pom.xml
+++ b/testsuite/testsuite-jmx-remote-management/pom.xml
@@ -15,10 +15,10 @@
   </parent>
 
   <groupId>org.wildfly.swarm</groupId>
-  <artifactId>testsuite-jmx</artifactId>
+  <artifactId>testsuite-jmx-remote-management</artifactId>
 
-  <name>Test Suite: JMX</name>
-  <description>Test Suite: JMX</description>
+  <name>Test Suite: JMX with Remoting over Management</name>
+  <description>Test Suite: JMX with Remoting over Management</description>
 
   <packaging>jar</packaging>
 

--- a/testsuite/testsuite-jmx-remote-management/src/test/java/org/wildfly/swarm/jmx/JMXRemoteManagementAutoEndpointArquillianTest.java
+++ b/testsuite/testsuite-jmx-remote-management/src/test/java/org/wildfly/swarm/jmx/JMXRemoteManagementAutoEndpointArquillianTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.jmx;
+
+import javax.management.MBeanServerConnection;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.arquillian.CreateSwarm;
+import org.wildfly.swarm.spi.api.JARArchive;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Bob McWhirter
+ */
+@RunWith(Arquillian.class)
+public class JMXRemoteManagementAutoEndpointArquillianTest {
+
+    @Deployment(testable = false)
+    public static Archive createDeployment() {
+        JARArchive deployment = ShrinkWrap.create(JARArchive.class);
+        deployment.add(EmptyAsset.INSTANCE, "nothing");
+        return deployment;
+    }
+
+    @CreateSwarm
+    public static Swarm newSwarm() throws Exception {
+        return new Swarm().fraction(
+                new JMXFraction()
+                        .expressionExposeModel()
+                        .resolvedExposeModel()
+                        .jmxRemotingConnector()
+        );
+    }
+
+    @Test
+    @RunAsClient
+    public void testRemoteConnection() throws Exception {
+        String urlString = "service:jmx:remote+http://localhost:9990";
+
+        JMXServiceURL serviceURL = new JMXServiceURL(urlString);
+        JMXConnector jmxConnector = JMXConnectorFactory.connect(serviceURL, null);
+        MBeanServerConnection connection = jmxConnector.getMBeanServerConnection();
+
+        int count = connection.getMBeanCount();
+        assertThat(count).isGreaterThan(1);
+
+        jmxConnector.close();
+    }
+
+}

--- a/testsuite/testsuite-jmx-remote-management/src/test/java/org/wildfly/swarm/jmx/JMXRemoteManagementEndpointArquillianTest.java
+++ b/testsuite/testsuite-jmx-remote-management/src/test/java/org/wildfly/swarm/jmx/JMXRemoteManagementEndpointArquillianTest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.jmx;
+
+import java.util.ArrayList;
+
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanServer;
+import javax.management.MBeanServerConnection;
+import javax.management.MBeanServerFactory;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.arquillian.CreateSwarm;
+import org.wildfly.swarm.spi.api.JARArchive;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Bob McWhirter
+ */
+@RunWith(Arquillian.class)
+public class JMXRemoteManagementEndpointArquillianTest {
+
+    @Deployment(testable = false)
+    public static Archive createDeployment() {
+        JARArchive deployment = ShrinkWrap.create(JARArchive.class);
+        deployment.add(EmptyAsset.INSTANCE, "nothing");
+        return deployment;
+    }
+
+    @CreateSwarm
+    public static Swarm newSwarm() throws Exception {
+        return new Swarm().fraction(
+                new JMXFraction()
+                        .expressionExposeModel()
+                        .resolvedExposeModel()
+                        .jmxRemotingConnector( (connector)->{
+                            connector.useManagementEndpoint( true );
+                        })
+        );
+    }
+
+    @Test
+    @RunAsClient
+    public void testRemoteConnection() throws Exception {
+        String urlString = "service:jmx:remote+http://localhost:9990";
+
+        JMXServiceURL serviceURL = new JMXServiceURL(urlString);
+        JMXConnector jmxConnector = JMXConnectorFactory.connect(serviceURL, null);
+        MBeanServerConnection connection = jmxConnector.getMBeanServerConnection();
+
+        int count = connection.getMBeanCount();
+        assertThat(count).isGreaterThan(1);
+
+        jmxConnector.close();
+    }
+
+}

--- a/testsuite/testsuite-jmx-remote-management/src/test/java/org/wildfly/swarm/jmx/JMXRemoteNonManagementEndpointArquillianTest.java
+++ b/testsuite/testsuite-jmx-remote-management/src/test/java/org/wildfly/swarm/jmx/JMXRemoteNonManagementEndpointArquillianTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.jmx;
+
+import javax.management.MBeanServerConnection;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.arquillian.CreateSwarm;
+import org.wildfly.swarm.spi.api.JARArchive;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Bob McWhirter
+ */
+@RunWith(Arquillian.class)
+public class JMXRemoteNonManagementEndpointArquillianTest {
+
+    @Deployment(testable = false)
+    public static Archive createDeployment() {
+        JARArchive deployment = ShrinkWrap.create(JARArchive.class);
+        deployment.add(EmptyAsset.INSTANCE, "nothing");
+        return deployment;
+    }
+
+    @CreateSwarm
+    public static Swarm newSwarm() throws Exception {
+        return new Swarm().fraction(
+                new JMXFraction()
+                        .expressionExposeModel()
+                        .resolvedExposeModel()
+                        .jmxRemotingConnector( (connector)->{
+                            connector.useManagementEndpoint( false );
+                        })
+        );
+    }
+
+    @Test
+    @RunAsClient
+    public void testRemoteConnection() throws Exception {
+        String urlString = "service:jmx:remote+http://localhost:8080";
+
+        JMXServiceURL serviceURL = new JMXServiceURL(urlString);
+        JMXConnector jmxConnector = JMXConnectorFactory.connect(serviceURL, null);
+        MBeanServerConnection connection = jmxConnector.getMBeanServerConnection();
+
+        int count = connection.getMBeanCount();
+        assertThat( count ).isGreaterThan( 1 );
+
+        jmxConnector.close();
+    }
+
+}

--- a/testsuite/testsuite-jmx-remote-remoting/pom.xml
+++ b/testsuite/testsuite-jmx-remote-remoting/pom.xml
@@ -15,10 +15,10 @@
   </parent>
 
   <groupId>org.wildfly.swarm</groupId>
-  <artifactId>testsuite-jmx</artifactId>
+  <artifactId>testsuite-jmx-remote-remoting</artifactId>
 
-  <name>Test Suite: JMX</name>
-  <description>Test Suite: JMX</description>
+  <name>Test Suite: JMX with Remoting</name>
+  <description>Test Suite: JMX with Remoting</description>
 
   <packaging>jar</packaging>
 
@@ -26,10 +26,6 @@
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>jmx</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.wildfly.swarm</groupId>
-      <artifactId>management</artifactId>
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>

--- a/testsuite/testsuite-jmx-remote-remoting/src/test/java/org/wildfly/swarm/jmx/JMXRemoteManagementAutoEndpointArquillianTest.java
+++ b/testsuite/testsuite-jmx-remote-remoting/src/test/java/org/wildfly/swarm/jmx/JMXRemoteManagementAutoEndpointArquillianTest.java
@@ -15,15 +15,7 @@
  */
 package org.wildfly.swarm.jmx;
 
-import java.util.ArrayList;
-
-import javax.management.InstanceNotFoundException;
-import javax.management.MBeanServer;
 import javax.management.MBeanServerConnection;
-import javax.management.MBeanServerFactory;
-import javax.management.MalformedObjectNameException;
-import javax.management.ObjectInstance;
-import javax.management.ObjectName;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
@@ -41,13 +33,12 @@ import org.wildfly.swarm.arquillian.CreateSwarm;
 import org.wildfly.swarm.spi.api.JARArchive;
 
 import static org.fest.assertions.Assertions.assertThat;
-import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Bob McWhirter
  */
 @RunWith(Arquillian.class)
-public class JMXRemoteArquillianTest {
+public class JMXRemoteManagementAutoEndpointArquillianTest {
 
     @Deployment(testable = false)
     public static Archive createDeployment() {
@@ -69,14 +60,14 @@ public class JMXRemoteArquillianTest {
     @Test
     @RunAsClient
     public void testRemoteConnection() throws Exception {
-        String urlString = "service:jmx:remote+http://localhost:9990";
-        
+        String urlString = "service:jmx:remote://localhost:4777";
+
         JMXServiceURL serviceURL = new JMXServiceURL(urlString);
         JMXConnector jmxConnector = JMXConnectorFactory.connect(serviceURL, null);
         MBeanServerConnection connection = jmxConnector.getMBeanServerConnection();
 
         int count = connection.getMBeanCount();
-        assertThat( count ).isGreaterThan( 1 );
+        assertThat(count).isGreaterThan(1);
 
         jmxConnector.close();
     }

--- a/testsuite/testsuite-jmx-remote-remoting/src/test/java/org/wildfly/swarm/jmx/JMXRemoteNonManagementEndpointArquillianTest.java
+++ b/testsuite/testsuite-jmx-remote-remoting/src/test/java/org/wildfly/swarm/jmx/JMXRemoteNonManagementEndpointArquillianTest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.jmx;
+
+import javax.management.MBeanServerConnection;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.arquillian.CreateSwarm;
+import org.wildfly.swarm.logging.LoggingFraction;
+import org.wildfly.swarm.spi.api.JARArchive;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Bob McWhirter
+ */
+@RunWith(Arquillian.class)
+public class JMXRemoteNonManagementEndpointArquillianTest {
+
+    @Deployment(testable = false)
+    public static Archive createDeployment() {
+        JARArchive deployment = ShrinkWrap.create(JARArchive.class);
+        deployment.add(EmptyAsset.INSTANCE, "nothing");
+        return deployment;
+    }
+
+    @CreateSwarm
+    public static Swarm newSwarm() throws Exception {
+        return new Swarm().fraction(
+                new JMXFraction()
+                        .expressionExposeModel()
+                        .resolvedExposeModel()
+                        .jmxRemotingConnector((connector) -> {
+                            connector.useManagementEndpoint(false);
+                        })
+        );
+    }
+
+    @Test
+    @RunAsClient
+    public void testRemoteConnection() throws Exception {
+        String urlString = "service:jmx:remote://localhost:4777";
+
+        JMXServiceURL serviceURL = new JMXServiceURL(urlString);
+        JMXConnector jmxConnector = JMXConnectorFactory.connect(serviceURL, null);
+        MBeanServerConnection connection = jmxConnector.getMBeanServerConnection();
+
+        int count = connection.getMBeanCount();
+        assertThat(count).isGreaterThan(1);
+
+        jmxConnector.close();
+    }
+
+}

--- a/testsuite/testsuite-jmx-remote-undertow/pom.xml
+++ b/testsuite/testsuite-jmx-remote-undertow/pom.xml
@@ -15,10 +15,10 @@
   </parent>
 
   <groupId>org.wildfly.swarm</groupId>
-  <artifactId>testsuite-jmx</artifactId>
+  <artifactId>testsuite-jmx-remote-undertow</artifactId>
 
-  <name>Test Suite: JMX</name>
-  <description>Test Suite: JMX</description>
+  <name>Test Suite: JMX with Remoting over Undertow</name>
+  <description>Test Suite: JMX with Remoting over Undertow</description>
 
   <packaging>jar</packaging>
 
@@ -29,7 +29,7 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
-      <artifactId>management</artifactId>
+      <artifactId>undertow</artifactId>
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>

--- a/testsuite/testsuite-jmx-remote-undertow/src/test/java/org/wildfly/swarm/jmx/JMXRemoteManagementAutoEndpointArquillianTest.java
+++ b/testsuite/testsuite-jmx-remote-undertow/src/test/java/org/wildfly/swarm/jmx/JMXRemoteManagementAutoEndpointArquillianTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.jmx;
+
+import javax.management.MBeanServerConnection;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.arquillian.CreateSwarm;
+import org.wildfly.swarm.spi.api.JARArchive;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Bob McWhirter
+ */
+@RunWith(Arquillian.class)
+public class JMXRemoteManagementAutoEndpointArquillianTest {
+
+    @Deployment(testable = false)
+    public static Archive createDeployment() {
+        JARArchive deployment = ShrinkWrap.create(JARArchive.class);
+        deployment.add(EmptyAsset.INSTANCE, "nothing");
+        return deployment;
+    }
+
+    @CreateSwarm
+    public static Swarm newSwarm() throws Exception {
+        return new Swarm().fraction(
+                new JMXFraction()
+                        .expressionExposeModel()
+                        .resolvedExposeModel()
+                        .jmxRemotingConnector()
+        );
+    }
+
+    @Test
+    @RunAsClient
+    public void testRemoteConnection() throws Exception {
+        String urlString = "service:jmx:remote+http://localhost:8080";
+
+        JMXServiceURL serviceURL = new JMXServiceURL(urlString);
+        JMXConnector jmxConnector = JMXConnectorFactory.connect(serviceURL, null);
+        MBeanServerConnection connection = jmxConnector.getMBeanServerConnection();
+
+        int count = connection.getMBeanCount();
+        assertThat(count).isGreaterThan(1);
+
+        jmxConnector.close();
+    }
+
+}

--- a/testsuite/testsuite-jmx-remote-undertow/src/test/java/org/wildfly/swarm/jmx/JMXRemoteNonManagementEndpointArquillianTest.java
+++ b/testsuite/testsuite-jmx-remote-undertow/src/test/java/org/wildfly/swarm/jmx/JMXRemoteNonManagementEndpointArquillianTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.jmx;
+
+import javax.management.MBeanServerConnection;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.arquillian.CreateSwarm;
+import org.wildfly.swarm.spi.api.JARArchive;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Bob McWhirter
+ */
+@RunWith(Arquillian.class)
+public class JMXRemoteNonManagementEndpointArquillianTest {
+
+    @Deployment(testable = false)
+    public static Archive createDeployment() {
+        JARArchive deployment = ShrinkWrap.create(JARArchive.class);
+        deployment.add(EmptyAsset.INSTANCE, "nothing");
+        return deployment;
+    }
+
+    @CreateSwarm
+    public static Swarm newSwarm() throws Exception {
+        return new Swarm().fraction(
+                new JMXFraction()
+                        .expressionExposeModel()
+                        .resolvedExposeModel()
+                        .jmxRemotingConnector( (connector)->{
+                            connector.useManagementEndpoint( false );
+                        })
+        );
+    }
+
+    @Test
+    @RunAsClient
+    public void testRemoteConnection() throws Exception {
+        String urlString = "service:jmx:remote+http://localhost:8080";
+
+        JMXServiceURL serviceURL = new JMXServiceURL(urlString);
+        JMXConnector jmxConnector = JMXConnectorFactory.connect(serviceURL, null);
+        MBeanServerConnection connection = jmxConnector.getMBeanServerConnection();
+
+        int count = connection.getMBeanCount();
+        assertThat( count ).isGreaterThan( 1 );
+
+        jmxConnector.close();
+    }
+
+}


### PR DESCRIPTION
Previous fix for SWARM-599 transitively brought in org.wildfly.swarm:management,
which then consistently opens port 9990, which is too eager.

Now, bringing in JMX only brings in the remoting subsystem, which by
default does not open any additional ports.

The remoting subsystem will/can use either the management or standard
interfaces for performing remoting over http for things such as
remote-jmx.

Therefore, to use remote-jmx, and if you desire to do it over the
management or HTTP interfaces, you must additionally specify the
dependency of org.wildfly.swarm:management or at least org.wildfly.swarm:undertow.

In the event you have an extremely lightweight application that has
no requirement for :management nor :undertow, and you have enabled
remote JMX, then the legacy remoting port, defined by the configuration
property of swarm.remoting.port, and defaults to 4777 will be opened.

In the event all of the above are available within your application,
no remote JMX will occur at all unless you enable the remote connector
on the JMXFraction.

If you generically enable it, it will prefer management port, falling
back to undertow, falling back to the legacy remoting port.

If you specifically enable it to use the management interface, and
management is not available, it will disable the remote connector for
JMX and will _not_ fall back to either undertow or the legacy remoting
port, because you were explicit in asking for management interface.
