### PR TITLE
Convert the container module to use i18n messages.

### DIFF
--- a/container/pom.xml
+++ b/container/pom.xml
@@ -56,6 +56,27 @@
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-all</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-annotations</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-processor</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
 
     <dependency>
       <groupId>javax.inject</groupId>

--- a/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -64,6 +64,7 @@ import org.wildfly.swarm.container.internal.ServerBootstrap;
 import org.wildfly.swarm.container.runtime.cdi.ProjectStageFactory;
 import org.wildfly.swarm.container.runtime.logging.JBossLoggingManager;
 import org.wildfly.swarm.internal.ArtifactManager;
+import org.wildfly.swarm.internal.SwarmMessages;
 import org.wildfly.swarm.spi.api.ArtifactLookup;
 import org.wildfly.swarm.spi.api.Fraction;
 import org.wildfly.swarm.spi.api.OutboundSocketBinding;
@@ -220,7 +221,7 @@ public class Swarm {
 
     public StageConfig stageConfig() {
         if (!stageConfig.isPresent())
-            throw new RuntimeException("Stage config is not present");
+            throw SwarmMessages.MESSAGES.missingStageConfig();
         return new StageConfig(stageConfig.get());
     }
 
@@ -349,7 +350,7 @@ public class Swarm {
      */
     public Swarm stop() throws Exception {
         if (this.server == null) {
-            throw new Exception("Unable to call stop() until start() called");
+            throw SwarmMessages.MESSAGES.containerNotStarted("stop()");
         }
 
         this.server.stop();
@@ -367,7 +368,7 @@ public class Swarm {
      */
     public Swarm deploy() throws Exception {
         if (this.server == null) {
-            throw new Exception("Unable to call deploy() until start() called");
+            throw SwarmMessages.MESSAGES.containerNotStarted("deploy()");
         }
 
         this.server.deployer().deploy();
@@ -383,7 +384,7 @@ public class Swarm {
      */
     public Swarm deploy(Archive<?> deployment) throws Exception {
         if (this.server == null) {
-            throw new Exception("Unable to call deploy() until start() called");
+            throw SwarmMessages.MESSAGES.containerNotStarted("deploy(Archive<?>)");
         }
 
         this.server.deployer().deploy(deployment);
@@ -395,7 +396,7 @@ public class Swarm {
      */
     public Archive<?> createDefaultDeployment() throws Exception {
         if (this.server == null) {
-            throw new Exception("Unable to call createDefaultDeployment() until start() called");
+            throw SwarmMessages.MESSAGES.containerNotStarted("createDefaultDeployment()");
         }
 
         return this.server.deployer().createDefaultDeployment();
@@ -474,7 +475,7 @@ public class Swarm {
         }
 
         if (null == stage)
-            throw new RuntimeException("Project stage '" + stageName + "' cannot be found");
+            throw SwarmMessages.MESSAGES.stageNotFound(stageName);
 
         System.out.println("[INFO] Using project stage: " + stageName);
 

--- a/container/src/main/java/org/wildfly/swarm/cli/Option.java
+++ b/container/src/main/java/org/wildfly/swarm/cli/Option.java
@@ -15,6 +15,8 @@
  */
 package org.wildfly.swarm.cli;
 
+import org.wildfly.swarm.internal.SwarmMessages;
+
 import java.io.File;
 import java.io.PrintStream;
 import java.net.MalformedURLException;
@@ -320,12 +322,12 @@ public class Option<T> {
         }
 
         if (hasValue() && value == null && !this.valueMayBeSeparate) {
-            throw new RuntimeException(matchedArg + " requires an argument");
+            throw SwarmMessages.MESSAGES.argumentRequired(matchedArg);
         }
 
         if (hasValue() && value == null) {
             if (state.la() == null) {
-                throw new RuntimeException(matchedArg + " requires an argument");
+                throw SwarmMessages.MESSAGES.argumentRequired(matchedArg);
             }
             value = state.consume();
         }

--- a/container/src/main/java/org/wildfly/swarm/cli/ParseState.java
+++ b/container/src/main/java/org/wildfly/swarm/cli/ParseState.java
@@ -40,6 +40,7 @@ class ParseState {
 
     String consume() {
         if ( la() == null ) {
+            // TODO (jrp) this may need to be internationalized, but I'm not certain what the error is
             throw new RuntimeException( "parse error" );
         }
         return this.args[ this.cur++ ];

--- a/container/src/main/java/org/wildfly/swarm/container/DeploymentException.java
+++ b/container/src/main/java/org/wildfly/swarm/container/DeploymentException.java
@@ -44,6 +44,11 @@ public class DeploymentException extends Exception {
         this.archive = archive;
     }
 
+    public DeploymentException(String message, Throwable cause, Archive<?> archive) {
+        super(message, cause);
+        this.archive = archive;
+    }
+
     public Archive<?> getArchive() {
         return this.archive;
     }

--- a/container/src/main/java/org/wildfly/swarm/container/internal/JARArchiveImpl.java
+++ b/container/src/main/java/org/wildfly/swarm/container/internal/JARArchiveImpl.java
@@ -21,6 +21,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ArchivePath;
 import org.jboss.shrinkwrap.impl.base.container.ContainerBase;
 import org.jboss.shrinkwrap.impl.base.path.BasicPath;
+import org.wildfly.swarm.internal.SwarmMessages;
 import org.wildfly.swarm.spi.api.JARArchive;
 
 /**
@@ -49,7 +50,7 @@ public class JARArchiveImpl extends ContainerBase<JARArchive> implements JARArch
      */
     @Override
     public ArchivePath getLibraryPath() {
-        throw new UnsupportedOperationException("JavaArchive spec does not support Libraries");
+        throw SwarmMessages.MESSAGES.librariesNotSupported();
     }
 
     /**

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeDeployer.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeDeployer.java
@@ -47,6 +47,7 @@ import org.wildfly.swarm.container.internal.Deployer;
 import org.wildfly.swarm.container.runtime.deployments.DefaultDeploymentCreator;
 import org.wildfly.swarm.container.runtime.wildfly.SimpleContentProvider;
 import org.wildfly.swarm.internal.FileSystemLayout;
+import org.wildfly.swarm.internal.SwarmMessages;
 import org.wildfly.swarm.spi.api.ArchiveMetadataProcessor;
 import org.wildfly.swarm.spi.api.ArchivePreparer;
 import org.wildfly.swarm.spi.api.SwarmProperties;
@@ -71,7 +72,7 @@ public class RuntimeDeployer implements Deployer {
     public void deploy() throws DeploymentException {
         Archive<?> deployment = createDefaultDeployment();
         if (deployment == null) {
-            throw new DeploymentException("Unable to create default deployment");
+            throw SwarmMessages.MESSAGES.cannotCreateDefaultDeployment();
         } else {
             deploy(deployment);
         }
@@ -165,7 +166,7 @@ public class RuntimeDeployer implements Deployer {
             Closeable closeable = VFS.mountZipExpanded(in, deployment.getName(), mountPoint, tempFileProvider);
             this.mountPoints.add(closeable);
         } catch (IOException e) {
-            throw new DeploymentException(deployment, e);
+            throw SwarmMessages.MESSAGES.failToMountDeployment(e, deployment);
         }
 
         byte[] hash = this.contentProvider.addContent(mountPoint);
@@ -199,9 +200,9 @@ public class RuntimeDeployer implements Deployer {
             }
 
             ModelNode description = result.get("failure-description");
-            throw new DeploymentException(deployment, description.asString());
+            throw new DeploymentException(deployment, SwarmMessages.MESSAGES.deploymentFailed(description.asString()));
         } catch (IOException e) {
-            throw new DeploymentException(deployment, e);
+            throw SwarmMessages.MESSAGES.deploymentFailed(e, deployment);
         }
     }
 

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/ProjectStageFactory.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/ProjectStageFactory.java
@@ -26,6 +26,7 @@ import java.util.Set;
 
 import javax.enterprise.inject.Vetoed;
 
+import org.wildfly.swarm.internal.SwarmMessages;
 import org.wildfly.swarm.spi.api.ProjectStage;
 import org.yaml.snakeyaml.Yaml;
 
@@ -40,7 +41,7 @@ public class ProjectStageFactory {
         try {
             return this.loadStages(url.openStream());
         } catch (IOException e) {
-            throw new RuntimeException("Failed to load stage configuration from URL :" + url.toExternalForm(), e);
+            throw SwarmMessages.MESSAGES.failedLoadingStageConfig(e, url);
         }
     }
 
@@ -72,7 +73,7 @@ public class ProjectStageFactory {
                     .findFirst();
 
             if (!defaultStage.isPresent())
-                throw new RuntimeException("Missing stage 'default' in project-stages.yml");
+                throw SwarmMessages.MESSAGES.missingDefaultStage();
 
             // inherit values from default stage
             final Map<String, String> defaults = defaultStage.get().getProperties();

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/StandaloneXMLParserProducer.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/StandaloneXMLParserProducer.java
@@ -22,6 +22,7 @@ import org.jboss.modules.Module;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoadException;
 import org.jboss.staxmapper.XMLElementReader;
+import org.wildfly.swarm.internal.SwarmMessages;
 import org.wildfly.swarm.spi.api.Fraction;
 import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
 
@@ -87,8 +88,7 @@ public class StandaloneXMLParserProducer {
                 }
 
                 if (extensions.size() > 1) {
-                    throw new RuntimeException("Fraction \"" + fraction.getClass().getName() + "\" was configured using @WildFlyExtension with a module='',"
-                            + " but has multiple extension classes.  Please use classname='' to specify exactly one, or noClass=true to ignore all. " + extensions);
+                    throw SwarmMessages.MESSAGES.fractionHasMultipleExtensions(fraction.getClass().getName(), extensions);
                 }
 
                 if (!extensions.isEmpty()) {

--- a/container/src/main/java/org/wildfly/swarm/internal/ArtifactManager.java
+++ b/container/src/main/java/org/wildfly/swarm/internal/ArtifactManager.java
@@ -72,7 +72,7 @@ public class ArtifactManager implements ArtifactLookup {
         final File file = findFile(gav);
 
         if (file == null) {
-            throw new RuntimeException("Artifact '" + gav + "' not found.");
+            throw SwarmMessages.MESSAGES.artifactNotFound(gav);
         }
 
         return ShrinkWrap.create(ZipImporter.class, asName == null ? file.getName() : asName)
@@ -134,7 +134,7 @@ public class ArtifactManager implements ArtifactLookup {
         String[] parts = gav.split(":");
 
         if (parts.length < 2) {
-            throw new RuntimeException("GAV must includes at least 2 segments");
+            throw SwarmMessages.MESSAGES.gavMinimumSegments();
         }
 
         String groupId = parts[0];
@@ -171,7 +171,7 @@ public class ArtifactManager implements ArtifactLookup {
         }
 
         if (version == null) {
-            throw new RuntimeException("Unable to determine version number from GAV: " + gav);
+            throw SwarmMessages.MESSAGES.unableToDetermineVersion(gav);
         }
         ArtifactCoordinates coords= new ArtifactCoordinates(
                 groupId,

--- a/container/src/main/java/org/wildfly/swarm/internal/FileSystemLayout.java
+++ b/container/src/main/java/org/wildfly/swarm/internal/FileSystemLayout.java
@@ -45,7 +45,7 @@ public abstract class FileSystemLayout {
 
         String userDir = System.getProperty(USER_DIR);
         if(null==userDir)
-            throw new IllegalStateException("System property 'user.dir' not provided");
+            throw SwarmMessages.MESSAGES.systemPropertyNotFound("user.dir");
 
         return create(userDir);
     }
@@ -64,7 +64,7 @@ public abstract class FileSystemLayout {
             return new GradleFileSystemLayout(root);
         }
 
-        throw new IllegalArgumentException("Cannot identify FileSystemLayout for given path: "+root);
+        throw SwarmMessages.MESSAGES.cannotIdentifyFileSystemLayout(root);
     }
 
 

--- a/container/src/main/java/org/wildfly/swarm/internal/SwarmMessages.java
+++ b/container/src/main/java/org/wildfly/swarm/internal/SwarmMessages.java
@@ -1,0 +1,90 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.swarm.internal;
+
+import org.jboss.as.controller.Extension;
+import org.jboss.logging.Messages;
+import org.jboss.logging.annotations.*;
+import org.jboss.shrinkwrap.api.Archive;
+import org.wildfly.swarm.container.DeploymentException;
+
+import java.net.URL;
+import java.util.Collection;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@MessageBundle(projectCode = "WFSWARM", length = 4)
+public interface SwarmMessages {
+
+    SwarmMessages MESSAGES = Messages.getBundle(SwarmMessages.class);
+
+    @Message(id = 1, value = "Stage config is not present.")
+    RuntimeException missingStageConfig();
+
+    @Message(id = 2, value = "Cannot invoke %s on a container that has not been started.")
+    IllegalStateException containerNotStarted(String method);
+
+    @Message(id = 3, value = "Project stage '%s' cannot be found.")
+    RuntimeException stageNotFound(String stageName);
+
+    @Message(id = 4, value = "%s requires an argument.")
+    RuntimeException argumentRequired(String arg);
+
+    @Message(id = 5, value = "Unable to create default deployment")
+    DeploymentException cannotCreateDefaultDeployment();
+
+    @Message(id = 6, value = "Failed to mount deployment.")
+    DeploymentException failToMountDeployment(@Cause Throwable cause, @Param Archive<?> archive);
+
+    @Message(id = 7, value = "Deployment failed: %s")
+    String deploymentFailed(String failureMessage);
+
+    @Message(id = 8, value = "Failure during deployment")
+    DeploymentException deploymentFailed(@Cause Throwable cause, @Param Archive<?> archive);
+
+    @Message(id = 9, value = "JavaArchive spec does not support Libraries")
+    UnsupportedOperationException librariesNotSupported();
+
+    @Message(id = 10, value = "Failed to load stage configuration from URL : %s")
+    RuntimeException failedLoadingStageConfig(@Cause Throwable cause, URL url);
+
+    @Message(id = 11, value = "Missing stage 'default' in project-stages.yml")
+    RuntimeException missingDefaultStage();
+
+    @Message(id = 12, value = "Fraction \"%s\" was configured using @WildFlyExtension with a module='',"
+            + " but has multiple extension classes.  Please use classname='' to specify exactly one, or noClass=true to ignore all. %s")
+    RuntimeException fractionHasMultipleExtensions(@Transform(Transform.TransformType.GET_CLASS) String className, Collection<Extension> extensions);
+
+    @Message(id = 13, value = "Artifact '%s' not found.")
+    RuntimeException artifactNotFound(String gav);
+
+    @Message(id = 14, value = "Unable to determine version number from GAV: %s")
+    RuntimeException unableToDetermineVersion(String gav);
+
+    @Message(id = 15, value = "GAV must includes at least 2 segments")
+    RuntimeException gavMinimumSegments();
+
+    @Message(id = 16, value = "System property '%s' not provided.")
+    IllegalStateException systemPropertyNotFound(String key);
+
+    @Message(id = 17, value = "Cannot identify FileSystemLayout for given path: %s")
+    IllegalArgumentException cannotIdentifyFileSystemLayout(String path);
+}

--- a/container/src/test/java/org/wildfly/swarm/cli/OptionTest.java
+++ b/container/src/test/java/org/wildfly/swarm/cli/OptionTest.java
@@ -116,7 +116,7 @@ public class OptionTest {
             configOpt.parse(state, null);
             fail("should have throw a missing-argument exception");
         } catch (RuntimeException e) {
-            assertThat(e.getMessage()).isEqualTo("-c requires an argument");
+            assertThat(e.getMessage()).endsWith("-c requires an argument.");
         }
     }
 

--- a/container/src/test/java/org/wildfly/swarm/internal/ArtifactManagerTest.java
+++ b/container/src/test/java/org/wildfly/swarm/internal/ArtifactManagerTest.java
@@ -120,7 +120,7 @@ public class ArtifactManagerTest {
             manager.artifact(String.format("%s:%s:%s", ARTIFACT_INVALID_GROUP_ID, ARTIFACT_INVALID_ARTIFACT_ID, ARTIFACT_INVALID_VERSION));
             fail("RuntimeException should have been thrown");
         } catch (RuntimeException e) {
-            assertThat(e).hasMessage("Artifact 'no.such:thingy:1.0.0' not found.");
+            assertThat(e).hasMessage("WFSWARM0013: Artifact 'no.such:thingy:1.0.0' not found.");
         }
     }
 
@@ -132,7 +132,7 @@ public class ArtifactManagerTest {
                                            ARTIFACT_INVALID_VERSION));
             fail("RuntimeException should have been thrown");
         } catch (RuntimeException e) {
-            assertThat(e).hasMessage("Artifact 'no.such:thingy:jar:1.0.0' not found.");
+            assertThat(e).hasMessage("WFSWARM0013: Artifact 'no.such:thingy:jar:1.0.0' not found.");
         }
     }
 


### PR DESCRIPTION
This adds JBoss Logging and JBoss Logging Tools dependencies to the container module. The messages have been converted to use the interface message bundle for internationalization support.

Messages that just wrapped and rethrew other messages I did not convert. In some use cases it shouldn't need to be done, but I didn't look extensively at all use cases where it was done.
