### PR TITLE
SWARM-607 - Avoid substring-out-of-bounds in auto-detector.

### DIFF
--- a/tools/src/main/java/org/wildfly/swarm/tools/FractionUsageAnalyzer.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/FractionUsageAnalyzer.java
@@ -83,6 +83,10 @@ public class FractionUsageAnalyzer {
     private static String asClassNameMatch(final String n) {
         final int idx = n.lastIndexOf('.');
 
+        if ( idx < 0 ) {
+            return n;
+        }
+
         return n.substring(0, idx) + ":" + n.substring(idx + 1);
     }
 


### PR DESCRIPTION
- Motivation:

When fraction-detection fires, it assumes any class that
the detector finds includes at least one dot in the name,
such as com.foo.Bar.

For classes in the root default package, they have no dot.
- Modifications:

Protected against a substring-out-of-bounds exception
by validating that the location of the dot is not
less than 0.  If it is, return the class-name unmolested.
- Result:

No more substring-out-of-bounds exceptions.
