### PR TITLE
SWARM-608 - Display fraction stability at boot

### DIFF
--- a/container/src/main/java/org/wildfly/swarm/internal/SwarmMessages.java
+++ b/container/src/main/java/org/wildfly/swarm/internal/SwarmMessages.java
@@ -87,4 +87,7 @@ public interface SwarmMessages {
 
     @Message(id = 17, value = "Cannot identify FileSystemLayout for given path: %s")
     IllegalArgumentException cannotIdentifyFileSystemLayout(String path);
+
+    @Message(id=18, value = "Installed fraction: %24s - %-15s %s:%s:%s")
+    String availableFraction(String name, String stabilityLevel, String groupId, String artifactId, String version);
 }

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   </scm>
 
   <properties>
-    <version.wildfly.swarm.fraction.plugin>34</version.wildfly.swarm.fraction.plugin>
+    <version.wildfly.swarm.fraction.plugin>35</version.wildfly.swarm.fraction.plugin>
 
     <version.cdi2>2.0.Alpha4</version.cdi2>
 


### PR DESCRIPTION
- Motivation:

Since we do not communicate "quality" through release
versioning (no Alpha or Beta or Final), we maintain this
information on a per-fraction basis within each fraction.
- Modifications:

Upgrade the fraction-plugin which exposes the per-fraction
information via META-INF/fraction.properties.  Use this
information to display quality indicators upon process
startup.
- Result:

Each installed fraction, along with its quality is displayed
each time a -swarm process boots.

In the case of STABLE or above, the log message is INFO level.
Else, it's a WARN.
