### PR TITLE
stageConfig url ignored

### DIFF
--- a/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -211,7 +211,7 @@ public class Swarm {
     public Swarm withStageConfig(URL url) {
         this.stageConfigUrl = Optional.of(url);
 
-        if (!this.stageConfig.isPresent()) {
+        if (this.stageConfig.isPresent()) {
             loadStageConfiguration(stageConfigUrl.get());
         } else {
             System.out.println("[INFO] Project stage superseded by external configuration " + System.getProperty(SwarmProperties.PROJECT_STAGE_FILE));


### PR DESCRIPTION
build 2016.8.1 is ignoring the stage config file when calling swarm.withStageConfig(url)
