### PR TITLE
SWARM-598 - Allow selection of JMX endpoints without main()

### DIFF
--- a/jmx/src/main/java/org/wildfly/swarm/jmx/JMXFraction.java
+++ b/jmx/src/main/java/org/wildfly/swarm/jmx/JMXFraction.java
@@ -27,4 +27,9 @@ import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
 @MarshalDMR
 public class JMXFraction extends JMX<JMXFraction> implements Fraction<JMXFraction> {
 
+    @Override
+    public JMXFraction applyDefaults() {
+        return expressionExposeModel()
+                .resolvedExposeModel();
+    }
 }

--- a/jmx/src/main/java/org/wildfly/swarm/jmx/JMXProperties.java
+++ b/jmx/src/main/java/org/wildfly/swarm/jmx/JMXProperties.java
@@ -1,0 +1,20 @@
+package org.wildfly.swarm.jmx;
+
+/** Configuration property keys for the JMX fraction.
+ *
+ * @author Bob McWhirter
+ */
+public class JMXProperties {
+
+    /** Key for configuration value to enable and optionally select remote JMX endpoint.
+     *
+     * <p>Values may include</p>
+     *
+     * <ul>
+     *     <li><code>management</code> to explicitly select the management interface</li>
+     *     <li><code>http</code> to select the HTTP interface</li>
+     *     <li>any other non-null value to allow for auto-detection.</li>
+     * </ul>
+     */
+    public static final String REMOTE = "swarm.jmx.remote";
+}


### PR DESCRIPTION
- Motivation:

While we provide mechanisms for enabling and selecting a remote
JMX endpoint when a user provides a main(), we have no capability
for doing the same without a main(), such as in a vanilla .war.
- Modifications:

Added a swarm.jmx.remote configuration key, which can be set to
- 'management' to explicitly request the management interface.
- 'http' to request the standard-sockets http interface.
- any other non-null value to allow auto-selection.
- Result:

It should now be possible to enable remote JMX endpoint without
providing a main(), by using -Dswarm.jmx.remote or providing
a value through project-stages.yml.
