### PR TITLE
SWARM-611 - Remove some (but not all) WELD circular warnings.

### DIFF
--- a/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
@@ -127,13 +128,13 @@ public class RuntimeServer implements Server {
     }
 
     @Produces
-    @Dependent
+    @Singleton
     public StageConfig stageConfig() {
         return new StageConfig(projectStage());
     }
 
     @Produces
-    @Singleton
+    @ApplicationScoped
     ModelControllerClient client() {
         return this.client;
     }

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/marshal/ExtensionMarshaller.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/marshal/ExtensionMarshaller.java
@@ -24,6 +24,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import org.jboss.dmr.ModelNode;
 import org.wildfly.swarm.spi.api.Fraction;
@@ -37,7 +38,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_
 /**
  * @author Bob McWhirter
  */
-@ApplicationScoped
+@Singleton
 public class ExtensionMarshaller implements ConfigurationMarshaller {
 
     @Inject @Any

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/marshal/InterfaceMarshaller.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/marshal/InterfaceMarshaller.java
@@ -21,6 +21,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
@@ -36,7 +37,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_
 /**
  * @author Bob McWhirter
  */
-@ApplicationScoped
+@Singleton
 public class InterfaceMarshaller implements ConfigurationMarshaller {
 
     @Inject

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/marshal/ProjectStagePropertyMarshaller.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/marshal/ProjectStagePropertyMarshaller.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import org.jboss.dmr.ModelNode;
 import org.wildfly.swarm.spi.api.ProjectStage;
@@ -32,7 +33,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VAL
 /**
  * @author Bob McWhirter
  */
-@ApplicationScoped
+@Singleton
 public class ProjectStagePropertyMarshaller implements ConfigurationMarshaller {
 
     @Inject

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/marshal/SubsystemMarshaller.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/marshal/SubsystemMarshaller.java
@@ -23,6 +23,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
@@ -40,7 +41,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUB
 /**
  * @author Bob McWhirter
  */
-@ApplicationScoped
+@Singleton
 public class SubsystemMarshaller implements ConfigurationMarshaller {
 
     @Inject

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/marshal/XMLMarshaller.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/marshal/XMLMarshaller.java
@@ -21,6 +21,7 @@ import java.util.List;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import org.jboss.dmr.ModelNode;
 import org.wildfly.swarm.container.runtime.xmlconfig.StandaloneXMLParser;
@@ -29,7 +30,7 @@ import org.wildfly.swarm.container.runtime.xmlconfig.XMLConfig;
 /**
  * @author Bob McWhirter
  */
-@ApplicationScoped
+@Singleton
 public class XMLMarshaller implements ConfigurationMarshaller {
 
     @Inject

--- a/drools-server/src/main/java/org/wildfly/swarm/drools/server/runtime/DroolsSetup.java
+++ b/drools-server/src/main/java/org/wildfly/swarm/drools/server/runtime/DroolsSetup.java
@@ -25,7 +25,7 @@ import org.wildfly.swarm.spi.runtime.annotations.Post;
  * @author Ken Finnigan
  */
 @Post
-@ApplicationScoped
+@Singleton
 public class DroolsSetup implements Customizer {
 
     private static String configFolder = System.getProperty("org.drools.server.swarm.security.conf");

--- a/ee/src/main/java/org/wildfly/swarm/ee/runtime/DefaultBindingCustomizer.java
+++ b/ee/src/main/java/org/wildfly/swarm/ee/runtime/DefaultBindingCustomizer.java
@@ -19,6 +19,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import org.wildfly.swarm.config.MessagingActiveMQ;
 import org.wildfly.swarm.config.ee.DefaultBindingsService;
@@ -30,7 +31,7 @@ import org.wildfly.swarm.spi.runtime.annotations.Pre;
  * @author Bob McWhirter
  */
 @Pre
-@ApplicationScoped
+@Singleton
 public class DefaultBindingCustomizer implements Customizer {
 
     @Inject

--- a/ejb/src/main/java/org/wildfly/swarm/ejb/runtime/EJBSecurityCustomizer.java
+++ b/ejb/src/main/java/org/wildfly/swarm/ejb/runtime/EJBSecurityCustomizer.java
@@ -19,6 +19,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import org.wildfly.swarm.config.security.Flag;
 import org.wildfly.swarm.config.security.SecurityDomain;
@@ -32,7 +33,7 @@ import org.wildfly.swarm.spi.runtime.annotations.Post;
  * @author Ken Finnigan
  */
 @Post
-@ApplicationScoped
+@Singleton
 public class EJBSecurityCustomizer implements Customizer {
     @Inject
     @Any

--- a/jpa/src/main/java/org/wildfly/swarm/jpa/runtime/DefaultDatasourceCustomizer.java
+++ b/jpa/src/main/java/org/wildfly/swarm/jpa/runtime/DefaultDatasourceCustomizer.java
@@ -30,8 +30,8 @@ import org.wildfly.swarm.spi.runtime.annotations.Post;
  * @author Ken Finnigan
  */
 
-@ApplicationScoped
 @Post
+@Singleton
 public class DefaultDatasourceCustomizer implements Customizer {
     @Inject
     @DefaultDatasource

--- a/management/src/main/java/org/wildfly/swarm/management/runtime/ManagementSocketBindingsCustomizer.java
+++ b/management/src/main/java/org/wildfly/swarm/management/runtime/ManagementSocketBindingsCustomizer.java
@@ -18,6 +18,7 @@ package org.wildfly.swarm.management.runtime;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import org.wildfly.swarm.management.ManagementProperties;
 import org.wildfly.swarm.spi.api.Customizer;
@@ -30,7 +31,7 @@ import org.wildfly.swarm.spi.runtime.annotations.Pre;
  * @author Bob McWhirter
  */
 @Pre
-@ApplicationScoped
+@Singleton
 public class ManagementSocketBindingsCustomizer implements Customizer {
 
     @Inject

--- a/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/UndertowFilterCustomizer.java
+++ b/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/UndertowFilterCustomizer.java
@@ -29,7 +29,7 @@ import org.wildfly.swarm.undertow.UndertowFraction;
  * @author Ken Finnigan
  */
 @Post
-@ApplicationScoped
+@Singleton
 public class UndertowFilterCustomizer implements Customizer {
     @Inject
     @Any

--- a/topology-consul/src/main/java/org/wildfly/swarm/topology/consul/runtime/ConsultURLCustomizer.java
+++ b/topology-consul/src/main/java/org/wildfly/swarm/topology/consul/runtime/ConsultURLCustomizer.java
@@ -20,6 +20,7 @@ import java.net.MalformedURLException;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Any;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import org.wildfly.swarm.spi.api.Customizer;
 import org.wildfly.swarm.spi.runtime.annotations.ConfigurationValue;
@@ -30,7 +31,7 @@ import org.wildfly.swarm.topology.consul.ConsulTopologyFraction;
  * @author Bob McWhirter
  */
 @Pre
-@ApplicationScoped
+@Singleton
 public class ConsultURLCustomizer implements Customizer {
 
     @Inject

--- a/transactions/src/main/java/org/wildfly/swarm/transactions/runtime/TransactionsSocketBindingCustomizer.java
+++ b/transactions/src/main/java/org/wildfly/swarm/transactions/runtime/TransactionsSocketBindingCustomizer.java
@@ -20,6 +20,7 @@ import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import org.wildfly.swarm.spi.api.Customizer;
 import org.wildfly.swarm.spi.api.SocketBinding;
@@ -31,7 +32,7 @@ import org.wildfly.swarm.transactions.TransactionsFraction;
  * @author Bob McWhirter
  */
 @Pre
-@ApplicationScoped
+@Singleton
 public class TransactionsSocketBindingCustomizer implements Customizer {
 
     @Inject

--- a/undertow/src/main/java/org/wildfly/swarm/undertow/runtime/AJPCustomizer.java
+++ b/undertow/src/main/java/org/wildfly/swarm/undertow/runtime/AJPCustomizer.java
@@ -20,6 +20,7 @@ import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import org.wildfly.swarm.spi.api.Customizer;
 import org.wildfly.swarm.spi.api.SocketBinding;
@@ -32,7 +33,7 @@ import org.wildfly.swarm.undertow.UndertowFraction;
  * @author Bob McWhirter
  */
 @Pre
-@ApplicationScoped
+@Singleton
 public class AJPCustomizer implements Customizer {
 
     @Inject

--- a/undertow/src/main/java/org/wildfly/swarm/undertow/runtime/HTTPSCustomizer.java
+++ b/undertow/src/main/java/org/wildfly/swarm/undertow/runtime/HTTPSCustomizer.java
@@ -21,6 +21,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 import org.wildfly.swarm.config.ManagementCoreService;
 import org.wildfly.swarm.config.undertow.Server;
@@ -32,7 +33,7 @@ import org.wildfly.swarm.undertow.UndertowFraction;
  * @author Bob McWhirter
  */
 @Pre
-@ApplicationScoped
+@Singleton
 public class HTTPSCustomizer implements Customizer {
 
     @Inject


### PR DESCRIPTION
- Motivation:

Warnings are ugly.
- Modifications:

By denoting one end of the circular as a normal scope (and thus
proxy'd), instead of @Dependent, we can avoid the warning.
- Result:

Half as many warnings.
