### PR TITLE
SWARM-611 - Remove more Weld warnings by better architecture.

### DIFF
--- a/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
@@ -72,10 +72,6 @@ import org.wildfly.swarm.spi.runtime.annotations.Pre;
 public class RuntimeServer implements Server {
 
     @Inject
-    @Any
-    private Instance<Fraction> allFractions;
-
-    @Inject
     @Pre
     private Instance<Customizer> preCustomizers;
 
@@ -103,44 +99,16 @@ public class RuntimeServer implements Server {
     @Inject
     private Instance<RuntimeDeployer> deployer;
 
-    private String defaultDeploymentType;
-
+    @Inject
+    private StageConfig stageConfig;
 
     public RuntimeServer() {
-    }
-
-    public void setXmlConfig(Optional<URL> xmlConfig) {
-        this.xmlConfig = xmlConfig;
-    }
-
-    public void setStageConfig(Optional<ProjectStage> enabledConfig) {
-        this.enabledStage = enabledConfig;
-    }
-
-    @Produces
-    @Singleton
-    public ProjectStage projectStage() {
-        if (this.enabledStage.isPresent()) {
-            return this.enabledStage.get();
-        }
-
-        return new ProjectStageImpl("default");
-    }
-
-    @Produces
-    @Singleton
-    public StageConfig stageConfig() {
-        return new StageConfig(projectStage());
     }
 
     @Produces
     @ApplicationScoped
     ModelControllerClient client() {
         return this.client;
-    }
-
-    public void debug(boolean debug) {
-        this.debug = debug;
     }
 
     public Deployer start(boolean eagerOpen) throws Exception {
@@ -202,7 +170,7 @@ public class RuntimeServer implements Server {
             Class<?> use = module.getClassLoader().loadClass("org.wildfly.swarm.cdi.InjectStageConfigExtension");
             Field field = use.getDeclaredField("stageConfig");
             field.setAccessible(true);
-            field.set(null, this.stageConfig());
+            field.set(null, this.stageConfig);
         } catch (ModuleLoadException e) {
             // ignore, don't do it.
         } catch (ClassNotFoundException | IllegalAccessException | NoSuchFieldException e) {
@@ -235,14 +203,5 @@ public class RuntimeServer implements Server {
 
     private ModelControllerClient client;
 
-    // optional XML config
-    private Optional<URL> xmlConfig = Optional.empty();
-
     private BootstrapLogger LOG = BootstrapLogger.logger("org.wildfly.swarm.runtime.server");
-
-    // TODO : still needed or merge error?
-    private boolean debug;
-
-    private Optional<ProjectStage> enabledStage = Optional.empty();
-
 }

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/ServerBootstrapImpl.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/ServerBootstrapImpl.java
@@ -16,6 +16,8 @@ import org.jboss.weld.environment.se.WeldContainer;
 import org.wildfly.swarm.container.internal.Server;
 import org.wildfly.swarm.container.internal.ServerBootstrap;
 import org.wildfly.swarm.container.runtime.cdi.FractionProducingExtension;
+import org.wildfly.swarm.container.runtime.cdi.ProjectStageProducingExtension;
+import org.wildfly.swarm.container.runtime.cdi.XMLConfigProducingExtension;
 import org.wildfly.swarm.container.runtime.cli.CommandLineArgsExtension;
 import org.wildfly.swarm.internal.SwarmMessages;
 import org.wildfly.swarm.spi.api.Fraction;
@@ -83,6 +85,8 @@ public class ServerBootstrapImpl implements ServerBootstrap {
         // Add Extension that adds User custom bits into configurator
         weld.addExtension(new FractionProducingExtension(explicitlyInstalledFractions));
         weld.addExtension(new CommandLineArgsExtension(args));
+        weld.addExtension(new ProjectStageProducingExtension(this.stageConfig));
+        weld.addExtension(new XMLConfigProducingExtension(this.xmlConfigURL));
 
         for (Class<?> each : this.userComponents) {
             weld.addBeanClass(each);
@@ -91,8 +95,6 @@ public class ServerBootstrapImpl implements ServerBootstrap {
         WeldContainer weldContainer = weld.initialize();
 
         RuntimeServer server = weldContainer.select(RuntimeServer.class).get();
-        server.setXmlConfig( this.xmlConfigURL );
-        server.setStageConfig( this.stageConfig );
         server.start(true);
         return server;
     }

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/ProjectStageProducingExtension.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/ProjectStageProducingExtension.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.container.runtime.cdi;
+
+import java.util.Optional;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AfterBeanDiscovery;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.Extension;
+
+import org.jboss.weld.literal.DefaultLiteral;
+import org.wildfly.swarm.spi.api.ProjectStage;
+import org.wildfly.swarm.spi.api.StageConfig;
+
+/** Produces an explicitly set project-stage.
+ *
+ * @author Bob McWhirter
+ */
+public class ProjectStageProducingExtension implements Extension {
+
+    private final Optional<ProjectStage> projectStage;
+
+    public ProjectStageProducingExtension(Optional<ProjectStage> projectStage) {
+        this.projectStage = projectStage;
+    }
+
+    void afterBeanDiscovery(@Observes AfterBeanDiscovery abd, BeanManager beanManager) {
+        abd.addBean().addType( ProjectStage.class )
+                .scope(Dependent.class)
+                .qualifiers( DefaultLiteral.INSTANCE )
+                .produceWith(this::getProjectStage);
+
+        abd.addBean().addType(StageConfig.class)
+                .scope(Dependent.class)
+                .qualifiers(DefaultLiteral.INSTANCE)
+                .produceWith(this::getStageConfig);
+    }
+
+    protected ProjectStage getProjectStage() {
+        if (this.projectStage.isPresent()) {
+            return this.projectStage.get();
+        }
+
+        return new ProjectStageImpl("default");
+    }
+
+    protected StageConfig getStageConfig() {
+        return new StageConfig( getProjectStage() );
+    }
+}

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/XMLConfigProducingExtension.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/XMLConfigProducingExtension.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.container.runtime.cdi;
+
+import java.net.URL;
+import java.util.Optional;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AfterBeanDiscovery;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.Extension;
+
+import org.wildfly.swarm.container.runtime.xmlconfig.XMLConfig;
+
+/** Produces any explicitly-set XML configuration URL (standalone.xml)
+ *
+ * @author Bob McWhirter
+ */
+public class XMLConfigProducingExtension implements Extension {
+
+    private final Optional<URL> xmlConfig;
+
+    public XMLConfigProducingExtension(Optional<URL> xmlConfig) {
+        this.xmlConfig = xmlConfig;
+    }
+
+    void afterBeanDiscovery(@Observes AfterBeanDiscovery abd, BeanManager beanManager) {
+        abd.addBean().addType( URL.class )
+                .scope(Dependent.class)
+                .qualifiers( XMLConfig.Literal.INSTANCE )
+                .produceWith(this::getXMLConfig);
+    }
+
+    protected URL getXMLConfig() {
+        if ( this.xmlConfig.isPresent() ) {
+            return this.xmlConfig.get();
+        }
+        return null;
+    }
+
+}

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/marshal/XMLMarshaller.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/marshal/XMLMarshaller.java
@@ -16,7 +16,9 @@
 package org.wildfly.swarm.container.runtime.marshal;
 
 import java.net.URL;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Instance;
@@ -27,7 +29,8 @@ import org.jboss.dmr.ModelNode;
 import org.wildfly.swarm.container.runtime.xmlconfig.StandaloneXMLParser;
 import org.wildfly.swarm.container.runtime.xmlconfig.XMLConfig;
 
-/**
+/** Marshals a collection of XML configurations (standalone.xml) to DMR.
+ *
  * @author Bob McWhirter
  */
 @Singleton
@@ -45,16 +48,21 @@ public class XMLMarshaller implements ConfigurationMarshaller {
             return;
         }
 
-        xmlConfig.forEach( url-> parse(url, list));
+        Set<URL> seen = new HashSet<>();
+        xmlConfig.forEach(url -> parse(url, seen, list));
     }
 
-    protected void parse(URL url, List<ModelNode> list) {
-        if ( url == null ) {
+    protected void parse(URL url, Set<URL> seen, List<ModelNode> list) {
+        if (url == null) {
             return;
         }
+        if (seen.contains(url)) {
+            return;
+        }
+        seen.add(url);
         try {
             List<ModelNode> subList = this.parser.parse(url);
-            list.addAll( subList );
+            list.addAll(subList);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/StandaloneXMLConfigProducer.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/StandaloneXMLConfigProducer.java
@@ -9,10 +9,9 @@ import org.jboss.modules.Module;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoadException;
 
-/**
+/** Produces auto-discovered XML configuration (standalone.xml) URLs.
  * @author Bob McWhirter
  */
-
 @Singleton
 public class StandaloneXMLConfigProducer {
 

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/StandaloneXMLParserProducer.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/StandaloneXMLParserProducer.java
@@ -28,7 +28,8 @@ import org.wildfly.swarm.internal.SwarmMessages;
 import org.wildfly.swarm.spi.api.Fraction;
 import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
 
-/**
+/** Produces an XML configuration (standalone.xml) parser for available fractions.
+ *
  * @author Bob McWhirter
  */
 @Singleton

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/XMLConfig.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/XMLConfig.java
@@ -5,6 +5,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import javax.enterprise.util.AnnotationLiteral;
 import javax.inject.Qualifier;
 
 /**
@@ -14,4 +15,7 @@ import javax.inject.Qualifier;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE})
 public @interface XMLConfig {
+    class Literal extends AnnotationLiteral<XMLConfig> implements XMLConfig {
+        public static Literal INSTANCE = new Literal();
+    }
 }


### PR DESCRIPTION
- Motivation:

Weld has been providing ciruclar injection warnings.  While non-fatal,
they are both ugly and indicative of intertwingly architecture.
- Modifications:

Instead of putting project-stage and xml-config bits into RuntimeServer
to further @Produces them, they are produced directly through their
own CDI extension, and RuntimeServer may simply consume the bit(s)
it needs.
- Result:

Fewer warnings, clearer delegation of responsibilities between
CDI and RuntimeServer.
