### PR TITLE
SWARM-293 - Separate -swarm container from deployments.

### DIFF
--- a/container/src/main/java/org/wildfly/swarm/HollowSwarm.java
+++ b/container/src/main/java/org/wildfly/swarm/HollowSwarm.java
@@ -1,0 +1,50 @@
+package org.wildfly.swarm;
+
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.importer.ZipImporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+/**
+ * @author Bob McWhirter
+ */
+public class HollowSwarm {
+
+    public static void main(String... args) throws Exception {
+        if (args.length == 0) {
+            System.err.println("Provide one or more deployments as arguments");
+            System.exit(1);
+        }
+
+        if (System.getProperty("boot.module.loader") == null) {
+            System.setProperty("boot.module.loader", "org.wildfly.swarm.bootstrap.modules.BootModuleLoader");
+        }
+
+        Swarm swarm = new Swarm(args);
+        swarm.start();
+        archives(swarm.getCommandLine().extraArguments()).forEach(archive -> {
+                    try {
+                        swarm.deploy(archive);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+        );
+    }
+
+    protected static List<Archive> archives(List<String> paths) {
+        return paths.stream()
+                .map(e -> Paths.get(e))
+                .map(path -> {
+                    String simpleName = path.getFileName().toString();
+                    Archive archive = ShrinkWrap.create(JavaArchive.class, simpleName);
+                    archive.as(ZipImporter.class).importFrom(path.toFile());
+                    return archive;
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -91,6 +91,8 @@ public class Swarm {
 
     public static ArtifactManager ARTIFACT_MANAGER;
 
+    private final CommandLine commandLine;
+
     /**
      * Construct a new, un-started container.
      *
@@ -165,8 +167,8 @@ public class Swarm {
 
         createShrinkWrapDomain();
 
-        CommandLine cmd = CommandLine.parse(args);
-        cmd.apply(this);
+        this.commandLine = CommandLine.parse(args);
+        this.commandLine.apply(this);
 
         if (!this.stageConfig.isPresent()) {
             try {
@@ -197,6 +199,10 @@ public class Swarm {
                 System.err.println("[WARN] Failed to parse project stage URL reference, ignoring: " + e.getMessage());
             }
         }
+    }
+
+    public CommandLine getCommandLine() {
+        return this.commandLine;
     }
 
     public void setArgs(String... args) {

--- a/plugin/src/main/java/org/wildfly/swarm/plugin/maven/PackageMojo.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/maven/PackageMojo.java
@@ -59,6 +59,9 @@ public class PackageMojo extends AbstractSwarmMojo {
     @Parameter(alias = "executableScript")
     protected File executableScript;
 
+    @Parameter(alias = "hollow", defaultValue = "false")
+    protected boolean hollow;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         initProperties(false);
@@ -67,13 +70,13 @@ public class PackageMojo extends AbstractSwarmMojo {
         final String type = primaryArtifact.getType();
         final BuildTool tool = new BuildTool()
                 .projectArtifact(primaryArtifact.getGroupId(),
-                                 primaryArtifact.getArtifactId(),
-                                 primaryArtifact.getBaseVersion(),
-                                 type,
-                                 primaryArtifact.getFile(),
-                                 finalName.endsWith("." + type) ?
-                                         finalName :
-                                         String.format("%s.%s", finalName, type))
+                        primaryArtifact.getArtifactId(),
+                        primaryArtifact.getBaseVersion(),
+                        type,
+                        primaryArtifact.getFile(),
+                        finalName.endsWith("." + type) ?
+                                finalName :
+                                String.format("%s.%s", finalName, type))
                 .fractionList(FractionList.get())
                 .properties(this.properties)
                 .mainClass(this.mainClass)
@@ -82,6 +85,7 @@ public class PackageMojo extends AbstractSwarmMojo {
                 .executableScript(executableScript)
                 .fractionDetectionMode(fractionDetectMode)
                 .artifactResolvingHelper(mavenArtifactResolvingHelper())
+                .hollow(hollow )
                 .logger(new BuildTool.SimpleLogger() {
                     @Override
                     public void info(String msg) {

--- a/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
@@ -161,6 +161,12 @@ public class BuildTool {
         return this;
     }
 
+    public BuildTool hollow(boolean hollow) {
+        this.hollow = hollow;
+        this.mainClass = "org.wildfly.swarm.HollowSwarm";
+        return this;
+    }
+
     public BuildTool logger(SimpleLogger logger) {
         this.log = logger;
 
@@ -224,6 +230,9 @@ public class BuildTool {
     }
 
     private void addProjectAsset() {
+        if ( this.hollow ) {
+            return;
+        }
         this.archive.add(this.projectAsset);
     }
 
@@ -367,7 +376,7 @@ public class BuildTool {
     }
 
     private void addWildFlySwarmApplicationConf() throws Exception {
-        WildFlySwarmApplicationConf appConf = this.dependencyManager.getWildFlySwarmApplicationConf(this.projectAsset);
+        WildFlySwarmApplicationConf appConf = this.dependencyManager.getWildFlySwarmApplicationConf( this.hollow ? null : this.projectAsset);
         this.archive.add(new StringAsset(appConf.toString()), WildFlySwarmApplicationConf.CLASSPATH_LOCATION);
     }
 
@@ -443,6 +452,8 @@ public class BuildTool {
     private FractionList fractionList = null;
 
     private SimpleLogger log = STD_LOGGER;
+
+    private boolean hollow;
 
     private static SimpleLogger STD_LOGGER = new SimpleLogger() {
         @Override

--- a/tools/src/main/java/org/wildfly/swarm/tools/DependencyManager.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/DependencyManager.java
@@ -405,7 +405,9 @@ public class DependencyManager {
             }
         }
 
-        appConf.addEntry(new WildFlySwarmApplicationConf.PathEntry(projectAsset.getName()));
+        if ( projectAsset != null ) {
+            appConf.addEntry(new WildFlySwarmApplicationConf.PathEntry(projectAsset.getName()));
+        }
 
         return appConf;
 


### PR DESCRIPTION
- Motivation:

When dockering or other things, it may be nice to have the
runtime container separate from the deployment.  Container
could be placed on a docker layer, while the deployment is
updated, as a smaller item, on a higher layer.
- Modifications:

Added a <hollow>true</hollow> paramter to the package
Maven task, which if set, creates a deployment-less -swarm.jar.

This option passes to BuildTool#hollow(boolean) and thus may
also be easily exposed through the SwarmTool at some point.

Additionally, it wires up a HollowSwarm as the main(),
since there is no user-provided main().  This main iterates
all extra command-line arguments, creating ShrinkWrap
archives from them, and deploys them.  Anything deployable
may be accepted.
- Result:

If a project is built with <hollow>true</hollow>, then
the resulting -swarm.jar does not contain the deployment.
