### PR TITLE
SWARM-609

### DIFF
--- a/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -174,6 +174,7 @@ public class Swarm {
         if (!this.stageConfig.isPresent()) {
             try {
                 String stageFile = System.getProperty(SwarmProperties.PROJECT_STAGE_FILE);
+                SwarmMessages.MESSAGES.stageConfigLocation(SwarmProperties.PROJECT_STAGE_FILE + " system property", stageFile);
 
                 URL url = null;
 
@@ -183,6 +184,9 @@ public class Swarm {
                     try {
                         Module module = Module.getBootModuleLoader().loadModule(ModuleIdentifier.create("swarm.application"));
                         url = module.getClassLoader().getResource("project-stages.yml");
+                        if (url != null) {
+                            SwarmMessages.MESSAGES.stageConfigLocation("'swarm.application' module", url.toExternalForm());
+                        }
                     } catch (ModuleLoadException e) {
                         e.printStackTrace();
                     }
@@ -190,6 +194,9 @@ public class Swarm {
 
                 if (url == null) {
                     url = ClassLoader.getSystemClassLoader().getResource("project-stages.yml");
+                    if (url != null) {
+                        SwarmMessages.MESSAGES.stageConfigLocation("ClassLoader", url.toExternalForm());
+                    }
                 }
 
                 if (url != null) {
@@ -197,7 +204,7 @@ public class Swarm {
                     loadStageConfiguration(url);
                 }
             } catch (MalformedURLException e) {
-                System.err.println("[WARN] Failed to parse project stage URL reference, ignoring: " + e.getMessage());
+                SwarmMessages.MESSAGES.malformedStageConfigUrl(e.getMessage());
             }
         }
     }
@@ -221,7 +228,7 @@ public class Swarm {
         if (!this.stageConfig.isPresent()) {
             loadStageConfiguration(stageConfigUrl.get());
         } else {
-            System.out.println("[INFO] Project stage superseded by external configuration " + System.getProperty(SwarmProperties.PROJECT_STAGE_FILE));
+            SwarmMessages.MESSAGES.stageConfigSuperseded(System.getProperty(SwarmProperties.PROJECT_STAGE_FILE));
         }
         return this;
     }
@@ -432,7 +439,7 @@ public class Swarm {
             domain.getConfiguration().getExtensionLoader().addOverride(JavaArchive.class, JavaArchiveImpl.class);
             domain.getConfiguration().getExtensionLoader().addOverride(WebArchive.class, WebArchiveImpl.class);
         } catch (Exception e) {
-            e.printStackTrace();
+            SwarmMessages.MESSAGES.shrinkwrapDomainSetupFailed(e);
         } finally {
             Thread.currentThread().setContextClassLoader(originalCl);
         }
@@ -493,7 +500,7 @@ public class Swarm {
         if (null == stage)
             throw SwarmMessages.MESSAGES.stageNotFound(stageName);
 
-        System.out.println("[INFO] Using project stage: " + stageName);
+        SwarmMessages.MESSAGES.usingProjectStage(stageName);
 
         this.stageConfig = Optional.of(stage);
     }

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/DeploymentModulesArchivePreparer.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/DeploymentModulesArchivePreparer.java
@@ -21,6 +21,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import org.jboss.shrinkwrap.api.Archive;
+import org.wildfly.swarm.internal.SwarmMessages;
 import org.wildfly.swarm.spi.api.ArchivePreparer;
 import org.wildfly.swarm.spi.api.Fraction;
 import org.wildfly.swarm.spi.api.JARArchive;
@@ -61,6 +62,8 @@ public class DeploymentModulesArchivePreparer implements ArchivePreparer {
     }
 
     protected void addModule(JARArchive archive, DeploymentModule entry) {
+        SwarmMessages.MESSAGES.deploymentModuleAdded(entry);
+
         String moduleName = entry.name();
         String moduleSlot = entry.slot();
         if (moduleSlot.equals("")) {

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
@@ -57,6 +57,7 @@ import org.wildfly.swarm.container.runtime.deployments.DefaultDeploymentCreator;
 import org.wildfly.swarm.container.runtime.marshal.DMRMarshaller;
 import org.wildfly.swarm.container.runtime.wildfly.SimpleContentProvider;
 import org.wildfly.swarm.container.runtime.wildfly.UUIDFactory;
+import org.wildfly.swarm.internal.SwarmMessages;
 import org.wildfly.swarm.spi.api.Customizer;
 import org.wildfly.swarm.spi.api.Fraction;
 import org.wildfly.swarm.spi.api.ProjectStage;
@@ -117,19 +118,19 @@ public class RuntimeServer implements Server {
         System.setProperty("jboss.server.management.uuid", uuid.toString());
 
         for (Customizer each : this.preCustomizers) {
+            SwarmMessages.MESSAGES.callingPreCustomizer(each);
             each.customize();
         }
 
         for (Customizer each : this.postCustomizers) {
+            SwarmMessages.MESSAGES.callingPostCustomizer(each);
             each.customize();
         }
 
         List<ModelNode> bootstrapOperations = new ArrayList<>();
         this.dmrMarshaller.marshal(bootstrapOperations);
 
-        if (LOG.isDebugEnabled()) {
-            LOG.debug(bootstrapOperations);
-        }
+        SwarmMessages.MESSAGES.wildflyBootstrap(bootstrapOperations.toString());
 
         Thread.currentThread().setContextClassLoader(RuntimeServer.class.getClassLoader());
 

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/cli/CommandLineArgsServiceActivator.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/cli/CommandLineArgsServiceActivator.java
@@ -11,6 +11,7 @@ import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistryException;
 import org.jboss.msc.service.ValueService;
 import org.jboss.msc.value.ImmediateValue;
+import org.wildfly.swarm.internal.SwarmMessages;
 
 /**
  * @author Bob McWhirter
@@ -19,10 +20,12 @@ import org.jboss.msc.value.ImmediateValue;
 public class CommandLineArgsServiceActivator implements ServiceActivator {
 
     @Inject
-    @CommandLineArgs String[] args;
+    @CommandLineArgs
+    String[] args;
 
     @Override
     public void activate(ServiceActivatorContext context) throws ServiceRegistryException {
+        SwarmMessages.MESSAGES.argsInstalled(Arrays.asList(this.args));
         context.getServiceTarget().addService(ServiceName.of("wildfly", "swarm", "main-args"), new ValueService<>(new ImmediateValue<>(this.args)))
                 .install();
     }

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/marshal/ProjectStagePropertyMarshaller.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/marshal/ProjectStagePropertyMarshaller.java
@@ -18,11 +18,11 @@ package org.wildfly.swarm.container.runtime.marshal;
 import java.util.List;
 import java.util.Map;
 
-import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import org.jboss.dmr.ModelNode;
+import org.wildfly.swarm.internal.SwarmMessages;
 import org.wildfly.swarm.spi.api.ProjectStage;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
@@ -42,6 +42,7 @@ public class ProjectStagePropertyMarshaller implements ConfigurationMarshaller {
     public void marshal(List<ModelNode> list) {
         Map<String, String> properties = this.stage.getProperties();
         for (String key : properties.keySet()) {
+            SwarmMessages.MESSAGES.marshalProjectStageProperty(key);
             ModelNode modelNode = new ModelNode();
             modelNode.get(OP).set(ADD);
             modelNode.get(ADDRESS).set("system-property", key);

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/marshal/XMLMarshaller.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/marshal/XMLMarshaller.java
@@ -20,7 +20,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -28,8 +27,10 @@ import javax.inject.Singleton;
 import org.jboss.dmr.ModelNode;
 import org.wildfly.swarm.container.runtime.xmlconfig.StandaloneXMLParser;
 import org.wildfly.swarm.container.runtime.xmlconfig.XMLConfig;
+import org.wildfly.swarm.internal.SwarmMessages;
 
-/** Marshals a collection of XML configurations (standalone.xml) to DMR.
+/**
+ * Marshals a collection of XML configurations (standalone.xml) to DMR.
  *
  * @author Bob McWhirter
  */
@@ -62,6 +63,7 @@ public class XMLMarshaller implements ConfigurationMarshaller {
         seen.add(url);
         try {
             List<ModelNode> subList = this.parser.parse(url);
+            SwarmMessages.MESSAGES.marshalXml(url.toExternalForm(), subList.toString());
             list.addAll(subList);
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/StandaloneXMLConfigProducer.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/StandaloneXMLConfigProducer.java
@@ -8,8 +8,11 @@ import javax.inject.Singleton;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoadException;
+import org.wildfly.swarm.internal.SwarmMessages;
 
-/** Produces auto-discovered XML configuration (standalone.xml) URLs.
+/**
+ * Produces auto-discovered XML configuration (standalone.xml) URLs.
+ *
  * @author Bob McWhirter
  */
 @Singleton
@@ -22,6 +25,9 @@ public class StandaloneXMLConfigProducer {
             Module app = Module.getBootModuleLoader().loadModule(ModuleIdentifier.create("swarm.application"));
             ClassLoader cl = app.getClassLoader();
             URL result = cl.getResource("standalone.xml");
+            if (result != null) {
+                SwarmMessages.MESSAGES.loadingStandaloneXml("'swarm.application' module", result.toExternalForm());
+            }
             return result;
         } catch (ModuleLoadException e) {
             e.printStackTrace();
@@ -34,6 +40,9 @@ public class StandaloneXMLConfigProducer {
     public URL fromClassLoader() {
         ClassLoader cl = ClassLoader.getSystemClassLoader();
         URL result = cl.getResource("standalone.xml");
+        if (result != null) {
+            SwarmMessages.MESSAGES.loadingStandaloneXml("system classloader", result.toExternalForm());
+        }
         return result;
     }
 }

--- a/container/src/main/java/org/wildfly/swarm/internal/SwarmMessages.java
+++ b/container/src/main/java/org/wildfly/swarm/internal/SwarmMessages.java
@@ -21,22 +21,27 @@ package org.wildfly.swarm.internal;
 
 import java.net.URL;
 import java.util.Collection;
+import java.util.List;
 
-import org.jboss.logging.Messages;
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
-import org.jboss.logging.annotations.MessageBundle;
+import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.Param;
 import org.jboss.shrinkwrap.api.Archive;
 import org.wildfly.swarm.container.DeploymentException;
+import org.wildfly.swarm.spi.api.Customizer;
+import org.wildfly.swarm.spi.api.annotations.DeploymentModule;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@MessageBundle(projectCode = "WFSWARM", length = 4)
-public interface SwarmMessages {
+@MessageLogger(projectCode = "WFSWARM", length = 4)
+public interface SwarmMessages extends BasicLogger {
 
-    SwarmMessages MESSAGES = Messages.getBundle(SwarmMessages.class);
+    SwarmMessages MESSAGES = Logger.getMessageLogger(SwarmMessages.class, "org.wildfly.swarm");
 
     @Message(id = 1, value = "Stage config is not present.")
     RuntimeException missingStageConfig();
@@ -93,6 +98,58 @@ public interface SwarmMessages {
     @Message(id = 18, value = "Installed fraction: %24s - %-15s %s:%s:%s")
     String availableFraction(String name, String stabilityLevel, String groupId, String artifactId, String version);
 
-    @Message(id=19, value="No deployments specified on the command-line" )
+    @Message(id = 19, value = "No deployments specified on the command-line")
     String noDeploymentsSpecified();
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 20, value = "Stage Config found in %s at location: %s")
+    void stageConfigLocation(String configType, String configLocation);
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 21, value = "Failed to parse project stage URL reference, ignoring: %s")
+    void malformedStageConfigUrl(String error);
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 22, value = "Project stage superseded by external configuration %s")
+    void stageConfigSuperseded(String location);
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 23, value = "Unable to setup Shrinkwrap Domain")
+    void shrinkwrapDomainSetupFailed(@Cause Throwable cause);
+
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 24, value = "Using project stage: %s")
+    void usingProjectStage(String stageName);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 25, value = "Add deployment module: %s")
+    void deploymentModuleAdded(DeploymentModule module);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 26, value = "Calling Pre Customizer: %s")
+    void callingPreCustomizer(Customizer customizer);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 27, value = "Calling Post Customizer: %s")
+    void callingPostCustomizer(Customizer customizer);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 28, value = "WildFly Bootstrap operations: \n %s")
+    void wildflyBootstrap(String operations);
+
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 29, value = "Install MSC service for command line args: %s")
+    void argsInstalled(List<String> args);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 30, value = "Marshalling Project Stage property %s")
+    void marshalProjectStageProperty(String key);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 31, value = "Marshalling XML from %s as: \n %s")
+    void marshalXml(String location, String xml);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 32, value = "Load standalone.xml via %s from %s")
+    void loadingStandaloneXml(String loader, String location);
 }

--- a/logging/src/main/resources/logging.properties
+++ b/logging/src/main/resources/logging.properties
@@ -4,13 +4,16 @@
 #
 
 # Additional loggers to configure (the root logger is always configured)
-loggers=com.arjuna,jacorb,org.jboss.as.config,org.apache.tomcat.util.modeler,sun.rmi,jacorb.config
+loggers=org.wildfly.swarm,com.arjuna,jacorb,org.jboss.as.config,org.apache.tomcat.util.modeler,sun.rmi,jacorb.config
 
 logger.level=INFO
 logger.handlers=CONSOLE
 
 logger.com.arjuna.level=WARN
 logger.com.arjuna.useParentHandlers=true
+
+logger.org.wildfly.swarm.level=${swarm.logging:INFO}
+logger.org.wildfly.swarm.useParentHandlers=true
 
 logger.jacorb.level=WARN
 logger.jacorb.useParentHandlers=true


### PR DESCRIPTION
Added back some of the logging that had been removed as it was using println, but added using the @LogMessage format.

Also added "org.wildfly.swarm" category, as that's the logger category we're using, into logging.properties with a default INFO level but it is overridable with -Dswarm.logging={LEVEL}
