### PR TITLE
Subject: SWARM-564 Unable to access wrapped connection

### DIFF
--- a/databases/h2/pom.xml
+++ b/databases/h2/pom.xml
@@ -44,6 +44,14 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- Provided Dependencies -->
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <version>${version.h2}</version>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- Fraction Dependencies -->
     <dependency>
       <groupId>org.wildfly.swarm</groupId>

--- a/databases/h2/src/main/java/org/wildfly/swarm/database/h2/H2Fraction.java
+++ b/databases/h2/src/main/java/org/wildfly/swarm/database/h2/H2Fraction.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.database.h2;
+
+import org.wildfly.swarm.spi.api.Fraction;
+import org.wildfly.swarm.spi.api.annotations.DeploymentModule;
+
+/**
+ * @author Ken Finnigan
+ */
+@DeploymentModule(name = "com.h2database.h2")
+public class H2Fraction implements Fraction<H2Fraction> {
+}

--- a/databases/mysql/pom.xml
+++ b/databases/mysql/pom.xml
@@ -45,6 +45,14 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- Provided Dependencies -->
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <version>${version.mysql}</version>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- Fraction Dependencies -->
     <dependency>
       <groupId>org.wildfly.swarm</groupId>

--- a/databases/mysql/src/main/java/org/wildfly/swarm/database/mysql/MySQLFraction.java
+++ b/databases/mysql/src/main/java/org/wildfly/swarm/database/mysql/MySQLFraction.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.database.mysql;
+
+import org.wildfly.swarm.spi.api.Fraction;
+import org.wildfly.swarm.spi.api.annotations.DeploymentModule;
+
+/**
+ * @author Ken Finnigan
+ */
+@DeploymentModule(name = "com.mysql")
+public class MySQLFraction implements Fraction<MySQLFraction> {
+}

--- a/databases/postgresql/pom.xml
+++ b/databases/postgresql/pom.xml
@@ -51,6 +51,14 @@
       <artifactId>datasources</artifactId>
     </dependency>
 
+    <!-- Provided Dependencies -->
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>${version.postgresql}</version>
+      <scope>provided</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.wildfly.core</groupId>
       <artifactId>wildfly-core-feature-pack</artifactId>

--- a/databases/postgresql/src/main/java/org/wildfly/swarm/database/postgresql/PostgresSQLFraction.java
+++ b/databases/postgresql/src/main/java/org/wildfly/swarm/database/postgresql/PostgresSQLFraction.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.database.postgresql;
+
+import org.wildfly.swarm.spi.api.Fraction;
+import org.wildfly.swarm.spi.api.annotations.DeploymentModule;
+
+/**
+ * @author Ken Finnigan
+ */
+@DeploymentModule(name = "org.postgresql")
+public class PostgresSQLFraction implements Fraction<PostgresSQLFraction> {
+}

--- a/datasources/pom.xml
+++ b/datasources/pom.xml
@@ -55,6 +55,12 @@
       <artifactId>security</artifactId>
     </dependency>
 
+    <!-- Provided APIs -->
+    <dependency>
+      <groupId>org.jboss.ironjacamar</groupId>
+      <artifactId>ironjacamar-jdbc</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>

--- a/datasources/src/main/java/org/wildfly/swarm/datasources/DatasourcesFraction.java
+++ b/datasources/src/main/java/org/wildfly/swarm/datasources/DatasourcesFraction.java
@@ -19,6 +19,7 @@ import org.wildfly.swarm.config.Datasources;
 import org.wildfly.swarm.config.datasources.DataSource;
 import org.wildfly.swarm.config.datasources.JDBCDriverConsumer;
 import org.wildfly.swarm.spi.api.Fraction;
+import org.wildfly.swarm.spi.api.annotations.DeploymentModule;
 import org.wildfly.swarm.spi.api.annotations.MarshalDMR;
 import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
 
@@ -26,6 +27,7 @@ import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
  * @author Bob McWhirter
  */
 @WildFlyExtension(module = "org.jboss.as.connector", classname = "org.jboss.as.connector.subsystems.datasources.DataSourcesExtension")
+@DeploymentModule(name = "org.jboss.ironjacamar.jdbcadapters")
 @MarshalDMR
 public class DatasourcesFraction extends Datasources<DatasourcesFraction> implements Fraction<DatasourcesFraction> {
     @Override


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

Currently it's not possible to get the WrappedConnection class that underlies the DataSource.
It's also not possible to access the underlying DataSource class whether it be H2, MySQL or PostgreSQL.
## Modifications
- Add the IronJacamar JDBC adaptar module to the deployment so WrappedConnection can be found on the classpath. Also add as provided dependency to datasource fraction.
- Add Fraction instances for each database type so that their respective modules can also be added to the deployment if the underlying connection class needs to be used.
## Result

No more CNFE errors when trying to cast a connection to WrappedConnection within a user application.
