### PR TITLE
SWARM-617: Upgrade to WildFly 10.1.0.Final

### DIFF
--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -82,10 +82,6 @@
       <artifactId>jboss-modules</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jboss.spec.javax.sql</groupId>
-      <artifactId>jboss-javax-sql-api_7.0_spec</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.jboss.shrinkwrap</groupId>
       <artifactId>shrinkwrap-api</artifactId>
       <scope>test</scope>

--- a/bootstrap/src/main/resources/modules/javax/sql/api/main/module.xml
+++ b/bootstrap/src/main/resources/modules/javax/sql/api/main/module.xml
@@ -23,11 +23,19 @@
   -->
 
 <module xmlns="urn:jboss:module:1.3" name="javax.sql.api">
-  <resources>
-    <artifact name="org.jboss.spec.javax.sql:jboss-javax-sql-api_7.0_spec:${version.org.jboss.spec.javax.sql.jboss-javax-sql-api_7.0_spec}"/>
-  </resources>
+
+  <resources/>
 
   <dependencies>
+    <system export="true">
+      <paths>
+        <path name="javax/sql"/>
+        <path name="javax/sql/rowset"/>
+        <path name="javax/sql/rowset/serial"/>
+        <path name="javax/sql/rowset/spi"/>
+        <path name="javax/transaction/xa"/>
+      </paths>
+    </system>
     <module name="javax.api"/>
   </dependencies>
 </module>

--- a/camel/pom.xml
+++ b/camel/pom.xml
@@ -41,7 +41,7 @@
     <properties>
         <!-- keep in sync with wildfly-camel -->
         <version.apache.camel>2.17.2</version.apache.camel>
-        <version.wildfly.camel>4.2.0</version.wildfly.camel>
+        <version.wildfly.camel>4.2.1</version.wildfly.camel>
     </properties>
 
     <!-- Modules -->

--- a/naming/module.conf
+++ b/naming/module.conf
@@ -1,1 +1,2 @@
 org.jboss.as.naming
+org.wildfly.naming

--- a/pom.xml
+++ b/pom.xml
@@ -39,9 +39,8 @@
     <version.maven.aether>3.2.5</version.maven.aether>
     <version.wildfly.config-api>0.4.5</version.wildfly.config-api>
     <version.swarm.spi>1.0.11.Final</version.swarm.spi>
-    <version.wildfly>10.0.0.Final</version.wildfly>
+    <version.wildfly>10.1.0.Final</version.wildfly>
     <version.org.jboss.msc.jboss-msc>1.2.6.Final</version.org.jboss.msc.jboss-msc>
-    <version.org.jboss.spec.javax.sql.jboss-javax-sql-api_7.0_spec>2.0.0.Final</version.org.jboss.spec.javax.sql.jboss-javax-sql-api_7.0_spec>
     <version.jboss-logmanager-ext>1.0.0.Alpha3</version.jboss-logmanager-ext>
 
     <version.org.arquillian>1.1.10.Final</version.org.arquillian>
@@ -71,7 +70,7 @@
 
     <version.openshift.client>3.0.1.Final</version.openshift.client>
     <version.org.openshift.ping>1.0.0.Beta7-swarm-1</version.org.openshift.ping>
-    <version.org.jgroups>3.6.6.Final</version.org.jgroups>
+    <version.org.jgroups>3.6.10.Final</version.org.jgroups>
 
     <version.vertx>3.3.2</version.vertx>
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

This upgrade resolves SWARM-526 and allows the management console to be deployed as part of the AS, thus eliminating the need to provide a connection URL when opening the management console home page.
## Modifications

The pom.xml was changed to depend on WildFly 10.1.0.Final
## Result

WildFly 10.1.0.Final is used and WildFly Swarm version is printed in the logging output
