### PR TITLE
SWARM-526: Product name is now displayed correctly

### DIFF
--- a/container/src/main/resources/modules/org/jboss/as/product/main/dir/META-INF/MANIFEST.MF
+++ b/container/src/main/resources/modules/org/jboss/as/product/main/dir/META-INF/MANIFEST.MF
@@ -1,0 +1,2 @@
+JBoss-Product-Release-Name: WildFly Swarm
+JBoss-Product-Release-Version: ${project.version}

--- a/container/src/main/resources/modules/org/jboss/as/product/main/module.xml
+++ b/container/src/main/resources/modules/org/jboss/as/product/main/module.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.product" slot="main">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <resource-root path="dir"/>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+    </dependencies>
+</module>


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?
## IMPORTANT: This depends on https://github.com/wildfly-swarm/wildfly-swarm/pull/96
## Motivation

It is interesting to display the Swarm version used when the container starts (and also make room for productization in the future)
## Modifications

Created `org.jboss.as.product` module with a META-INF/MANIFEST.MF containing the product name and version.
## Result

The following output is displayed when the container starts:

```
INFO [org.jboss.as] (MSC service thread 1-6) WFLYSRV0049: WildFly Swarm 2016.9-SNAPSHOT (WildFly Core 2.2.0.Final) starting
INFO [org.jboss.as] (Controller Boot Thread) WFLYSRV0025: WildFly Swarm 2016.9-SNAPSHOT (WildFly Core 2.2.0.Final) started in 1735ms
```
