### PR TITLE
SWARM-616 (again) - Remove gratuitous stuff from WEB-INF/lib

### DIFF
--- a/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/PackageTask.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/PackageTask.java
@@ -124,6 +124,6 @@ public class PackageTask extends DefaultTask {
         String classifier = artifact.getClassifier();
         File file = artifact.getFile();
 
-        this.tool.dependency("compile", groupId, artifactId, version, extension, classifier, file);
+        this.tool.explicitDependency("compile", groupId, artifactId, version, extension, classifier, file);
     }
 }

--- a/swarmtool/src/main/java/org/wildfly/swarm/swarmtool/Main.java
+++ b/swarmtool/src/main/java/org/wildfly/swarm/swarmtool/Main.java
@@ -224,7 +224,6 @@ public class Main {
                                              BuildTool.FractionDetectionMode.force)
                 .bundleDependencies(!foundOptions.has(DISABLE_BUNDLE_DEPS_OPT))
                 .executable(foundOptions.has(EXECUTABLE_OPT))
-                .resolveTransitiveDependencies(true)
                 .properties(properties)
                 .hollow(foundOptions.has(HOLLOW_OPT));
 

--- a/swarmtool/src/test/java/org/wildfly/swarm/swarmtool/MainTest.java
+++ b/swarmtool/src/test/java/org/wildfly/swarm/swarmtool/MainTest.java
@@ -64,7 +64,8 @@ public class MainTest {
         result.err = err.toString();
         result.out = out.toString();
 
-        //System.out.println(result.err);
+        System.err.println(result.err);
+        System.out.println(result.err);
 
         return result;
     }

--- a/testsuite/testsuite-management/pom.xml
+++ b/testsuite/testsuite-management/pom.xml
@@ -42,13 +42,6 @@
       <artifactId>arquillian-junit-container</artifactId>
       <scope>test</scope>
     </dependency>
-<!--
-    <dependency>
-      <groupId>org.wildfly.core</groupId>
-      <artifactId>wildfly-controller</artifactId>
-      <scope>test</scope>
-    </dependency>
--->
     <dependency>
       <groupId>org.wildfly.core</groupId>
       <artifactId>wildfly-controller-client</artifactId>

--- a/tools/src/main/java/org/wildfly/swarm/tools/FractionUsageAnalyzer.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/FractionUsageAnalyzer.java
@@ -63,16 +63,16 @@ public class FractionUsageAnalyzer {
                                    .collect(Collectors.toSet()));
         specs.addAll(findFractions(detectables));
 
-        // Remove fractions that have a dependency on each other
+        // Remove fractions that have a explicitDependency on each other
         Iterator<FractionDescriptor> it = specs.iterator();
         while (it.hasNext()) {
             FractionDescriptor descriptor = it.next();
-            // Is set as a dependency to any other descriptor? If so, remove it
+            // Is set as a explicitDependency to any other descriptor? If so, remove it
             if (specs.stream().anyMatch(fd->fd.getDependencies().contains(descriptor))) {
                 it.remove();
             }
         }
-        // Add container only if no fractions are detected, as they have a transitive dependency to container
+        // Add container only if no fractions are detected, as they have a transitive explicitDependency to container
         if (specs.isEmpty()) {
             specs.add(this.fractionList.getFractionDescriptor(DependencyManager.WILDFLY_SWARM_GROUP_ID, "container"));
         }

--- a/tools/src/main/java/org/wildfly/swarm/tools/WebInfLibFilteringArchiveAsset.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/WebInfLibFilteringArchiveAsset.java
@@ -12,8 +12,11 @@ public class WebInfLibFilteringArchiveAsset implements ProjectAsset {
 
     private final ProjectAsset asset;
 
-    public WebInfLibFilteringArchiveAsset(ProjectAsset asset) {
+    private final DependencyManager dependencyManager;
+
+    public WebInfLibFilteringArchiveAsset(ProjectAsset asset, DependencyManager dependencyManager) {
         this.asset = asset;
+        this.dependencyManager = dependencyManager;
     }
 
     @Override
@@ -28,6 +31,6 @@ public class WebInfLibFilteringArchiveAsset implements ProjectAsset {
 
     @Override
     public InputStream openStream() {
-        return new WebInfLibFilteringArchive( this.asset.getArchive() ).as(ZipExporter.class).exportAsInputStream();
+        return new WebInfLibFilteringArchive( this.asset.getArchive(), this.dependencyManager ).as(ZipExporter.class).exportAsInputStream();
     }
 }

--- a/tools/src/test/java/org/wildfly/swarm/tools/DependencyManagerTest.java
+++ b/tools/src/test/java/org/wildfly/swarm/tools/DependencyManagerTest.java
@@ -151,7 +151,7 @@ public class DependencyManagerTest {
 
     @Test
     public void analyzeDependenciesNoModules() throws Exception {
-        manager.addDependency(ArtifactSpec.fromMscGav("test:no-module-A:1.0"));
+        manager.addExplicitDependency(ArtifactSpec.fromMscGav("test:no-module-A:1.0"));
         manager.analyzeDependencies(false);
         assertThat(manager.getDependencies()).hasSize(1);
         assertThat(manager.getBootstrapDependencies()).isEmpty();
@@ -159,8 +159,8 @@ public class DependencyManagerTest {
 
     @Test
     public void analyzeDependenciesWithBootstrapJar() throws Exception {
-        manager.addDependency(ArtifactSpec.fromMscGav("test:no-module-A:1.0"));
-        manager.addDependency(BOOTSTRAP_JAR);
+        manager.addExplicitDependency(ArtifactSpec.fromMscGav("test:no-module-A:1.0"));
+        manager.addExplicitDependency(BOOTSTRAP_JAR);
         manager.analyzeDependencies(false);
         assertThat(manager.getDependencies()).hasSize(2);
         assertThat(manager.getBootstrapDependencies()).hasSize(1);
@@ -170,10 +170,10 @@ public class DependencyManagerTest {
 
     @Test
     public void analyzeDependenciesWithBootstrapJarAndBootstrapConf() throws Exception {
-        manager.addDependency(BOOTSTRAP_JAR);
-        manager.addDependency(ArtifactSpec.fromMscGav("test:no-module-A:1.0"));
-        manager.addDependency(MODULES_EMPTY_A);
-        manager.addDependency(MODULES_EMPTY_B);
+        manager.addExplicitDependency(BOOTSTRAP_JAR);
+        manager.addExplicitDependency(ArtifactSpec.fromMscGav("test:no-module-A:1.0"));
+        manager.addExplicitDependency(MODULES_EMPTY_A);
+        manager.addExplicitDependency(MODULES_EMPTY_B);
         manager.analyzeDependencies(false);
         assertThat(manager.getDependencies()).hasSize(4);
         assertThat(manager.getBootstrapDependencies()).hasSize(1);
@@ -185,8 +185,8 @@ public class DependencyManagerTest {
 
     @Test
     public void analyzeDependenciesWithBootstrapConfContents() throws Exception {
-        manager.addDependency(BOOTSTRAP_JAR);
-        manager.addDependency(BOOTSTRAP_CONF);
+        manager.addExplicitDependency(BOOTSTRAP_JAR);
+        manager.addExplicitDependency(BOOTSTRAP_CONF);
         manager.analyzeDependencies(false);
         assertThat(manager.getDependencies()).hasSize(2);
         assertThat(manager.getBootstrapDependencies()).hasSize(1);
@@ -198,7 +198,7 @@ public class DependencyManagerTest {
 
     @Test
     public void analyzeDependenciesWithModuleXml() throws Exception {
-        manager.addDependency(MODULES_A);
+        manager.addExplicitDependency(MODULES_A);
         manager.analyzeDependencies(false);
         assertThat(manager.getDependencies()).hasSize(1);
         assertThat(manager.getDependencies()).contains(MODULES_A);
@@ -211,10 +211,10 @@ public class DependencyManagerTest {
 
     @Test
     public void populateUberJarMavenRepository() throws Exception {
-        manager.addDependency(BOOTSTRAP_JAR);
-        manager.addDependency(BOOTSTRAP_CONF);
-        manager.addDependency(MODULES_EMPTY_A);
-        manager.addDependency(MODULES_A);
+        manager.addExplicitDependency(BOOTSTRAP_JAR);
+        manager.addExplicitDependency(BOOTSTRAP_CONF);
+        manager.addExplicitDependency(MODULES_EMPTY_A);
+        manager.addExplicitDependency(MODULES_A);
         manager.analyzeDependencies(false);
 
         Archive archive = ShrinkWrap.create(JavaArchive.class);
@@ -235,7 +235,7 @@ public class DependencyManagerTest {
 
     @Test
     public void analyzeDependenciesWithProvided() throws Exception {
-        manager.addDependency(PROVIDED_A);
+        manager.addExplicitDependency(PROVIDED_A);
         manager.analyzeDependencies(false);
 
         assertThat(manager.getDependencies()).hasSize(1);
@@ -246,12 +246,12 @@ public class DependencyManagerTest {
 
     @Test
     public void populateUberJarMavenRepositoryAvoidingProvided() throws Exception {
-        manager.addDependency(BOOTSTRAP_JAR);
-        manager.addDependency(BOOTSTRAP_CONF);
-        manager.addDependency(MODULES_EMPTY_A);
-        manager.addDependency(MODULES_A);
-        manager.addDependency(PROVIDED_A);
-        manager.addDependency(COM_SUN_MAIL);
+        manager.addExplicitDependency(BOOTSTRAP_JAR);
+        manager.addExplicitDependency(BOOTSTRAP_CONF);
+        manager.addExplicitDependency(MODULES_EMPTY_A);
+        manager.addExplicitDependency(MODULES_A);
+        manager.addExplicitDependency(PROVIDED_A);
+        manager.addExplicitDependency(COM_SUN_MAIL);
         manager.analyzeDependencies(false);
 
         assertThat(manager.getProvidedGAVs()).contains("com.sun.mail:javax.mail");
@@ -275,7 +275,7 @@ public class DependencyManagerTest {
 
     @Test
     public void analyzeDependenciesUnresolveable() throws Exception {
-        manager.addDependency(ArtifactSpec.fromMscGav("no:such-thing:1.0"));
+        manager.addExplicitDependency(ArtifactSpec.fromMscGav("no:such-thing:1.0"));
         manager.analyzeDependencies(false);
 
     }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

As previously, there's entirely too much cruft inside WEB-INF/lib
that shouldn't be there.
## Modifications

We now track explicit top-level dependencies asked for by an
application, weed out the wildfly-swarm ones (via detection of
wildfly-swarm-bootstrap.conf), and recalculate the dependencies.
## Result

This allows an app to ask for a jar that Swarm needs, and still
get it in its WEB-INF/lib.  But things only needed by Swarm proper
will get removed from WEB-INF/lib.

Additionally, if a .war is the primary artifact of a user's
application, we re-package it with a cleansed WEB-INF/lib,
leaving a .war.original in the build directory.
