### PR TITLE
Subject: SWARM-596, Test class with inheritence or interfaces

### DIFF
--- a/testsuite/testsuite-undertow/src/test/java/org/wildfly/swarm/undertow/staticcontent/StaticContentCommonTests.java
+++ b/testsuite/testsuite-undertow/src/test/java/org/wildfly/swarm/undertow/staticcontent/StaticContentCommonTests.java
@@ -18,9 +18,11 @@ package org.wildfly.swarm.undertow.staticcontent;
 public interface StaticContentCommonTests {
 
     default void assertBasicStaticContentWorks(String context) throws Exception {
-        if (context.length() > 0 && !context.endsWith("/")) {
+        if (context.length() > 0 || !context.endsWith("/")) {
+            System.out.println("Inside if");
             context = context + "/";
         }
+        System.out.println(context);
         assertContains(context + "static-content.txt", "This is static.");
         assertContains(context + "index.html", "This is index.html.");
         assertContains(context + "foo/index.html", "This is foo/index.html.");

--- a/testsuite/testsuite-undertow/src/test/java/org/wildfly/swarm/undertow/staticcontent/deployment/StaticContentContextRootDeploymentTest.java
+++ b/testsuite/testsuite-undertow/src/test/java/org/wildfly/swarm/undertow/staticcontent/deployment/StaticContentContextRootDeploymentTest.java
@@ -39,23 +39,24 @@ import static org.fest.assertions.Fail.fail;
  * @author Bob McWhirter
  */
 @RunWith(Arquillian.class)
-public class StaticContentDeploymentTest implements StaticContentCommonTests {
+public class StaticContentContextRootDeploymentTest implements StaticContentCommonTests {
 
     @Deployment(testable = false)
-    public static Archive getFirst() throws Exception {
+    public static Archive getSecond() throws Exception {
         WARArchive deployment = ShrinkWrap.create(WARArchive.class);
+        deployment.setContextRoot("/static");
         deployment.staticContent();
         return deployment;
     }
 
     @Test
-    public void testStaticContent() throws Exception {
-        assertBasicStaticContentWorks("");
-        assertFileChangesReflected("");
+    public void testStaticContentWithContext() throws Exception {
+        assertBasicStaticContentWorks("static");
+        assertFileChangesReflected("static");
     }
 
     public void assertContains(String path, String text) throws Exception {
-        assertThat(fetch("http://localhost:8080" + path)).contains(text);
+        assertThat(fetch("http://localhost:8080/" + path)).contains(text);
     }
 
     public void assertNotFound(String path) throws Exception {

--- a/testsuite/testsuite-undertow/src/test/java/org/wildfly/swarm/undertow/staticcontent/deployment/StaticContentPathDeploymentTest.java
+++ b/testsuite/testsuite-undertow/src/test/java/org/wildfly/swarm/undertow/staticcontent/deployment/StaticContentPathDeploymentTest.java
@@ -39,19 +39,19 @@ import static org.fest.assertions.Fail.fail;
  * @author Bob McWhirter
  */
 @RunWith(Arquillian.class)
-public class StaticContentDeploymentTest implements StaticContentCommonTests {
+public class StaticContentPathDeploymentTest implements StaticContentCommonTests {
 
     @Deployment(testable = false)
-    public static Archive getFirst() throws Exception {
+    public static Archive getThird() throws Exception {
         WARArchive deployment = ShrinkWrap.create(WARArchive.class);
-        deployment.staticContent();
+        deployment.staticContent("foo");
         return deployment;
     }
 
     @Test
-    public void testStaticContent() throws Exception {
-        assertBasicStaticContentWorks("");
-        assertFileChangesReflected("");
+    public void testStaticContentWithBase() throws Exception {
+        assertContains("", "This is foo/index.html.");
+        assertContains("/index.html", "This is foo/index.html.");
     }
 
     public void assertContains(String path, String text) throws Exception {


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

Currently when @CreateSwarm is present on the method of a test class that has super types or implements interfaces it fails to load the class as these inherited types are not present in the Archive being classloaded.
## Modifications

Modify the UberJarSimpleContainer to recursively find all super types and interfaces to add the classes into the deployment archive.

Also modified the way the classes are added to utilize ClassContainer as its common to jar or war types but handles the correct /classes location depending on the archive type. There is an exception for ResourceAdapterArchive, but I believe it to be a bug in Shrinkwrap which has been raised: SHRINKWRAP-510
## Result

No impact on product, but allows test classes to inherit classes and implement interfaces when @CreateSwarm is annotated on a method
