### PR TITLE
SWARM-619: Enable HTTP/2 in the HTTP/S connectors

### DIFF
--- a/undertow/src/main/java/org/wildfly/swarm/undertow/UndertowFraction.java
+++ b/undertow/src/main/java/org/wildfly/swarm/undertow/UndertowFraction.java
@@ -53,14 +53,14 @@ public class UndertowFraction extends Undertow<UndertowFraction> implements Frac
 
     public UndertowFraction applyDefaults() {
         server(new Server("default-server")
-                .httpListener("default", (listener) -> {
-                    listener.socketBinding("http");
-                })
-                .host(new Host("default-host")))
+                       .httpListener("default", (listener) -> {
+                           listener.socketBinding("http");
+                       })
+                       .host(new Host("default-host")))
                 .bufferCache(new BufferCache("default"))
                 .servletContainer(new ServletContainer("default")
-                        .websocketsSetting(new WebsocketsSetting())
-                        .jspSetting(new JSPSetting()))
+                                          .websocketsSetting(new WebsocketsSetting())
+                                          .jspSetting(new JSPSetting()))
                 .handlerConfiguration(new HandlerConfiguration());
 
         return this;

--- a/undertow/src/main/java/org/wildfly/swarm/undertow/runtime/HTTP2Customizer.java
+++ b/undertow/src/main/java/org/wildfly/swarm/undertow/runtime/HTTP2Customizer.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.undertow.runtime;
+
+
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.wildfly.swarm.config.undertow.Server;
+import org.wildfly.swarm.config.undertow.server.HttpsListener;
+import org.wildfly.swarm.spi.api.Customizer;
+import org.wildfly.swarm.spi.runtime.annotations.Post;
+import org.wildfly.swarm.undertow.UndertowFraction;
+
+/**
+ * A {@link Customizer} implementation to enable HTTP/2
+ *
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+@Post
+public class HTTP2Customizer implements Customizer {
+
+    @Inject
+    @Any
+    private Instance<UndertowFraction> undertowInstance;
+
+    @Override
+    public void customize() {
+        UndertowFraction undertowFraction = undertowInstance.get();
+        for (Server server : undertowFraction.subresources().servers()) {
+            server.subresources().httpsListeners().forEach(httpsListener -> httpsListener.enableHttp2(true));
+        }
+    }
+}


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

Enables HTTP/2 in the existing HTTP/S listeners.
## Modifications

Created an HTTP2Customizer to add the necessary parameters to the existing HTTP/S listeners
## Result

When HTTP/S is enabled, any resource accessed using Google Chrome or Mozilla Firefox should use the h2 protocol
