### PR TITLE
SWARM-616 - Repacked .war shouldn't fail on Windows

### DIFF
--- a/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
@@ -188,11 +188,14 @@ public class BuildTool {
 
     public void repackageWar(File file) throws IOException {
         this.log.info("Repackaging .war: " + file );
+
+        Path backupPath = Paths.get( file.toString() + ".original" );
+        Files.move( file.toPath(), backupPath, StandardCopyOption.REPLACE_EXISTING );
+
         Archive original = ShrinkWrap.create( JavaArchive.class );
-        original.as(ZipImporter.class).importFrom( file );
+        original.as(ZipImporter.class).importFrom( backupPath.toFile() );
 
         WebInfLibFilteringArchive repackaged = new WebInfLibFilteringArchive(original, this.dependencyManager);
-        Files.move( file.toPath(), Paths.get( file.toString() + ".original" ), StandardCopyOption.REPLACE_EXISTING );
         repackaged.as( ZipExporter.class).exportTo( file, true );
     }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

Moving the .war to .war.original before repackaging is failing on Windows.
## Modifications

ShrinkWrap seems to lock the file when the archive is opened. Change the order of things so that we backup the file first, then open the backup, filter the archive and output the result back to the original location.
## Result

Builds on Windows are fixed.
