### PR TITLE
SWARM-631: Removed default value for @ConfigurationValue

### DIFF
--- a/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/ConfigurationValueProducer.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/ConfigurationValueProducer.java
@@ -37,14 +37,14 @@ public class ConfigurationValueProducer {
     private StageConfig stageConfig;
 
     @Produces
-    @ConfigurationValue
+    @ConfigurationValue("")
     @Dependent
     Resolver<String> produceResolver(InjectionPoint injectionPoint) {
         return resolver(injectionPoint);
     }
 
     @Produces
-    @ConfigurationValue
+    @ConfigurationValue("")
     @Dependent
     String produceStringConfigValue(InjectionPoint injectionPoint) {
         return resolve(injectionPoint, String.class);
@@ -52,7 +52,7 @@ public class ConfigurationValueProducer {
 
 
     @Produces
-    @ConfigurationValue
+    @ConfigurationValue("")
     @Dependent
     Integer produceIntegerConfigValue(InjectionPoint injectionPoint) {
         return resolve(injectionPoint, Integer.class);
@@ -60,26 +60,26 @@ public class ConfigurationValueProducer {
 
     @Produces
     @Dependent
-    @ConfigurationValue
+    @ConfigurationValue("")
     Boolean produceBooleanConfigValue(InjectionPoint injectionPoint) {
         return resolve(injectionPoint, Boolean.class);
     }
 
-    @ConfigurationValue
+    @ConfigurationValue("")
     @Dependent
     @Produces
     Long produceLongConfigValue(InjectionPoint injectionPoint) {
         return resolve(injectionPoint, Long.class);
     }
 
-    @ConfigurationValue
+    @ConfigurationValue("")
     @Dependent
     @Produces
     Float produceFloatConfigValue(InjectionPoint injectionPoint) {
         return resolve(injectionPoint, Float.class);
     }
 
-    @ConfigurationValue
+    @ConfigurationValue("")
     @Dependent
     @Produces
     Double produceDoubleConfigValue(InjectionPoint injectionPoint) {

--- a/spi/src/main/java/org/wildfly/swarm/spi/runtime/annotations/ConfigurationValue.java
+++ b/spi/src/main/java/org/wildfly/swarm/spi/runtime/annotations/ConfigurationValue.java
@@ -32,7 +32,7 @@ import javax.inject.Qualifier;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE})
 public @interface ConfigurationValue {
-    @Nonbinding String value() default "";
+    @Nonbinding String value();
 
     final class Literal extends AnnotationLiteral<ConfigurationValue> implements ConfigurationValue {
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

While producing a @ConfigurationValue object in ConfigurationValueProducer,
the configuration value is tested against empty values. The current design
allows user to erroneously use @ConfigurationValue without specifying its value.
## Modifications

Removed the default value for the value() method in the @ConfigurationValue annotation
## Result

@ConfigurationValue's value() is now required
