### PR TITLE
Fix unit test exceptions in ArtifactManagerTest

### DIFF
--- a/container/src/main/java/org/wildfly/swarm/internal/SystemDependencyResolution.java
+++ b/container/src/main/java/org/wildfly/swarm/internal/SystemDependencyResolution.java
@@ -62,13 +62,17 @@ public class SystemDependencyResolution implements DependencyResolution {
 
                     // Read wildfly-swarm-classpath.conf entries
                     if(element.endsWith(JAR)) {
-                        try (JarFile jar = new JarFile(new File(element))) {
-                            ZipEntry entry = jar.getEntry(WildFlySwarmClasspathConf.CLASSPATH_LOCATION);
-                            if (entry != null) {
-                                classpathConf.read(jar.getInputStream(entry));
+
+                        File file = new File(element);
+                        if(file.exists()) { // better then running into IOException, i.e. when executing unit tests
+                            try (JarFile jar = new JarFile(file)) {
+                                ZipEntry entry = jar.getEntry(WildFlySwarmClasspathConf.CLASSPATH_LOCATION);
+                                if (entry != null) {
+                                    classpathConf.read(jar.getInputStream(entry));
+                                }
+                            } catch (IOException e) {
+                                e.printStackTrace();
                             }
-                        } catch (IOException e) {
-                            e.printStackTrace();
                         }
                     }
 


### PR DESCRIPTION
Fixes these unit test exceptions: 

```
14:31:27 java.io.FileNotFoundException: /Users/hbraun/.m2/repository/org/wildfly/swarm/config-api-modules/0.4.4/config-api-modules-0.4.4.jar (No such file or directory)
14:31:27    at java.util.zip.ZipFile.open(Native Method)
14:31:27    at java.util.zip.ZipFile.<init>(ZipFile.java:219)
14:31:27    at java.util.zip.ZipFile.<init>(ZipFile.java:149)
14:31:27    at java.util.jar.JarFile.<init>(JarFile.java:166)
14:31:27    at java.util.jar.JarFile.<init>(JarFile.java:130)
14:31:27    at org.wildfly.swarm.internal.SystemDependencyResolution.resolve(SystemDependencyResolution.java:65)
```
