### PR TITLE
SWARM-527: jboss-web defined context-root is ignored by for health ch…

### DIFF
--- a/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/HealthAnnotationProcessor.java
+++ b/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/HealthAnnotationProcessor.java
@@ -29,6 +29,7 @@ import org.jboss.jandex.MethodInfo;
 import org.jboss.shrinkwrap.api.Archive;
 import org.wildfly.swarm.monitor.HealthMetaData;
 import org.wildfly.swarm.spi.api.ArchiveMetadataProcessor;
+import org.wildfly.swarm.undertow.descriptors.JBossWebContainer;
 
 /**
  * @author Ken Finnigan
@@ -45,8 +46,15 @@ public class HealthAnnotationProcessor implements ArchiveMetadataProcessor {
     @Override
     public void processArchive(Archive<?> archive, Index index) {
 
+        // first pass: jboss-web context root
+        Optional<String> jbossWebContext = Optional.empty();
+        if(archive instanceof JBossWebContainer) {
+            JBossWebContainer war = (JBossWebContainer)archive;
+            if(war.getContextRoot() !=null )
+                jbossWebContext = Optional.of(war.getContextRoot());
+        }
 
-        // first pass: JAX-RS applications
+        // second pass: JAX-RS applications
         Optional<String> appPath = Optional.empty();
         List<AnnotationInstance> appPathAnnotations = index.getAnnotations(APP_PATH);
         for (AnnotationInstance annotation : appPathAnnotations) {
@@ -55,7 +63,7 @@ public class HealthAnnotationProcessor implements ArchiveMetadataProcessor {
             }
         }
 
-        // second pass: JAX-RS resources
+        // third pass: JAX-RS resources
         List<AnnotationInstance> pathAnnotations = index.getAnnotations(PATH);
         for (AnnotationInstance annotation : pathAnnotations) {
             if (annotation.target().kind() == AnnotationTarget.Kind.CLASS) {
@@ -63,20 +71,24 @@ public class HealthAnnotationProcessor implements ArchiveMetadataProcessor {
 
                 for (MethodInfo methodInfo : classInfo.methods()) {
                     if (methodInfo.hasAnnotation(HEALTH)) {
-                        StringBuffer sb = new StringBuffer();
+                        StringBuilder sb = new StringBuilder();
                         boolean isSecure = false;
 
 
+                        // prepend the jboss-web cntext if given
+                        if (jbossWebContext.isPresent() && !jbossWebContext.get().equals("/"))
+                            safeAppend(sb, jbossWebContext.get());
+
                         // prepend the appPath if given
                         if (appPath.isPresent() && !appPath.get().equals("/"))
-                            sb.append(appPath.get());
+                            safeAppend(sb, appPath.get());
 
                         // the class level @Path
                         for (AnnotationInstance classAnnotation : classInfo.classAnnotations()) {
                             if (classAnnotation.name().equals(PATH)) {
                                 String methodPathValue = classAnnotation.value().asString();
                                 if (!methodPathValue.equals("/"))
-                                    sb.append(methodPathValue);
+                                    safeAppend(sb, methodPathValue);
                             }
                         }
 
@@ -104,5 +116,20 @@ public class HealthAnnotationProcessor implements ArchiveMetadataProcessor {
 
             }
         }
+    }
+
+
+    public static void safeAppend(StringBuilder sb, String pathToken) {
+
+        // normalise the token to '/foobar'
+        if(!pathToken.startsWith("/"))
+            pathToken = "/"+pathToken;
+
+        if(pathToken.endsWith("/"))
+            pathToken = pathToken.substring(0, pathToken.length()-1);
+
+        // append to buffer
+        sb.append(pathToken);
+
     }
 }

--- a/monitor/src/test/java/org/wildfly/swarm/monitor/MonitorTest.java
+++ b/monitor/src/test/java/org/wildfly/swarm/monitor/MonitorTest.java
@@ -17,6 +17,7 @@ package org.wildfly.swarm.monitor;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.wildfly.swarm.monitor.runtime.HealthAnnotationProcessor;
 
 /**
  * @author Heiko Braun
@@ -35,5 +36,48 @@ public class MonitorTest {
         Assert.assertTrue("Expected a", message.contains("a"));
         Assert.assertTrue("Expected c", message.contains("c"));
         System.out.println(message);
+    }
+
+    @Test
+    public void testPathStructures() {
+        StringBuilder sb = new StringBuilder();
+        HealthAnnotationProcessor.safeAppend(sb, "jboss-web");
+        HealthAnnotationProcessor.safeAppend(sb, "/webcontext");
+        HealthAnnotationProcessor.safeAppend(sb, "/app");
+        Assert.assertEquals("/jboss-web/webcontext/app", sb.toString());
+
+        // --
+
+        sb = new StringBuilder();
+        HealthAnnotationProcessor.safeAppend(sb, "jboss-web/");
+        HealthAnnotationProcessor.safeAppend(sb, "/webcontext");
+        HealthAnnotationProcessor.safeAppend(sb, "app");
+        Assert.assertEquals("/jboss-web/webcontext/app", sb.toString());
+
+        // --
+
+        sb = new StringBuilder();
+        HealthAnnotationProcessor.safeAppend(sb, "jboss-web");
+        HealthAnnotationProcessor.safeAppend(sb, "webcontext");
+        HealthAnnotationProcessor.safeAppend(sb, "app");
+        Assert.assertEquals("/jboss-web/webcontext/app", sb.toString());
+
+        // --
+
+        sb = new StringBuilder();
+        HealthAnnotationProcessor.safeAppend(sb, "jboss-web/");
+        HealthAnnotationProcessor.safeAppend(sb, "webcontext/");
+        HealthAnnotationProcessor.safeAppend(sb, "app/");
+        Assert.assertEquals("/jboss-web/webcontext/app", sb.toString());
+
+        // --
+
+        sb = new StringBuilder();
+        HealthAnnotationProcessor.safeAppend(sb, "/jboss-web/");
+        HealthAnnotationProcessor.safeAppend(sb, "/webcontext/");
+        HealthAnnotationProcessor.safeAppend(sb, "/app/");
+        Assert.assertEquals("/jboss-web/webcontext/app", sb.toString());
+
+
     }
 }

--- a/testsuite/testsuite-jaxrs/src/main/java/org/wildfly/swarm/jaxrs/HealthCheckResource.java
+++ b/testsuite/testsuite-jaxrs/src/main/java/org/wildfly/swarm/jaxrs/HealthCheckResource.java
@@ -24,7 +24,7 @@ import org.wildfly.swarm.monitor.HealthStatus;
 /**
  * @author Heiko Braun
  */
-@Path("/app")
+@Path("/monitor")
 public class HealthCheckResource {
 
 

--- a/testsuite/testsuite-jaxrs/src/main/java/org/wildfly/swarm/jaxrs/JaxRsActivator.java
+++ b/testsuite/testsuite-jaxrs/src/main/java/org/wildfly/swarm/jaxrs/JaxRsActivator.java
@@ -3,6 +3,6 @@ package org.wildfly.swarm.jaxrs;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
-@ApplicationPath("/webcontext")
+@ApplicationPath("/v1")
 public class JaxRsActivator extends Application {
 }

--- a/testsuite/testsuite-jaxrs/src/test/java/org/wildfly/swarm/jaxrs/JAXRSArqMonitorTest.java
+++ b/testsuite/testsuite-jaxrs/src/test/java/org/wildfly/swarm/jaxrs/JAXRSArqMonitorTest.java
@@ -42,9 +42,10 @@ public class JAXRSArqMonitorTest extends SimpleHttp {
         JAXRSArchive deployment = ShrinkWrap.create(JAXRSArchive.class, "myapp.war");
         deployment.addClass(TimeResource.class);
         deployment.addClass(SimpleHttp.class);
-        deployment.addClass(HealthCheckResource.class);
         deployment.addClass(JaxRsActivator.class);
+        deployment.addClass(HealthCheckResource.class);
         deployment.addAllDependencies();
+        deployment.setContextRoot("rest");
         return deployment;
     }
 
@@ -80,37 +81,37 @@ public class JAXRSArqMonitorTest extends SimpleHttp {
 
         System.out.println(endpointList.getBody());
 
-        Assert.assertTrue(endpointList.getBody().contains("/health/webcontext/app/health-secure") );
+        Assert.assertTrue(endpointList.getBody().contains("/health/rest/v1/monitor/health-secure") );
 
         // verify direct access to secure resources
-        Response response = getUrlContents("http://localhost:8080/webcontext/app/health-secure"); // 403
+        Response response = getUrlContents("http://localhost:8080/rest/v1/monitor/health-secure"); // 403
 
         Assert.assertTrue("Expected 403 when directly accessing secured health endpoint", response.getStatus() == 403);
 
         // verify indirect access to secure resources
-        response = getUrlContents("http://localhost:8080/health/webcontext/app/health-secure");
+        response = getUrlContents("http://localhost:8080/health/rest/v1/monitor/health-secure");
 
         Assert.assertTrue(response.getBody(). contains("UP") );
 
         // verify indirect access, without auth, to secure resources
-        response = getUrlContents("http://localhost:8080/health/webcontext/app/health-secure", false);
+        response = getUrlContents("http://localhost:8080/health/rest/v1/monitor/health-secure", false);
         Assert.assertEquals(401, response.getStatus());
 
         // verify direct access to insecure resources
-        response = getUrlContents("http://localhost:8080/webcontext/app/health-insecure");
+        response = getUrlContents("http://localhost:8080/rest/v1/monitor/health-insecure");
         Assert.assertTrue(response.getBody(). contains("UP") );
 
         // verify indirect access, without auth, to insecure resources
-        response = getUrlContents("http://localhost:8080/health/webcontext/app/health-insecure", false);
+        response = getUrlContents("http://localhost:8080/health/rest/v1/monitor/health-insecure", false);
 
         Assert.assertEquals(200, response.getStatus());
 
         // verify indirect access to insecure resources
-        response = getUrlContents("http://localhost:8080/health/webcontext/app/health-insecure");
+        response = getUrlContents("http://localhost:8080/health/rest/v1/monitor/health-insecure");
         Assert.assertTrue(response.getBody(). contains("UP") );
 
         // verify other resources remain untouched
-        response = getUrlContents("http://localhost:8080/webcontext/another-app/time");
+        response = getUrlContents("http://localhost:8080/rest/v1/another-app/time");
 
         Assert.assertTrue(response.getBody(). contains("Time") );
 

--- a/testsuite/testsuite-jaxrs/src/test/java/org/wildfly/swarm/jaxrs/JAXRSArquillianTest.java
+++ b/testsuite/testsuite-jaxrs/src/test/java/org/wildfly/swarm/jaxrs/JAXRSArquillianTest.java
@@ -43,6 +43,7 @@ public class JAXRSArquillianTest {
         deployment.addClass(HealthCheckResource.class);
         deployment.addClass(CustomJsonProvider.class);
         deployment.addClass(MyResource.class);
+        deployment.setContextRoot("rest");
         deployment.addAllDependencies();
         return deployment;
     }
@@ -55,14 +56,14 @@ public class JAXRSArquillianTest {
     @Test
     @RunAsClient
     public void testResource() {
-        browser.navigate().to("http://localhost:8080/health/app/health-secure");
+        browser.navigate().to("http://localhost:8080/health/rest/monitor/health-secure");
         assertThat(browser.getPageSource()).contains("UP");
     }
 
     @RunAsClient
     @Test
     public void testSimple() throws IOException {
-        browser.navigate().to("http://localhost:8080");
+        browser.navigate().to("http://localhost:8080/rest");
         assertThat(browser.getPageSource()).contains("Howdy at ");
     }
 


### PR DESCRIPTION
## Motivation

Setting a jboss-web context root like `deployment.setContextRoot(“rest”); is not working with health resources. The resulting /health URL we exposes ignores the jboss-web defined context and thus leads to a 404.
## Modifications

Update the parsing algo to support `jboss-web` defined context roots in addition to `@ApplicationPath` and `@Path` meta-data.
## Result

You can now rely on arbitrary combination of jboss-web,  @ApplicationPath and @Path meta-data to define the entry point to your health check resources.
