### PR TITLE
SWARM-633: Arquillian container not in `bom` artifact

### DIFF
--- a/arquillian/api/pom.xml
+++ b/arquillian/api/pom.xml
@@ -23,7 +23,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <swarm.fraction.stability>unstable</swarm.fraction.stability>
+    <swarm.fraction.stability>stable</swarm.fraction.stability>
     <swarm.fraction.tags>Testing</swarm.fraction.tags>
   </properties>
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

Currently the Arquillian container is only available in `bom-all` as its marked unstable.
This prevents anyone that only wants to stable components using `bom` to use Arquillian for testing.
## Modifications

Mark Arquillian container as `stable`
## Result

Moves Arquillian container from `bom-all` only to `bom` as well
