### PR TITLE
SWARM-571: Arquillian does not include src/main/resource/modules

### DIFF
--- a/arquillian/api/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
+++ b/arquillian/api/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
@@ -130,7 +130,15 @@ public class UberjarSimpleContainer implements SimpleContainer {
                 .fractionDetectionMode(BuildTool.FractionDetectionMode.never)
                 .bundleDependencies(false);
 
-        final String additionalModules = System.getProperty(SwarmInternalProperties.BUILD_MODULES);
+        String additionalModules = System.getProperty(SwarmInternalProperties.BUILD_MODULES);
+
+        // See https://issues.jboss.org/browse/SWARM-571
+        if(null==additionalModules) {
+            // see if we can find it
+            File modulesDir = new File("target/classes/modules");
+            additionalModules = modulesDir.exists() ? modulesDir.getAbsolutePath() : null;
+        }
+
         if (additionalModules != null) {
             tool.additionalModules(Stream.of(additionalModules.split(":"))
                                            .map(File::new)

--- a/arquillian/test/pom.xml
+++ b/arquillian/test/pom.xml
@@ -44,6 +44,7 @@
     </plugins>
   </build>
 
+
   <dependencies>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>

--- a/testsuite/testsuite-datasources/pom.xml
+++ b/testsuite/testsuite-datasources/pom.xml
@@ -22,6 +22,19 @@
 
   <packaging>jar</packaging>
 
+  <properties>
+    <version.h2>1.4.187</version.h2>
+  </properties>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
@@ -36,6 +49,12 @@
     <dependency>
       <groupId>org.jboss.arquillian.junit</groupId>
       <artifactId>arquillian-junit-container</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>jaxrs</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/testsuite/testsuite-datasources/src/main/resources/modules/com/h2database/h2/main/module.xml
+++ b/testsuite/testsuite-datasources/src/main/resources/modules/com/h2database/h2/main/module.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<module xmlns="urn:jboss:module:1.3" name="com.h2database.h2">
+
+  <resources>
+    <artifact name="com.h2database:h2:${version.h2}"/>
+  </resources>
+  <dependencies>
+    <module name="javax.api"/>
+    <module name="javax.transaction.api"/>
+    <module name="javax.servlet.api" optional="true"/>
+  </dependencies>
+</module>

--- a/testsuite/testsuite-datasources/src/test/java/org/wildfly/swarm/datasources/ArquillianModulesTest.java
+++ b/testsuite/testsuite-datasources/src/test/java/org/wildfly/swarm/datasources/ArquillianModulesTest.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.datasources;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.arquillian.CreateSwarm;
+import org.wildfly.swarm.jaxrs.JAXRSArchive;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Heiko Braun
+ */
+@RunWith(Arquillian.class)
+public class ArquillianModulesTest {
+
+    @Deployment(testable = false)
+    public static Archive createDeployment() {
+        JAXRSArchive appDeployment = ShrinkWrap.create(JAXRSArchive.class);
+        appDeployment.addResource(MyResource.class);
+        appDeployment.addModule("com.h2database.h2");
+        return appDeployment;
+    }
+
+    @CreateSwarm
+    public static Swarm newContainer() throws Exception {
+        Swarm swarm = new Swarm();
+
+        swarm.fraction(
+                new DatasourcesFraction()
+                        .jdbcDriver("h2", (d) -> {
+                            d.driverClassName("org.h2.Driver");
+                            d.xaDatasourceClass("org.h2.jdbcx.JdbcDataSource");
+                            d.driverModuleName("com.h2database.h2");
+                        })
+                        .dataSource("ExampleDS", (ds) -> {
+                            ds.driverName("h2");
+                            ds.connectionUrl("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE");
+                            ds.userName("sa");
+                            ds.password("sa");
+                        })
+        );
+
+        return swarm;
+    }
+
+    @Test
+    @RunAsClient
+    public void testDatasource() {
+        String response = getUrlContents("http://localhost:8080/");
+        assertThat(response).contains("Howdy using connection: org.jboss.jca.adapters.jdbc.jdk7.WrappedConnectionJDK7" );
+    }
+
+    private static String getUrlContents(String theUrl) {
+        StringBuilder content = new StringBuilder();
+
+        try {
+            URL url = new URL(theUrl);
+            URLConnection urlConnection = url.openConnection();
+            BufferedReader bufferedReader = new BufferedReader(
+                    new InputStreamReader(urlConnection.getInputStream())
+            );
+
+            String line;
+
+            while ((line = bufferedReader.readLine()) != null) {
+                content.append(line + "\n");
+            }
+            bufferedReader.close();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        return content.toString();
+    }
+}

--- a/testsuite/testsuite-datasources/src/test/java/org/wildfly/swarm/datasources/MyResource.java
+++ b/testsuite/testsuite-datasources/src/test/java/org/wildfly/swarm/datasources/MyResource.java
@@ -1,0 +1,32 @@
+package org.wildfly.swarm.datasources;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.sql.DataSource;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+/**
+ * @author Bob McWhirter
+ */
+@Path("/")
+public class MyResource {
+
+    @GET
+    @Produces("text/plain")
+    public String get() throws NamingException, SQLException {
+        Context ctx = new InitialContext();
+        DataSource ds = (DataSource) ctx.lookup("jboss/datasources/ExampleDS");
+        Connection conn = ds.getConnection();
+        try {
+            return "Howdy using connection: " + conn;
+        } finally {
+            conn.close();
+        }
+    }
+}


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

module.xml has not been discovered in arquillian tests so the build tool didn't package additonal module automatically.
## Modifications

Change the UberjarSimpleContainer to attempt an auto detection if an external reference to "swarm.build.modules" is not given"
## Result

modules declared in src/main/resources will now be automatically packaged into the uberJar created for the arq test execution.
