### PR TITLE
SWARM-628: Introduce configuration to generate self-signed certificate

### DIFF
--- a/container/src/main/java/org/wildfly/swarm/internal/SwarmMessages.java
+++ b/container/src/main/java/org/wildfly/swarm/internal/SwarmMessages.java
@@ -152,4 +152,7 @@ public interface SwarmMessages extends BasicLogger {
     @LogMessage(level = Logger.Level.DEBUG)
     @Message(id = 32, value = "Load standalone.xml via %s from %s")
     void loadingStandaloneXml(String loader, String location);
+
+    @Message(id = 33, value = "HTTP/S is configured correctly, but org.wildfly.swarm:management is not available")
+    RuntimeException httpsRequiresManagementFraction();
 }

--- a/spi/src/main/java/org/wildfly/swarm/spi/api/SwarmProperties.java
+++ b/spi/src/main/java/org/wildfly/swarm/spi/api/SwarmProperties.java
@@ -58,6 +58,17 @@ public interface SwarmProperties {
     String HTTPS_PORT = "swarm.https.port";
 
     /**
+     * If true, generates a self-signed certificate for development purposes
+     */
+    String HTTPS_GENERATE_SELF_SIGNED_CERTIFICATE = "swarm.https.certificate.generate";
+
+    /**
+     * The host used in the self-signed certificate if {@link SwarmProperties#HTTPS_GENERATE_SELF_SIGNED_CERTIFICATE} is true
+     * Defaults to localhost
+     */
+    String HTTPS_GENERATE_SELF_SIGNED_CERTIFICATE_HOST = "swarm.https.certificate.generate.host";
+
+    /**
      * The context path to be used, defaults to /
      */
     String CONTEXT_PATH = "swarm.context.path";

--- a/testsuite/testsuite-undertow/pom.xml
+++ b/testsuite/testsuite-undertow/pom.xml
@@ -29,6 +29,10 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>management</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>arquillian</artifactId>
       <scope>test</scope>
     </dependency>

--- a/testsuite/testsuite-undertow/src/test/java/org/wildfly/swarm/undertow/HTTPSCustomizerSelfSignedCertificateTest.java
+++ b/testsuite/testsuite-undertow/src/test/java/org/wildfly/swarm/undertow/HTTPSCustomizerSelfSignedCertificateTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.undertow;
+
+import java.net.URL;
+
+import javax.net.ssl.SSLHandshakeException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.arquillian.CreateSwarm;
+import org.wildfly.swarm.management.ManagementFraction;
+import org.wildfly.swarm.spi.api.SwarmProperties;
+
+/**
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+@RunWith(Arquillian.class)
+public class HTTPSCustomizerSelfSignedCertificateTest {
+
+    @Deployment(testable = false)
+    public static Archive createDeployment() {
+        return ShrinkWrap.create(WARArchive.class, "test.war")
+                .add(EmptyAsset.INSTANCE, "index.html");
+    }
+
+    @CreateSwarm
+    public static Swarm newSwarm() throws Exception {
+        System.setProperty(SwarmProperties.HTTPS_GENERATE_SELF_SIGNED_CERTIFICATE, "true");
+        return new Swarm()
+                .fraction(UndertowFraction.createDefaultFraction())
+                .fraction(ManagementFraction.createDefaultFraction());
+    }
+
+    @Test(expected = SSLHandshakeException.class)
+    @RunAsClient
+    public void testHTTPSIsEnabledWhenSelfSignedCertificateIsSet() throws Exception {
+        new URL("https://localhost:8443").openStream().close();
+    }
+
+}

--- a/undertow/src/main/java/org/wildfly/swarm/undertow/UndertowFraction.java
+++ b/undertow/src/main/java/org/wildfly/swarm/undertow/UndertowFraction.java
@@ -144,8 +144,26 @@ public class UndertowFraction extends Undertow<UndertowFraction> implements Frac
      * @return This fraction.
      */
     public UndertowFraction enableHTTPS(String path, String password, String alias) {
+        return enableHTTPS(path, password, password, alias);
+    }
+
+    /**
+     * Enable HTTPS on this fraction.
+     *
+     * <p>This will enable HTTPS of the fraction. The application also
+     * <b>must</b> include the <code>management</code> fraction in its
+     * dependencies.</p>
+     *
+     * @param path             The keystore path.
+     * @param keystorePassword The keystore password.
+     * @param keyPassword      The key password inside the keystore.
+     * @param alias            The server certificate alias.
+     * @return This fraction.
+     */
+    public UndertowFraction enableHTTPS(String path, String keystorePassword, String keyPassword, String alias) {
         this.keystorePath = path;
-        this.keystorePassword = password;
+        this.keystorePassword = keystorePassword;
+        this.keyPassword = keyPassword;
         this.alias = alias;
         return this;
     }
@@ -162,6 +180,10 @@ public class UndertowFraction extends Undertow<UndertowFraction> implements Frac
 
     public String keystorePassword() {
         return this.keystorePassword;
+    }
+
+    public String keyPassword() {
+        return this.keyPassword;
     }
 
     public String keystorePath() {
@@ -213,6 +235,11 @@ public class UndertowFraction extends Undertow<UndertowFraction> implements Frac
      * Password for the keystore.
      */
     private String keystorePassword;
+
+    /**
+     * Password for the key.
+     */
+    private String keyPassword;
 
     /**
      * Server certificate alias.

--- a/undertow/src/main/java/org/wildfly/swarm/undertow/descriptors/CertInfo.java
+++ b/undertow/src/main/java/org/wildfly/swarm/undertow/descriptors/CertInfo.java
@@ -1,0 +1,69 @@
+package org.wildfly.swarm.undertow.descriptors;
+
+/**
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+public class CertInfo {
+
+    public static final CertInfo INVALID = new CertInfo(null, null, null, null);
+
+    public String keystorePath() {
+        return keystorePath;
+    }
+
+    public String keystorePassword() {
+        return keystorePassword;
+    }
+
+    public String keyPassword() {
+        return keyPassword;
+    }
+
+    public String keystoreAlias() {
+        return keystoreAlias;
+    }
+
+    public String generateSelfSignedCertificateHost() {
+        return generateSelfSignedCertificateHost;
+    }
+
+    public String keystoreRelativeTo() {
+        return keystoreRelativeTo;
+    }
+
+    public CertInfo(String keystorePath, String keystorePassword, String keyPassword, String keystoreAlias) {
+        this.keystorePath = keystorePath;
+        this.keystorePassword = keystorePassword;
+        this.keyPassword = keyPassword;
+        this.keystoreAlias = keystoreAlias;
+        this.generateSelfSignedCertificateHost = null;
+        this.keystoreRelativeTo = null;
+    }
+
+    public CertInfo(String generateSelfSignedCertificateHost, String keystoreRelativeTo) {
+        this.keystorePath = "application.keystore";
+        this.keystorePassword = "password";
+        this.keystoreAlias = "server";
+        this.keyPassword = "password";
+
+        this.generateSelfSignedCertificateHost = generateSelfSignedCertificateHost == null ? "localhost" : generateSelfSignedCertificateHost;
+        this.keystoreRelativeTo = keystoreRelativeTo;
+    }
+
+    private final String keystorePath;
+
+    private final String keystorePassword;
+
+    private final String keyPassword;
+
+    private final String keystoreAlias;
+
+    private final String keystoreRelativeTo;
+
+    private final String generateSelfSignedCertificateHost;
+
+
+    public boolean isValid() {
+        return ((keystorePath != null && keystorePassword != null && keystoreAlias != null) || generateSelfSignedCertificateHost != null);
+    }
+}

--- a/undertow/src/main/java/org/wildfly/swarm/undertow/runtime/CertInfoProducer.java
+++ b/undertow/src/main/java/org/wildfly/swarm/undertow/runtime/CertInfoProducer.java
@@ -1,0 +1,64 @@
+package org.wildfly.swarm.undertow.runtime;
+
+import java.io.File;
+import java.io.IOException;
+
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.wildfly.swarm.bootstrap.util.TempFileManager;
+import org.wildfly.swarm.spi.api.SwarmProperties;
+import org.wildfly.swarm.spi.runtime.annotations.ConfigurationValue;
+import org.wildfly.swarm.undertow.UndertowFraction;
+import org.wildfly.swarm.undertow.descriptors.CertInfo;
+
+/**
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+public class CertInfoProducer {
+
+    @Inject
+    @Any
+    private Instance<UndertowFraction> undertowInstance;
+
+    @Inject
+    @ConfigurationValue(SwarmProperties.HTTPS_GENERATE_SELF_SIGNED_CERTIFICATE)
+    private Boolean generateSelfCertificate;
+
+    @Inject
+    @ConfigurationValue(SwarmProperties.HTTPS_GENERATE_SELF_SIGNED_CERTIFICATE_HOST)
+    private String selfCertificateHost;
+
+    @Produces
+    @Singleton
+    public CertInfo produceCertInfo() {
+        if (undertowInstance.isUnsatisfied()) {
+            return CertInfo.INVALID;
+        }
+        UndertowFraction undertowFraction = undertowInstance.get();
+
+        if (generateSelfCertificate != null && generateSelfCertificate) {
+            // Remove when SWARM-634 is fixed
+            if (System.getProperty("jboss.server.data.dir") == null) {
+                File tmpDir = null;
+                try {
+                    tmpDir = TempFileManager.INSTANCE.newTempDirectory("wildfly-swarm-data", ".d");
+                    System.setProperty("jboss.server.data.dir", tmpDir.getAbsolutePath());
+                } catch (IOException e) {
+                    // Ignore
+                }
+            }
+            return new CertInfo(selfCertificateHost, "jboss.server.data.dir");
+
+        } else {
+            String keystorePath = undertowFraction.keystorePath();
+            String keystorePassword = undertowFraction.keystorePassword();
+            String keyPassword = undertowFraction.keyPassword();
+            String keystoreAlias = undertowFraction.alias();
+            return new CertInfo(keystorePath, keystorePassword, keyPassword, keystoreAlias);
+        }
+    }
+}


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

This is more focused on quick-enabling HTTP/s for development purposes.
HTTP/2 support was introduced in SWARM-619 and is only enabled on HTTP/s listeners.
## Modifications

Introduced two new configuration options: `swarm.https.certificate.generate` and `swarm.https.certificate.generate.host`
## Result

When the new configuration option is set, it will generate a self-signed certificate and enable HTTP/s
for development and testing out-of-the-box
