### PR TITLE
SWARM-615: CDI.current() fails to find provider

### DIFF
--- a/container/src/main/resources/modules/javax/enterprise/api/main/module.xml
+++ b/container/src/main/resources/modules/javax/enterprise/api/main/module.xml
@@ -11,6 +11,7 @@
     <module name="javax.interceptor.api" export="true"/>
 
     <!-- CDIProvider -->
+    <module name="org.jboss.as.weld" services="import" optional="true"/>
     <module name="org.jboss.weld.core" optional="true"/>
   </dependencies>
 </module>

--- a/testsuite/testsuite-cdi/src/test/java/org/wildfly/swarm/cdi/CDIArquillianTest.java
+++ b/testsuite/testsuite-cdi/src/test/java/org/wildfly/swarm/cdi/CDIArquillianTest.java
@@ -15,6 +15,7 @@
  */
 package org.wildfly.swarm.cdi;
 
+import javax.enterprise.inject.spi.CDI;
 import javax.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -53,8 +54,12 @@ public class CDIArquillianTest {
     private Cheddar cheddar;
 
     @Test
-    public void testNothing() {
-        assertNotNull( cheddar );
+    public void testInjection() {
+        assertNotNull(cheddar);
     }
 
+    @Test
+    public void testCDIContainerPresence() throws Exception {
+        assertNotNull(CDI.current());
+    }
 }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

Being able to access CDI.current() is critical for some use cases and this behavior is a regression from 1.0.0.Final to 2016.8
## Modifications

Add weld subsystem as an optional dependency to javax.enterprise.api module so that when user application uses CDI that module will be present and CDI.current() set.

Also added a test to verify its presence so that we don't get a regression
## Result

CDI.current() is available in a user application that uses CDI.
