### PR TITLE
SWARM-640: Upgrade to ShrinkWrap Resolver 2.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
     <version.org.jboss.arquillian.drone>2.0.0.Alpha4</version.org.jboss.arquillian.drone>
     <version.org.arquillian.graphene>2.1.0.CR2</version.org.arquillian.graphene>
     <version.org.jboss.shrinkwrap.descriptors>2.0.0-alpha-9</version.org.jboss.shrinkwrap.descriptors>
+    <version.org.jboss.shrinkwrap.resolver>2.2.3</version.org.jboss.shrinkwrap.resolver>
     <version.org.objectweb.asm>5.0.4</version.org.objectweb.asm>
     <version.fest-assert>1.4</version.fest-assert>
     <version.junit>4.12</version.junit>
@@ -972,6 +973,15 @@
         <version>${version.wildfly}</version>
         <type>zip</type>
         <scope>provided</scope>
+      </dependency>
+
+      <!-- ShrinkWrap Resolver -->
+      <dependency>
+        <groupId>org.jboss.shrinkwrap.resolver</groupId>
+        <artifactId>shrinkwrap-resolver-bom</artifactId>
+        <version>${version.org.jboss.shrinkwrap.resolver}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

While building PRs, the CI server throws a FileNotFoundException while reading the settings-security.xml file,
which is placed inside the private repository and is not mounted for security reasons
## Modifications

The Shrinkwrap Resolver BOM is added to the parent pom BEFORE the arquillian-bom, as it will take precedence when resolving the resolver version.
## Result

The ShrinkWrap Resolver 2.2.3 is used
