### PR TITLE
We shouldn't deploy testsuite-* artifacts.

### DIFF
--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -38,6 +38,13 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
       </plugin>
       <plugin>


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

The testsuite is just for testing, locally.  We already don't
install into the local repository, so we also shouldn't deploy
them into the remote repository.
## Modifications

Added skip=true to the testsuite parent pom, for the maven-deploy-plugin.
## Result

Hopefuly we don't deploy testsuite artifacts to sonatype/central.
