### PR TITLE
SWARM-562 - Improve fraction.tags for Camel bits.

### DIFF
--- a/camel/components/cdi/pom.xml
+++ b/camel/components/cdi/pom.xml
@@ -34,7 +34,7 @@
   <artifactId>camel-cdi</artifactId>
 
   <properties>
-    <swarm.fraction.tags>Camel</swarm.fraction.tags>
+    <swarm.fraction.tags>Camel,Integration,EIP,CDI</swarm.fraction.tags>
   </properties>
 
   <dependencies>

--- a/camel/components/cxf/pom.xml
+++ b/camel/components/cxf/pom.xml
@@ -34,7 +34,7 @@
   <artifactId>camel-cxf</artifactId>
 
   <properties>
-    <swarm.fraction.tags>Camel</swarm.fraction.tags>
+    <swarm.fraction.tags>Camel,Integration,EIP,WebServices</swarm.fraction.tags>
   </properties>
 
   <dependencies>

--- a/camel/components/ejb/pom.xml
+++ b/camel/components/ejb/pom.xml
@@ -34,7 +34,7 @@
   <artifactId>camel-ejb</artifactId>
 
   <properties>
-    <swarm.fraction.tags>Camel</swarm.fraction.tags>
+    <swarm.fraction.tags>Camel,Integration,EIP,EJB</swarm.fraction.tags>
   </properties>
 
   <dependencies>

--- a/camel/components/jaxb/pom.xml
+++ b/camel/components/jaxb/pom.xml
@@ -34,7 +34,7 @@
   <artifactId>camel-jaxb</artifactId>
 
   <properties>
-    <swarm.fraction.tags>Camel</swarm.fraction.tags>
+    <swarm.fraction.tags>Camel,Integration,EIP,JAXB</swarm.fraction.tags>
   </properties>
 
 

--- a/camel/components/jms/pom.xml
+++ b/camel/components/jms/pom.xml
@@ -34,7 +34,7 @@
   <artifactId>camel-jms</artifactId>
 
   <properties>
-    <swarm.fraction.tags>Camel</swarm.fraction.tags>
+    <swarm.fraction.tags>Camel,Integration,EIP,JMS</swarm.fraction.tags>
   </properties>
 
 

--- a/camel/components/jmx/pom.xml
+++ b/camel/components/jmx/pom.xml
@@ -34,7 +34,7 @@
   <artifactId>camel-jmx</artifactId>
 
   <properties>
-    <swarm.fraction.tags>Camel</swarm.fraction.tags>
+    <swarm.fraction.tags>Camel,Integration,EIP,JMX</swarm.fraction.tags>
   </properties>
 
 

--- a/camel/components/jpa/pom.xml
+++ b/camel/components/jpa/pom.xml
@@ -34,7 +34,7 @@
   <artifactId>camel-jpa</artifactId>
 
   <properties>
-    <swarm.fraction.tags>Camel</swarm.fraction.tags>
+    <swarm.fraction.tags>Camel,Integration,EIP,JPA</swarm.fraction.tags>
   </properties>
 
 

--- a/camel/components/mail/pom.xml
+++ b/camel/components/mail/pom.xml
@@ -34,7 +34,7 @@
   <artifactId>camel-mail</artifactId>
 
   <properties>
-    <swarm.fraction.tags>Camel</swarm.fraction.tags>
+    <swarm.fraction.tags>Camel,Integration,EIP,Mail</swarm.fraction.tags>
   </properties>
 
 

--- a/camel/components/other/pom.xml
+++ b/camel/components/other/pom.xml
@@ -34,7 +34,7 @@
   <artifactId>camel-other</artifactId>
 
   <properties>
-    <swarm.fraction.tags>Camel</swarm.fraction.tags>
+    <swarm.fraction.tags>Camel,Integration,EIP</swarm.fraction.tags>
   </properties>
 
 

--- a/camel/components/undertow/pom.xml
+++ b/camel/components/undertow/pom.xml
@@ -34,7 +34,7 @@
   <artifactId>camel-undertow</artifactId>
 
   <properties>
-    <swarm.fraction.tags>Camel</swarm.fraction.tags>
+    <swarm.fraction.tags>Camel,Integration,EIP,Undertow,Servlet</swarm.fraction.tags>
   </properties>
 
 

--- a/camel/core/main/pom.xml
+++ b/camel/core/main/pom.xml
@@ -34,7 +34,7 @@
     <artifactId>camel-core</artifactId>
 
   <properties>
-    <swarm.fraction.tags>Camel</swarm.fraction.tags>
+    <swarm.fraction.tags>Camel,Integration,EIP</swarm.fraction.tags>
   </properties>
 
     <dependencies>


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

In order to make the online generator more useful, having
appropriate tags on the Camel fractions would be good.
## Modifications

Added a variety of tags to the Camel componentry.
## Result

Camel fractions should appear in more search terms now.
