### PR TITLE
SWARM-582: Webservices fraction should bundle org.jboss.ws.saaj-impl

### DIFF
--- a/webservices/module.conf
+++ b/webservices/module.conf
@@ -1,3 +1,4 @@
 org.jboss.ws.cxf.jbossws-cxf-server
 org.jboss.ws.cxf.jbossws-cxf-client
 org.jboss.ws.cxf.jbossws-cxf-transports-undertow
+org.jboss.ws.saaj-impl


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

While having an EJB invoking an external SOAP service, the following exception is thrown:

org.jboss.modules.ModuleNotFoundException: org.jboss.ws.saaj-impl:main
## Modifications

Added org.jboss.ws.saaj-impl:main module to webservices/module.conf
## Result

Module org.jboss.ws.saaj-impl is now available when the webservices fraction is used
