### PR TITLE
SWARM-644: H2 Fraction stability level = stable

### DIFF
--- a/databases/h2/pom.xml
+++ b/databases/h2/pom.xml
@@ -16,6 +16,7 @@
   <description>H2 driver and datasource</description>
 
   <properties>
+    <swarm.fraction.stability>stable</swarm.fraction.stability>
     <swarm.fraction.tags>Data,H2</swarm.fraction.tags>
   </properties>
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

A Fraction should be considered stable if it depends on another stable fractions too. JPA Fraction is already stable and depends on H2 by default.
Marking as stable eliminates warnings during boot time.
## Modifications

Added swarm.fraction.stability = stable in pom.xml
## Result

Fraction is displayed as stable during boot time and in the generator
