### PR TITLE
SWARM-575 - stateless-ejb javaee7 sample doesn't work

### DIFF
--- a/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/GradleArtifactResolvingHelper.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/GradleArtifactResolvingHelper.java
@@ -82,14 +82,14 @@ public class GradleArtifactResolvingHelper implements ArtifactResolvingHelper {
     }
 
     @Override
-    public Set<ArtifactSpec> resolveAll(final Set<ArtifactSpec> specs) throws Exception {
+    public Set<ArtifactSpec> resolveAll(final Set<ArtifactSpec> specs, boolean transitive) throws Exception {
         if (specs.isEmpty()) {
             return specs;
         }
 
         final Set<ArtifactSpec> resolvedSpecs = new HashSet<>();
 
-        doResolve(specs, true).forEach(dep -> dep.getModuleArtifacts()
+        doResolve(specs, transitive).forEach(dep -> dep.getModuleArtifacts()
                 .forEach(artifact -> resolvedSpecs
                         .add(new ArtifactSpec(dep.getConfiguration(),
                                 dep.getModuleGroup(),

--- a/tools/src/main/java/org/wildfly/swarm/tools/ArtifactResolvingHelper.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/ArtifactResolvingHelper.java
@@ -30,5 +30,9 @@ public interface ArtifactResolvingHelper {
      */
     ArtifactSpec resolve(ArtifactSpec spec) throws Exception;
 
-    Set<ArtifactSpec> resolveAll(Set<ArtifactSpec> specs) throws Exception;
+    default Set<ArtifactSpec> resolveAll(Set<ArtifactSpec> specs) throws Exception {
+        return resolveAll( specs, true );
+    }
+
+    Set<ArtifactSpec> resolveAll(Set<ArtifactSpec> specs, boolean transitive) throws Exception;
 }

--- a/tools/src/main/java/org/wildfly/swarm/tools/DependencyManager.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/DependencyManager.java
@@ -147,17 +147,17 @@ public class DependencyManager {
             dependencies.add(dependency);
         }
 
-        resolveAllArtifacts(dependencies);
+        resolveAllArtifactsNonTransitively(dependencies);
         for (ArtifactSpec dependency : dependencies) {
             addArtifactToArchiveMavenRepository(archive, dependency);
         }
     }
 
     public void populateUserMavenRepository() throws Exception {
-        resolveAllArtifacts(this.dependencies);
-        for (ArtifactSpec each : this.moduleDependencies) {
-            resolveArtifact(each);
-        }
+        Set<ArtifactSpec> dependencies = new HashSet<>();
+        dependencies.addAll( this.dependencies );
+        dependencies.addAll( this.moduleDependencies );
+        resolveAllArtifactsNonTransitively( dependencies );
     }
 
     public void addArtifactToArchiveMavenRepository(Archive archive, ArtifactSpec artifact) throws Exception {
@@ -199,7 +199,7 @@ public class DependencyManager {
     }
 
     protected void analyzeDependencies(boolean autodetect) throws Exception {
-        Set<ArtifactSpec> allResolvedDependencies = resolveAllArtifacts(this.explicitDependencies);
+        Set<ArtifactSpec> allResolvedDependencies = resolveAllArtifactsTransitively(this.explicitDependencies);
 
         /*
         for (ArtifactSpec each : allResolvedDependencies) {
@@ -269,7 +269,7 @@ public class DependencyManager {
 
         // re-resolve the application's dependencies minus
         // any of our swarm dependencies
-        Set<ArtifactSpec> simplifiedDeps = resolveAllArtifacts(nonBootstrapDeps);
+        Set<ArtifactSpec> simplifiedDeps = resolveAllArtifactsTransitively(nonBootstrapDeps);
 
         /*
         for (ArtifactSpec each : simplifiedDeps) {
@@ -431,8 +431,12 @@ public class DependencyManager {
         return spec;
     }
 
-    protected Set<ArtifactSpec> resolveAllArtifacts(Set<ArtifactSpec> specs) throws Exception {
+    protected Set<ArtifactSpec> resolveAllArtifactsTransitively(Set<ArtifactSpec> specs) throws Exception {
         return this.resolver.resolveAll(specs);
+    }
+
+    protected Set<ArtifactSpec> resolveAllArtifactsNonTransitively(Set<ArtifactSpec> specs) throws Exception {
+        return this.resolver.resolveAll(specs, false);
     }
 
     private final WildFlySwarmManifest applicationManifest = new WildFlySwarmManifest();

--- a/tools/src/test/java/org/wildfly/swarm/tools/MockArtifactResolver.java
+++ b/tools/src/test/java/org/wildfly/swarm/tools/MockArtifactResolver.java
@@ -72,11 +72,13 @@ public class MockArtifactResolver implements ArtifactResolvingHelper {
     }
 
     @Override
-    public Set<ArtifactSpec> resolveAll(Set<ArtifactSpec> specs) throws Exception {
+    public Set<ArtifactSpec> resolveAll(Set<ArtifactSpec> specs, boolean transitive) throws Exception {
         Set<ArtifactSpec> resolved = new HashSet<>();
         for (ArtifactSpec spec : specs) {
             resolved.add(resolve(spec));
-            resolved.addAll( resolveAll( this.entries.get( spec ).getDependencies() ) );
+            if ( transitive ) {
+                resolved.addAll(resolveAll(this.entries.get(spec).getDependencies()));
+            }
         }
         return resolved;
     }


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

When trying to apply swarmtool commandline tool to the
stateless-ejb example, it would fail, being unable to
resolve the jta-1.0.1B artifact.  Meanwhile, the plugin
would successfully build the -swarm.jar.  Both modes
of turning a .war into a -swarm.jar should work the
same, so having a difference is bad.
## Modifications

The jta-1.0.1B artifact was a symptom of a larger problem.
We were asking our ResolvingHelpers (maven, gradle and shrinkwrap)
to _transitively_ resolve all the dependencies that BuildTool
figured we needed.  Which was gratuitous and ignored the fact
that the dependencies between module.xml are already handled and
solved, and did not require an additional transitive resolution
step.

Therefore, I added an additional helper.resolveAll(deps, boolean isTransitive)
that allows us to disable transitive resolution when provided with a
list of dependencies to resolve.

By default, the single-arg helper.resolveAll(deps) does work
transitively, still. The interface provides a default implementation
that calls resolveAll(deps, true) to provide the existing, legacy
behaviour of the single-parameter version.

In BuildTool's populateWhateverRepository() methods, we now
take our already-solved list of dependencies, and call resolveAll(deps, false)
to simply ensure that they are present on disk, in the uberjar
or in the user's local M2REPO.
## Result

SwarmTool now can be applied to the stateless-ejb example without
throwing a DependencyResolutionException on jta-1.0.1B.
