### PR TITLE
SWARM-654: Hollow jars are not recognized, not deploying

### DIFF
--- a/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/Main.java
+++ b/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/Main.java
@@ -33,8 +33,6 @@ import org.wildfly.swarm.bootstrap.util.BootstrapProperties;
  */
 public class Main {
 
-    public static final String DEFAULT_MAIN_CLASS_NAME = "org.wildfly.swarm.Swarm";
-
     public Main(String... args) throws Throwable {
         this.args = args;
     }

--- a/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/WildFlySwarmManifest.java
+++ b/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/WildFlySwarmManifest.java
@@ -149,7 +149,9 @@ public class WildFlySwarmManifest {
     }
 
     public void setAsset(String asset) {
-        this.asset = asset;
+        if (!this.isHollow()) {
+            this.asset = asset;
+        }
     }
 
     public String getAsset() {
@@ -187,6 +189,10 @@ public class WildFlySwarmManifest {
 
     public void setHollow(boolean hollow) {
         this.hollow = hollow;
+
+        if (this.isHollow()) {
+            this.asset = null;
+        }
     }
 
     public boolean isHollow() {

--- a/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -56,6 +56,7 @@ import org.jboss.shrinkwrap.impl.base.importer.ExplodedImporterImpl;
 import org.jboss.shrinkwrap.impl.base.importer.zip.ZipImporterImpl;
 import org.jboss.shrinkwrap.impl.base.spec.JavaArchiveImpl;
 import org.jboss.shrinkwrap.impl.base.spec.WebArchiveImpl;
+import org.wildfly.swarm.bootstrap.env.ApplicationEnvironment;
 import org.wildfly.swarm.bootstrap.logging.BootstrapLogger;
 import org.wildfly.swarm.bootstrap.modules.BootModuleLoader;
 import org.wildfly.swarm.bootstrap.util.BootstrapProperties;
@@ -387,15 +388,15 @@ public class Swarm {
             throw SwarmMessages.MESSAGES.containerNotStarted("deploy()");
         }
 
-        if (System.getProperty("swarm.hollow") == null) {
-            this.server.deployer().deploy();
-        } else {
+        if (ApplicationEnvironment.get().isHollow()) {
             this.server.deployer().deploy(
                     getCommandLine().extraArguments()
                             .stream()
                             .map(e -> Paths.get(e))
                             .collect(Collectors.toList())
             );
+        } else {
+            this.server.deployer().deploy();
         }
         return this;
     }

--- a/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
@@ -88,7 +88,7 @@ public class BuildTool {
     public BuildTool projectArtifact(String groupId, String artifactId, String version,
                                      String packaging, File file, String artifactName) {
         this.projectAsset = new ArtifactAsset(new ArtifactSpec(null, groupId, artifactId, version, packaging, null, file),
-                artifactName);
+                                              artifactName);
         this.dependencyManager.setProjectAsset(this.projectAsset);
         return this;
     }
@@ -108,7 +108,7 @@ public class BuildTool {
     public BuildTool explicitDependency(String scope, String groupId, String artifactId, String version,
                                         String packaging, String classifier, File file) {
         explicitDependency(new ArtifactSpec(scope, groupId, artifactId, version,
-                packaging, classifier, file));
+                                            packaging, classifier, file));
 
         return this;
     }
@@ -121,7 +121,7 @@ public class BuildTool {
     public BuildTool presolvedDependency(String scope, String groupId, String artifactId, String version,
                                          String packaging, String classifier, File file) {
         presolvedDependency(new ArtifactSpec(scope, groupId, artifactId, version,
-                packaging, classifier, file));
+                                             packaging, classifier, file));
 
         return this;
     }
@@ -275,16 +275,16 @@ public class BuildTool {
 
         //don't overwrite fractions added by the user
         detectedFractions.removeAll(this.fractions.stream()
-                .map(x -> FractionDescriptor.fromArtifactSpec(x))
-                .collect(Collectors.toSet()));
+                                            .map(x -> FractionDescriptor.fromArtifactSpec(x))
+                                            .collect(Collectors.toSet()));
 
         this.log.info(String.format("Detected %sfractions: %s",
-                this.fractions.isEmpty() ? "" : "additional ",
-                String.join(", ",
-                        detectedFractions.stream()
-                                .map(FractionDescriptor::av)
-                                .sorted()
-                                .collect(Collectors.toList()))));
+                                    this.fractions.isEmpty() ? "" : "additional ",
+                                    String.join(", ",
+                                                detectedFractions.stream()
+                                                        .map(FractionDescriptor::av)
+                                                        .sorted()
+                                                        .collect(Collectors.toList()))));
         detectedFractions.stream()
                 .map(FractionDescriptor::toArtifactSpec)
                 .forEach(this::fraction);
@@ -311,10 +311,10 @@ public class BuildTool {
                 .forEach(allFractions::add);
 
         this.log.info("Adding fractions: " +
-                String.join(", ", allFractions.stream()
-                        .map(BuildTool::strippedSwarmGav)
-                        .sorted()
-                        .collect(Collectors.toList())));
+                              String.join(", ", allFractions.stream()
+                                      .map(BuildTool::strippedSwarmGav)
+                                      .sorted()
+                                      .collect(Collectors.toList())));
 
         allFractions.forEach(f -> this.dependencyManager.addExplicitDependency(f));
         analyzeDependencies(true);
@@ -377,7 +377,7 @@ public class BuildTool {
             manifest.write(out);
             out.close();
             byte[] bytes = out.toByteArray();
-            this.archive.addAsManifestResource( new ByteArrayAsset( bytes ), "MANIFEST.MF" );
+            this.archive.addAsManifestResource(new ByteArrayAsset(bytes), "MANIFEST.MF");
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -389,12 +389,14 @@ public class BuildTool {
         String timestamp = ISO_DATE.format(new Date());
         this.properties.put("swarm.uberjar.build.timestamp", timestamp);
         this.properties.put("swarm.uberjar.build.user", System.getProperty("user.name"));
-        this.properties.put(BootstrapProperties.APP_ARTIFACT, this.projectAsset.getSimpleName());
+        if (!this.hollow) {
+            this.properties.put(BootstrapProperties.APP_ARTIFACT, this.projectAsset.getSimpleName());
+        }
 
         manifest.setProperties(this.properties);
         manifest.bundleDependencies(this.bundleDependencies);
-        manifest.setMainClass( this.mainClass );
-        manifest.setHollow( this.hollow );
+        manifest.setMainClass(this.mainClass);
+        manifest.setHollow(this.hollow);
         this.archive.add(new StringAsset(manifest.toString()), WildFlySwarmManifest.CLASSPATH_LOCATION);
 
     }
@@ -428,7 +430,7 @@ public class BuildTool {
             final File moduleDir = new File(additionalModule);
             this.archive.addAsResource(moduleDir, "modules");
             Files.find(moduleDir.toPath(), 20,
-                    (p, __) -> p.getFileName().toString().equals("module.xml"))
+                       (p, __) -> p.getFileName().toString().equals("module.xml"))
                     .forEach(p -> this.dependencyManager.addAdditionalModule(p));
 
         }

--- a/tools/src/main/java/org/wildfly/swarm/tools/DependencyManager.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/DependencyManager.java
@@ -408,8 +408,10 @@ public class DependencyManager {
     }
 
     void setProjectAsset(ProjectAsset projectAsset) {
-        this.projectAsset = projectAsset;
-        this.applicationManifest.setAsset(this.projectAsset.getName());
+        if (!this.applicationManifest.isHollow()) {
+            this.projectAsset = projectAsset;
+            this.applicationManifest.setAsset(this.projectAsset.getName());
+        }
     }
 
     protected WildFlySwarmManifest getWildFlySwarmManifest() {


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

With the switch to using ApplicationEnvironment it looks like some previous behavior wasn't updated. This results in Hollow jars being generated with an `asset` in the YAML even though there is no deployment in /bootstrap of the uber jar.

Also, deployments are not recognized on the command line as its trying to deploy a default deployment in the hollow jar, which doesn't exist
## Modifications

Don't set asset and application artifact values in YAML when hollow is true, and use ApplicationEnvironment.isHollow() to determine what Swarm.deploy() should do.
## Result

Fixes broken hollow jar creation and properly deploys the correct artifact.
