### PR TITLE
SWARM-657: can't run tests using the Arquillian Daemon when another application listens on port 12345

### DIFF
--- a/arquillian/api/src/main/resources/arquillian.xml
+++ b/arquillian/api/src/main/resources/arquillian.xml
@@ -6,7 +6,7 @@
   <container qualifier="daemon" default="true">
     <configuration>
       <property name="host">localhost</property>
-      <property name="port">12345</property>
+      <property name="port">${swarm.arquillian.daemon.port:12345}</property>
     </configuration>
   </container>
 

--- a/spi/src/main/java/org/wildfly/swarm/spi/api/SwarmProperties.java
+++ b/spi/src/main/java/org/wildfly/swarm/spi/api/SwarmProperties.java
@@ -138,6 +138,11 @@ public interface SwarmProperties {
     String DATABASE_DRIVER = "swarm.jdbc.driver";
 
     /**
+     * Port number for Swarm's Arquillian Daemon.
+     */
+    String ARQUILLIAN_DAEMON_PORT = "swarm.arquillian.daemon.port";
+
+    /**
      * Formats a property as ${property}
      *
      * @param property the property to be formatted

--- a/testsuite/testsuite-jaxrs/src/test/resources/arquillian.xml
+++ b/testsuite/testsuite-jaxrs/src/test/resources/arquillian.xml
@@ -7,7 +7,7 @@
   <container qualifier="daemon" default="true">
     <configuration>
       <property name="host">localhost</property>
-      <property name="port">12345</property>
+      <property name="port">${swarm.arquillian.daemon.port:12345}</property>
     </configuration>
   </container>
 

--- a/testsuite/testsuite-management-console/src/test/resources/arquillian.xml
+++ b/testsuite/testsuite-management-console/src/test/resources/arquillian.xml
@@ -7,7 +7,7 @@
   <container qualifier="daemon" default="true">
     <configuration>
       <property name="host">localhost</property>
-      <property name="port">12345</property>
+      <property name="port">${swarm.arquillian.daemon.port:12345}</property>
     </configuration>
   </container>
 

--- a/testsuite/testsuite-ribbon-secured/src/test/resources/arquillian.xml
+++ b/testsuite/testsuite-ribbon-secured/src/test/resources/arquillian.xml
@@ -7,7 +7,7 @@
   <container qualifier="daemon" default="true">
     <configuration>
       <property name="host">localhost</property>
-      <property name="port">12345</property>
+      <property name="port">${swarm.arquillian.daemon.port:12345}</property>
     </configuration>
   </container>
 

--- a/testsuite/testsuite-undertow/src/test/resources/arquillian.xml
+++ b/testsuite/testsuite-undertow/src/test/resources/arquillian.xml
@@ -7,7 +7,7 @@
   <container qualifier="daemon" default="true">
     <configuration>
       <property name="host">localhost</property>
-      <property name="port">12345</property>
+      <property name="port">${swarm.arquillian.daemon.port:12345}</property>
     </configuration>
   </container>
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

Running tests using the Arquillian Daemon is impossible when another
application listens on port 12345. In my case, that application is
the HipChat client.
## Modifications

Make the Arquillian Daemon's port configurable using a system property.
Change all the arquillian.xml files to use the system property as well.
On both places, 12345 is used as the default value.
## Result

By default, nothing changes. Passing `-Dswarm.arquillian.daemon.port=34567`
to the Maven invocation makes the Arquillian Daemon use a different port.
The tests will pick up the new port number as well, so they run correctly.
