### PR TITLE
SWARM-234 - JGroups config-api has weird name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <version.jboss.management-console>2.8.25.Final</version.jboss.management-console>
 
     <version.maven.aether>3.2.5</version.maven.aether>
-    <version.wildfly.config-api>0.4.6</version.wildfly.config-api>
+    <version.wildfly.config-api>0.4.8</version.wildfly.config-api>
     <version.wildfly>10.1.0.Final</version.wildfly>
     <version.org.jboss.msc.jboss-msc>1.2.6.Final</version.org.jboss.msc.jboss-msc>
     <version.jboss-logmanager-ext>1.0.0.Alpha3</version.jboss-logmanager-ext>


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

As noted in the bug, the JGroups config-api produced a
method named rELAY2() due to strange yet beloved camel-casing
heuristics.
## Modifications

Updated to a newer config-api release which fixes the abovementioned
problem.
## Result

A method named .rELAY2() is replaced by a method named .RELAY2().
