### PR TITLE
SWARM-662: Avoid NPE when calling addAllDependencies()

### DIFF
--- a/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/MavenDependencyResolution.java
+++ b/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/MavenDependencyResolution.java
@@ -34,7 +34,11 @@ public class MavenDependencyResolution implements DependencyResolution {
 
                     try {
                         final File artifact = MavenResolvers.get().resolveJarArtifact( coords );
-                        archivePaths.add( artifact.getAbsolutePath() );
+                        if ( artifact == null ) {
+                            System.err.println( "Unable to resolve artifact: " + coords );
+                        } else {
+                            archivePaths.add(artifact.getAbsolutePath());
+                        }
                     } catch (IOException e) {
                         e.printStackTrace();
                     }


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

When an unresolvable dependency occurs (which should never happen),
at least avoid an NPE until we figure out why it's happening.
## Modifications

Check for null before attempting to resolve the full path of
a possibly-null java.io.File.
## Result

Fewer NPEs.
