### PR TITLE
SWARM-664 - API for jolokia-access.xml

### DIFF
--- a/jolokia/src/main/java/org/wildfly/swarm/jolokia/JolokiaFraction.java
+++ b/jolokia/src/main/java/org/wildfly/swarm/jolokia/JolokiaFraction.java
@@ -15,6 +15,17 @@
  */
 package org.wildfly.swarm.jolokia;
 
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.wildfly.swarm.jolokia.access.APIJolokiaAccessPreparer;
+import org.wildfly.swarm.jolokia.access.FileJolokiaAccessPreparer;
+import org.wildfly.swarm.jolokia.access.JolokiaAccess;
+import org.wildfly.swarm.jolokia.access.URLJolokiaAccessPreparer;
 import org.wildfly.swarm.spi.api.Fraction;
 
 /**
@@ -39,5 +50,36 @@ public class JolokiaFraction implements Fraction<JolokiaFraction> {
         return this.context;
     }
 
+    public JolokiaFraction prepareJolokiaWar(Consumer<Archive> jolokiaWarPreparer) {
+        this.jolokiaWarPreparer = jolokiaWarPreparer;
+        return this;
+    }
+
+    public Consumer<Archive> jolokiaWarPreparer() {
+        return this.jolokiaWarPreparer;
+    }
+
+    public static Consumer<Archive> jolokiaAccessXml(File file) {
+        return new FileJolokiaAccessPreparer( file );
+
+    }
+
+    public static Consumer<Archive> jolokiaAccessXml(URL url) {
+        return new URLJolokiaAccessPreparer(url);
+    }
+
+    public static Consumer<Archive> jolokiaAccess(Consumer<JolokiaAccess> config) {
+        JolokiaAccess access = new JolokiaAccess();
+        config.accept( access );
+        return new APIJolokiaAccessPreparer( access );
+    }
+
+    public static Consumer<Archive> jolokiaAccess(Supplier<JolokiaAccess> supplier) {
+        return new APIJolokiaAccessPreparer( supplier.get() );
+    }
+
     private String context;
+
+    private Consumer<Archive> jolokiaWarPreparer;
+
 }

--- a/jolokia/src/main/java/org/wildfly/swarm/jolokia/JolokiaProperties.java
+++ b/jolokia/src/main/java/org/wildfly/swarm/jolokia/JolokiaProperties.java
@@ -1,0 +1,10 @@
+package org.wildfly.swarm.jolokia;
+
+/**
+ * @author Bob McWhirter
+ */
+public interface JolokiaProperties {
+
+    String CONTEXT = "swarm.jolokia.context";
+    String ACCESS_XML = "swarm.jolokia.access.xml";
+}

--- a/jolokia/src/main/java/org/wildfly/swarm/jolokia/access/APIJolokiaAccessPreparer.java
+++ b/jolokia/src/main/java/org/wildfly/swarm/jolokia/access/APIJolokiaAccessPreparer.java
@@ -1,0 +1,22 @@
+package org.wildfly.swarm.jolokia.access;
+
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+
+/**
+ * @author Bob McWhirter
+ */
+public class APIJolokiaAccessPreparer extends AbstractJolokiaAccessPreparer {
+
+    public APIJolokiaAccessPreparer(JolokiaAccess access) {
+        this.access = access;
+    }
+
+    @Override
+    protected Asset getJolokiaAccessXmlAsset() {
+        return new StringAsset( this.access.toXML() );
+    }
+
+    private final JolokiaAccess access;
+
+}

--- a/jolokia/src/main/java/org/wildfly/swarm/jolokia/access/AbstractJolokiaAccessPreparer.java
+++ b/jolokia/src/main/java/org/wildfly/swarm/jolokia/access/AbstractJolokiaAccessPreparer.java
@@ -1,0 +1,26 @@
+package org.wildfly.swarm.jolokia.access;
+
+import java.util.function.Consumer;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.Node;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.wildfly.swarm.undertow.WARArchive;
+
+/**
+ * @author Bob McWhirter
+ */
+abstract class AbstractJolokiaAccessPreparer implements Consumer<Archive> {
+
+    public void accept(Archive archive) {
+        Node node = archive.get("WEB-INF/classes/jolokia-access.xml");
+        if (node == null) {
+            Asset asset = getJolokiaAccessXmlAsset();
+            if (asset != null) {
+                archive.as(WARArchive.class).add(asset, "WEB-INF/classes/jolokia-access.xml");
+            }
+        }
+    }
+
+    abstract protected Asset getJolokiaAccessXmlAsset();
+}

--- a/jolokia/src/main/java/org/wildfly/swarm/jolokia/access/ConfigurationValueAccessPreparer.java
+++ b/jolokia/src/main/java/org/wildfly/swarm/jolokia/access/ConfigurationValueAccessPreparer.java
@@ -1,0 +1,49 @@
+package org.wildfly.swarm.jolokia.access;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.UrlAsset;
+
+/**
+ * @author Bob McWhirter
+ */
+public class ConfigurationValueAccessPreparer extends AbstractJolokiaAccessPreparer {
+
+
+    public ConfigurationValueAccessPreparer(String jolokiaAccessXml) {
+        this.jolokiaAccessXml = jolokiaAccessXml;
+    }
+
+    @Override
+    protected Asset getJolokiaAccessXmlAsset() {
+        if (this.jolokiaAccessXml == null) {
+            return null;
+        }
+
+        try {
+            URL url = null;
+            try {
+                url = new URL(this.jolokiaAccessXml);
+            } catch (MalformedURLException e) {
+                File file = new File(this.jolokiaAccessXml);
+                if (file.exists()) {
+                    url = file.toURL();
+                }
+            }
+
+            if ( url != null ) {
+                return new UrlAsset( url );
+            }
+        } catch (MalformedURLException e) {
+            // ignore;
+        }
+
+        return null;
+    }
+
+    private final String jolokiaAccessXml;
+
+}

--- a/jolokia/src/main/java/org/wildfly/swarm/jolokia/access/FileJolokiaAccessPreparer.java
+++ b/jolokia/src/main/java/org/wildfly/swarm/jolokia/access/FileJolokiaAccessPreparer.java
@@ -1,0 +1,27 @@
+package org.wildfly.swarm.jolokia.access;
+
+import java.io.File;
+
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.FileAsset;
+
+/**
+ * @author Bob McWhirter
+ */
+public class FileJolokiaAccessPreparer extends AbstractJolokiaAccessPreparer {
+
+    public FileJolokiaAccessPreparer(File file) {
+        this.file = file;
+    }
+
+    @Override
+    protected Asset getJolokiaAccessXmlAsset() {
+        if ( this.file.exists() ) {
+            return new FileAsset(this.file);
+        }
+        return null;
+    }
+
+    private final File file;
+
+}

--- a/jolokia/src/main/java/org/wildfly/swarm/jolokia/access/JolokiaAccess.java
+++ b/jolokia/src/main/java/org/wildfly/swarm/jolokia/access/JolokiaAccess.java
@@ -1,0 +1,139 @@
+package org.wildfly.swarm.jolokia.access;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * API for jolokia-access.xml configuration.
+ *
+ * @author Bob McWhirter
+ */
+public class JolokiaAccess {
+
+    public interface Supplier extends java.util.function.Supplier<JolokiaAccess> {
+
+    }
+
+    public interface Consumer extends java.util.function.Consumer<JolokiaAccess> {
+
+    }
+
+    public JolokiaAccess() {
+
+    }
+
+    public JolokiaAccess host(String host) {
+        this.hosts.add(host);
+        return this;
+    }
+
+    public JolokiaAccess command(String command) {
+        this.commands.add(command);
+        return this;
+    }
+
+    public JolokiaAccess httpMethod(String method) {
+        this.methods.add(method);
+        return this;
+    }
+
+    public JolokiaAccess allowOrigin(String origin) {
+        this.origins.add(origin);
+        return this;
+    }
+
+    public JolokiaAccess strictChecking() {
+        this.strictChecking = true;
+        return this;
+    }
+
+    public JolokiaAccess allow(Section.Consumer config) {
+        Section rule = Section.allow();
+        config.accept(rule);
+        this.sections.add(rule);
+        return this;
+    }
+
+    public JolokiaAccess deny(Section.Consumer config) {
+        Section rule = Section.deny();
+        config.accept(rule);
+        this.sections.add(rule);
+        return this;
+    }
+
+    public String toXML() {
+        StringBuilder builder = new StringBuilder();
+
+        builder.append("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n");
+        builder.append("<restrict>\n");
+
+        if (!this.hosts.isEmpty()) {
+            builder.append("  <remote>\n");
+            this.hosts.forEach(e -> {
+                builder.append("    <host>").append(e).append("</host>\n");
+            });
+            builder.append("  </remote>\n");
+        }
+
+        if (!this.methods.isEmpty()) {
+            builder.append("  <http>\n");
+            this.methods.forEach(e -> {
+                builder.append("    <method>").append(e).append("</method>\n");
+            });
+            builder.append("  </http>\n");
+        }
+
+        if (!this.origins.isEmpty()) {
+            builder.append("  <cors>\n");
+            this.origins.forEach(e -> {
+                builder.append("    <allow-origin>").append(e).append("</allow-origin>\n");
+            });
+            if ( this.strictChecking ) {
+                builder.append("    <strict-checking/>\n" );
+            }
+            builder.append("  </cors>\n");
+        }
+
+        if (!this.commands.isEmpty()) {
+            builder.append("  <commands>\n");
+            this.commands.forEach(e -> {
+                builder.append("    <command>").append(e).append("</command>\n");
+            });
+            builder.append("  </commands>\n");
+        }
+
+        if (!this.sections.isEmpty()) {
+            this.sections.forEach(e -> {
+                builder.append("  <" + e.type() + ">\n");
+                e.mbeans().forEach(mbean -> {
+                    builder.append("    <mbean>\n");
+                    builder.append("      <name>").append(mbean.name()).append("</name>\n");
+                    mbean.attributes().forEach(attr -> {
+                        builder.append("      <attribute>").append(mbean.name()).append("</attribute>\n");
+                    });
+                    mbean.operations().forEach(attr -> {
+                        builder.append("      <operation>").append(mbean.name()).append("</operation>\n");
+                    });
+                    builder.append("    </mbean>\n");
+                });
+                builder.append("  </" + e.type() + ">\n");
+            });
+        }
+
+        builder.append("</restrict>\n");
+
+        return builder.toString();
+    }
+
+    private List<String> hosts = new ArrayList<>();
+
+    private List<String> origins = new ArrayList<>();
+
+    private List<String> methods = new ArrayList<>();
+
+    private List<String> commands = new ArrayList<>();
+
+    private boolean strictChecking = false;
+
+    private List<Section> sections = new ArrayList<>();
+}

--- a/jolokia/src/main/java/org/wildfly/swarm/jolokia/access/MBeanRule.java
+++ b/jolokia/src/main/java/org/wildfly/swarm/jolokia/access/MBeanRule.java
@@ -1,0 +1,55 @@
+package org.wildfly.swarm.jolokia.access;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** An MBean rule.
+ *
+ * @author Bob McWhirter
+ */
+public class MBeanRule {
+
+    public interface Consumer extends java.util.function.Consumer<MBeanRule> {
+
+    }
+
+    MBeanRule(String name) {
+        this.name = name;
+    }
+
+    public String name() {
+        return this.name;
+    }
+
+    /** An operation name or pattern.
+     *
+     * @param operation The operation.
+     * @return This rule.
+     */
+    public MBeanRule operation(String operation) {
+        this.operations.add( operation );
+        return this;
+    }
+
+    public List<String> operations() {
+        return this.operations;
+    }
+
+    /** An attribute name or pattern.
+     *
+     * @param attribute The attribute.
+     * @return This rule.
+     */
+    public MBeanRule attribute(String attribute) {
+        this.attributes.add( attribute );
+        return this;
+    }
+
+    public List<String> attributes() {
+        return this.attributes;
+    }
+
+    private String name;
+    private List<String> operations = new ArrayList<>();
+    private List<String> attributes = new ArrayList<>();
+}

--- a/jolokia/src/main/java/org/wildfly/swarm/jolokia/access/Section.java
+++ b/jolokia/src/main/java/org/wildfly/swarm/jolokia/access/Section.java
@@ -1,0 +1,56 @@
+package org.wildfly.swarm.jolokia.access;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** An allow or deny section.
+ *
+ * @author Bob McWhirter
+ */
+public class Section {
+
+    public interface Consumer extends java.util.function.Consumer<Section> {
+
+    }
+
+    public static Section allow() {
+        return new Section(Type.allow);
+    }
+
+    public static Section deny() {
+        return new Section(Type.deny);
+    }
+
+    private enum Type {
+        allow,
+        deny
+    }
+
+    private Section(Type type) {
+        this.type = type;
+    }
+
+    public String type() {
+        return this.type.toString();
+    }
+
+    /** Define a rule for a given MBean.
+     *
+     * @param name The mbean name or pattern.
+     * @param config Configuration.
+     * @return This section.
+     */
+    public Section mbean(String name, MBeanRule.Consumer config) {
+        MBeanRule rule = new MBeanRule(name);
+        config.accept( rule );
+        this.rules.add( rule );
+        return this;
+    }
+
+    public List<MBeanRule> mbeans() {
+        return this.rules;
+    }
+
+    private Type type;
+    private List<MBeanRule> rules = new ArrayList<>();
+}

--- a/jolokia/src/main/java/org/wildfly/swarm/jolokia/access/URLJolokiaAccessPreparer.java
+++ b/jolokia/src/main/java/org/wildfly/swarm/jolokia/access/URLJolokiaAccessPreparer.java
@@ -1,0 +1,24 @@
+package org.wildfly.swarm.jolokia.access;
+
+import java.net.URL;
+
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.UrlAsset;
+
+/**
+ * @author Bob McWhirter
+ */
+public class URLJolokiaAccessPreparer extends AbstractJolokiaAccessPreparer {
+
+    public URLJolokiaAccessPreparer(URL url) {
+        this.url = url;
+    }
+
+    @Override
+    protected Asset getJolokiaAccessXmlAsset() {
+        return new UrlAsset( this.url );
+    }
+
+    private final URL url;
+
+}

--- a/jolokia/src/test/java/org/wildfly/swarm/jolokia/runtime/JolokiaWarDeploymentProducerTest.java
+++ b/jolokia/src/test/java/org/wildfly/swarm/jolokia/runtime/JolokiaWarDeploymentProducerTest.java
@@ -1,0 +1,243 @@
+package org.wildfly.swarm.jolokia.runtime;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.Node;
+import org.junit.Test;
+import org.wildfly.swarm.jolokia.JolokiaFraction;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Bob McWhirter
+ */
+public class JolokiaWarDeploymentProducerTest {
+
+    @Test
+    public void testNoJolokiaAccessAtAll() throws Exception {
+        JolokiaWarDeploymentProducer producer = new JolokiaWarDeploymentProducer();
+
+        producer.fraction = new JolokiaFraction();
+        producer.lookup = new MockArtifactLookup();
+
+        Archive war = producer.jolokiaWar();
+
+        Node xml = war.get("WEB-INF/classes/jolokia-access.xml");
+
+        assertThat(xml).isNull();
+    }
+
+    @Test
+    public void testJolokiaAccessViaUrlOnFraction() throws Exception {
+        URL resource = getClass().getClassLoader().getResource("my-jolokia-access.xml");
+
+        JolokiaWarDeploymentProducer producer = new JolokiaWarDeploymentProducer();
+
+        producer.fraction = new JolokiaFraction()
+                .prepareJolokiaWar(JolokiaFraction.jolokiaAccessXml(resource));
+        producer.lookup = new MockArtifactLookup();
+
+        Archive war = producer.jolokiaWar();
+
+        Node xml = war.get("WEB-INF/classes/jolokia-access.xml");
+
+        assertThat(xml).isNotNull();
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(xml.getAsset().openStream()))) {
+            List<String> lines = reader.lines().collect(Collectors.toList());
+
+            assertThat(lines).isNotEmpty();
+            assertThat(lines.get(0)).contains("This is my-jolokia-access.xml");
+        }
+    }
+
+    @Test
+    public void testJolokiaAccessViaFileOnFraction() throws Exception {
+        URL resource = getClass().getClassLoader().getResource("my-jolokia-access2.xml");
+
+        String path = resource.getPath();
+
+        File file = new File(path);
+
+        JolokiaWarDeploymentProducer producer = new JolokiaWarDeploymentProducer();
+
+        producer.fraction = new JolokiaFraction()
+                .prepareJolokiaWar(JolokiaFraction.jolokiaAccessXml(file));
+
+        producer.lookup = new MockArtifactLookup();
+
+        Archive war = producer.jolokiaWar();
+
+        Node xml = war.get("WEB-INF/classes/jolokia-access.xml");
+
+        assertThat(xml).isNotNull();
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(xml.getAsset().openStream()))) {
+            List<String> lines = reader.lines().collect(Collectors.toList());
+
+            assertThat(lines).isNotEmpty();
+            assertThat(lines.get(0)).contains("This is my-jolokia-access2.xml");
+        }
+    }
+
+    @Test
+    public void testJolokiaAccessViaAPI() throws Exception {
+
+        JolokiaWarDeploymentProducer producer = new JolokiaWarDeploymentProducer();
+
+        producer.fraction = new JolokiaFraction()
+                .prepareJolokiaWar(JolokiaFraction.jolokiaAccess(access -> {
+                    access.host("1.1.1.1");
+                }));
+
+        producer.lookup = new MockArtifactLookup();
+
+        Archive war = producer.jolokiaWar();
+
+        Node xml = war.get("WEB-INF/classes/jolokia-access.xml");
+
+        assertThat(xml).isNotNull();
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(xml.getAsset().openStream()))) {
+            List<String> lines = reader.lines().map(String::trim).collect(Collectors.toList());
+
+            assertThat(lines).isNotEmpty();
+            assertThat(lines).contains("<host>1.1.1.1</host>");
+        }
+    }
+
+    @Test
+    public void testPreferConfigValueFile_vs_API() throws Exception {
+
+        URL resource = getClass().getClassLoader().getResource("my-jolokia-access2.xml");
+
+        String path = resource.getPath();
+
+        File file = new File(path);
+
+        JolokiaWarDeploymentProducer producer = new JolokiaWarDeploymentProducer();
+
+        producer.fraction = new JolokiaFraction()
+                .prepareJolokiaWar(JolokiaFraction.jolokiaAccess(access -> {
+                    access.host("1.1.1.1");
+                }));
+
+        producer.lookup = new MockArtifactLookup();
+
+        producer.jolokiaAccessXML = file.getAbsolutePath();
+
+        Archive war = producer.jolokiaWar();
+
+        Node xml = war.get("WEB-INF/classes/jolokia-access.xml");
+
+        assertThat(xml).isNotNull();
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(xml.getAsset().openStream()))) {
+            List<String> lines = reader.lines().collect(Collectors.toList());
+
+            assertThat(lines).isNotEmpty();
+            assertThat(lines.get(0)).contains("This is my-jolokia-access2.xml");
+        }
+
+    }
+
+    @Test
+    public void testPreferConfigValueURL_vs_API() throws Exception {
+
+        URL resource = getClass().getClassLoader().getResource("my-jolokia-access2.xml");
+
+        JolokiaWarDeploymentProducer producer = new JolokiaWarDeploymentProducer();
+
+        producer.fraction = new JolokiaFraction()
+                .prepareJolokiaWar(JolokiaFraction.jolokiaAccess(access -> {
+                    access.host("1.1.1.1");
+                }));
+
+        producer.lookup = new MockArtifactLookup();
+
+        producer.jolokiaAccessXML = resource.toExternalForm();
+
+        Archive war = producer.jolokiaWar();
+
+        Node xml = war.get("WEB-INF/classes/jolokia-access.xml");
+
+        assertThat(xml).isNotNull();
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(xml.getAsset().openStream()))) {
+            List<String> lines = reader.lines().collect(Collectors.toList());
+
+            assertThat(lines).isNotEmpty();
+            assertThat(lines.get(0)).contains("This is my-jolokia-access2.xml");
+        }
+
+    }
+
+    public void testPreferConfigValueFile_vs_FractionSetting() throws Exception {
+
+        URL resource = getClass().getClassLoader().getResource("my-jolokia-access2.xml");
+        URL fractionResource = getClass().getClassLoader().getResource("my-jolokia-access3.xml");
+
+        String path = resource.getPath();
+
+        File file = new File(path);
+
+        JolokiaWarDeploymentProducer producer = new JolokiaWarDeploymentProducer();
+
+        producer.fraction = new JolokiaFraction()
+                .prepareJolokiaWar(JolokiaFraction.jolokiaAccessXml(fractionResource));
+
+        producer.lookup = new MockArtifactLookup();
+
+        producer.jolokiaAccessXML = file.getAbsolutePath();
+
+        Archive war = producer.jolokiaWar();
+
+        Node xml = war.get("WEB-INF/classes/jolokia-access.xml");
+
+        assertThat(xml).isNotNull();
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(xml.getAsset().openStream()))) {
+            List<String> lines = reader.lines().collect(Collectors.toList());
+
+            assertThat(lines).isNotEmpty();
+            assertThat(lines.get(0)).contains("This is my-jolokia-access2.xml");
+        }
+
+    }
+
+    @Test
+    public void testPreferConfigValueURL_vs_FractionSetting() throws Exception {
+
+        URL resource = getClass().getClassLoader().getResource("my-jolokia-access2.xml");
+        URL fractionResource = getClass().getClassLoader().getResource("my-jolokia-access3.xml");
+
+        JolokiaWarDeploymentProducer producer = new JolokiaWarDeploymentProducer();
+
+        producer.fraction = new JolokiaFraction()
+                .prepareJolokiaWar(JolokiaFraction.jolokiaAccessXml(fractionResource));
+
+        producer.lookup = new MockArtifactLookup();
+
+        producer.jolokiaAccessXML = resource.toExternalForm();
+
+        Archive war = producer.jolokiaWar();
+
+        Node xml = war.get("WEB-INF/classes/jolokia-access.xml");
+
+        assertThat(xml).isNotNull();
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(xml.getAsset().openStream()))) {
+            List<String> lines = reader.lines().collect(Collectors.toList());
+
+            assertThat(lines).isNotEmpty();
+            assertThat(lines.get(0)).contains("This is my-jolokia-access2.xml");
+        }
+
+    }
+}

--- a/jolokia/src/test/java/org/wildfly/swarm/jolokia/runtime/MockArtifactLookup.java
+++ b/jolokia/src/test/java/org/wildfly/swarm/jolokia/runtime/MockArtifactLookup.java
@@ -1,0 +1,34 @@
+package org.wildfly.swarm.jolokia.runtime;
+
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.wildfly.swarm.spi.api.ArtifactLookup;
+
+/**
+ * @author Bob McWhirter
+ */
+public class MockArtifactLookup implements ArtifactLookup {
+
+    @Override
+    public Archive artifact(String gav) throws Exception {
+        return ShrinkWrap.create( JavaArchive.class, gav + ".jar" );
+    }
+
+    @Override
+    public Archive artifact(String gav, String asName) throws Exception {
+        return ShrinkWrap.create( JavaArchive.class, asName );
+    }
+
+    @Override
+    public List<JavaArchive> allArtifacts() throws Exception {
+        return null;
+    }
+
+    @Override
+    public List<JavaArchive> allArtifacts(String... groupIdExclusions) throws Exception {
+        return null;
+    }
+}

--- a/jolokia/src/test/resources/my-jolokia-access.xml
+++ b/jolokia/src/test/resources/my-jolokia-access.xml
@@ -1,0 +1,1 @@
+This is my-jolokia-access.xml

--- a/jolokia/src/test/resources/my-jolokia-access2.xml
+++ b/jolokia/src/test/resources/my-jolokia-access2.xml
@@ -1,0 +1,1 @@
+This is my-jolokia-access2.xml

--- a/jolokia/src/test/resources/my-jolokia-access3.xml
+++ b/jolokia/src/test/resources/my-jolokia-access3.xml
@@ -1,0 +1,1 @@
+This is my-jolokia-access3.xml

--- a/testsuite/testsuite-jolokia/src/test/java/org/wildfly/swarm/jolokia/JolokiaSecuredTest.java
+++ b/testsuite/testsuite-jolokia/src/test/java/org/wildfly/swarm/jolokia/JolokiaSecuredTest.java
@@ -1,0 +1,77 @@
+package org.wildfly.swarm.jolokia;
+
+import java.io.InputStream;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.arquillian.CreateSwarm;
+import org.wildfly.swarm.spi.api.JARArchive;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Bob McWhirter
+ */
+@RunWith(Arquillian.class)
+public class JolokiaSecuredTest {
+
+    @Deployment(testable = false)
+    public static Archive deployment() {
+        JARArchive deployment = ShrinkWrap.create(JARArchive.class);
+        deployment.add(EmptyAsset.INSTANCE, "nothing");
+        return deployment;
+    }
+
+    @CreateSwarm
+    public static Swarm createSwarm() throws Exception {
+        Swarm swarm = new Swarm()
+                .fraction(new JolokiaFraction()
+                        .prepareJolokiaWar(JolokiaFraction.jolokiaAccess(access -> {
+                            // allow nobody, basically
+                            access.host("1.1.1.1");
+                        }))
+                );
+        return swarm;
+    }
+
+
+    @Test
+    public void testJolokia() throws Exception {
+
+        HttpClientBuilder builder = HttpClientBuilder.create();
+        CloseableHttpClient client = builder.build();
+
+        HttpUriRequest request = new HttpGet("http://localhost:8080/jolokia");
+        CloseableHttpResponse response = client.execute(request);
+
+        // oddly it returns a 200, with a json status of 403
+
+        HttpEntity entity = response.getEntity();
+
+        InputStream content = entity.getContent();
+
+        byte[] buf = new byte[1024];
+        int len = 0;
+
+        StringBuilder str = new StringBuilder();
+
+        while ((len = content.read(buf)) >= 0) {
+            str.append(new String(buf, 0, len));
+        }
+
+        assertTrue(str.toString().contains("\"status\":403"));
+    }
+}


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---

```
Motivation
----------

Having an open and unsecured jolokia end-point is potentially
dangerous.

Modifications
-------------

Provided several methods for creating/using a jolokia-access.xml,
along with general configuration of the deployed jolokia.war.

The JolokiaFraction supports prepareJolokiaWar(Consumer<Archive>)
which can be used for any random customization of the deployed
jolokia.war.

Additionally, several static methods exist on JolokiaFraction
that producer Consumer<Archive> that know how to configure
jolokia-access.xml based upon a URL, a File, or the JolokiaAccess
API.

In all cases, once a jolokia-access.xml has been set, further
setting is disallowed.  The deployment-producer also sets up,
as the head of any Consumer<Archive>, a jolokia-access.xml
preparer that knows how to check the swarm.jolokia.access.xml
configuration value, therefore preferring that to any subsequent,
user-installed, programatic preparers that muck with
jolokia-access.xml.

Result
------

You can now secure Jolokia using Jolokia's own mechanisms, for
some small values of "secure".
```
