### PR TITLE
SWARM-605 Clustering/Session Replication not working

### DIFF
--- a/undertow/module.conf
+++ b/undertow/module.conf
@@ -1,5 +1,6 @@
 javax.servlet.api export=true
 org.wildfly.extension.undertow
+org.wildfly.clustering.web.undertow
 io.undertow.core
 io.undertow.servlet
 org.ow2.asm


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

The undertow clustering is not working because it's missing required module and cannot create clustered session manager.
## Modifications

Add org.wildfly.clustering.web.undertow module to undertow/module.conf
## Result

Undertow can create clustered session manager for session replication
