### PR TITLE
SWARM-665 Setup infinispan module for cachecontainer

### DIFF
--- a/infinispan/src/main/java/org/wildfly/swarm/infinispan/runtime/InfinispanCustomizer.java
+++ b/infinispan/src/main/java/org/wildfly/swarm/infinispan/runtime/InfinispanCustomizer.java
@@ -74,6 +74,7 @@ public class InfinispanCustomizer implements Customizer {
                 cc -> cc.defaultCache("default")
                         .alias("singleton")
                         .alias("cluster")
+                        .module("org.wildfly.clustering.server")
                         .jgroupsTransport(t -> t.lockTimeout(60000L))
                         .replicatedCache("default",
                                 c -> c.mode(Mode.SYNC)
@@ -81,6 +82,7 @@ public class InfinispanCustomizer implements Customizer {
         if (!this.undertow.isUnsatisfied()) {
             this.fraction.cacheContainer("web",
                     cc -> cc.defaultCache("dist")
+                            .module("org.wildfly.clustering.web.infinispan")
                             .jgroupsTransport(t -> t.lockTimeout(60000L))
                             .distributedCache("dist",
                                     c -> c.mode(Mode.ASYNC)
@@ -95,6 +97,7 @@ public class InfinispanCustomizer implements Customizer {
             this.fraction.cacheContainer("ejb",
                     cc -> cc.defaultCache("dist")
                             .alias("sfsb")
+                            .module("org.wildfly.clustering.ejb.infinispan")
                             .jgroupsTransport(t -> t.lockTimeout(60000L))
                             .distributedCache("dist",
                                     c -> c.mode(Mode.ASYNC)
@@ -109,6 +112,7 @@ public class InfinispanCustomizer implements Customizer {
         if (!this.jpa.isUnsatisfied()) {
             this.fraction.cacheContainer("hibernate",
                     cc -> cc.defaultCache("local-query")
+                            .module("org.hibernate.infinispan")
                             .jgroupsTransport(t -> t.lockTimeout(60000L))
                             .localCache("local-query",
                                     c -> c.evictionComponent(ec -> ec.maxEntries(10000L).strategy(EvictionComponent.Strategy.LRU))

--- a/undertow/module.conf
+++ b/undertow/module.conf
@@ -1,5 +1,6 @@
 javax.servlet.api export=true
 org.wildfly.extension.undertow
+org.wildfly.clustering.web.undertow
 io.undertow.core
 io.undertow.servlet
 org.ow2.asm


### PR DESCRIPTION
#131 needs to be reviewed prior to this commit.
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

InfinispanCustomizer doesn't setup module for each cache container correctly, use wrong class loaders and produce errors
## Modifications

InfinispanCustomizer is aligned to WildFly standalone-ha.xml and setup modules
## Result

Undertow clustering no longer produce errors and works
