### PR TITLE
SWARM-666: Support @Inject @ConfigurationValue Optional<TYPE>.

### DIFF
--- a/testsuite/testsuite-cdi/src/test/java/org/wildfly/swarm/cdi/ConfigurationValueProducerTest.java
+++ b/testsuite/testsuite-cdi/src/test/java/org/wildfly/swarm/cdi/ConfigurationValueProducerTest.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.cdi;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.ClassLoaderAsset;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.spi.api.JARArchive;
+import org.wildfly.swarm.spi.runtime.annotations.ConfigurationValue;
+
+/**
+ * @author George Gastaldi
+ */
+@RunWith(Arquillian.class)
+public class ConfigurationValueProducerTest {
+
+    @Inject
+    @ConfigurationValue("logger.level")
+    private Optional<String> loggerLevel;
+
+    @Deployment
+    public static Archive<?> createDeployment() throws Exception {
+        return ShrinkWrap.create(JARArchive.class, "arqDeployment.jar")
+                .add(new ClassLoaderAsset("project-stages.yml", ConfigurationValueProducerTest.class.getClassLoader()), "project-stages.yml")
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void testServerAddressExists() {
+        Assert.assertNotNull(loggerLevel);
+        Assert.assertEquals("DEBUG",loggerLevel.get());
+    }
+
+}


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

Some configuration values may not exist and it would be nice to use Java 8's Optional
feature to prevent potential NullPointerExceptions
## Modifications

Created a new @Producer in ConfigurationValueProducer that handles Optional arguments and
extracts its parameterized type.
## Result

@Inject @ConfigurationValue Optional<String> now works
