### PR TITLE
SWARM-668: Removed leftovers from pre-CDI internals

### DIFF
--- a/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -263,54 +263,6 @@ public class Swarm {
     }
 
     /**
-     * Configure a network interface.
-     *
-     * @param name       The name of the interface.
-     * @param expression The expression to define the interface.
-     * @return The container.
-     */
-    public Swarm iface(String name, String expression) {
-        //swarmConfigurator.iface(name, expression);
-        return this;
-    }
-
-    public List<Interface> ifaces() {
-        //return swarmConfigurator.ifaces();
-        return null;
-    }
-
-    /**
-     * Configure a socket-binding-group.
-     *
-     * @param group The socket-binding group to add.
-     * @return The container.
-     */
-    public Swarm socketBindingGroup(SocketBindingGroup group) {
-        //swarmConfigurator.socketBindingGroup(group);
-        return this;
-    }
-
-    public List<SocketBindingGroup> socketBindingGroups() {
-        //return swarmConfigurator.socketBindingGroups();
-        return null;
-    }
-
-    public SocketBindingGroup getSocketBindingGroup(String name) {
-        //return swarmConfigurator.getSocketBindingGroup(name);
-        return null;
-    }
-
-    public Map<String, List<SocketBinding>> socketBindings() {
-        //return swarmConfigurator.socketBindings();
-        return null;
-    }
-
-    public Map<String, List<OutboundSocketBinding>> outboundSocketBindings() {
-        //return swarmConfigurator.outboundSocketBindings();
-        return null;
-    }
-
-    /**
      * Start the container.
      *
      * @return The container.

--- a/container/src/main/java/org/wildfly/swarm/container/Container.java
+++ b/container/src/main/java/org/wildfly/swarm/container/Container.java
@@ -70,18 +70,6 @@ public class Container extends Swarm {
 
     @Override
     @Deprecated
-    public Container iface(String name, String expression) {
-        return (Container) super.iface(name, expression);
-    }
-
-    @Override
-    @Deprecated
-    public Container socketBindingGroup(SocketBindingGroup group) {
-        return (Container) super.socketBindingGroup(group);
-    }
-
-    @Override
-    @Deprecated
     public Container start(boolean eagerlyOpen) throws Exception {
         return (Container) super.start(eagerlyOpen);
     }


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

Some methods in the Swarm class do not work and are not used anywhere. These are leftovers from pre-CDI
## Modifications

Removed methods in the Swarm class
## Result

The Swarm class is cleaner
