### PR TITLE
EclipseLink as JPA provider

### DIFF
--- a/jpa-eclipselink/module.conf
+++ b/jpa-eclipselink/module.conf
@@ -1,0 +1,1 @@
+org.jboss.as.jpa

--- a/jpa-eclipselink/pom.xml
+++ b/jpa-eclipselink/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>wildfly-swarm</artifactId>
+        <version>2016.10-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+
+
+
+    <artifactId>jpa-eclipselink</artifactId>
+
+    <name>JPA EclipseLink</name>
+    <description>Java Persistence API with EclipseLink</description>
+
+    <properties>
+        <swarm.fraction.stability>stable</swarm.fraction.stability>
+        <swarm.fraction.tags>JavaEE,Data,EclipseLink</swarm.fraction.tags>
+    </properties>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+
+    <dependencies>
+        <!-- Fraction Dependencies -->
+        <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>jpa</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>jipijapa-eclipselink</artifactId>
+        </dependency>
+
+    </dependencies>
+
+
+
+</project>

--- a/jpa-eclipselink/src/main/java/org/wildfly/swarm/jpa/persistence/EclipseLinkPersistenceFraction.java
+++ b/jpa-eclipselink/src/main/java/org/wildfly/swarm/jpa/persistence/EclipseLinkPersistenceFraction.java
@@ -1,0 +1,11 @@
+package org.wildfly.swarm.jpa.persistence;
+
+import org.wildfly.swarm.spi.api.Fraction;
+import org.wildfly.swarm.spi.api.annotations.DeploymentModule;
+
+/**
+ * Created by slobolai on 9/8/2016.
+ */
+@DeploymentModule(name="org.eclipse.persistence")
+public class EclipseLinkPersistenceFraction implements Fraction<EclipseLinkPersistenceFraction> {
+}

--- a/jpa-eclipselink/src/main/resources/modules/org/eclipse/persistence/main/module.xml
+++ b/jpa-eclipselink/src/main/resources/modules/org/eclipse/persistence/main/module.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<module xmlns="urn:jboss:module:1.5" name="org.eclipse.persistence">
+    <resources>
+        <artifact name="org.wildfly:jipijapa-eclipselink:${version.wildfly}"/>
+        <artifact name="org.eclipse.persistence:eclipselink:${version.eclipse.link}">
+            <filter>
+                <exclude path="javax/**" />
+            </filter>
+        </artifact>
+    </resources>
+    <dependencies>
+        <module name="asm.asm" />
+        <module name="javax.api"/>
+        <module name="javax.annotation.api"/>
+        <module name="javax.enterprise.api"/>
+        <module name="javax.persistence.api"/>
+        <module name="javax.transaction.api"/>
+        <module name="javax.validation.api"/>
+        <module name="javax.xml.bind.api"/>
+        <module name="javax.ws.rs.api"/>
+        <module name="org.antlr"/>
+        <module name="org.apache.commons.collections"/>
+        <module name="org.dom4j"/>
+        <module name="org.jboss.as.jpa.spi"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.jboss.vfs"/>
+    </dependencies>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
     <version.swagger.javassist>3.18.2-GA</version.swagger.javassist>
     <version.swagger.commons.lang>3.2.1</version.swagger.commons.lang>
 
+    <version.eclipse.link>2.6.2</version.eclipse.link>
     <version.h2>1.4.187</version.h2>
     <version.mysql>5.1.39</version.mysql>
     <version.postgresql>9.4.1208</version.postgresql>
@@ -655,6 +656,12 @@
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
+        <artifactId>jpa-eclipselink</artifactId>
+        <version>2016.10-SNAPSHOT</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.wildfly.swarm</groupId>
         <artifactId>jpa-mysql</artifactId>
         <version>2016.7-SNAPSHOT</version>
       </dependency>
@@ -1107,6 +1114,7 @@
     <module>jmx</module>
     <module>jolokia</module>
     <module>jpa</module>
+    <module>jpa-eclipselink</module>
     <module>jsf</module>
     <module>keycloak</module>
     <module>keycloak-server</module>


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

Module enables declarative configuration of EclipseLink as JPA provider.
## Modifications

New module definition with appropriate configuration assets added
## Result

Eclipselink can be enabled as JPA provider within persistance.xml
## Examples

I'll create another pull request for wildfly-swarm-examples project that utilize this module.
