### PR TITLE
SWARM-667: Dependencies not found in Maven Profile

### DIFF
--- a/arquillian/api/src/main/java/org/wildfly/swarm/arquillian/adapter/MavenProfileLoader.java
+++ b/arquillian/api/src/main/java/org/wildfly/swarm/arquillian/adapter/MavenProfileLoader.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.arquillian.adapter;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jboss.shrinkwrap.resolver.api.maven.ConfigurableMavenResolverSystem;
+import org.jboss.shrinkwrap.resolver.api.maven.PomEquippedResolveStage;
+
+/**
+ * @author Ken Finnigan
+ */
+public final class MavenProfileLoader {
+
+    private static Pattern profilePattern = Pattern.compile("-P([\\w\\-,]+)");
+
+    private static String[] profiles = new String[]{};
+
+    private static boolean profilesDiscovered = false;
+
+    private MavenProfileLoader() {
+    }
+
+    public static PomEquippedResolveStage loadPom(ConfigurableMavenResolverSystem resolver) {
+        if (!profilesDiscovered) {
+            String mavenArgs = System.getProperty("env.MAVEN_CMD_LINE_ARGS");
+
+            final Matcher matcher = profilePattern.matcher(mavenArgs);
+            if (matcher.find()) {
+                String activatedProfiles = matcher.group(1);
+                profiles = activatedProfiles.split(",");
+            }
+            profilesDiscovered = true;
+        }
+
+        return resolver.loadPomFromFile("pom.xml", profiles);
+    }
+}

--- a/arquillian/api/src/main/java/org/wildfly/swarm/arquillian/adapter/MavenProfileLoader.java
+++ b/arquillian/api/src/main/java/org/wildfly/swarm/arquillian/adapter/MavenProfileLoader.java
@@ -26,9 +26,9 @@ import org.jboss.shrinkwrap.resolver.api.maven.PomEquippedResolveStage;
  */
 public final class MavenProfileLoader {
 
-    private static Pattern profilePattern = Pattern.compile("-P([\\w\\-,]+)");
+    private static final Pattern profilePattern = Pattern.compile("-P([\\w\\-,]+)");
 
-    private static String[] profiles = new String[]{};
+    private static String[] profiles = new String[0];
 
     private static boolean profilesDiscovered = false;
 
@@ -36,17 +36,23 @@ public final class MavenProfileLoader {
     }
 
     public static PomEquippedResolveStage loadPom(ConfigurableMavenResolverSystem resolver) {
+        return resolver.loadPomFromFile("pom.xml", determineProfiles());
+    }
+
+    public static String[] determineProfiles() {
         if (!profilesDiscovered) {
             String mavenArgs = System.getProperty("env.MAVEN_CMD_LINE_ARGS");
 
-            final Matcher matcher = profilePattern.matcher(mavenArgs);
-            if (matcher.find()) {
-                String activatedProfiles = matcher.group(1);
-                profiles = activatedProfiles.split(",");
+            if (mavenArgs != null) {
+                final Matcher matcher = profilePattern.matcher(mavenArgs);
+                if (matcher.find()) {
+                    String activatedProfiles = matcher.group(1);
+                    profiles = activatedProfiles.split(",");
+                }
+                profilesDiscovered = true;
             }
-            profilesDiscovered = true;
         }
 
-        return resolver.loadPomFromFile("pom.xml", profiles);
+        return profiles;
     }
 }

--- a/arquillian/api/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
+++ b/arquillian/api/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
@@ -167,7 +167,7 @@ public class UberjarSimpleContainer implements SimpleContainer {
 
         if (!hasRequestedArtifacts) {
             final MavenResolvedArtifact[] explicitDeps =
-                    resolvingHelper.withResolver(r -> r.loadPomFromFile("pom.xml")
+                    resolvingHelper.withResolver(r -> MavenProfileLoader.loadPom(r)
                             .importRuntimeAndTestDependencies()
                             .resolve()
                             .withoutTransitivity()
@@ -181,7 +181,7 @@ public class UberjarSimpleContainer implements SimpleContainer {
             }
 
             final MavenResolvedArtifact[] presolvedDeps =
-                    resolvingHelper.withResolver(r -> r.loadPomFromFile("pom.xml")
+                    resolvingHelper.withResolver(r -> MavenProfileLoader.loadPom(r)
                             .importRuntimeAndTestDependencies()
                             .resolve()
                             .withTransitivity()
@@ -198,7 +198,7 @@ public class UberjarSimpleContainer implements SimpleContainer {
             this.requestedMavenArtifacts.add("org.wildfly.swarm:arquillian-daemon");
             for (String requestedDep : this.requestedMavenArtifacts) {
                 final MavenResolvedArtifact[] explicitDeps =
-                        resolvingHelper.withResolver(r -> r.loadPomFromFile("pom.xml")
+                        resolvingHelper.withResolver(r -> MavenProfileLoader.loadPom(r)
                                 .resolve(requestedDep)
                                 .withoutTransitivity()
                                 .asResolvedArtifact());
@@ -211,7 +211,7 @@ public class UberjarSimpleContainer implements SimpleContainer {
                 }
 
                 final MavenResolvedArtifact[] presolvedDeps =
-                        resolvingHelper.withResolver(r -> r.loadPomFromFile("pom.xml")
+                        resolvingHelper.withResolver(r -> MavenProfileLoader.loadPom(r)
                                 .resolve(requestedDep)
                                 .withTransitivity()
                                 .asResolvedArtifact());

--- a/arquillian/api/src/main/java/org/wildfly/swarm/arquillian/adapter/WildFlySwarmObserver.java
+++ b/arquillian/api/src/main/java/org/wildfly/swarm/arquillian/adapter/WildFlySwarmObserver.java
@@ -64,7 +64,7 @@ public class WildFlySwarmObserver {
         // Gather test and provided dependencies
         final ShrinkwrapArtifactResolvingHelper resolvingHelper = ShrinkwrapArtifactResolvingHelper.defaultInstance();
         final MavenResolvedArtifact[] deps =
-                resolvingHelper.withResolver(r -> r.loadPomFromFile("pom.xml")
+                resolvingHelper.withResolver(r -> MavenProfileLoader.loadPom(r)
                         .importDependencies(ScopeType.TEST, ScopeType.PROVIDED)
                         .resolve()
                         .withTransitivity()

--- a/arquillian/api/src/test/java/org/wildfly/swarm/arquillian/adapter/MavenProfileLoaderTest.java
+++ b/arquillian/api/src/test/java/org/wildfly/swarm/arquillian/adapter/MavenProfileLoaderTest.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.arquillian.adapter;
+
+import java.lang.reflect.Field;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Ken Finnigan
+ */
+public class MavenProfileLoaderTest {
+
+    @Before
+    public void reset() throws Exception {
+        final Field flagField = MavenProfileLoader.class.getDeclaredField("profilesDiscovered");
+        flagField.setAccessible(true);
+        flagField.setBoolean(null, false);
+
+        final Field arrayField = MavenProfileLoader.class.getDeclaredField("profiles");
+        arrayField.setAccessible(true);
+        arrayField.set(null, new String[0]);
+    }
+
+    @Test
+    public void testNullCommand() throws Exception {
+        System.clearProperty("env.MAVEN_CMD_LINE_ARGS");
+
+        String[] profiles = MavenProfileLoader.determineProfiles();
+
+        assertThat(profiles).hasSize(0);
+    }
+
+    @Test
+    public void testEmptyCommand() throws Exception {
+        System.setProperty("env.MAVEN_CMD_LINE_ARGS", "");
+
+        String[] profiles = MavenProfileLoader.determineProfiles();
+
+        assertThat(profiles).hasSize(0);
+    }
+
+    @Test
+    public void testNoProfile() throws Exception {
+        System.setProperty("env.MAVEN_CMD_LINE_ARGS", "mvn clean install");
+
+        String[] profiles = MavenProfileLoader.determineProfiles();
+
+        assertThat(profiles).hasSize(0);
+    }
+
+    @Test
+    public void testOneProfile() throws Exception {
+        System.setProperty("env.MAVEN_CMD_LINE_ARGS", "mvn clean install -Pwildfly");
+
+        String[] profiles = MavenProfileLoader.determineProfiles();
+
+        assertThat(profiles).hasSize(1);
+        assertThat(profiles[0]).contains("wildfly");
+    }
+
+    @Test
+    public void testTwoProfiles() throws Exception {
+        System.setProperty("env.MAVEN_CMD_LINE_ARGS", "mvn clean install -Pwildfly,testing");
+
+        String[] profiles = MavenProfileLoader.determineProfiles();
+
+        assertThat(profiles).hasSize(2);
+        assertThat(profiles[0]).contains("wildfly");
+        assertThat(profiles[1]).contains("testing");
+    }
+
+    @Test
+    public void testThreeProfiles() throws Exception {
+        System.setProperty("env.MAVEN_CMD_LINE_ARGS", "mvn clean install -Pwildfly,testing,another");
+
+        String[] profiles = MavenProfileLoader.determineProfiles();
+
+        assertThat(profiles).hasSize(3);
+        assertThat(profiles[0]).contains("wildfly");
+        assertThat(profiles[1]).contains("testing");
+        assertThat(profiles[2]).contains("another");
+    }
+}


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

When WildFly Swarm dependencies are present only in a Maven Profile, they are unable to be found when building the container for Arquillian tests.
## Modifications

Check for presence of `env.MAVEN_CMD_LINE_ARGS` which contains the Maven command line. Then extract the parts relating to profiles to pass it into ShrinkwrapResolver when loading pom.xml.
## Result

When dependencies are present in a Maven profile, Arquillian tests will find them when run on the command line.
