### PR TITLE
SWARM-681: health endpoints are counter-intuitive

### DIFF
--- a/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/Queries.java
+++ b/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/Queries.java
@@ -38,9 +38,9 @@ class Queries {
         });
     }
 
-    public final static boolean preventDirectAccess(Monitor monitor, String relativePath) {
+    public final static boolean isDirectAccessToHealthEndpoint(Monitor monitor, String relativePath) {
         return query(monitor, metaData -> {
-            return relativePath.equals(metaData.getWebContext()) && metaData.isSecure();
+            return relativePath.equals(metaData.getWebContext());
         });
     }
 

--- a/testsuite/testsuite-jaxrs/src/test/java/org/wildfly/swarm/jaxrs/JAXRSArqMonitorTest.java
+++ b/testsuite/testsuite-jaxrs/src/test/java/org/wildfly/swarm/jaxrs/JAXRSArqMonitorTest.java
@@ -75,45 +75,36 @@ public class JAXRSArqMonitorTest extends SimpleHttp {
 
         // verify listing of subresources
         Response endpointList = getUrlContents("http://localhost:8080/health");
-
-        Assert.assertTrue(endpointList.getBody().contains("links") ); //hateos structure
-
+        Assert.assertTrue(endpointList.getBody().contains("links")); //hateoas structure
         System.out.println(endpointList.getBody());
-
-        Assert.assertTrue(endpointList.getBody().contains("/health/rest/v1/monitor/health-secure") );
+        Assert.assertTrue(endpointList.getBody().contains("/health/rest/v1/monitor/health-secure"));
 
         // verify direct access to secure resources
-        Response response = getUrlContents("http://localhost:8080/rest/v1/monitor/health-secure"); // 403
-
-        Assert.assertTrue("Expected 403 when directly accessing secured health endpoint", response.getStatus() == 403);
+        Response response = getUrlContents("http://localhost:8080/rest/v1/monitor/health-secure", true, false);
+        Assert.assertEquals("Expected 301 when directly accessing secured health endpoint", 301, response.getStatus());
 
         // verify indirect access to secure resources
         response = getUrlContents("http://localhost:8080/health/rest/v1/monitor/health-secure");
-
-        Assert.assertTrue(response.getBody(). contains("UP") );
+        Assert.assertTrue(response.getBody().contains("UP"));
 
         // verify indirect access, without auth, to secure resources
         response = getUrlContents("http://localhost:8080/health/rest/v1/monitor/health-secure", false);
         Assert.assertEquals(401, response.getStatus());
 
         // verify direct access to insecure resources
-        response = getUrlContents("http://localhost:8080/rest/v1/monitor/health-insecure");
-        Assert.assertTrue(response.getBody(). contains("UP") );
+        response = getUrlContents("http://localhost:8080/rest/v1/monitor/health-insecure", true, false);
+        Assert.assertEquals("Expected 301 when directly accessing secured health endpoint", 301, response.getStatus());
 
         // verify indirect access, without auth, to insecure resources
         response = getUrlContents("http://localhost:8080/health/rest/v1/monitor/health-insecure", false);
-
         Assert.assertEquals(200, response.getStatus());
 
         // verify indirect access to insecure resources
         response = getUrlContents("http://localhost:8080/health/rest/v1/monitor/health-insecure");
-        Assert.assertTrue(response.getBody(). contains("UP") );
+        Assert.assertTrue(response.getBody().contains("UP"));
 
         // verify other resources remain untouched
         response = getUrlContents("http://localhost:8080/rest/v1/another-app/time");
-
-        Assert.assertTrue(response.getBody(). contains("Time") );
-
-
+        Assert.assertTrue(response.getBody().contains("Time"));
     }
 }

--- a/testsuite/testsuite-jaxrs/src/test/java/org/wildfly/swarm/jaxrs/SimpleHttp.java
+++ b/testsuite/testsuite-jaxrs/src/test/java/org/wildfly/swarm/jaxrs/SimpleHttp.java
@@ -38,6 +38,10 @@ public class SimpleHttp {
     }
 
     protected Response getUrlContents(String theUrl, boolean useAuth) {
+        return getUrlContents(theUrl, useAuth, true);
+    }
+
+    protected Response getUrlContents(String theUrl, boolean useAuth, boolean followRedirects) {
 
         StringBuilder content = new StringBuilder();
         int code;
@@ -49,6 +53,7 @@ public class SimpleHttp {
             provider.setCredentials(AuthScope.ANY, credentials);
 
             HttpClientBuilder builder = HttpClientBuilder.create();
+            if (!followRedirects) builder.disableRedirectHandling();
             if (useAuth) builder.setDefaultCredentialsProvider(provider);
             HttpClient client = builder.build();
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

If a health endpoint is defined at path `/app/health`, it's primarily
available under `/health/app/health`. If it's unsecured, it's also
available at the original path `/app/health`, but if it's secured,
the original path `/app/health` returns 403. That's inconsistent
and counter-intuitive.
## Modifications

All original paths of health endpoints simply return a 301 redirect.
## Result

More intuitive behavior when original path of a health endpoint
is accessed.
