### PR TITLE
Added shutdown hook to RuntimeServer

### DIFF
--- a/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
@@ -104,6 +104,16 @@ public class RuntimeServer implements Server {
     private StageConfig stageConfig;
 
     public RuntimeServer() {
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            if(serviceContainer!=null) {
+                try {
+                    LOG.info("Shutdown requested ...");
+                    stop();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        }));
     }
 
     @Produces


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

---

SWARM-684: Shutdown hook for RuntimeServer
## Motivation

When ctrl-c a process `RuntimeServer#stop()` is not invoked an thus leaves the service container and other resources in an undetermined state.
## Modifications

Added a shutdown hook to `RuntimeServer` that invokes `stop()`
## Result

ctrl-c now triggers stop which shutdowns the service container in a predictable manner
