### PR TITLE
SWARM-690: FractionList dependencies have incomplete information

### DIFF
--- a/fraction-list/src/test/java/org/wildfly/swarm/fractionlist/FractionListTest.java
+++ b/fraction-list/src/test/java/org/wildfly/swarm/fractionlist/FractionListTest.java
@@ -85,4 +85,10 @@ public class FractionListTest {
         assertThat(dependencies).contains(naming, container);
     }
 
+    @Test
+    public void testArchaiusFractionShouldBeInternal() {
+        FractionDescriptor archaius = FractionList.get().getFractionDescriptor("org.wildfly.swarm", "archaius");
+        assertThat(archaius.isInternal()).isTrue();;
+    }
+
 }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

Some metadata from FractionDescriptors are incorrect when a fraction (eg. archaius) is not present in the root
but declared only as a dependency.
## Modifications

The fraction list parsing code was optimized to use the complete information provide in the JSON file only.
## Result

The correct metadata is returned for the specified fraction
