### PR TITLE
SWARM-695: Bootstrap fails due to empty default deployment

### DIFF
--- a/container/src/main/java/org/wildfly/swarm/container/runtime/deployments/DefaultDeploymentCreator.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/deployments/DefaultDeploymentCreator.java
@@ -90,9 +90,9 @@ public class DefaultDeploymentCreator {
             jarArchive.addAsManifestResource(new Asset() {
                 @Override
                 public InputStream openStream() {
-                    return new ByteArrayInputStream(new String("Produced by EmptyJARArchiveDeploymentFactory").getBytes());
+                    return new ByteArrayInputStream(new String("Created-By: WildFly Swarm\n").getBytes());
                 }
-            }, ArchivePaths.create("readme.txt"));
+            }, ArchivePaths.create("MANIFEST.MF"));
             return jarArchive;
         }
 

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/deployments/DefaultDeploymentCreator.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/deployments/DefaultDeploymentCreator.java
@@ -1,7 +1,5 @@
 package org.wildfly.swarm.container.runtime.deployments;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -15,7 +13,7 @@ import javax.inject.Inject;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.wildfly.swarm.spi.api.DefaultDeploymentFactory;
 import org.wildfly.swarm.spi.api.JARArchive;
 
@@ -87,12 +85,7 @@ public class DefaultDeploymentCreator {
         @Override
         public Archive create() throws Exception {
             JARArchive jarArchive = ShrinkWrap.create(JARArchive.class, UUID.randomUUID().toString() + "." + this.type);
-            jarArchive.addAsManifestResource(new Asset() {
-                @Override
-                public InputStream openStream() {
-                    return new ByteArrayInputStream(new String("Created-By: WildFly Swarm\n").getBytes());
-                }
-            }, ArchivePaths.create("MANIFEST.MF"));
+            jarArchive.addAsManifestResource(new StringAsset("Created-By: WildFly Swarm\n"), ArchivePaths.create("MANIFEST.MF"));
             return jarArchive;
         }
 

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/deployments/DefaultDeploymentCreator.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/deployments/DefaultDeploymentCreator.java
@@ -1,5 +1,7 @@
 package org.wildfly.swarm.container.runtime.deployments;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -11,7 +13,9 @@ import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
 import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
 import org.wildfly.swarm.spi.api.DefaultDeploymentFactory;
 import org.wildfly.swarm.spi.api.JARArchive;
 
@@ -82,7 +86,14 @@ public class DefaultDeploymentCreator {
 
         @Override
         public Archive create() throws Exception {
-            return ShrinkWrap.create(JARArchive.class, UUID.randomUUID().toString() + "." + this.type );
+            JARArchive jarArchive = ShrinkWrap.create(JARArchive.class, UUID.randomUUID().toString() + "." + this.type);
+            jarArchive.addAsManifestResource(new Asset() {
+                @Override
+                public InputStream openStream() {
+                    return new ByteArrayInputStream(new String("Produced by EmptyJARArchiveDeploymentFactory").getBytes());
+                }
+            }, ArchivePaths.create("readme.txt"));
+            return jarArchive;
         }
 
         @Override

--- a/container/src/test/java/org/wildfly/swarm/container/runtime/deployments/DefaultDeploymentCreatorTest.java
+++ b/container/src/test/java/org/wildfly/swarm/container/runtime/deployments/DefaultDeploymentCreatorTest.java
@@ -21,6 +21,7 @@ public class DefaultDeploymentCreatorTest {
         Archive archive = factory.create();
         assertThat(archive).isNotNull();
         assertThat(archive.getName()).endsWith(".foo");
+        assertThat(archive.getContent().size()).isGreaterThan(0);
     }
 
     @Test


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

The DeploymentFactories have been moved into each respective fraction (i.e. Undertow -> WARDeploymentFactory). This means that without a corresponding fraction, the factory will not be available and in some cases the default deployment will be created by the EmptyJARDeplymentFactory
## Modifications

EmptyJARDeplymentFactory contains a single META-INF/MANIFEST.MF to prevent the error in ZipExporterDelegate.
## Result

Although useless, empty deployments now “deploy” correctly.
