### PR TITLE
SWARM-700: Fix swarm.port.offset not working

### DIFF
--- a/container/src/main/java/org/wildfly/swarm/container/runtime/config/DefaultSocketBindingGroupProducer.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/config/DefaultSocketBindingGroupProducer.java
@@ -21,6 +21,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.wildfly.swarm.spi.api.SocketBindingGroup;
+import org.wildfly.swarm.spi.api.SwarmProperties;
 
 /**
  * @author Bob McWhirter
@@ -32,7 +33,10 @@ public class DefaultSocketBindingGroupProducer {
 
     @Produces @Singleton @Named( STANDARD_SOCKETS )
     public SocketBindingGroup standardSockets() {
-        return new SocketBindingGroup( "standard-sockets", "public", "0");
+        return new SocketBindingGroup(
+                "standard-sockets",
+                "public",
+                SwarmProperties.propertyVar(SwarmProperties.PORT_OFFSET, "0"));
     }
 
 }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

The system property `swarm.port.offset` doesn't work because
portOffsetExpression of SocketBindingGroup is hard-coded with zero in
the constructor.
## Modifications

Pass SwarmProperties.PORT_OFFSET on to the portOffsetExpression.
## Result

`swarm.port.offset` works.
