### PR TITLE
SWARM-696: Transitive Swarm dependencies in multi module setups

### DIFF
--- a/arquillian/resolver/src/main/java/org/wildfly/swarm/arquillian/resolver/ShrinkwrapArtifactResolvingHelper.java
+++ b/arquillian/resolver/src/main/java/org/wildfly/swarm/arquillian/resolver/ShrinkwrapArtifactResolvingHelper.java
@@ -113,7 +113,7 @@ public class ShrinkwrapArtifactResolvingHelper implements ArtifactResolvingHelpe
     }
 
     @Override
-    public Set<ArtifactSpec> resolveAll(final Set<ArtifactSpec> specs, boolean trasitive) {
+    public Set<ArtifactSpec> resolveAll(final Set<ArtifactSpec> specs, boolean trasitive, boolean defaultExcludes) {
         if (specs.isEmpty()) {
             return specs;
         }

--- a/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/GradleArtifactResolvingHelper.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/GradleArtifactResolvingHelper.java
@@ -72,7 +72,7 @@ public class GradleArtifactResolvingHelper implements ArtifactResolvingHelper {
     }
 
     @Override
-    public Set<ArtifactSpec> resolveAll(final Set<ArtifactSpec> specs, boolean transitive) throws Exception {
+    public Set<ArtifactSpec> resolveAll(final Set<ArtifactSpec> specs, boolean transitive, boolean defaultExcludes) throws Exception {
         if (specs.isEmpty()) {
             return specs;
         }

--- a/plugin/src/main/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelper.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelper.java
@@ -105,7 +105,7 @@ public class MavenArtifactResolvingHelper implements ArtifactResolvingHelper {
     }
 
     @Override
-    public Set<ArtifactSpec> resolveAll(Set<ArtifactSpec> specs, boolean transitive) throws Exception {
+    public Set<ArtifactSpec> resolveAll(Set<ArtifactSpec> specs, boolean transitive, boolean defaultExcludes) throws Exception {
         if (specs.isEmpty()) {
             return specs;
         }
@@ -130,7 +130,7 @@ public class MavenArtifactResolvingHelper implements ArtifactResolvingHelper {
                                     new JavaScopeSelector(),
                                     new SimpleOptionalitySelector(),
                                     new JavaScopeDeriver()
-                            )
+                            ), defaultExcludes
                     );
 
             CollectResult result = this.system.collectDependencies(tempSession, request);

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -74,6 +74,7 @@
 
   <modules>
     <module>testsuite-batch-jberet</module>
+    <module>testsuite-buildtool</module>
     <module>testsuite-cdi</module>
     <module>testsuite-camel-cdi</module>
     <module>testsuite-camel-cxf</module>

--- a/testsuite/testsuite-buildtool/multi-module/api/pom.xml
+++ b/testsuite/testsuite-buildtool/multi-module/api/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>multi-module-test</artifactId>
+        <version>2016.10-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>multi-module-api</artifactId>
+
+    <dependencies>
+
+        <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.2</version>
+        </dependency>
+
+        <!-- http://mvnrepository.com/artifact/com.google.code.gson/gson -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.6.2</version>
+        </dependency>
+
+        <!-- http://mvnrepository.com/artifact/com.sun.jersey/jersey-client -->
+        <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-client</artifactId>
+            <version>1.19.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-json</artifactId>
+            <version>1.19.1</version>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/testsuite/testsuite-buildtool/multi-module/api/src/main/java/example/Sample.java
+++ b/testsuite/testsuite-buildtool/multi-module/api/src/main/java/example/Sample.java
@@ -1,0 +1,13 @@
+package example;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ * Created by wlw on 14.09.16.
+ */
+public class Sample {
+
+    public String saySomething() {
+        return "something";
+    }
+}

--- a/testsuite/testsuite-buildtool/multi-module/api/src/test/java/consumer/SampleTest.java
+++ b/testsuite/testsuite-buildtool/multi-module/api/src/test/java/consumer/SampleTest.java
@@ -1,0 +1,41 @@
+package consumer;
+
+import example.Sample;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.undertow.WARArchive;
+
+import javax.inject.Inject;
+
+/**
+ * Created by wlw on 13.09.16.
+ */
+
+@RunWith(Arquillian.class)
+@Ignore
+public class SampleTest {
+
+    @Deployment
+    public static Archive createDeployment() throws Exception {
+        WARArchive archive = ShrinkWrap.create(WARArchive.class, "SampleTest.war");
+        archive.addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        archive.addPackage("example");
+        archive.addAllDependencies();
+        return archive;
+    }
+
+    @Inject
+    private Sample sample;
+
+    @org.junit.Test
+    public void testGet() throws Exception {
+        Assert.assertEquals(this.sample.saySomething(), "something");
+    }
+
+}

--- a/testsuite/testsuite-buildtool/multi-module/pom.xml
+++ b/testsuite/testsuite-buildtool/multi-module/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>testsuite-buildtool</artifactId>
+        <version>2016.10-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>multi-module-test</artifactId>
+
+    <modules>
+        <module>view</module>
+        <module>api</module>
+    </modules>
+
+    <packaging>pom</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencyManagement>
+        <dependencies>
+
+            <dependency>
+                <groupId>org.wildfly.swarm</groupId>
+                <artifactId>bom-all</artifactId>
+                <version>${project.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.arquillian.extension</groupId>
+                <artifactId>arquillian-rest-warp-bom</artifactId>
+                <version>1.0.0.Alpha4</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+
+        <!-- Java EE 7 dependency -->
+        <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+            <version>7.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Wildfly Swarm Fractions -->
+        <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>cdi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>jaxrs</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>arquillian</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+
+</project>

--- a/testsuite/testsuite-buildtool/multi-module/view/pom.xml
+++ b/testsuite/testsuite-buildtool/multi-module/view/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>multi-module-test</artifactId>
+        <version>2016.10-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>multi-module-view</artifactId>
+
+    <packaging>war</packaging>
+
+    <build>
+        <finalName>endpoint</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.swarm</groupId>
+                <artifactId>wildfly-swarm-plugin</artifactId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <configuration>
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
+                </configuration>
+            </plugin>
+
+
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
+
+    <dependencies>
+
+
+        <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>multi-module-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>jaxrs</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+
+    </dependencies>
+
+
+</project>

--- a/testsuite/testsuite-buildtool/multi-module/view/src/main/java/example/Endpoint.java
+++ b/testsuite/testsuite-buildtool/multi-module/view/src/main/java/example/Endpoint.java
@@ -1,0 +1,19 @@
+package example;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ * @author Heiko Braun
+ * @since 27/09/16
+ */
+@Path("/")
+public class Endpoint {
+
+    private Sample sample = new Sample();
+
+    @GET
+    public String speak() {
+        return sample.saySomething();
+    }
+}

--- a/testsuite/testsuite-buildtool/multi-module/view/src/test/java/VerifyBuildArtefactIT.java
+++ b/testsuite/testsuite-buildtool/multi-module/view/src/test/java/VerifyBuildArtefactIT.java
@@ -1,0 +1,60 @@
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.Assert;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.jaxrs.JAXRSArchive;
+
+@RunWith(Arquillian.class)
+public class VerifyBuildArtefactIT {
+
+
+    @Deployment
+    public static Archive createDeployment() throws Exception {
+        try {
+            return ShrinkWrap.createFromZipFile(JAXRSArchive.class, new File("target/endpoint.war"));
+        } catch (Throwable e) {
+            e.printStackTrace();
+            throw e;
+        }
+    }
+
+    @org.junit.Test
+    public void testEndppoint() throws Exception {
+        String urlContents = getUrlContents("http://127.0.0.1:8080/");
+        Assert.assertEquals("something\n", urlContents);
+    }
+
+    private static String getUrlContents(String theUrl) {
+        StringBuilder content = new StringBuilder();
+
+        try {
+            URL url = new URL(theUrl);
+            URLConnection urlConnection = url.openConnection();
+            BufferedReader bufferedReader = new BufferedReader(
+                    new InputStreamReader(urlConnection.getInputStream())
+            );
+
+            String line;
+
+            while ((line = bufferedReader.readLine()) != null) {
+                content.append(line + "\n");
+            }
+            bufferedReader.close();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        return content.toString();
+    }
+
+    private static Swarm container;
+}

--- a/testsuite/testsuite-buildtool/pom.xml
+++ b/testsuite/testsuite-buildtool/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~
+  ~ Copyright 2016 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>testsuite</artifactId>
+    <version>2016.10-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>testsuite-buildtool</artifactId>
+
+  <name>Test Suite: Buildtool</name>
+  <description>Test Suite: Buildtool</description>
+
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>arquillian</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.junit</groupId>
+      <artifactId>arquillian-junit-container</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <modules>
+    <module>multi-module</module>
+  </modules>
+
+</project>

--- a/tools/src/main/java/org/wildfly/swarm/tools/ArtifactResolvingHelper.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/ArtifactResolvingHelper.java
@@ -31,8 +31,8 @@ public interface ArtifactResolvingHelper {
     ArtifactSpec resolve(ArtifactSpec spec) throws Exception;
 
     default Set<ArtifactSpec> resolveAll(Set<ArtifactSpec> specs) throws Exception {
-        return resolveAll( specs, true );
+        return resolveAll( specs, true, false );
     }
 
-    Set<ArtifactSpec> resolveAll(Set<ArtifactSpec> specs, boolean transitive) throws Exception;
+    Set<ArtifactSpec> resolveAll(Set<ArtifactSpec> specs, boolean transitive, boolean defaultExcludes) throws Exception;
 }

--- a/tools/src/main/java/org/wildfly/swarm/tools/DependencyManager.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/DependencyManager.java
@@ -202,7 +202,7 @@ public class DependencyManager {
     }
 
     protected void analyzeDependencies(boolean autodetect) throws Exception {
-        Set<ArtifactSpec> allResolvedDependencies = resolveAllArtifactsTransitively(this.explicitDependencies);
+        Set<ArtifactSpec> allResolvedDependencies = resolveAllArtifactsTransitively(this.explicitDependencies, false);
 
         /*
         for (ArtifactSpec each : allResolvedDependencies) {
@@ -272,7 +272,7 @@ public class DependencyManager {
 
         // re-resolve the application's dependencies minus
         // any of our swarm dependencies
-        Set<ArtifactSpec> simplifiedDeps = resolveAllArtifactsTransitively(nonBootstrapDeps);
+        Set<ArtifactSpec> simplifiedDeps = resolveAllArtifactsTransitively(nonBootstrapDeps, true);
 
         /*
         for (ArtifactSpec each : simplifiedDeps) {
@@ -435,12 +435,12 @@ public class DependencyManager {
         return spec;
     }
 
-    protected Set<ArtifactSpec> resolveAllArtifactsTransitively(Set<ArtifactSpec> specs) throws Exception {
-        return this.resolver.resolveAll(specs);
+    protected Set<ArtifactSpec> resolveAllArtifactsTransitively(Set<ArtifactSpec> specs, boolean defaultExcludes) throws Exception {
+        return this.resolver.resolveAll(specs, true, defaultExcludes);
     }
 
     protected Set<ArtifactSpec> resolveAllArtifactsNonTransitively(Set<ArtifactSpec> specs) throws Exception {
-        return this.resolver.resolveAll(specs, false);
+        return this.resolver.resolveAll(specs, false, false);
     }
 
     private final WildFlySwarmManifest applicationManifest = new WildFlySwarmManifest();

--- a/tools/src/test/java/org/wildfly/swarm/tools/MockArtifactResolver.java
+++ b/tools/src/test/java/org/wildfly/swarm/tools/MockArtifactResolver.java
@@ -72,7 +72,7 @@ public class MockArtifactResolver implements ArtifactResolvingHelper {
     }
 
     @Override
-    public Set<ArtifactSpec> resolveAll(Set<ArtifactSpec> specs, boolean transitive) throws Exception {
+    public Set<ArtifactSpec> resolveAll(Set<ArtifactSpec> specs, boolean transitive, boolean defaultExcludes) throws Exception {
         Set<ArtifactSpec> resolved = new HashSet<>();
         for (ArtifactSpec spec : specs) {
             resolved.add(resolve(spec));


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?
## Motivation

In multi-module setups (maven) Swarm fractions deps are brought trough a transtive dependency graph. This pollutes the WEB-INF/lib again and causes the same issues aas reported in SWARM-616
## Modifications

Change the resolver API's to specifiy whether Swarm should be traversed
## Result

Transitive Swarm deps will not be traveresed.
