### PR TITLE
SWARM-710: RuntimeDeployer should perform cleanup when destroyed

### DIFF
--- a/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeDeployer.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeDeployer.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javax.annotation.PreDestroy;
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Vetoed;
 import javax.inject.Inject;
@@ -245,6 +246,7 @@ public class RuntimeDeployer implements Deployer {
         }
     }
 
+    @PreDestroy
     void stop() {
         for (Closeable each : this.mountPoints) {
             try {

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
@@ -197,7 +197,6 @@ public class RuntimeServer implements Server {
 
         latch.await();
 
-        this.deployer.get().stop();
         this.serviceContainer = null;
         this.client = null;
         this.deployer = null;


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

RuntimeServer calls deployer.get().stop(), but that doesn't work if the CDI engine is down (when Ctrl+C)
## Modifications

Added a @PreDestroy annotation to RuntimeDeployer.stop() and removed the call to the Instance deployer object in RuntimeServer.stop
## Result

RuntimeDeployer.stop is called when the object is destroyed accordingly
