### PR TITLE
SWARM-437 - Allow annotations to advertise services.

### DIFF
--- a/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeDeployer.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeDeployer.java
@@ -160,12 +160,7 @@ public class RuntimeDeployer implements Deployer {
     @Override
     public void deploy(Archive<?> deployment) throws DeploymentException {
 
-        // 1. give fractions a chance to handle the deployment
-        for (ArchivePreparer preparer : this.archivePreparers) {
-            preparer.prepareArchive(deployment);
-        }
-
-        // 2. create a meta data index, but only if we have processors for it
+        // 1. create a meta data index, but only if we have processors for it
         if (!this.archiveMetadataProcessors.isUnsatisfied()) {
             Indexer indexer = new Indexer();
             Map<ArchivePath, Node> c = deployment.getContent();
@@ -185,6 +180,11 @@ public class RuntimeDeployer implements Deployer {
             for (ArchiveMetadataProcessor processor : this.archiveMetadataProcessors) {
                 processor.processArchive(deployment, index);
             }
+        }
+
+        // 2. give fractions a chance to handle the deployment
+        for (ArchivePreparer preparer : this.archivePreparers) {
+            preparer.prepareArchive(deployment);
         }
 
         if (this.debug) {

--- a/topology/src/main/java/org/wildfly/swarm/topology/Advertise.java
+++ b/topology/src/main/java/org/wildfly/swarm/topology/Advertise.java
@@ -1,0 +1,19 @@
+package org.wildfly.swarm.topology;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.wildfly.swarm.spi.api.annotations.DeploymentModules;
+
+/**
+ * @author Bob McWhirter
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Repeatable(Advertises.class)
+public @interface Advertise {
+    String value();
+}

--- a/topology/src/main/java/org/wildfly/swarm/topology/Advertises.java
+++ b/topology/src/main/java/org/wildfly/swarm/topology/Advertises.java
@@ -1,0 +1,20 @@
+package org.wildfly.swarm.topology;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.enterprise.util.Nonbinding;
+import javax.inject.Qualifier;
+
+import org.wildfly.swarm.spi.api.annotations.DeploymentModule;
+
+/**
+ * @author Bob McWhirter
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface Advertises {
+    @Nonbinding Advertise[] value();
+}

--- a/topology/src/main/java/org/wildfly/swarm/topology/TopologyArchive.java
+++ b/topology/src/main/java/org/wildfly/swarm/topology/TopologyArchive.java
@@ -15,6 +15,10 @@
  */
 package org.wildfly.swarm.topology;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
 import org.jboss.shrinkwrap.api.Assignable;
 
 /**
@@ -27,6 +31,9 @@ public interface TopologyArchive extends Assignable {
     TopologyArchive advertise();
 
     TopologyArchive advertise(String... serviceNames);
+    TopologyArchive advertise(Collection<String> serviceNames);
+
+    List<String> advertisements();
 
     boolean hasAdvertised();
 }

--- a/topology/src/main/java/org/wildfly/swarm/topology/internal/TopologyArchiveImpl.java
+++ b/topology/src/main/java/org/wildfly/swarm/topology/internal/TopologyArchiveImpl.java
@@ -15,10 +15,15 @@
  */
 package org.wildfly.swarm.topology.internal;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import org.jboss.shrinkwrap.api.Node;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.impl.base.ArchiveBase;
 import org.jboss.shrinkwrap.impl.base.AssignableBase;
@@ -41,6 +46,18 @@ public class TopologyArchiveImpl extends AssignableBase<ArchiveBase<?>> implemen
      */
     public TopologyArchiveImpl(ArchiveBase<?> archive) {
         super(archive);
+
+        Node regConf = as(JARArchive.class).get(REGISTRATION_CONF);
+        if ( regConf != null && regConf.getAsset() != null ) {
+            try ( BufferedReader reader = new BufferedReader( new InputStreamReader( regConf.getAsset().openStream() ) ) ) {
+                reader.lines()
+                        .forEach( line->{
+                            this.serviceNames.add( line );
+                        });
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
     }
 
     @Override
@@ -56,6 +73,17 @@ public class TopologyArchiveImpl extends AssignableBase<ArchiveBase<?>> implemen
         }
 
         return advertise();
+    }
+
+    @Override
+    public TopologyArchive advertise(Collection<String> serviceNames) {
+        this.serviceNames.addAll( serviceNames );
+        return advertise();
+    }
+
+    @Override
+    public List<String> advertisements() {
+        return Collections.unmodifiableList( this.serviceNames );
     }
 
     @Override

--- a/topology/src/main/java/org/wildfly/swarm/topology/runtime/AdvertisingMetadataProcessor.java
+++ b/topology/src/main/java/org/wildfly/swarm/topology/runtime/AdvertisingMetadataProcessor.java
@@ -1,0 +1,40 @@
+package org.wildfly.swarm.topology.runtime;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.shrinkwrap.api.Archive;
+import org.wildfly.swarm.spi.api.ArchiveMetadataProcessor;
+import org.wildfly.swarm.topology.Advertise;
+import org.wildfly.swarm.topology.Advertises;
+import org.wildfly.swarm.topology.TopologyArchive;
+
+/**
+ * @author Bob McWhirter
+ */
+public class AdvertisingMetadataProcessor implements ArchiveMetadataProcessor {
+
+    @Override
+    public void processArchive(Archive<?> archive, Index index) {
+        List<AnnotationInstance> annos = index.getAnnotations(DotName.createSimple(Advertise.class.getName()));
+        List<AnnotationInstance> repeatingAnnos = index.getAnnotations(DotName.createSimple(Advertises.class.getName()));
+
+        List<String> names = Stream.concat( annos.stream(),
+                repeatingAnnos
+                .stream()
+                .flatMap( anno-> Stream.of( anno.value().asNestedArray() )) )
+                .map( anno-> anno.value().asString() )
+                .collect(Collectors.toList());
+
+        if ( ! names.isEmpty() ) {
+            archive.as(TopologyArchive.class)
+                    .advertise(names);
+        }
+
+    }
+
+}

--- a/topology/src/test/java/org/wildfly/swarm/topology/MyClass.java
+++ b/topology/src/test/java/org/wildfly/swarm/topology/MyClass.java
@@ -1,0 +1,9 @@
+package org.wildfly.swarm.topology;
+
+/**
+ * @author Bob McWhirter
+ */
+@Advertise("foo")
+public class MyClass {
+
+}

--- a/topology/src/test/java/org/wildfly/swarm/topology/MyRepeatingClass.java
+++ b/topology/src/test/java/org/wildfly/swarm/topology/MyRepeatingClass.java
@@ -1,0 +1,10 @@
+package org.wildfly.swarm.topology;
+
+/**
+ * @author Bob McWhirter
+ */
+@Advertise("cheddar")
+@Advertise("gouda")
+public class MyRepeatingClass {
+
+}

--- a/topology/src/test/java/org/wildfly/swarm/topology/TopologyArchiveTest.java
+++ b/topology/src/test/java/org/wildfly/swarm/topology/TopologyArchiveTest.java
@@ -1,0 +1,21 @@
+package org.wildfly.swarm.topology;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.Test;
+import org.wildfly.swarm.spi.api.JARArchive;
+import static org.fest.assertions.Assertions.*;
+
+/**
+ * @author Bob McWhirter
+ */
+public class TopologyArchiveTest {
+
+    @Test
+    public void testMultipleCastingToTopologyArchive() {
+        JARArchive archive = ShrinkWrap.create(JARArchive.class);
+        archive.as(TopologyArchive.class).advertise("foo");
+
+        assertThat( archive.as( TopologyArchive.class).advertisements() ).hasSize(1);
+        assertThat( archive.as( TopologyArchive.class).advertisements() ).contains("foo");
+    }
+}

--- a/topology/src/test/java/org/wildfly/swarm/topology/runtime/AdvertisingMetadataProcessorTest.java
+++ b/topology/src/test/java/org/wildfly/swarm/topology/runtime/AdvertisingMetadataProcessorTest.java
@@ -1,0 +1,83 @@
+package org.wildfly.swarm.topology.runtime;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.jandex.Index;
+import org.jboss.jandex.Indexer;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.Node;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.Test;
+import org.wildfly.swarm.spi.api.JARArchive;
+import org.wildfly.swarm.topology.MyClass;
+import org.wildfly.swarm.topology.MyRepeatingClass;
+import org.wildfly.swarm.topology.TopologyArchive;
+
+import static org.fest.assertions.Assertions.*;
+
+/**
+ * @author Bob McWhirter
+ */
+public class AdvertisingMetadataProcessorTest {
+
+    @Test
+    public void testNoAnnotations() throws IOException {
+        JARArchive archive = ShrinkWrap.create(JARArchive.class);
+
+        AdvertisingMetadataProcessor processor = new AdvertisingMetadataProcessor();
+        processor.processArchive(archive, createIndex(archive));
+
+        List<String> advertisements = archive.as(TopologyArchive.class).advertisements();
+
+        assertThat(advertisements).isEmpty();
+    }
+
+    @Test
+    public void testWithSingleAnnotation() throws IOException {
+        JARArchive archive = ShrinkWrap.create(JARArchive.class);
+
+        archive.addClass(MyClass.class);
+
+        AdvertisingMetadataProcessor processor = new AdvertisingMetadataProcessor();
+        processor.processArchive(archive, createIndex(archive));
+
+        List<String> advertisements = archive.as(TopologyArchive.class).advertisements();
+
+        assertThat(advertisements).hasSize(1);
+        assertThat(advertisements).contains("foo");
+    }
+
+    @Test
+    public void testWithRepeatingAnnotation() throws IOException {
+        JARArchive archive = ShrinkWrap.create(JARArchive.class);
+
+        archive.addClass(MyRepeatingClass.class);
+
+        AdvertisingMetadataProcessor processor = new AdvertisingMetadataProcessor();
+        processor.processArchive(archive, createIndex(archive));
+
+        List<String> advertisements = archive.as(TopologyArchive.class).advertisements();
+
+        assertThat(advertisements).hasSize(2);
+        assertThat(advertisements).contains("cheddar");
+        assertThat(advertisements).contains("gouda");
+    }
+
+    Index createIndex(Archive archive) throws IOException {
+        Indexer indexer = new Indexer();
+
+        Map<ArchivePath, Node> c = archive.getContent();
+        for (Map.Entry<ArchivePath, Node> each : c.entrySet()) {
+            if (each.getKey().get().endsWith(".class")) {
+                System.err.println( "indexing: " + each.getKey().get() );
+                indexer.index(each.getValue().getAsset().openStream());
+            }
+        }
+
+
+        return indexer.complete();
+    }
+}


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

In the case a person doesn't use a main(), and wants to perform
multiple advertisements, particularly those not based on the simplified
archive name, provide an @Advertise annotation.
## Modifications

@Annotation is inspected for each archive, and can specify the
name of services to advertise.  It is a repeatable annotation
and several can be applied to any class, for whatever reason.
## Result

@Advertise("tacos")
public class Tacos { ... }

Will cause the same behaviour as calling

  archive.as(TopologyArchive.class).advertise("tacos")

on the deployed archive containing the aforementioned class.
