### PR TITLE
SWARM-543 & SWARM-721 - Remote MQ Connections

### DIFF
--- a/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -68,6 +68,8 @@ import org.wildfly.swarm.container.internal.ServerBootstrap;
 import org.wildfly.swarm.container.runtime.cdi.ProjectStageFactory;
 import org.wildfly.swarm.container.runtime.logging.JBossLoggingManager;
 import org.wildfly.swarm.internal.ArtifactManager;
+import org.wildfly.swarm.internal.OutboundSocketBindingRequest;
+import org.wildfly.swarm.internal.SocketBindingRequest;
 import org.wildfly.swarm.internal.SwarmMessages;
 import org.wildfly.swarm.spi.api.ArtifactLookup;
 import org.wildfly.swarm.spi.api.Fraction;
@@ -262,6 +264,16 @@ public class Swarm {
         return this;
     }
 
+    public Swarm outboundSocketBinding(String socketBindingGroup, OutboundSocketBinding binding) {
+        this.outboundSocketBindings.add( new OutboundSocketBindingRequest( socketBindingGroup, binding ) );
+        return this;
+    }
+
+    public Swarm socketBinding(String socketBindingGroup, SocketBinding binding) {
+        this.socketBindings.add( new SocketBindingRequest( socketBindingGroup, binding ));
+        return this;
+    }
+
     /**
      * Start the container.
      *
@@ -282,6 +294,8 @@ public class Swarm {
                 .withArguments(this.args)
                 .withBootstrapDebug(this.debugBootstrap)
                 .withExplicitlyInstalledFractions(this.explicitlyInstalledFractions)
+                .withSocketBindings(this.socketBindings)
+                .withOutboundSocketBindings(this.outboundSocketBindings)
                 .withUserComponents(this.userComponentClasses)
                 .withXmlConfig(this.xmlConfig);
 
@@ -517,6 +531,10 @@ public class Swarm {
     private Server server;
 
     private Set<Class<?>> userComponentClasses = new HashSet<>();
+
+    private List<SocketBindingRequest> socketBindings = new ArrayList<>();
+
+    private List<OutboundSocketBindingRequest> outboundSocketBindings = new ArrayList<>();
 
     private List<Fraction> explicitlyInstalledFractions = new ArrayList<>();
 

--- a/container/src/main/java/org/wildfly/swarm/container/internal/ServerBootstrap.java
+++ b/container/src/main/java/org/wildfly/swarm/container/internal/ServerBootstrap.java
@@ -2,12 +2,14 @@ package org.wildfly.swarm.container.internal;
 
 import java.net.URL;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import org.wildfly.swarm.internal.OutboundSocketBindingRequest;
+import org.wildfly.swarm.internal.SocketBindingRequest;
 import org.wildfly.swarm.spi.api.Fraction;
 import org.wildfly.swarm.spi.api.ProjectStage;
-import org.wildfly.swarm.spi.api.StageConfig;
 
 /**
  * @author Bob McWhirter
@@ -27,6 +29,10 @@ public interface ServerBootstrap {
     ServerBootstrap withExplicitlyInstalledFractions(Collection<Fraction> explicitlyInstalledFractions);
 
     ServerBootstrap withUserComponents(Set<Class<?>> userComponentClasses);
+
+    ServerBootstrap withSocketBindings(List<SocketBindingRequest> bindings);
+
+    ServerBootstrap withOutboundSocketBindings(List<OutboundSocketBindingRequest> bindings);
 
     Server bootstrap() throws Exception;
 }

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/ServerBootstrapImpl.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/ServerBootstrapImpl.java
@@ -1,11 +1,11 @@
 package org.wildfly.swarm.container.runtime;
 
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.net.URL;
 import java.util.Collection;
-import java.util.Enumeration;
+import java.util.List;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.Set;
 
 import org.jboss.logging.Logger;
@@ -18,12 +18,18 @@ import org.wildfly.swarm.bootstrap.env.FractionManifest;
 import org.wildfly.swarm.container.internal.Server;
 import org.wildfly.swarm.container.internal.ServerBootstrap;
 import org.wildfly.swarm.container.runtime.cdi.FractionProducingExtension;
+import org.wildfly.swarm.container.runtime.cdi.OutboundSocketBindingExtension;
 import org.wildfly.swarm.container.runtime.cdi.ProjectStageProducingExtension;
+import org.wildfly.swarm.container.runtime.cdi.SocketBindingExtension;
 import org.wildfly.swarm.container.runtime.cdi.XMLConfigProducingExtension;
 import org.wildfly.swarm.container.runtime.cli.CommandLineArgsExtension;
+import org.wildfly.swarm.internal.OutboundSocketBindingRequest;
+import org.wildfly.swarm.internal.SocketBindingRequest;
 import org.wildfly.swarm.internal.SwarmMessages;
 import org.wildfly.swarm.spi.api.Fraction;
+import org.wildfly.swarm.spi.api.OutboundSocketBinding;
 import org.wildfly.swarm.spi.api.ProjectStage;
+import org.wildfly.swarm.spi.api.SocketBinding;
 
 /**
  * @author Bob McWhirter
@@ -75,6 +81,18 @@ public class ServerBootstrapImpl implements ServerBootstrap {
     }
 
     @Override
+    public ServerBootstrap withSocketBindings(List<SocketBindingRequest> bindings) {
+        this.socketBindings = bindings;
+        return this;
+    }
+
+    @Override
+    public ServerBootstrap withOutboundSocketBindings(List<OutboundSocketBindingRequest> bindings) {
+        this.outboundSocketBindings = bindings;
+        return this;
+    }
+
+    @Override
     public Server bootstrap() throws Exception {
         Module module = Module.getBootModuleLoader().loadModule(ModuleIdentifier.create("swarm.container"));
         Thread.currentThread().setContextClassLoader(module.getClassLoader());
@@ -89,6 +107,8 @@ public class ServerBootstrapImpl implements ServerBootstrap {
         weld.addExtension(new CommandLineArgsExtension(args));
         weld.addExtension(new ProjectStageProducingExtension(this.stageConfig));
         weld.addExtension(new XMLConfigProducingExtension(this.xmlConfigURL));
+        weld.addExtension(new OutboundSocketBindingExtension(this.outboundSocketBindings));
+        weld.addExtension(new SocketBindingExtension(this.socketBindings));
 
         for (Class<?> each : this.userComponents) {
             weld.addBeanClass(each);
@@ -126,6 +146,10 @@ public class ServerBootstrapImpl implements ServerBootstrap {
     private Optional<URL> xmlConfigURL = Optional.empty();
 
     private boolean bootstrapDebug;
+
+    private List<SocketBindingRequest> socketBindings;
+
+    private List<OutboundSocketBindingRequest> outboundSocketBindings;
 
     private String stageConfigUrl;
 }

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/OutboundSocketBindingExtension.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/OutboundSocketBindingExtension.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.container.runtime.cdi;
+
+import java.util.List;
+import java.util.Set;
+
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.spi.AfterBeanDiscovery;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.util.AnnotationLiteral;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.jboss.weld.literal.AnyLiteral;
+import org.wildfly.swarm.internal.OutboundSocketBindingRequest;
+import org.wildfly.swarm.spi.api.Customizer;
+import org.wildfly.swarm.spi.api.SocketBindingGroup;
+import org.wildfly.swarm.spi.runtime.annotations.Pre;
+
+/**
+ * @author Bob McWhirter
+ */
+public class OutboundSocketBindingExtension implements Extension {
+
+    private final List<OutboundSocketBindingRequest> bindings;
+
+    public OutboundSocketBindingExtension(List<OutboundSocketBindingRequest> bindings) {
+        this.bindings = bindings;
+    }
+
+    void afterBeanDiscovery(@Observes AfterBeanDiscovery abd, BeanManager beanManager) {
+
+        for (OutboundSocketBindingRequest each : this.bindings ) {
+            abd.addBean()
+                    .addTypes(Customizer.class)
+                    .scope(Singleton.class)
+                    .addQualifier(new AnnotationLiteral<Pre>() {
+                    })
+                    .produceWith( ()-> (Customizer) () -> {
+                        Set<Bean<?>> groups = beanManager.getBeans(SocketBindingGroup.class, AnyLiteral.INSTANCE);
+
+                        groups.stream()
+                                .map( (Bean e)->{
+                                    CreationalContext<SocketBindingGroup> ctx = beanManager.createCreationalContext(e);
+                                    return (SocketBindingGroup) beanManager.getReference(e, SocketBindingGroup.class, ctx);
+                                })
+                                .filter( group-> group.name().equals( each.socketBindingGroup() ))
+                                .findFirst()
+                                .ifPresent( (group)->{
+                                    group.outboundSocketBinding( each.outboundSocketBinding() );
+                                });
+                    });
+        }
+
+    }
+}

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/SocketBindingExtension.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/SocketBindingExtension.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.container.runtime.cdi;
+
+import java.util.List;
+import java.util.Set;
+
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AfterBeanDiscovery;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.util.AnnotationLiteral;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.jboss.weld.literal.AnyLiteral;
+import org.wildfly.swarm.internal.SocketBindingRequest;
+import org.wildfly.swarm.spi.api.Customizer;
+import org.wildfly.swarm.spi.api.SocketBindingGroup;
+import org.wildfly.swarm.spi.runtime.annotations.Pre;
+
+/**
+ * @author Bob McWhirter
+ */
+public class SocketBindingExtension implements Extension {
+
+    private final List<SocketBindingRequest> bindings;
+
+    public SocketBindingExtension(List<SocketBindingRequest> bindings) {
+        this.bindings = bindings;
+    }
+
+
+    void afterBeanDiscovery(@Observes AfterBeanDiscovery abd, BeanManager beanManager) {
+
+        for (SocketBindingRequest each : this.bindings ) {
+            abd.addBean()
+                    .addTypes(Customizer.class)
+                    .scope(Singleton.class)
+                    .addQualifier(new AnnotationLiteral<Pre>() {
+                    })
+                    .produceWith( ()-> (Customizer) () -> {
+                        Set<Bean<?>> groups = beanManager.getBeans(SocketBindingGroup.class, AnyLiteral.INSTANCE);
+
+
+                        groups.stream()
+                                .map( (Bean e)->{
+                                    CreationalContext<SocketBindingGroup> ctx = beanManager.createCreationalContext(e);
+                                    return (SocketBindingGroup) beanManager.getReference(e, SocketBindingGroup.class, ctx);
+                                })
+                                .filter( group-> group.name().equals( each.socketBindingGroup() ))
+                                .findFirst()
+                                .ifPresent( (group)->{
+                                    group.socketBinding( each.socketBinding() );
+                                });
+                    });
+        }
+
+    }
+}

--- a/container/src/main/java/org/wildfly/swarm/internal/OutboundSocketBindingRequest.java
+++ b/container/src/main/java/org/wildfly/swarm/internal/OutboundSocketBindingRequest.java
@@ -1,0 +1,25 @@
+package org.wildfly.swarm.internal;
+
+import org.wildfly.swarm.spi.api.OutboundSocketBinding;
+
+/**
+ * @author Bob McWhirter
+ */
+public class OutboundSocketBindingRequest {
+
+    public OutboundSocketBindingRequest(String socketBindingGroup, OutboundSocketBinding binding) {
+        this.socketBindingGroup = socketBindingGroup;
+        this.binding = binding;
+    }
+
+    public String socketBindingGroup() {
+        return this.socketBindingGroup;
+    }
+
+    public OutboundSocketBinding outboundSocketBinding() {
+        return this.binding;
+    }
+
+    private final String socketBindingGroup;
+    private final OutboundSocketBinding binding;
+}

--- a/container/src/main/java/org/wildfly/swarm/internal/SocketBindingRequest.java
+++ b/container/src/main/java/org/wildfly/swarm/internal/SocketBindingRequest.java
@@ -1,0 +1,25 @@
+package org.wildfly.swarm.internal;
+
+import org.wildfly.swarm.spi.api.SocketBinding;
+
+/**
+ * @author Bob McWhirter
+ */
+public class SocketBindingRequest {
+
+    public SocketBindingRequest(String socketBindingGroup, SocketBinding binding) {
+        this.socketBindingGroup = socketBindingGroup;
+        this.binding = binding;
+    }
+
+    public String socketBindingGroup() {
+        return this.socketBindingGroup;
+    }
+
+    public SocketBinding socketBinding() {
+        return this.binding;
+    }
+
+    private final String socketBindingGroup;
+    private final SocketBinding binding;
+}

--- a/messaging/src/main/java/org/wildfly/swarm/messaging/MessagingFraction.java
+++ b/messaging/src/main/java/org/wildfly/swarm/messaging/MessagingFraction.java
@@ -32,9 +32,8 @@ import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
 @DeploymentModule(name = "javax.jms.api")
 public class MessagingFraction extends MessagingActiveMQ<MessagingFraction> implements Fraction<MessagingFraction> {
 
-    @PostConstruct
-    public void postConstruct() {
-        applyDefaults();
+    public MessagingFraction() {
+
     }
 
     /**

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -115,6 +115,7 @@
     <module>testsuite-management</module>
     <module>testsuite-management-console</module>
     <module>testsuite-messaging</module>
+    <module>testsuite-messaging-remote</module>
     <module>testsuite-mod_cluster</module>
     <module>testsuite-monitor</module>
     <module>testsuite-msc</module>

--- a/testsuite/testsuite-messaging-remote/pom.xml
+++ b/testsuite/testsuite-messaging-remote/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>testsuite</artifactId>
+    <version>2016.10-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>testsuite-messaging-remote</artifactId>
+
+  <name>Test Suite: Messaging-remote</name>
+  <description>Test Suite: Messaging-remote</description>
+
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>messaging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>arquillian</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.junit</groupId>
+      <artifactId>arquillian-junit-container</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/testsuite/testsuite-messaging-remote/src/test/java/org/wildfly/swarm/messaging/RemoteMessagingArquillianTest.java
+++ b/testsuite/testsuite-messaging-remote/src/test/java/org/wildfly/swarm/messaging/RemoteMessagingArquillianTest.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.messaging;
+
+import javax.jms.ConnectionFactory;
+import javax.naming.InitialContext;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.arquillian.CreateSwarm;
+import org.wildfly.swarm.spi.api.JARArchive;
+import org.wildfly.swarm.spi.api.OutboundSocketBinding;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Bob McWhirter
+ */
+@RunWith(Arquillian.class)
+public class RemoteMessagingArquillianTest {
+
+    @Deployment
+    public static Archive createDeployment() {
+        JARArchive deployment = ShrinkWrap.create(JARArchive.class);
+        deployment.add(EmptyAsset.INSTANCE, "nothing");
+        deployment.addModule( "org.wildfly.swarm.messaging" );
+        return deployment;
+    }
+
+    @CreateSwarm
+    public static Swarm newContainer() throws Exception {
+        return new Swarm()
+                .outboundSocketBinding("standard-sockets",
+                        new OutboundSocketBinding("remote-activemq")
+                                .remoteHost("localhost")
+                                .remotePort(61616))
+                .fraction(new MessagingFraction()
+                        .server("default", server -> {
+                            server.remoteConnector("remote-activemq", connector -> {
+                                connector.socketBinding("remote-activemq");
+                            });
+                            server.pooledConnectionFactory("remote", factory -> {
+                                factory.connectors("remote-activemq");
+                                factory.entry("java:/jms/remoteCF");
+                            });
+                        })
+                );
+    }
+
+    @ArquillianResource
+    InitialContext context;
+
+    @Test
+    public void testDefaultConnectionFactory() throws Exception {
+        ConnectionFactory factory = (ConnectionFactory) context.lookup("java:/jms/remoteCF");
+        assertNotNull(factory);
+    }
+
+}


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

While the WildFly ActiveMQ/Artemis subsystem supports
remote connections to remote servers, we did not expose
enough to provide configuration, nor document it well.
## Modifications

Expose, for SWARM-721 -

  swarm.socketBinding(...)
  swarm.outboundSocketBinding(...)

Which allow for user-centric provisioning of additional
socket-bindings and outbound-socket-bindings.

Additionally, provide a test (as an example) of how to use
them, along with configuring the MessagingFraction, to connect
to an external ActiveMQ/Artemis server.
## Result

A remote connection-factory is now available in the pooled
connection pool, and can also be used for MDBs if the
correct @ResourceAdapter is used.

Further information available:

https://docs.jboss.org/author/display/WFLY10/Connect+a+pooled-connection-factory+to+a+Remote+Artemis+Server
