### PR TITLE
Swarm 720 - Update Logging Fraction to support the creation of a default File Logging handler

### DIFF
--- a/logging/src/main/java/org/wildfly/swarm/logging/LoggingProperties.java
+++ b/logging/src/main/java/org/wildfly/swarm/logging/LoggingProperties.java
@@ -18,4 +18,14 @@ package org.wildfly.swarm.logging;
 public class LoggingProperties {
     //public
     public static final String LOGGING = "swarm.logging";
+
+    public static final String DEFAULT_FILE_HANDLER_NAME = "FILE";
+
+    public static final String DEFAULT_LOGGING_FILE_NAME = "swarm.log";
+
+    public static final String DEFAULT_LOGGING_DIR = System.getProperty("user.dir");
+
+    public static final String DEFAULT_PATTERN = "%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n";
+
+    public static final String DEFAULT_COLOR_PATTERN = "%K{level}%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n";
 }

--- a/testsuite/testsuite-logging/src/test/java/org/wildfly/swarm/logging/DefaultFileLoggingArquillianTest.java
+++ b/testsuite/testsuite-logging/src/test/java/org/wildfly/swarm/logging/DefaultFileLoggingArquillianTest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.logging;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.UUID;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.arquillian.CreateSwarm;
+import org.wildfly.swarm.config.logging.Level;
+import org.wildfly.swarm.spi.api.JARArchive;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Charles Moulliard
+ */
+@RunWith(Arquillian.class)
+public class DefaultFileLoggingArquillianTest {
+
+    final static String logFile = System.getProperty("user.dir") + File.separator + "swarm.log";
+
+    @Deployment
+    public static Archive createDeployment() {
+        JARArchive archive = ShrinkWrap.create(JARArchive.class, "empty.jar");
+        archive.addPackage(DefaultFileLoggingArquillianTest.class.getPackage());
+        return archive;
+    }
+
+    @CreateSwarm
+    public static Swarm newContainer() throws Exception {
+        return new Swarm()
+                .fraction(LoggingFraction
+                                  .createDefaultLoggingFraction() // Required for Testing reason as Arquillian Swarm looks if the deployment of the jar is done
+                                  .createFileLoggingFraction()
+                                  .rootLogger(Level.INFO, "CONSOLE", "FILE"));
+    }
+
+    @Test
+    public void doLogging() throws IOException {
+        String message = "testing: " + UUID.randomUUID().toString();
+        Logger logger = Logger.getLogger("org.wildfly.swarm.logging");
+        logger.info(message);
+
+        Path path = Paths.get(logFile);
+        assertTrue("File not found: " + logFile, Files.exists(path));
+        List<String> lines = Files.readAllLines(path);
+
+        boolean found = false;
+
+        for (String line : lines) {
+            if (line.contains(message)) {
+                found = true;
+                break;
+            }
+        }
+
+        assertTrue("Expected message " + message, found);
+    }
+
+}

--- a/testsuite/testsuite-logging/src/test/java/org/wildfly/swarm/logging/FileHandlerApiArquillianTest.java
+++ b/testsuite/testsuite-logging/src/test/java/org/wildfly/swarm/logging/FileHandlerApiArquillianTest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.logging;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.arquillian.CreateSwarm;
+import org.wildfly.swarm.config.logging.Level;
+import org.wildfly.swarm.spi.api.JARArchive;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Charles Moulliard
+ */
+@RunWith(Arquillian.class)
+public class FileHandlerApiArquillianTest {
+
+    final static String logFile = System.getProperty("user.dir") + File.separator + "swarmy.log";
+
+    @Deployment
+    public static Archive createDeployment() {
+        JARArchive archive = ShrinkWrap.create(JARArchive.class, "empty.jar");
+        archive.addPackage(FileHandlerApiArquillianTest.class.getPackage());
+        return archive;
+    }
+
+    @CreateSwarm
+    public static Swarm newContainer() throws Exception {
+        return new Swarm()
+                .fraction(new LoggingFraction()
+                                  .createDefaultLoggingFraction()  // Required for Testing reason as Arquillian Swarm looks if the deployment of the jar is done
+                                  .fileHandler("FILE",f -> {
+                                      HashMap<String, String> props = new HashMap<String, String>();
+                                      props.put("path",logFile);
+                                      f.file(props);
+                                      f.level(Level.INFO);
+                                      f.formatter("%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n");
+                                  })
+                                  .rootLogger(Level.INFO, "CONSOLE", "FILE"));
+    }
+
+    @Test
+    public void doLogging() throws IOException {
+        String message = "testing: " + UUID.randomUUID().toString();
+        Logger logger = Logger.getLogger("org.wildfly.swarm.logging");
+        logger.info(message);
+
+        Path path = Paths.get(logFile);
+        assertTrue("File not found: " + logFile, Files.exists(path));
+        List<String> lines = Files.readAllLines(path);
+
+        boolean found = false;
+
+        for (String line : lines) {
+            if (line.contains(message)) {
+                found = true;
+                break;
+            }
+        }
+
+        assertTrue("Expected message " + message, found);
+    }
+
+}

--- a/testsuite/testsuite-logging/src/test/java/org/wildfly/swarm/logging/FileLoggingDebugLevelArquillianTest.java
+++ b/testsuite/testsuite-logging/src/test/java/org/wildfly/swarm/logging/FileLoggingDebugLevelArquillianTest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.logging;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.UUID;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.arquillian.CreateSwarm;
+import org.wildfly.swarm.config.logging.Level;
+import org.wildfly.swarm.spi.api.JARArchive;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Charles Moulliard
+ */
+@RunWith(Arquillian.class)
+public class FileLoggingDebugLevelArquillianTest {
+
+    final static String logFile = System.getProperty("user.dir") + File.separator + "swarmyy.log";
+    final static String packageName = "my.cool.demo";
+
+    @Deployment
+    public static Archive createDeployment() {
+        JARArchive archive = ShrinkWrap.create(JARArchive.class, "empty.jar");
+        archive.addPackage(FileLoggingDebugLevelArquillianTest.class.getPackage());
+        return archive;
+    }
+
+    @CreateSwarm
+    public static Swarm newContainer() throws Exception {
+        return new Swarm()
+                .fraction(LoggingFraction
+                                  .createDefaultLoggingFraction() // Required for Testing reason as Arquillian Swarm looks if the deployment of the jar is done
+                                  .createFileLoggingFraction(System.getProperty("user.dir"), "swarmyy.log", Level.DEBUG, packageName )
+                                  .rootLogger(Level.INFO, "CONSOLE", "FILE"));
+    }
+
+    @Test
+    public void doLogging() throws IOException {
+        Logger logger = Logger.getLogger(packageName);
+        String debugMessage = "testing : " + UUID.randomUUID().toString();
+        logger.debug(debugMessage);
+
+        Path path = Paths.get(logFile);
+        assertTrue("File not found: " + logFile, Files.exists(path));
+        List<String> lines = Files.readAllLines(path);
+
+        boolean found = false;
+
+        for (String line : lines) {
+            if (line.contains(debugMessage)) {
+                found = true;
+                break;
+            }
+        }
+
+        assertTrue("Expected message " + debugMessage, found);
+    }
+
+}

--- a/testsuite/testsuite-logging/src/test/java/org/wildfly/swarm/logging/FileLoggingInfoLevelArquillianTest.java
+++ b/testsuite/testsuite-logging/src/test/java/org/wildfly/swarm/logging/FileLoggingInfoLevelArquillianTest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.logging;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.UUID;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.arquillian.CreateSwarm;
+import org.wildfly.swarm.config.logging.Level;
+import org.wildfly.swarm.spi.api.JARArchive;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Charles Moulliard
+ */
+@RunWith(Arquillian.class)
+public class FileLoggingInfoLevelArquillianTest {
+
+    final static String logFile = System.getProperty("user.dir") + File.separator + "swarmy.log";
+
+    @Deployment
+    public static Archive createDeployment() {
+        JARArchive archive = ShrinkWrap.create(JARArchive.class, "empty.jar");
+        archive.addPackage(FileLoggingInfoLevelArquillianTest.class.getPackage());
+        return archive;
+    }
+
+    @CreateSwarm
+    public static Swarm newContainer() throws Exception {
+        return new Swarm()
+                .fraction(LoggingFraction
+                                  .createDefaultLoggingFraction()  // Required for Testing reason as Arquillian Swarm looks if the deployment of the jar is done
+                                  .createFileLoggingFraction(System.getProperty("user.dir"),"swarmy.log")
+                                  .rootLogger(Level.INFO, "CONSOLE", "FILE"));
+    }
+
+    @Test
+    public void doLogging() throws IOException {
+        String message = "testing: " + UUID.randomUUID().toString();
+        Logger logger = Logger.getLogger("org.wildfly.swarm.logging");
+        logger.info(message);
+
+        Path path = Paths.get(logFile);
+        assertTrue("File not found: " + logFile, Files.exists(path));
+        List<String> lines = Files.readAllLines(path);
+
+        boolean found = false;
+
+        for (String line : lines) {
+            if (line.contains(message)) {
+                found = true;
+                break;
+            }
+        }
+
+        assertTrue("Expected message " + message, found);
+    }
+
+}


### PR DESCRIPTION
- Update Logging Fraction to support the creation of a default File Logging handler
- Add new default values : DEFAULT_FILE_HANDLER_NAME, DEFAULT_LOGGING_FILE_NAME, DEFAULT_LOGGING_DIR
- Design new test cases to support the DSL
- Include package name to also configure the Logger with the level passed
