### PR TITLE
SWARM-728: Archive.as(Secured.class) throws exception

### DIFF
--- a/keycloak/src/main/java/org/wildfly/swarm/keycloak/internal/SecuredImpl.java
+++ b/keycloak/src/main/java/org/wildfly/swarm/keycloak/internal/SecuredImpl.java
@@ -26,10 +26,8 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
 import org.jboss.shrinkwrap.api.importer.ZipImporter;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.impl.base.ArchiveBase;
 import org.jboss.shrinkwrap.impl.base.AssignableBase;
-import org.jboss.shrinkwrap.impl.base.importer.zip.ZipImporterImpl;
 import org.wildfly.swarm.bootstrap.util.BootstrapProperties;
 import org.wildfly.swarm.keycloak.Secured;
 import org.wildfly.swarm.spi.api.JARArchive;
@@ -74,7 +72,7 @@ public class SecuredImpl extends AssignableBase<ArchiveBase<?>> implements Secur
 
             if (appArtifact != null) {
                 try (InputStream in = ClassLoader.getSystemClassLoader().getResourceAsStream("_bootstrap/" + appArtifact)) {
-                    Archive tmpArchive = ShrinkWrap.create(JavaArchive.class);
+                    Archive tmpArchive = ShrinkWrap.create(JARArchive.class);
                     tmpArchive.as(ZipImporter.class).importFrom(in);
                     Node jsonNode = tmpArchive.get("keycloak.json");
                     if (jsonNode == null) {


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

---

Motivation:
Archive.as(Secured.class) throws exception

Changes:
Use JARArchive instead of JavaArchive which is included in the module loader scopes

Result:
It works.
