### PR TITLE
SWARM-438 - Programttic API for advertising services.

### DIFF
--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -130,6 +130,7 @@
     <module>testsuite-swagger</module>
     <module>testsuite-swagger-webapp</module>
     <module>testsuite-topology</module>
+    <module>testsuite-topology-api</module>
     <module>testsuite-topology-consul</module>
     <module>testsuite-topology-jgroups</module>
     <module>testsuite-topology-openshift</module>

--- a/testsuite/testsuite-topology-api/pom.xml
+++ b/testsuite/testsuite-topology-api/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>testsuite</artifactId>
+    <version>2016.10-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>testsuite-topology-api</artifactId>
+
+  <name>Test Suite: Topology Direct API</name>
+  <description>Test Suite: Topology Direct API</description>
+
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>topology</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>arquillian</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.junit</groupId>
+      <artifactId>arquillian-junit-container</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/testsuite/testsuite-topology-api/src/test/java/org/wildfly/swarm/topology/MyApplication.java
+++ b/testsuite/testsuite-topology-api/src/test/java/org/wildfly/swarm/topology/MyApplication.java
@@ -1,0 +1,15 @@
+package org.wildfly.swarm.topology;
+
+import javax.naming.NamingException;
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+/**
+ * @author Bob McWhirter
+ */
+@ApplicationPath("/")
+public class MyApplication extends Application {
+    public MyApplication() throws NamingException {
+        Topology.lookup().advertise( "tacos" );
+    }
+}

--- a/testsuite/testsuite-topology-api/src/test/java/org/wildfly/swarm/topology/MyResource.java
+++ b/testsuite/testsuite-topology-api/src/test/java/org/wildfly/swarm/topology/MyResource.java
@@ -1,0 +1,11 @@
+package org.wildfly.swarm.topology;
+
+import javax.ws.rs.Path;
+
+/**
+ * @author Bob McWhirter
+ */
+@Path("/")
+public class MyResource {
+
+}

--- a/testsuite/testsuite-topology-api/src/test/java/org/wildfly/swarm/topology/TopologyArquillianTest.java
+++ b/testsuite/testsuite-topology-api/src/test/java/org/wildfly/swarm/topology/TopologyArquillianTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.topology;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistry;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.jaxrs.JAXRSArchive;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Bob McWhirter
+ */
+@RunWith(Arquillian.class)
+public class TopologyArquillianTest {
+
+    @Deployment
+    public static Archive createDeployment() {
+        JAXRSArchive deployment = ShrinkWrap.create(JAXRSArchive.class);
+        deployment.addClass(MyApplication.class);
+        deployment.addClass(MyResource.class);
+        return deployment;
+    }
+
+    @ArquillianResource
+    private ServiceRegistry registry;
+
+    @Test
+    public void testNothing() {
+        ServiceController<?> manager = this.registry.getService(ServiceName.of("swarm", "topology"));
+        assertNotNull( manager );
+
+        ServiceController<?> httpAdvert = this.registry.getService(ServiceName.of("swarm", "topology", "register", "tacos", "http"));
+        assertNotNull( httpAdvert );
+
+        ServiceController<?> httpsAdvert = this.registry.getService(ServiceName.of("swarm", "topology", "register", "tacos", "https"));
+        assertNotNull( httpsAdvert );
+    }
+
+}

--- a/topology/module.conf
+++ b/topology/module.conf
@@ -4,3 +4,5 @@ org.jboss.msc
 org.jboss.as.naming
 org.jboss.shrinkwrap
 org.jboss.as.network
+org.jboss.jandex
+org.wildfly.swarm.topology:deployment

--- a/topology/src/main/java/org/wildfly/swarm/topology/AdvertisemetHandle.java
+++ b/topology/src/main/java/org/wildfly/swarm/topology/AdvertisemetHandle.java
@@ -1,0 +1,8 @@
+package org.wildfly.swarm.topology;
+
+/**
+ * @author Bob McWhirter
+ */
+public interface AdvertisemetHandle {
+    void unadvertise();
+}

--- a/topology/src/main/java/org/wildfly/swarm/topology/Topology.java
+++ b/topology/src/main/java/org/wildfly/swarm/topology/Topology.java
@@ -36,6 +36,8 @@ public interface Topology {
 
     void removeListener(TopologyListener listener);
 
+    AdvertisemetHandle advertise(String name);
+
     Map<String, List<Entry>> asMap();
 
     interface Entry {

--- a/topology/src/main/java/org/wildfly/swarm/topology/TopologyConnector.java
+++ b/topology/src/main/java/org/wildfly/swarm/topology/TopologyConnector.java
@@ -21,7 +21,6 @@ import org.jboss.as.network.SocketBinding;
  * @author Bob McWhirter
  */
 public interface TopologyConnector {
-    //ServiceName SERVICE_NAME = ServiceName.of("swarm", "topology", "connector");
 
     void advertise(String name, SocketBinding binding, String... tags);
 

--- a/topology/src/main/java/org/wildfly/swarm/topology/TopologyFraction.java
+++ b/topology/src/main/java/org/wildfly/swarm/topology/TopologyFraction.java
@@ -22,6 +22,7 @@ import org.wildfly.swarm.spi.api.annotations.DeploymentModule;
  * @author Bob McWhirter
  */
 @DeploymentModule(name="org.wildfly.swarm.topology")
+@DeploymentModule(name="org.wildfly.swarm.topology", slot="deployment")
 public class TopologyFraction implements Fraction<TopologyFraction> {
 
 }

--- a/topology/src/main/java/org/wildfly/swarm/topology/internal/TopologyArchiveImpl.java
+++ b/topology/src/main/java/org/wildfly/swarm/topology/internal/TopologyArchiveImpl.java
@@ -106,7 +106,7 @@ public class TopologyArchiveImpl extends AssignableBase<ArchiveBase<?>> implemen
     protected TopologyArchive doAdvertise() {
         if (!as(ServiceActivatorArchive.class).containsServiceActivator(SERVICE_ACTIVATOR_CLASS_NAME)) {
             as(ServiceActivatorArchive.class).addServiceActivator(SERVICE_ACTIVATOR_CLASS_NAME);
-            as(JARArchive.class).addModule("org.wildfly.swarm.topology", "deployment");
+            //as(JARArchive.class).addModule("org.wildfly.swarm.topology", "deployment");
         }
 
         StringBuffer buf = new StringBuffer();

--- a/topology/src/main/java/org/wildfly/swarm/topology/runtime/AdvertisementHandleImpl.java
+++ b/topology/src/main/java/org/wildfly/swarm/topology/runtime/AdvertisementHandleImpl.java
@@ -1,0 +1,24 @@
+package org.wildfly.swarm.topology.runtime;
+
+import org.jboss.msc.service.ServiceController;
+import org.wildfly.swarm.topology.AdvertisemetHandle;
+
+/**
+ * @author Bob McWhirter
+ */
+class AdvertisementHandleImpl implements AdvertisemetHandle {
+
+    AdvertisementHandleImpl(ServiceController<?>...controllers) {
+        this.controllers = controllers;
+    }
+
+    @Override
+    public void unadvertise() {
+        for (ServiceController<?> controller : this.controllers) {
+            controller.setMode(ServiceController.Mode.REMOVE);
+        }
+    }
+
+    private final ServiceController<?>[] controllers;
+
+}

--- a/topology/src/main/java/org/wildfly/swarm/topology/runtime/TopologyManagerActivator.java
+++ b/topology/src/main/java/org/wildfly/swarm/topology/runtime/TopologyManagerActivator.java
@@ -44,6 +44,8 @@ public class TopologyManagerActivator implements ServiceActivator {
     public void activate(ServiceActivatorContext context) throws ServiceRegistryException {
         ServiceTarget target = context.getServiceTarget();
 
+        TopologyManager.INSTANCE.setServiceTarget( target );
+
         target.addService(SERVICE_NAME, new ValueService<>(new ImmediateValue<>(TopologyManager.INSTANCE)))
                 .install();
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

In the case where a user desires run-time advertisement of
services, as opposed to using archive.advertise() or the
@Advertise annotation, we should provide a way to accomplish
it.
## Modifications

Added a method to the Topology interface, which can be obtained
through JNDI.  topology.advertise(name) will advertise for
http and https (if available) for the current IP address of the
process, the given service-name provided as an argument.

The return value is a handle which may be used to unadvertise()
the service.  Once unadvertised, the service may not be re-used
without obtaining a new handle.
## Result

A user may now, from within a running deployment, advertise
arbitrary services.
