### PR TITLE
SWARM-726 - Easier configuration of remote MQ connections.

### DIFF
--- a/messaging/pom.xml
+++ b/messaging/pom.xml
@@ -74,6 +74,17 @@
       <artifactId>undertow</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- Provided APIs -->
     <dependency>
       <groupId>org.jboss.spec.javax.jms</groupId>

--- a/messaging/src/main/java/org/wildfly/swarm/messaging/MessagingProperties.java
+++ b/messaging/src/main/java/org/wildfly/swarm/messaging/MessagingProperties.java
@@ -1,0 +1,18 @@
+package org.wildfly.swarm.messaging;
+
+/**
+ * @author Bob McWhirter
+ */
+public interface MessagingProperties {
+
+    String DEFAULT_REMOTE_MQ_NAME = "remote-mq";
+    String DEFAULT_REMOTE_HOST = "localhost";
+    String DEFAULT_REMOTE_PORT = "61616";
+    String DEFAULT_REMOTE_JNDI_NAME = "java:/jms/" + DEFAULT_REMOTE_MQ_NAME;
+
+    String REMOTE = "swarm.message.remote";
+    String REMOTE_MQ_NAME = "swarm.message.remote.name";
+    String REMOTE_HOST = "swarm.messaging.remote.host";
+    String REMOTE_PORT = "swarm.messaging.remote.port";
+    String REMOTE_JNDI_NAME = "swarm.messaging.remote.jndi-name";
+}

--- a/messaging/src/main/java/org/wildfly/swarm/messaging/RemoteConnection.java
+++ b/messaging/src/main/java/org/wildfly/swarm/messaging/RemoteConnection.java
@@ -1,0 +1,117 @@
+package org.wildfly.swarm.messaging;
+
+import java.util.function.Consumer;
+
+import org.wildfly.swarm.spi.api.OutboundSocketBinding;
+
+/** Details for a remote message-queue connection.
+ *
+ * <p>Supports outboard ActiveMQ/Artemis servers.</p>
+ *
+ * @author Bob McWhirter
+ */
+public class RemoteConnection {
+
+    /** Configuration functional interface for container-supplied objects. */
+    public interface Consumer extends java.util.function.Consumer<RemoteConnection> {
+    }
+
+    /** Supplier functional interface for user-supplied object. */
+    public interface Supplier extends java.util.function.Supplier<RemoteConnection> {
+    }
+
+    /** Construct.
+     *
+     * @param name The name of the connection. Also used for {@link #jndiName}.
+     */
+    public RemoteConnection(String name) {
+        this.name = name;
+    }
+
+    /** Retrieve the name of the connection.
+     *
+     * @return The name.
+     */
+    public String name() {
+        return this.name;
+    }
+
+    /** Set the host (or host expression).
+     *
+     * @param host The host literal or expression.
+     * @return This connection.
+     */
+    public RemoteConnection host(String host) {
+        this.host = host;
+        return this;
+    }
+
+    /** Retrieve the host (or host expression).
+     *
+     * @return The host (or host expression).
+     */
+    public String host() {
+        return this.host;
+    }
+
+    /** Set the port.
+     *
+     * @param port The port.
+     * @return This connection.
+     */
+    public RemoteConnection port(int port) {
+        this.port = "" + port;
+        return this;
+    }
+
+    /** Set the port (or port expression).
+     *
+     * @param port The port (or port expression).
+     * @return This connectoin.
+     */
+    public RemoteConnection port(String port) {
+        this.port = port;
+        return this;
+    }
+
+    /** Retrieve the port (or port expression).
+     *
+     * @return The port (or port expression).
+     */
+    public String port() {
+        return this.port;
+    }
+
+    /** Set the JNDI name for the associated connection factory.
+     *
+     * <p>If unset, defaults to <code>java:/jms/<b>name</b></code></p>.
+     *
+     * @see #name()
+     *
+     * @param jndiName The explicit JNDI name to bind the connection factory.
+     * @return This connection.
+     */
+    public RemoteConnection jndiName(String jndiName) {
+        this.jndiName = jndiName;
+        return this;
+    }
+
+    /** Retrieve the JNDI name of the associated connection factory.
+     *
+     * @return The JNDI name of the associated connection factory.
+     */
+    public String jndiName() {
+        if ( jndiName != null ) {
+            return this.jndiName;
+        }
+
+        return "java:/jms/" + this.name;
+    }
+
+    private String name;
+    private String host = MessagingProperties.DEFAULT_REMOTE_HOST;
+    private String port = MessagingProperties.DEFAULT_REMOTE_PORT;
+    private String jndiName;
+
+
+}

--- a/messaging/src/main/java/org/wildfly/swarm/messaging/runtime/RemoteConnectionCustomizer.java
+++ b/messaging/src/main/java/org/wildfly/swarm/messaging/runtime/RemoteConnectionCustomizer.java
@@ -1,0 +1,47 @@
+package org.wildfly.swarm.messaging.runtime;
+
+import java.util.List;
+
+import javax.enterprise.inject.Any;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.wildfly.swarm.config.messaging.activemq.Server;
+import org.wildfly.swarm.messaging.EnhancedServer;
+import org.wildfly.swarm.messaging.MessagingFraction;
+import org.wildfly.swarm.spi.api.Customizer;
+import org.wildfly.swarm.spi.runtime.annotations.Post;
+
+/** Performs re-configuration of the MessagingFraction for available RemoteConnections.
+ *
+ * @author Bob McWhirter
+ */
+@Post
+public class RemoteConnectionCustomizer implements Customizer {
+
+    @Inject
+    @Any
+    MessagingFraction fraction;
+
+    @Override
+    public void customize() {
+        List<Server> servers = fraction.subresources().servers();
+
+        servers.stream()
+                .filter(e -> e instanceof EnhancedServer)
+                .forEach(server -> {
+                    ((EnhancedServer) server).remoteConnections()
+                            .forEach(connection -> {
+                                server.remoteConnector(connection.name(), connector -> {
+                                    connector.socketBinding(connection.name());
+                                });
+
+                                server.pooledConnectionFactory(connection.name(), factory -> {
+                                    factory.connectors(connection.name());
+                                    factory.entry(connection.jndiName());
+                                });
+                            });
+                });
+
+    }
+}

--- a/messaging/src/main/java/org/wildfly/swarm/messaging/runtime/RemoteConnectionInstallingCustomizer.java
+++ b/messaging/src/main/java/org/wildfly/swarm/messaging/runtime/RemoteConnectionInstallingCustomizer.java
@@ -1,0 +1,77 @@
+package org.wildfly.swarm.messaging.runtime;
+
+import javax.enterprise.inject.Any;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.wildfly.swarm.messaging.MessagingFraction;
+import org.wildfly.swarm.messaging.MessagingProperties;
+import org.wildfly.swarm.spi.api.Customizer;
+import org.wildfly.swarm.spi.runtime.annotations.ConfigurationValue;
+import org.wildfly.swarm.spi.runtime.annotations.Pre;
+
+/** Installs a remote connection based upon properties or YAML configuration.
+ *
+ * @see MessagingProperties#REMOTE_MQ_NAME
+ * @see MessagingProperties#REMOTE_HOST
+ * @see MessagingProperties#REMOTE_PORT
+ * @see MessagingProperties#REMOTE_JNDI_NAME
+ *
+ * @author Bob McWhirter
+ */
+@Pre
+public class RemoteConnectionInstallingCustomizer implements Customizer {
+
+    @Inject
+    @Any
+    MessagingFraction fraction;
+
+    @Inject
+    @ConfigurationValue(MessagingProperties.REMOTE_MQ_NAME)
+    Boolean remote;
+
+    @Inject
+    @ConfigurationValue(MessagingProperties.REMOTE_MQ_NAME)
+    String remoteMqName;
+
+    @Inject
+    @ConfigurationValue(MessagingProperties.REMOTE_JNDI_NAME)
+    String jndiName;
+
+    @Inject
+    @ConfigurationValue(MessagingProperties.REMOTE_HOST)
+    String remoteHost;
+
+    @Inject
+    @ConfigurationValue(MessagingProperties.REMOTE_PORT)
+    String remotePort;
+
+    @Override
+    public void customize() {
+        if ( ( this.remote != null && this.remote ) || this.remoteMqName != null || this.jndiName != null || this.remoteHost != null || this.remotePort != null ) {
+
+            fraction.defaultServer( (server)->{
+                String mqName = this.remoteMqName;
+
+                if ( mqName == null ) {
+                    mqName = MessagingProperties.DEFAULT_REMOTE_MQ_NAME;
+                }
+
+                server.remoteConnection( mqName, (config)->{
+                    if ( this.jndiName != null ) {
+                        config.jndiName( this.jndiName );
+                    }
+
+                    if ( this.remoteHost != null ) {
+                        config.host( this.remoteHost );
+                    }
+
+                    if ( this.remotePort != null ) {
+                        config.port( this.remotePort );
+                    }
+                });
+            });
+        }
+
+    }
+}

--- a/messaging/src/main/java/org/wildfly/swarm/messaging/runtime/RemoteConnectionJndiNameCustomizer.java
+++ b/messaging/src/main/java/org/wildfly/swarm/messaging/runtime/RemoteConnectionJndiNameCustomizer.java
@@ -1,0 +1,63 @@
+package org.wildfly.swarm.messaging.runtime;
+
+import java.util.List;
+
+import javax.enterprise.inject.Any;
+import javax.inject.Inject;
+
+import org.wildfly.swarm.config.messaging.activemq.Server;
+import org.wildfly.swarm.messaging.EnhancedServer;
+import org.wildfly.swarm.messaging.MessagingFraction;
+import org.wildfly.swarm.messaging.MessagingProperties;
+import org.wildfly.swarm.spi.api.Customizer;
+import org.wildfly.swarm.spi.runtime.annotations.ConfigurationValue;
+import org.wildfly.swarm.spi.runtime.annotations.Post;
+
+/** Overrides JNDI name of the connection factory from a property/YAML configuration value.
+ *
+ * @see MessagingProperties#REMOTE_JNDI_NAME
+ *
+ * @author Bob McWhirter
+ */
+@Post
+public class RemoteConnectionJndiNameCustomizer implements Customizer {
+
+    @Inject
+    @Any
+    MessagingFraction fraction;
+
+    @Inject
+    @ConfigurationValue(MessagingProperties.REMOTE_MQ_NAME)
+    String mqName;
+
+    @Inject
+    @ConfigurationValue(MessagingProperties.REMOTE_JNDI_NAME)
+    String jndiName;
+
+    @Override
+    public void customize() {
+        List<Server> servers = fraction.subresources().servers();
+
+        String mqName = this.mqName;
+        if ( mqName == null ) {
+            mqName = MessagingProperties.DEFAULT_REMOTE_MQ_NAME;
+        }
+
+        String finalMqName = mqName;
+        servers.stream()
+                .filter(e -> e instanceof EnhancedServer)
+                .forEach( server->{
+                    ((EnhancedServer) server).remoteConnections()
+                            .stream()
+                            .filter( e->e.name().equals( finalMqName ) )
+                            .findFirst()
+                            .ifPresent(connection -> {
+                                String jndiName = this.jndiName;
+                                if ( jndiName != null ) {
+                                    connection.jndiName( jndiName );
+                                }
+                            });
+                });
+
+    }
+}

--- a/messaging/src/main/java/org/wildfly/swarm/messaging/runtime/RemoteConnectionSocketBindingCustomizer.java
+++ b/messaging/src/main/java/org/wildfly/swarm/messaging/runtime/RemoteConnectionSocketBindingCustomizer.java
@@ -1,0 +1,89 @@
+package org.wildfly.swarm.messaging.runtime;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.wildfly.swarm.config.messaging.activemq.Server;
+import org.wildfly.swarm.messaging.EnhancedServer;
+import org.wildfly.swarm.messaging.MessagingFraction;
+import org.wildfly.swarm.messaging.MessagingProperties;
+import org.wildfly.swarm.spi.api.Customizer;
+import org.wildfly.swarm.spi.api.OutboundSocketBinding;
+import org.wildfly.swarm.spi.api.SocketBindingGroup;
+import org.wildfly.swarm.spi.runtime.annotations.ConfigurationValue;
+import org.wildfly.swarm.spi.runtime.annotations.Post;
+import org.wildfly.swarm.spi.runtime.annotations.Pre;
+
+/** Creates an outbound-socket binding for each RemoteConnection.
+ * @author Bob McWhirter
+ */
+@Post
+public class RemoteConnectionSocketBindingCustomizer implements Customizer {
+
+    @Inject
+    @Named("standard-sockets")
+    SocketBindingGroup group;
+
+    @Inject
+    @Any
+    MessagingFraction fraction;
+
+    @Inject
+    @ConfigurationValue(MessagingProperties.REMOTE_MQ_NAME)
+    String mqName;
+
+    @Inject
+    @ConfigurationValue(MessagingProperties.REMOTE_HOST)
+    String remoteHost;
+
+    @Inject
+    @ConfigurationValue(MessagingProperties.REMOTE_PORT)
+    String remotePort;
+
+    @Override
+    public void customize() {
+        List<Server> servers = fraction.subresources().servers();
+
+        String mqName = this.mqName;
+        if (mqName == null) {
+            mqName = MessagingProperties.DEFAULT_REMOTE_MQ_NAME;
+        }
+
+        String finalMqName = mqName;
+
+        servers.stream()
+                .filter(e -> e instanceof EnhancedServer)
+                .forEach(server -> {
+                    ((EnhancedServer) server).remoteConnections()
+                            .forEach(connection -> {
+                                OutboundSocketBinding binding = new OutboundSocketBinding(connection.name());
+                                if (connection.name().equals(finalMqName)) {
+                                    String host = this.remoteHost;
+                                    if (host == null) {
+                                        host = connection.host();
+                                    }
+
+                                    String port = this.remotePort;
+                                    if (port == null) {
+                                        port = connection.port();
+                                    }
+
+                                    binding.remoteHost(host)
+                                            .remotePort(port);
+                                } else {
+                                    binding.remoteHost(connection.host())
+                                            .remotePort(connection.port());
+                                }
+
+                                group.outboundSocketBinding(binding);
+                            });
+                });
+
+    }
+}

--- a/messaging/src/test/java/org/wildfly/swarm/messaging/runtime/RemoteConnectionCustomizerTest.java
+++ b/messaging/src/test/java/org/wildfly/swarm/messaging/runtime/RemoteConnectionCustomizerTest.java
@@ -1,0 +1,59 @@
+package org.wildfly.swarm.messaging.runtime;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.wildfly.swarm.config.messaging.activemq.server.PooledConnectionFactory;
+import org.wildfly.swarm.config.messaging.activemq.server.RemoteConnector;
+import org.wildfly.swarm.messaging.EnhancedServer;
+import org.wildfly.swarm.messaging.MessagingFraction;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Bob McWhirter
+ */
+public class RemoteConnectionCustomizerTest {
+
+    private RemoteConnectionCustomizer customizer;
+
+    private MessagingFraction fraction;
+
+    @Before
+    public void setUp() {
+        this.customizer = new RemoteConnectionCustomizer();
+        this.fraction = new MessagingFraction();
+
+        this.customizer.fraction = fraction;
+    }
+
+    @Test
+    public void testIfNoRemoteConnections() {
+        this.customizer.customize();
+        assertThat( this.fraction.subresources().servers()).isEmpty();
+    }
+
+    @Test
+    public void testIfRemoteConnection() {
+        this.fraction.server( "default", (server)->{
+            server.remoteConnection( "postoffice" );
+        });
+
+        this.customizer.customize();
+
+        EnhancedServer server = (EnhancedServer) this.fraction.subresources().servers().get(0);
+
+        assertThat( server.remoteConnections()).hasSize(1);
+        assertThat( server.subresources().pooledConnectionFactories()).hasSize(1);
+
+        PooledConnectionFactory connectionFactory = server.subresources().pooledConnectionFactories().get(0);
+
+        assertThat( connectionFactory.getKey() ).isEqualTo( "postoffice" );
+        assertThat( connectionFactory.entries() ).containsExactly( "java:/jms/postoffice" );
+
+        assertThat( server.subresources().remoteConnectors() ).hasSize(1);
+        RemoteConnector remoteConnector = server.subresources().remoteConnectors().get(0);
+
+        assertThat( remoteConnector.getKey() ).isEqualTo( "postoffice" );
+        assertThat( remoteConnector.socketBinding() ).isEqualTo( "postoffice" );
+    }
+}

--- a/messaging/src/test/java/org/wildfly/swarm/messaging/runtime/RemoteConnectionInstallingCustomizerTest.java
+++ b/messaging/src/test/java/org/wildfly/swarm/messaging/runtime/RemoteConnectionInstallingCustomizerTest.java
@@ -1,0 +1,138 @@
+package org.wildfly.swarm.messaging.runtime;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.wildfly.swarm.messaging.EnhancedServer;
+import org.wildfly.swarm.messaging.MessagingFraction;
+import org.wildfly.swarm.messaging.MessagingProperties;
+import org.wildfly.swarm.messaging.RemoteConnection;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Bob McWhirter
+ */
+public class RemoteConnectionInstallingCustomizerTest {
+
+    private RemoteConnectionInstallingCustomizer customizer;
+    private MessagingFraction fraction;
+
+    @Before
+    public void setUp() {
+        this.customizer = new RemoteConnectionInstallingCustomizer();
+        this.fraction = new MessagingFraction();
+
+        this.customizer.fraction = fraction;
+    }
+
+    @Test
+    public void testNoOpIfNoConfigSettings() {
+        customizer.customize();
+        assertThat( fraction.subresources().servers() ).isEmpty();
+    }
+
+    @Test
+    public void testIfPortSet() {
+        customizer.remotePort = "61666";
+        customizer.customize();
+
+        assertThat( fraction.subresources().servers() ).hasSize(1);
+
+        EnhancedServer server = (EnhancedServer) fraction.subresources().server("default");
+
+        assertThat( server ).isNotNull();
+
+        assertThat( server.remoteConnections() ).hasSize(1);
+
+        RemoteConnection connection = server.remoteConnections().get(0);
+
+        assertThat( connection.name() ).isEqualTo(MessagingProperties.DEFAULT_REMOTE_MQ_NAME );
+        assertThat( connection.host() ).isEqualTo(MessagingProperties.DEFAULT_REMOTE_HOST );
+        assertThat( connection.port() ).isEqualTo("61666");
+        assertThat( connection.jndiName() ).isEqualTo(MessagingProperties.DEFAULT_REMOTE_JNDI_NAME );
+    }
+
+    @Test
+    public void testIfHostSet() {
+        customizer.remoteHost = "mq.foo.com";
+        customizer.customize();
+
+        assertThat( fraction.subresources().servers() ).hasSize(1);
+
+        EnhancedServer server = (EnhancedServer) fraction.subresources().server("default");
+
+        assertThat( server ).isNotNull();
+
+        assertThat( server.remoteConnections() ).hasSize(1);
+
+        RemoteConnection connection = server.remoteConnections().get(0);
+
+        assertThat( connection.name() ).isEqualTo(MessagingProperties.DEFAULT_REMOTE_MQ_NAME );
+        assertThat( connection.host() ).isEqualTo("mq.foo.com");
+        assertThat( connection.port() ).isEqualTo(MessagingProperties.DEFAULT_REMOTE_PORT);
+        assertThat( connection.jndiName() ).isEqualTo(MessagingProperties.DEFAULT_REMOTE_JNDI_NAME );
+    }
+
+    @Test
+    public void testIfJndiNameSet() {
+        customizer.jndiName = "java:/jms/iliketacos";
+        customizer.customize();
+
+        assertThat( fraction.subresources().servers() ).hasSize(1);
+
+        EnhancedServer server = (EnhancedServer) fraction.subresources().server("default");
+
+        assertThat( server ).isNotNull();
+
+        assertThat( server.remoteConnections() ).hasSize(1);
+
+        RemoteConnection connection = server.remoteConnections().get(0);
+
+        assertThat( connection.name() ).isEqualTo(MessagingProperties.DEFAULT_REMOTE_MQ_NAME );
+        assertThat( connection.host() ).isEqualTo(MessagingProperties.DEFAULT_REMOTE_HOST);
+        assertThat( connection.port() ).isEqualTo(MessagingProperties.DEFAULT_REMOTE_PORT);
+        assertThat( connection.jndiName() ).isEqualTo("java:/jms/iliketacos");
+    }
+
+    @Test
+    public void testIfMqNameSet() {
+        customizer.remoteMqName = "postoffice";
+        customizer.customize();
+
+        assertThat( fraction.subresources().servers() ).hasSize(1);
+
+        EnhancedServer server = (EnhancedServer) fraction.subresources().server("default");
+
+        assertThat( server ).isNotNull();
+
+        assertThat( server.remoteConnections() ).hasSize(1);
+
+        RemoteConnection connection = server.remoteConnections().get(0);
+
+        assertThat( connection.name() ).isEqualTo("postoffice");
+        assertThat( connection.host() ).isEqualTo(MessagingProperties.DEFAULT_REMOTE_HOST);
+        assertThat( connection.port() ).isEqualTo(MessagingProperties.DEFAULT_REMOTE_PORT);
+        assertThat( connection.jndiName() ).isEqualTo("java:/jms/postoffice");
+    }
+
+    @Test
+    public void testIfRemoteFlagSet() {
+        customizer.remote = true;
+        customizer.customize();
+
+        assertThat( fraction.subresources().servers() ).hasSize(1);
+
+        EnhancedServer server = (EnhancedServer) fraction.subresources().server("default");
+
+        assertThat( server ).isNotNull();
+
+        assertThat( server.remoteConnections() ).hasSize(1);
+
+        RemoteConnection connection = server.remoteConnections().get(0);
+
+        assertThat( connection.name() ).isEqualTo(MessagingProperties.DEFAULT_REMOTE_MQ_NAME );
+        assertThat( connection.host() ).isEqualTo(MessagingProperties.DEFAULT_REMOTE_HOST);
+        assertThat( connection.port() ).isEqualTo(MessagingProperties.DEFAULT_REMOTE_PORT);
+        assertThat( connection.jndiName() ).isEqualTo(MessagingProperties.DEFAULT_REMOTE_JNDI_NAME);
+    }
+}

--- a/messaging/src/test/java/org/wildfly/swarm/messaging/runtime/RemoteConnectionJndiNameCustomizerTest.java
+++ b/messaging/src/test/java/org/wildfly/swarm/messaging/runtime/RemoteConnectionJndiNameCustomizerTest.java
@@ -1,0 +1,68 @@
+package org.wildfly.swarm.messaging.runtime;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.wildfly.swarm.messaging.EnhancedServer;
+import org.wildfly.swarm.messaging.MessagingFraction;
+import org.wildfly.swarm.messaging.MessagingProperties;
+import org.wildfly.swarm.messaging.RemoteConnection;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Bob McWhirter
+ */
+public class RemoteConnectionJndiNameCustomizerTest {
+
+    private RemoteConnectionJndiNameCustomizer customizer;
+    private MessagingFraction fraction;
+
+    @Before
+    public void setUp() {
+        this.customizer = new RemoteConnectionJndiNameCustomizer();
+        this.fraction = new MessagingFraction();
+
+        this.customizer.fraction = this.fraction;
+    }
+
+    @Test
+    public void testNoOpCustomization() {
+        this.fraction.defaultServer( (server)->{
+            server.remoteConnection();
+        });
+
+        this.customizer.customize();
+
+        EnhancedServer server = (EnhancedServer) this.fraction.subresources().server("default");
+        assertThat( server ).isNotNull();
+
+        assertThat( server.remoteConnections() ).hasSize(1);
+
+        RemoteConnection connection = server.remoteConnections().get(0);
+
+        assertThat( connection.jndiName() ).isEqualTo(MessagingProperties.DEFAULT_REMOTE_JNDI_NAME );
+    }
+
+    @Test
+    public void testWithCustomization() {
+        this.fraction.defaultServer( (server)->{
+            server.remoteConnection();
+            server.remoteConnection( "other-mq" );
+        });
+
+        this.customizer.jndiName = "java:/jms/tacos";
+
+        this.customizer.customize();
+
+        EnhancedServer server = (EnhancedServer) this.fraction.subresources().server("default");
+        assertThat( server ).isNotNull();
+
+        assertThat( server.remoteConnections() ).hasSize(2);
+
+        RemoteConnection connection = server.remoteConnections().get(0);
+        RemoteConnection otherConnection = server.remoteConnections().get(1);
+
+        assertThat( connection.jndiName() ).isEqualTo("java:/jms/tacos");
+        assertThat( otherConnection.jndiName() ).isEqualTo("java:/jms/other-mq" );
+    }
+}

--- a/messaging/src/test/java/org/wildfly/swarm/messaging/runtime/RemoteConnectionSocketBindingCustomizerTest.java
+++ b/messaging/src/test/java/org/wildfly/swarm/messaging/runtime/RemoteConnectionSocketBindingCustomizerTest.java
@@ -1,0 +1,58 @@
+package org.wildfly.swarm.messaging.runtime;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.wildfly.swarm.messaging.MessagingFraction;
+import org.wildfly.swarm.messaging.MessagingProperties;
+import org.wildfly.swarm.spi.api.OutboundSocketBinding;
+import org.wildfly.swarm.spi.api.SocketBindingGroup;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Bob McWhirter
+ */
+public class RemoteConnectionSocketBindingCustomizerTest {
+
+    private SocketBindingGroup group;
+
+    private MessagingFraction fraction;
+
+    private RemoteConnectionSocketBindingCustomizer customizer;
+
+    @Before
+    public void setUp() {
+        this.group = new SocketBindingGroup("standard-sockets", "default", "0");
+        this.fraction = new MessagingFraction();
+        this.customizer = new RemoteConnectionSocketBindingCustomizer();
+
+        this.customizer.group = this.group;
+        this.customizer.fraction = fraction;
+    }
+
+    @Test
+    public void testNoOp() {
+        this.customizer.customize();
+        assertThat( this.group.outboundSocketBindings() ).isEmpty();
+    }
+
+    @Test
+    public void testSocketBinding() {
+
+        this.fraction.defaultServer( (server)->{
+            server.remoteConnection( "postoffice" );
+        });
+
+        this.customizer.customize();
+
+        assertThat( this.group.outboundSocketBindings() ).hasSize(1);
+
+        OutboundSocketBinding binding = this.group.outboundSocketBindings().get(0);
+
+        assertThat( binding.name() ).isEqualTo( "postoffice" );
+        assertThat( binding.remotePortExpression() ).isEqualTo(MessagingProperties.DEFAULT_REMOTE_PORT );
+        assertThat( binding.remoteHostExpression() ).isEqualTo(MessagingProperties.DEFAULT_REMOTE_HOST );
+
+    }
+
+}

--- a/testsuite/testsuite-messaging-remote/src/test/java/org/wildfly/swarm/messaging/ConfigRemoteMessagingArquillianTest.java
+++ b/testsuite/testsuite-messaging-remote/src/test/java/org/wildfly/swarm/messaging/ConfigRemoteMessagingArquillianTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.messaging;
+
+import javax.jms.ConnectionFactory;
+import javax.naming.InitialContext;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.arquillian.CreateSwarm;
+import org.wildfly.swarm.spi.api.JARArchive;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Bob McWhirter
+ */
+@RunWith(Arquillian.class)
+public class ConfigRemoteMessagingArquillianTest {
+
+    @Deployment
+    public static Archive createDeployment() {
+        JARArchive deployment = ShrinkWrap.create(JARArchive.class);
+        deployment.add(EmptyAsset.INSTANCE, "nothing");
+        deployment.addModule( "org.wildfly.swarm.messaging" );
+        return deployment;
+    }
+
+    @CreateSwarm
+    public static Swarm newContainer() throws Exception {
+        System.setProperty( MessagingProperties.REMOTE_MQ_NAME, "my-remote-activemq" );
+        return new Swarm();
+    }
+
+    @ArquillianResource
+    InitialContext context;
+
+    @Test
+    public void testDefaultConnectionFactory() throws Exception {
+        ConnectionFactory factory = (ConnectionFactory) context.lookup("java:/jms/my-remote-activemq");
+        assertNotNull(factory);
+    }
+
+}

--- a/testsuite/testsuite-messaging-remote/src/test/java/org/wildfly/swarm/messaging/SimplifiedRemoteMessagingArquillianTest.java
+++ b/testsuite/testsuite-messaging-remote/src/test/java/org/wildfly/swarm/messaging/SimplifiedRemoteMessagingArquillianTest.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.messaging;
+
+import javax.jms.ConnectionFactory;
+import javax.naming.InitialContext;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.arquillian.CreateSwarm;
+import org.wildfly.swarm.spi.api.JARArchive;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Bob McWhirter
+ */
+@RunWith(Arquillian.class)
+public class SimplifiedRemoteMessagingArquillianTest {
+
+    @Deployment
+    public static Archive createDeployment() {
+        JARArchive deployment = ShrinkWrap.create(JARArchive.class);
+        deployment.add(EmptyAsset.INSTANCE, "nothing");
+        deployment.addModule( "org.wildfly.swarm.messaging" );
+        return deployment;
+    }
+
+    @CreateSwarm
+    public static Swarm newContainer() throws Exception {
+        return new Swarm()
+                .fraction(new MessagingFraction()
+                        .server("default", server -> {
+                            server.remoteConnection( "remote-activemq", (config)->{
+                                // using default host/port
+                                config.jndiName( "java:/jms/remoteCF" );
+                            });
+                        })
+                );
+    }
+
+    @ArquillianResource
+    InitialContext context;
+
+    @Test
+    public void testDefaultConnectionFactory() throws Exception {
+        ConnectionFactory factory = (ConnectionFactory) context.lookup("java:/jms/remoteCF");
+        assertNotNull(factory);
+    }
+
+}


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

While we now (as of recently) support remote MQ connections, they
were very in-depth to configure, and exposed a little too much
implementation detail of WildFly in order to simply connect to
an outboard MQ.
## Modifications

Our EnhancedServer now provides a variety of methods:

  .remoteConnection() // completely default, localhost:61616, java:/jms/remote-mq
  .remoteConnection(name) // completely default, aside from name/jndi
  .remoteConnection(connection) // completely customized
  .remoteConnection(connectionSupplier) // completely customized
  .remoteConnection(name, connectionConsumer) // completely customized

Additionally, in the case you only need exactly 1 external remote
connection, it can be configured via configuration values
(via properties or YAML).

  swarm.messaging.remote.name
  swarm.messaging.remote.jndi-name
  swarm.messaging.remote.host
  swarm.messaging.remote.port

Where the jndi-name is usually derived from the name, but separately
overridable.  Host and port have defaults (localhost and 61616 respectively).

To enable config-value configuration of a remote connection, at least
one of the above keys must be set in order to trigger the auto-setup.
## Result

Significantly easier to setup a remote MQ connection.
