### PR TITLE
SWARM-737 - Healthchecks return HTTP Status 204 instead of 503 

### DIFF
--- a/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/HttpContexts.java
+++ b/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/HttpContexts.java
@@ -95,7 +95,7 @@ class HttpContexts implements HttpHandler {
     }
 
     private void noHealthEndpoints(HttpServerExchange exchange) {
-        exchange.setStatusCode(503);
+        exchange.setStatusCode(204);
         exchange.getResponseSender().send("No health endpoints configured!");
     }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

---

HTTP 204 when there is no health checks installed when accessing /health. This helps monitoring and cluster systems to not report an error and cause the WF swarm contaienr to be killed/restarted over and over again.
