### PR TITLE
SWARM-742: default initial logging format is different from default logging subsystem format

### DIFF
--- a/logging/src/main/resources/logging.properties
+++ b/logging/src/main/resources/logging.properties
@@ -39,7 +39,7 @@ handler.CONSOLE.target=SYSTEM_OUT
 
 formatter.COLOR-PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.COLOR-PATTERN.properties=pattern
-formatter.COLOR-PATTERN.pattern=%K{level}%d{HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%e%n
+formatter.COLOR-PATTERN.pattern=%K{level}%d{yyyy-MM-dd HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%e%n
 
 formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.PATTERN.properties=pattern


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

When running a `-swarm.jar` application with default logging configuration, there's a visible difference in log message format before and after the logging subsystem kicks in.
## Modifications

Change the default `logging.properties` configuration to be identical to the default `LoggingFraction` configuration.
## Result

With default logging configuration, there will be no visible difference in the log messages before and after the logging subsytem kicks in.
