### PR TITLE
SWARM-727 Prevent duplicate :package goals building servers.

### DIFF
--- a/standalone-servers/management-console/pom.xml
+++ b/standalone-servers/management-console/pom.xml
@@ -30,6 +30,7 @@
         </configuration>
         <executions>
           <execution>
+            <id>package</id>
             <goals>
               <goal>package</goal>
             </goals>

--- a/standalone-servers/microprofile/pom.xml
+++ b/standalone-servers/microprofile/pom.xml
@@ -29,6 +29,7 @@
         <artifactId>wildfly-swarm-plugin</artifactId>
         <executions>
           <execution>
+            <id>package</id>
             <goals>
               <goal>package</goal>
             </goals>

--- a/standalone-servers/swagger-ui/pom.xml
+++ b/standalone-servers/swagger-ui/pom.xml
@@ -32,6 +32,7 @@
         </configuration>
         <executions>
           <execution>
+            <id>package</id>
             <goals>
               <goal>package</goal>
             </goals>


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

We were doubly pacakging the standalone servers because of a
missing <id> tag on the mvn execution.
## Modifications

Added appropriate <id> tags.
## Result

Less time spent building stuff twice.
