### PR TITLE
SWARM-688 don't list all fractions in info log.

### DIFF
--- a/container/src/main/java/org/wildfly/swarm/container/runtime/ServerBootstrapImpl.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/ServerBootstrapImpl.java
@@ -131,7 +131,7 @@ public class ServerBootstrapImpl implements ServerBootstrap {
         if ( stabilityIndex < 3 ) {
             LOG.warn(SwarmMessages.MESSAGES.availableFraction(manifest.getName(), manifest.getStabilityLevel(), manifest.getGroupId(), manifest.getArtifactId(), manifest.getVersion()));
         } else {
-            LOG.info(SwarmMessages.MESSAGES.availableFraction(manifest.getName(), manifest.getStabilityLevel(), manifest.getGroupId(), manifest.getArtifactId(), manifest.getVersion()));
+            LOG.debug(SwarmMessages.MESSAGES.availableFraction(manifest.getName(), manifest.getStabilityLevel(), manifest.getGroupId(), manifest.getArtifactId(), manifest.getVersion()));
         }
     }
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

Currently all fractions are output at the startup of the container in the log.
## Modifications

Log list of fractions under DEBUG level
## Result

List of fractions is logged/available under DEBUG level only
