### PR TITLE
SWARM-687: Enable jaxrs-validator fraction if javax.validation+javax.ws.rs classes are detected.

### DIFF
--- a/fraction-list/src/main/resources/org/wildfly/swarm/fractionlist/fraction-packages.properties
+++ b/fraction-list/src/main/resources/org/wildfly/swarm/fractionlist/fraction-packages.properties
@@ -13,6 +13,7 @@ jaxrs=javax.ws.rs
 jaxrs-cdi=javax.ws.rs+javax.inject
 jaxrs-jaxb=javax.ws.rs+javax.xml.bind*
 jaxrs-jsonp=javax.ws.rs+javax.json
+jaxrs-validator=javax.ws.rs+javax.validation*
 jpa=javax.persistence
 jsf=javax.faces*
 mail=javax.mail


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

Whenever a Bean Validation annotation is used with a JAX-RS resource, Swarm would not auto-detect the necessary jaxrs-validation fraction.
## Modifications

Changed fraction-list.properties to add jaxrs-validator when the javax.validation and javax.ws.rs classes are used in the project.
## Result

The jaxrs-validator is now auto-detected
