### PR TITLE
SWARM-691: Multiple calls to Archive#as(Secured.class).protect should not create multiple login-config entries

### DIFF
--- a/testsuite/testsuite-keycloak/src/test/java/org/wildfly/swarm/keycloak/SecuredTest.java
+++ b/testsuite/testsuite-keycloak/src/test/java/org/wildfly/swarm/keycloak/SecuredTest.java
@@ -1,0 +1,38 @@
+package org.wildfly.swarm.keycloak;
+
+import java.io.InputStream;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathFactory;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.Assert;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.wildfly.swarm.spi.api.JARArchive;
+import org.wildfly.swarm.undertow.descriptors.WebXmlAsset;
+
+/**
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+public class SecuredTest {
+
+    @Test
+    public void testShouldContainOneLoginConfig() throws Exception {
+        JARArchive archive = ShrinkWrap.create(JARArchive.class, "test.jar");
+        archive.as(Secured.class).protect("/companies").withRole("default");
+        archive.as(Secured.class).protect("/accounts").withRole("manager");
+
+        InputStream assetStream = archive.get(WebXmlAsset.NAME).getAsset().openStream();
+
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        Document document = factory.newDocumentBuilder().parse(assetStream);
+        XPath xpath = XPathFactory.newInstance().newXPath();
+        XPathExpression xpr = xpath.compile("count(//web-app/login-config)");
+        Number count = (Number) xpr.evaluate(document, XPathConstants.NUMBER);
+        Assert.assertEquals("Should have only one login-config element", 1, count.intValue());
+    }
+}

--- a/undertow/src/main/java/org/wildfly/swarm/undertow/descriptors/WebXmlAsset.java
+++ b/undertow/src/main/java/org/wildfly/swarm/undertow/descriptors/WebXmlAsset.java
@@ -87,13 +87,13 @@ public class WebXmlAsset implements NamedAsset {
     }
 
     public void setLoginConfig(String authMethod, String realmName) {
-        this.descriptor.createLoginConfig()
+        this.descriptor.getOrCreateLoginConfig()
                 .authMethod(authMethod)
                 .realmName(realmName);
     }
 
     public void setFormLoginConfig(String realmName, String loginPage, String errorPage) {
-        this.descriptor.createLoginConfig()
+        this.descriptor.getOrCreateLoginConfig()
                 .authMethod("FORM")
                 .realmName(realmName)
                 .getOrCreateFormLoginConfig()


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

Multiple Archive#as(Secured.class) executions occur ParseError of web.xml.
The method sets up web.xml, and if you use it multiple times, multiple login-config elements in web.xml would be registered.
## Modifications

WebXmlAsset.createLoginConfig was changed to use getOrCreateLoginConfig instead of createLoginConfig
## Result

Only one login-config entry is now created regardless on how many times this method is called
