### PR TITLE
SWARM-661 - swarmtool script doesn't work without bash

### DIFF
--- a/swarmtool/src/main/assembly/genexe.sh
+++ b/swarmtool/src/main/assembly/genexe.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [[ -z "$1" ]]; then
+if [ -z "$1" ]; then
     echo "Usage: $0 path-to-jar"
     exit 1
 fi
@@ -12,11 +12,11 @@ echo "Making ${jar} executable"
 ARGS='"$@"'
 (echo '#!/bin/sh
 
-if [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]]; then
+if [ -n "$JAVA_HOME" ] && [ -x "$JAVA_HOME/bin/java" ]; then
     java="$JAVA_HOME/bin/java"
 elif type -p java > /dev/null 2>&1; then
     java=$(type -p java)
-elif [[ -x "/usr/bin/java" ]];  then
+elif [ -x "/usr/bin/java" ];  then
     java="/usr/bin/java"
 else
     echo "Failed to find Java - please make sure it is in your path or set $JAVA_HOME"


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

While the shebang line specifies /bin/sh, it was actually
using [[ ]] for test, needlessly, which is bash-specific.
## Modifications

Remove double brackets and replace with single brackets.
## Result

Should now work on non-bash shells.
