### PR TITLE
Update fraction-plugin to 37

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   </scm>
 
   <properties>
-    <version.wildfly.swarm.fraction.plugin>36</version.wildfly.swarm.fraction.plugin>
+    <version.wildfly.swarm.fraction.plugin>37</version.wildfly.swarm.fraction.plugin>
 
     <version.cdi2>2.0.Alpha4</version.cdi2>
     <version.org.snakeyaml>1.17</version.org.snakeyaml>


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

This upgrades the wildfly-swarm-fraction-plugin to 37.
Main changes are support for include: in module-rewrite.conf files and the introduction of a swarmVersion JS variable to ease the update of versions in the generator
## Modifications

Parent pom was changed
## Result

Fraction plugin 37 is now used
