### PR TITLE
SWARM-673: Internal container not stopped

### DIFF
--- a/container/src/main/java/org/wildfly/swarm/container/internal/ServerBootstrap.java
+++ b/container/src/main/java/org/wildfly/swarm/container/internal/ServerBootstrap.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.wildfly.swarm.container.internal;
 
 import java.net.URL;
@@ -16,6 +31,8 @@ import org.wildfly.swarm.spi.api.ProjectStage;
  * @author Ken Finnigan
  */
 public interface ServerBootstrap {
+    String WELD_INSTANCE_ID = "internal";
+
     ServerBootstrap withArguments(String[] args);
 
     ServerBootstrap withStageConfig(Optional<ProjectStage> stageConfig);

--- a/container/src/main/java/org/wildfly/swarm/container/internal/WeldShutdown.java
+++ b/container/src/main/java/org/wildfly/swarm/container/internal/WeldShutdown.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.container.internal;
+
+/**
+ * @author Ken Finnigan
+ */
+public interface WeldShutdown {
+    void shutdown() throws Exception;
+}

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/ServerBootstrapImpl.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/ServerBootstrapImpl.java
@@ -1,7 +1,21 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.wildfly.swarm.container.runtime;
 
 import java.io.IOException;
-import java.lang.annotation.Annotation;
 import java.net.URL;
 import java.util.Collection;
 import java.util.List;
@@ -27,9 +41,7 @@ import org.wildfly.swarm.internal.OutboundSocketBindingRequest;
 import org.wildfly.swarm.internal.SocketBindingRequest;
 import org.wildfly.swarm.internal.SwarmMessages;
 import org.wildfly.swarm.spi.api.Fraction;
-import org.wildfly.swarm.spi.api.OutboundSocketBinding;
 import org.wildfly.swarm.spi.api.ProjectStage;
-import org.wildfly.swarm.spi.api.SocketBinding;
 
 /**
  * @author Bob McWhirter
@@ -99,7 +111,7 @@ public class ServerBootstrapImpl implements ServerBootstrap {
 
         logFractions();
 
-        Weld weld = new Weld();
+        Weld weld = new Weld(WELD_INSTANCE_ID);
         weld.setClassLoader(module.getClassLoader());
 
         // Add Extension that adds User custom bits into configurator

--- a/container/src/main/java/org/wildfly/swarm/container/runtime/WeldShutdownImpl.java
+++ b/container/src/main/java/org/wildfly/swarm/container/runtime/WeldShutdownImpl.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.container.runtime;
+
+import org.jboss.weld.environment.se.WeldContainer;
+import org.wildfly.swarm.container.internal.ServerBootstrap;
+import org.wildfly.swarm.container.internal.WeldShutdown;
+
+/**
+ * @author Ken Finnigan
+ */
+public class WeldShutdownImpl implements WeldShutdown {
+    @Override
+    public void shutdown() throws Exception {
+        WeldContainer internalContainer = WeldContainer.instance(ServerBootstrap.WELD_INSTANCE_ID);
+        if (internalContainer != null) {
+            internalContainer.shutdown();
+        }
+    }
+}

--- a/testsuite/testsuite-container/src/test/java/org/wildfly/swarm/container/ProjectStagesTest.java
+++ b/testsuite/testsuite-container/src/test/java/org/wildfly/swarm/container/ProjectStagesTest.java
@@ -32,7 +32,6 @@ import static org.junit.Assert.*;
  * @author Heiko Braun
  * @since 07/04/16
  */
-@Ignore
 public class ProjectStagesTest {
 
     @Before


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

If the JVM doesn't shutdown then our internal Weld container is still present even after calling Swarm.stop().
## Modifications

Add WeldShutdownImpl to be called from Swarm.stop() to shutdown Weld when JVM is still active
## Result

Prevents errors, mostly in tests, of calling new Swarm() after Swarm.stop()
