### PR TITLE
SWARM-752: Enable Module's MBeanServer

### DIFF
--- a/container/src/main/java/org/wildfly/swarm/internal/SwarmMessages.java
+++ b/container/src/main/java/org/wildfly/swarm/internal/SwarmMessages.java
@@ -159,4 +159,8 @@ public interface SwarmMessages extends BasicLogger {
     @LogMessage(level = Logger.Level.WARN)
     @Message(id = 34, value = "Ignoring subsystem %s:%s")
     void ignoringSubsystem(String nsURI, String name);
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 35, value = "Failed to register modules mbeans")
+    void moduleMBeanServerNotInstalled(@Cause Throwable cause);
 }


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

Debugging Module classloaders can be a pain most of the times. JBoss Modules offers some MBeans to help in this (awful) task.
## Modifications

Called ModuleLoader#installMBeanServer using reflection since the method is not public
## Result

Running jconsole you should see the jboss.modules mbeans in a running swarm app
