### PR TITLE
SWARM-757: Missing org.hibernate.infinispan module in Hibernate 2nd-level cache.

### DIFF
--- a/infinispan/src/main/java/org/wildfly/swarm/infinispan/runtime/InfinispanCustomizer.java
+++ b/infinispan/src/main/java/org/wildfly/swarm/infinispan/runtime/InfinispanCustomizer.java
@@ -109,6 +109,7 @@ public class InfinispanCustomizer implements Customizer {
         if (!this.jpa.isUnsatisfied()) {
             this.fraction.cacheContainer("hibernate",
                     cc -> cc.defaultCache("local-query")
+                            .module("org.hibernate.infinispan")
                             .jgroupsTransport(t -> t.lockTimeout(60000L))
                             .localCache("local-query",
                                     c -> c.evictionComponent(ec -> ec.maxEntries(10000L).strategy(EvictionComponent.Strategy.LRU))
@@ -159,6 +160,7 @@ public class InfinispanCustomizer implements Customizer {
         if (!this.jpa.isUnsatisfied()) {
             this.fraction.cacheContainer("hibernate",
                     cc -> cc.defaultCache("local-query")
+                            .module("org.hibernate.infinispan")
                             .localCache("entity",
                                     c -> c.transactionComponent(t -> t.mode(TransactionComponent.Mode.NON_XA))
                                             .evictionComponent(e -> e.strategy(EvictionComponent.Strategy.LRU).maxEntries(10000L))


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

When using Infinispan as a 2nd-level cache, an exception is thrown because the classloader where Infinispan lives couldn't find the Hibernate Infinispan cache provider
## Modifications

Added module("org.hibernate.infinispan") in InfinispanCustomizer to be similar to what's in WildFly's standalone.xml
## Result

No error occurs when using Infinispan as a 2nd-level cache
