### PR TITLE
SWARM-768: Honor swarm.project.stage as an environment variable

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/core/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -464,7 +464,14 @@ public class Swarm {
 
     private void loadStageConfiguration(URL url) {
         List<ProjectStage> projectStages = new ProjectStageFactory().loadStages(url);
-        String stageName = System.getProperty(SwarmProperties.PROJECT_STAGE, "default");
+        String stageName = System.getProperty(SwarmProperties.PROJECT_STAGE);
+        if (stageName == null) {
+            // Try with SWARM_PROJECT_STAGE
+            stageName = System.getenv(SwarmProperties.PROJECT_STAGE.replace('.', '_').toUpperCase());
+        }
+        if (stageName == null) {
+            stageName = "default";
+        }
         ProjectStage stage = null;
         for (ProjectStage projectStage : projectStages) {
             if (projectStage.getName().equals(stageName)) {


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

Docker environments use env vars to pass parameters to docker container
## Modifications

SwarmProperties.PROJECT_STAGE is resolved in System.getenv() if System.getProperty() doesn't return null
## Result

Swarm uses SwarmProperties.PROJECT_STAGE
