### PR TITLE
SWARM-769: Fix broken JIRA link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ mvn clean install -DskipTests
 
 # Issue Tracking
 
-Issues are being tracked using the [JBoss issue tracking system](https://issues.jboss.org/secure/RapidBoard.jspa?rapidView=2972) (JIRA). Bug reports and feature requests are greatly appreciated.
+Issues are being tracked using the [JBoss issue tracking system](https://issues.jboss.org/projects/SWARM/issues?filter=allopenissues) (JIRA). Bug reports and feature requests are greatly appreciated.
 
 # Documentation
 
@@ -89,6 +89,3 @@ Guide](https://wildfly-swarm.gitbooks.io/wildfly-swarm-users-guide/).
 
 * We hang out in `#wildfly-swarm` on irc.freenode.net.
 * Logs can be found [here](http://transcripts.jboss.org/channel/irc.freenode.org/%23wildfly-swarm/)
-
-
-


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

The JIRA link in README.md doesn't work properly.
It opens JBoss JIRA but says "The requested board cannot be viewed because it either does not exist or you do not have permission to view it.".
## Modifications

Fix the link with https://issues.jboss.org/projects/SWARM/issues?filter=allopenissues as WildFly Swarm Google Group.
## Result

The JIRA link in README opens WildFly Swarm JIRA properly.
