### PR TITLE
SWARM-770: Removal of redundant jboss repository

### DIFF
--- a/plugin/src/main/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelper.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelper.java
@@ -59,10 +59,6 @@ public class MavenArtifactResolvingHelper implements ArtifactResolvingHelper {
         this.resolver = resolver;
         this.system = system;
         this.session = session;
-        this.remoteRepositories.add(buildRemoteRepository("jboss-public-repository-group",
-                "http://repository.jboss.org/nexus/content/groups/public/",
-                null,
-                this.session));
     }
 
     public void remoteRepository(ArtifactRepository repo) {


### PR DESCRIPTION
## Motivation

Jboss repository inclusion is redundant as it is already included in user settings for this plugin to be fetched. Maven plugins should not add repositories
by themselves.
## Modifications

jboss repository removed from MavenArtifactResolver
## Result

A potential change in Jboss repository's URL or path structure will not affect users by having them to request artifacts from a repository they didn't specify.
