### PR TITLE
SWARM-676: CNFE when running tests in IDE

### DIFF
--- a/core/bootstrap/pom.xml
+++ b/core/bootstrap/pom.xml
@@ -47,29 +47,20 @@
         </configuration>
       </plugin>
       <plugin>
-        <artifactId>maven-shade-plugin</artifactId>
+        <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>
-            <phase>package</phase>
+            <id>unpack</id>
+            <phase>process-classes</phase>
             <goals>
-              <goal>shade</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactSet>
-                <includes>
-                  <include>org.jboss.modules:jboss-modules:*:*</include>
-                  <include>org.yaml:snakeyaml:*:*</include>
-                </includes>
-              </artifactSet>
-              <filters>
-                <filter>
-                  <artifact>org.jboss.modules:jboss-modules</artifact>
-                  <excludes>
-                    <exclude>org/jboss/modules/maven/MavenArtifactUtil.class</exclude>
-                    <exclude>org/jboss/modules/maven/ArtifactCoordinates.class</exclude>
-                  </excludes>
-                </filter>
-              </filters>
+              <excludeTransitive>true</excludeTransitive>
+              <includeGroupIds>org.jboss.modules,org.yaml</includeGroupIds>
+              <includeScope>compile</includeScope>
+              <excludes>**\/MavenArtifactUtil.class,**\/ArtifactCoordinates.class</excludes>
+              <outputDirectory>${project.build.directory}/classes</outputDirectory>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

Running Arquillian based tests within the IDE fails with a CNFE on classes that are shaded into /bootstrap
## Modifications

Instead of shading the dependencies in `package`, unpack them into target/classes as a pre compile step to make them available to the IDE.
## Result

No impact to product behavior.
