### PR TITLE
SWARM-478: Add Flyway fraction

### DIFF
--- a/fractions/flyway/module.conf
+++ b/fractions/flyway/module.conf
@@ -1,0 +1,4 @@
+org.flywaydb export=true
+org.wildfly.swarm.datasources
+org.wildfly.swarm.undertow
+javax.api

--- a/fractions/flyway/pom.xml
+++ b/fractions/flyway/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+~ JBoss, Home of Professional Open Source.
+~
+~ Copyright 2016 Red Hat, Inc., and individual contributors
+~ as indicated by the @author tags.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~     http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>wildfly-swarm</artifactId>
+        <version>2016.11.0-SNAPSHOT</version>
+        <relativePath>../../</relativePath>
+    </parent>
+
+    <artifactId>flyway</artifactId>
+
+    <name>Flyway</name>
+    <description>Evolve your Database Schema easily and reliably across all your instances</description>
+
+    <properties>
+        <swarm.fraction.stability>experimental</swarm.fraction.stability>
+        <swarm.fraction.tags>Data</swarm.fraction.tags>
+    </properties>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>datasources</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/fractions/flyway/src/main/java/org/wildfly/swarm/flyway/FlywayFraction.java
+++ b/fractions/flyway/src/main/java/org/wildfly/swarm/flyway/FlywayFraction.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.flyway;
+
+import org.wildfly.swarm.spi.api.Fraction;
+import org.wildfly.swarm.spi.api.annotations.DeploymentModule;
+
+/**
+ * Flyway Fraction
+ *
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+@DeploymentModule(name = "org.wildfly.swarm.flyway", slot = "deployment")
+public class FlywayFraction implements Fraction<FlywayFraction> {
+
+    /**
+     * Uses the specified connection info if not <code>null</code>. Otherwise
+     * use primary Datasource
+     */
+    private String jdbcUrl;
+    private String jdbcUser;
+    private String jdbcPassword;
+
+    public String jdbcPassword() {
+        return jdbcPassword;
+    }
+
+    public String jdbcUrl() {
+        return jdbcUrl;
+    }
+
+    public String jdbcUser() {
+        return jdbcUser;
+    }
+
+    public FlywayFraction jdbcPassword(String jdbcPassword) {
+        this.jdbcPassword = jdbcPassword;
+        return this;
+    }
+
+    public FlywayFraction jdbcUser(String jdbcUser) {
+        this.jdbcUser = jdbcUser;
+        return this;
+    }
+
+    public FlywayFraction jdbcUrl(String jdbcUrl) {
+        this.jdbcUrl = jdbcUrl;
+        return this;
+    }
+
+    public boolean usePrimaryDataSource() {
+        return this.jdbcPassword == null;
+    }
+}

--- a/fractions/flyway/src/main/java/org/wildfly/swarm/flyway/deployment/FlywayMigrationServletContextListener.java
+++ b/fractions/flyway/src/main/java/org/wildfly/swarm/flyway/deployment/FlywayMigrationServletContextListener.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.flyway.deployment;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.enterprise.inject.Vetoed;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.annotation.WebListener;
+import javax.sql.DataSource;
+import org.flywaydb.core.Flyway;
+
+/**
+ * A ServletContextListener implementation that performs DB migration with
+ * Flyway
+ *
+ * @author @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+@Vetoed
+@WebListener
+public class FlywayMigrationServletContextListener implements ServletContextListener {
+
+    public static final String FLYWAY_JNDI_DATASOURCE = "flyway.jndi.datasource";
+    public static final String FLYWAY_JDBC_PASSWORD = "flyway.jdbc.password";
+    public static final String FLYWAY_JDBC_USER = "flyway.jdbc.user";
+    public static final String FLYWAY_JDBC_URL = "flyway.jdbc.url";
+
+    private static final Logger logger = Logger.getLogger(FlywayMigrationServletContextListener.class.getName());
+
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+        ServletContext sc = sce.getServletContext();
+        Flyway flyway = new Flyway();
+        String dataSourceJndi = sc.getInitParameter(FLYWAY_JNDI_DATASOURCE);
+        if (dataSourceJndi != null) {
+            try {
+                DataSource dataSource = (DataSource) new InitialContext().lookup(dataSourceJndi);
+                flyway.setDataSource(dataSource);
+            } catch (NamingException ex) {
+                logger.log(Level.SEVERE, "Error while looking up DataSource", ex);
+                // Do not proceed
+                return;
+            }
+        } else {
+            String url = sc.getInitParameter(FLYWAY_JDBC_URL);
+            String user = sc.getInitParameter(FLYWAY_JDBC_USER);
+            String password = sc.getInitParameter(FLYWAY_JDBC_PASSWORD);
+            flyway.setDataSource(url, user, password);
+        }
+        flyway.migrate();
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent sce) {
+    }
+
+}

--- a/fractions/flyway/src/main/java/org/wildfly/swarm/flyway/runtime/FlywayMigrationArchivePreparer.java
+++ b/fractions/flyway/src/main/java/org/wildfly/swarm/flyway/runtime/FlywayMigrationArchivePreparer.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.flyway.runtime;
+
+import org.wildfly.swarm.flyway.deployment.FlywayMigrationServletContextListener;
+import java.util.List;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import org.jboss.shrinkwrap.api.Archive;
+import org.wildfly.swarm.config.datasources.DataSource;
+import org.wildfly.swarm.datasources.DatasourcesFraction;
+import org.wildfly.swarm.flyway.FlywayFraction;
+import org.wildfly.swarm.spi.api.ArchivePreparer;
+import org.wildfly.swarm.undertow.descriptors.WebXmlAsset;
+import org.wildfly.swarm.undertow.descriptors.WebXmlContainer;
+
+/**
+ *
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+public class FlywayMigrationArchivePreparer implements ArchivePreparer {
+
+    @Inject
+    private Instance<DatasourcesFraction> dsFractionInstance;
+
+    @Inject
+    private Instance<FlywayFraction> flywayFractionInstance;
+
+    @Override
+    public void prepareArchive(Archive<?> archive) {
+        if (archive instanceof WebXmlContainer) {
+            WebXmlContainer<? extends Archive<?>> webArchive = ((WebXmlContainer<?>) archive);
+            WebXmlAsset webXml = webArchive.findWebXmlAsset();
+            webXml.addListener("org.wildfly.swarm.flyway.deployment.FlywayMigrationServletContextListener");
+            FlywayFraction flywayFraction = flywayFractionInstance.get();
+            if (flywayFraction.usePrimaryDataSource()) {
+                String dataSourceJndi = getDatasourceNameJndi();
+                webXml.setContextParam(FlywayMigrationServletContextListener.FLYWAY_JNDI_DATASOURCE, dataSourceJndi);
+            } else {
+                webXml.setContextParam(FlywayMigrationServletContextListener.FLYWAY_JDBC_URL, flywayFraction.jdbcUrl());
+                webXml.setContextParam(FlywayMigrationServletContextListener.FLYWAY_JDBC_USER, flywayFraction.jdbcUser());
+                webXml.setContextParam(FlywayMigrationServletContextListener.FLYWAY_JDBC_PASSWORD, flywayFraction.jdbcPassword());
+            }
+        }
+    }
+
+    private String getDatasourceNameJndi() {
+        String jndiName = "java:jboss/datasources/ExampleDS";
+        if (!dsFractionInstance.isUnsatisfied()) {
+            List<DataSource> dataSources = dsFractionInstance.get().subresources().dataSources();
+            if (dataSources.size() > 0) {
+                jndiName = dataSources.get(0).jndiName();
+            }
+        }
+        return jndiName;
+    }
+
+}

--- a/fractions/flyway/src/main/resources/META-INF/beans.xml
+++ b/fractions/flyway/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"/>

--- a/fractions/flyway/src/main/resources/modules/org/flywaydb/main/module.xml
+++ b/fractions/flyway/src/main/resources/modules/org/flywaydb/main/module.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.5" name="org.flywaydb">
+    <resources>
+        <artifact name="org.flywaydb:flyway-core:${version.flyway}"/>
+    </resources>
+    <dependencies>
+        <module name="javax.api"/>
+        <module name="javax.transaction.api"/>
+        <module name="javax.servlet.api" optional="true"/>
+        <module name="org.slf4j"/>
+        <module name="org.jboss.vfs"/>
+    </dependencies>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,6 @@
     <version>7</version>
   </parent>
 
-  <groupId>org.wildfly.swarm</groupId>
   <artifactId>wildfly-swarm</artifactId>
   <version>2016.11.0-SNAPSHOT</version>
 
@@ -79,6 +78,8 @@
     <version.keycloak-secretstore>1.0.4.Final</version.keycloak-secretstore>
 
     <version.org.kie>6.4.0.Final</version.org.kie>
+
+    <version.flyway>4.0.3</version.flyway>
 
     <version.gradle>2.4</version.gradle>
     <version.gradle.plugins>1.12</version.gradle.plugins>
@@ -541,6 +542,17 @@
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>ejb-remote</artifactId>
+        <version>2016.11.0-SNAPSHOT</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.flywaydb</groupId>
+        <artifactId>flyway-core</artifactId>
+        <version>${version.flyway}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>flyway</artifactId>
         <version>2016.11.0-SNAPSHOT</version>
       </dependency>
 
@@ -1127,6 +1139,7 @@
     <module>fractions/databases/mysql</module>
     <module>fractions/databases/postgresql</module>
     <module>fractions/drools-server</module>
+    <module>fractions/flyway</module>
     <module>fractions/hibernate-search</module>
     <module>fractions/hibernate-validator</module>
     <module>fractions/infinispan</module>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -90,6 +90,7 @@
     <module>testsuite-ee</module>
     <module>testsuite-ejb</module>
     <module>testsuite-ejb-remote</module>
+    <module>testsuite-flyway</module>
     <module>testsuite-hystrix</module>
     <module>testsuite-infinispan</module>
     <module>testsuite-io</module>

--- a/testsuite/testsuite-flyway/pom.xml
+++ b/testsuite/testsuite-flyway/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>testsuite</artifactId>
+    <version>2016.11.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <artifactId>testsuite-flyway</artifactId>
+
+  <name>Test Suite: Flyway</name>
+  <description>Test Suite: Flyway</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>flyway</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>    
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>arquillian</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.junit</groupId>
+      <artifactId>arquillian-junit-container</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/testsuite/testsuite-flyway/src/test/java/org/wildfly/swarm/flyway/FlywayArquillianTest.java
+++ b/testsuite/testsuite-flyway/src/test/java/org/wildfly/swarm/flyway/FlywayArquillianTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.flyway;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import javax.naming.InitialContext;
+import javax.sql.DataSource;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.arquillian.CreateSwarm;
+import org.wildfly.swarm.database.h2.H2Fraction;
+import org.wildfly.swarm.undertow.WARArchive;
+
+/**
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+@RunWith(Arquillian.class)
+public class FlywayArquillianTest {
+
+    @Deployment
+    public static Archive<?> getDeployment() throws Exception {
+        return ShrinkWrap.create(WARArchive.class, "deployment.war")
+                .addAllDependencies()
+                .addAsResource(new File("src/test/resources/db"), "db");
+    }
+
+    @CreateSwarm
+    public static Swarm createSwarm() throws Exception {
+        return new Swarm()
+                .fraction(new H2Fraction())
+                .fraction(new FlywayFraction());
+    }
+
+    @Test
+    public void testDataSourceContents() throws Exception {
+        DataSource dataSource = (DataSource) new InitialContext().lookup("java:jboss/datasources/ExampleDS");
+        try (Connection con = dataSource.getConnection();
+                PreparedStatement stmt = con.prepareStatement("SELECT COUNT(*) FROM PERSON");
+                ResultSet rs = stmt.executeQuery()) {
+            Assert.assertTrue("No data found in SQL statement", rs.next());
+            Assert.assertEquals("Migration did not perform correctly", 3, rs.getInt(1));
+        }
+    }
+}

--- a/testsuite/testsuite-flyway/src/test/resources/db/migration/V1__Create_person_table.sql
+++ b/testsuite/testsuite-flyway/src/test/resources/db/migration/V1__Create_person_table.sql
@@ -1,0 +1,4 @@
+create table PERSON (
+    ID int not null,
+    NAME varchar(100) not null
+);

--- a/testsuite/testsuite-flyway/src/test/resources/db/migration/V2__Add_people.sql
+++ b/testsuite/testsuite-flyway/src/test/resources/db/migration/V2__Add_people.sql
@@ -1,0 +1,3 @@
+insert into PERSON (ID, NAME) values (1, 'Axel');
+insert into PERSON (ID, NAME) values (2, 'Mr. Foo');
+insert into PERSON (ID, NAME) values (3, 'Ms. Bar');


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

Flyway (https://flywaydb.org/) is an open-source database migration tool. It strongly favors simplicity and convention over configuration.
## Modifications

Created a flyway fraction that automatically bounds to the primary DataSource if not configured or uses the provided URL/user/pass otherwise.
It registers a ServletContextListener in the deployed app to perform the migration. Scripts must be placed under src/main/resources/db/migration
## Result

Flyway can now be activated in Swarm applications by simply adding the flyway fraction and dropping the scripts in the specified place.
