### PR TITLE
SWARM-781 - Implicitly add beans.xml if required.

### DIFF
--- a/fractions/javaee/cdi/src/main/java/org/wildfly/swarm/cdi/runtime/CDIArchivePreparer.java
+++ b/fractions/javaee/cdi/src/main/java/org/wildfly/swarm/cdi/runtime/CDIArchivePreparer.java
@@ -1,0 +1,38 @@
+package org.wildfly.swarm.cdi.runtime;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.Node;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.wildfly.swarm.spi.api.ArchivePreparer;
+
+/** Ensures that a <code>beans.xml</code> is present in the archive.
+ *
+ * @author Bob McWhirter
+ */
+public class CDIArchivePreparer implements ArchivePreparer {
+
+    public static final String META_INF_BEANS_XML = "META-INF/beans.xml";
+
+    public static final String WEB_INF_BEANS_XML = "WEB-INF/beans.xml";
+
+    @Override
+    public void prepareArchive(Archive<?> archive) {
+
+        if (archive.getName().endsWith(".jar")) {
+            Node node = archive.get(META_INF_BEANS_XML);
+            if (node != null && node.getAsset() != null) {
+                return;
+            }
+
+            archive.add(EmptyAsset.INSTANCE, META_INF_BEANS_XML);
+        }
+
+        if (archive.getName().endsWith(".war")) {
+            Node node = archive.get(WEB_INF_BEANS_XML);
+            if (node != null && node.getAsset() != null) {
+                return;
+            }
+            archive.add(EmptyAsset.INSTANCE, WEB_INF_BEANS_XML);
+        }
+    }
+}

--- a/fractions/javaee/cdi/src/test/java/org/wildfly/swarm/cdi/runtime/CDIArchivePreparerTest.java
+++ b/fractions/javaee/cdi/src/test/java/org/wildfly/swarm/cdi/runtime/CDIArchivePreparerTest.java
@@ -1,0 +1,78 @@
+package org.wildfly.swarm.cdi.runtime;
+
+import org.jboss.shrinkwrap.api.Node;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.Test;
+import org.wildfly.swarm.spi.api.JARArchive;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Bob McWhirter
+ */
+public class CDIArchivePreparerTest {
+
+    @Test
+    public void testJarWithBeansXml() {
+        JARArchive jar = ShrinkWrap.create(JARArchive.class, "my.jar");
+
+        StringAsset beansXml = new StringAsset("beans.xml content");
+        jar.add(beansXml, "META-INF/beans.xml");
+
+        CDIArchivePreparer preparer = new CDIArchivePreparer();
+
+        preparer.prepareArchive(jar);
+
+        Node fetched = jar.get("META-INF/beans.xml");
+        assertThat(fetched).isNotNull();
+        assertThat(fetched.getAsset()).isNotNull();
+        assertThat(((StringAsset) fetched.getAsset()).getSource()).isEqualTo("beans.xml content");
+    }
+
+    @Test
+    public void testJarWithoutBeansXml() {
+        JARArchive jar = ShrinkWrap.create(JARArchive.class, "my.jar");
+
+        CDIArchivePreparer preparer = new CDIArchivePreparer();
+
+        preparer.prepareArchive(jar);
+
+        Node fetched = jar.get("META-INF/beans.xml");
+        assertThat(fetched).isNotNull();
+        assertThat(fetched.getAsset()).isNotNull();
+        assertThat(fetched.getAsset()).isInstanceOf(EmptyAsset.class);
+    }
+
+    @Test
+    public void testWarWithBeansXml() {
+        JARArchive jar = ShrinkWrap.create(JARArchive.class, "my.war");
+
+        StringAsset beansXml = new StringAsset("beans.xml content");
+        jar.add(beansXml, "WEB-INF/beans.xml");
+
+        CDIArchivePreparer preparer = new CDIArchivePreparer();
+
+        preparer.prepareArchive(jar);
+
+        Node fetched = jar.get("WEB-INF/beans.xml");
+        assertThat(fetched).isNotNull();
+        assertThat(fetched.getAsset()).isNotNull();
+        assertThat(((StringAsset) fetched.getAsset()).getSource()).isEqualTo("beans.xml content");
+    }
+
+    @Test
+    public void testWarWithoutBeansXml() {
+        JARArchive jar = ShrinkWrap.create(JARArchive.class, "my.war");
+
+        CDIArchivePreparer preparer = new CDIArchivePreparer();
+
+        preparer.prepareArchive(jar);
+
+        Node fetched = jar.get("WEB-INF/beans.xml");
+        assertThat(fetched).isNotNull();
+        assertThat(fetched.getAsset()).isNotNull();
+        assertThat(fetched.getAsset()).isInstanceOf(EmptyAsset.class);
+    }
+}


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

A user includes our :cdi fraction, they shouldn't also be
required to ensure there's an empty beans.xml.

But if they do provide one, we should respect it.
## Modifications

An archive-preparer that checks for and adds a beans.xml
if one is missing from the deployment, if the CDI fraction
is involved.
## Result

No more requirement of an empty beans.xml.
