### PR TITLE
SWARM-787 - Allow specification of a main() from a @DefaultDeployment.

### DIFF
--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/DefaultDeployment.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/DefaultDeployment.java
@@ -21,6 +21,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.wildfly.swarm.Swarm;
+
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Documented
@@ -37,4 +39,6 @@ public @interface DefaultDeployment {
 
     Type type() default Type.JAR;
     boolean testable() default true;
+    Class<?> main() default Void.class;
+
 }

--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/DefaultDeploymentScenarioGenerator.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/DefaultDeploymentScenarioGenerator.java
@@ -12,7 +12,6 @@ import java.security.CodeSource;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -21,18 +20,15 @@ import org.jboss.arquillian.container.test.impl.client.deployment.AnnotationDepl
 import org.jboss.arquillian.test.spi.TestClass;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ArchivePath;
-import org.jboss.shrinkwrap.api.Node;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.Asset;
-import org.jboss.shrinkwrap.api.asset.ClassLoaderAsset;
 import org.jboss.shrinkwrap.api.asset.FileAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.impl.base.URLPackageScanner;
 import org.jboss.shrinkwrap.impl.base.asset.AssetUtil;
 import org.jboss.shrinkwrap.impl.base.path.BasicPath;
 import org.wildfly.swarm.arquillian.DefaultDeployment;
-import org.wildfly.swarm.spi.api.JARArchive;
 
 /**
  * @author Bob McWhirter
@@ -130,6 +126,11 @@ public class DefaultDeploymentScenarioGenerator extends AnnotationDeploymentScen
         */
 
         DeploymentDescription description = new DeploymentDescription(testClass.getName(), archive);
+
+        Class<?> mainClass = anno.main();
+        if ( mainClass != Void.class ) {
+            archive.add(new StringAsset( mainClass.getName() ), "META-INF/arquillian-main-class" );
+        }
 
         description.shouldBeTestable(anno.testable());
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

To cleanly handle testing better, and avoid duplication, allow
provisioning of a main() through an attribute on the @DefaultDeployment
annotation.
## Modifications

Adding @DefaultDeployment(main=MyMain.class) capability.
## Result

Instead of requiring a @CreateSwarm which may replicate the logic
performed within an exist main(), just allow pointing to the existing
main().
