### PR TITLE
SWARM-791: Dependencies should be collected and resolved later.

### DIFF
--- a/plugin/src/main/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelper.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelper.java
@@ -28,6 +28,7 @@ import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.collection.CollectResult;
 import org.eclipse.aether.graph.DefaultDependencyNode;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyNode;
@@ -39,8 +40,6 @@ import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
-import org.eclipse.aether.resolution.DependencyRequest;
-import org.eclipse.aether.resolution.DependencyResult;
 import org.eclipse.aether.util.graph.transformer.ConflictResolver;
 import org.eclipse.aether.util.graph.transformer.JavaScopeDeriver;
 import org.eclipse.aether.util.graph.transformer.JavaScopeSelector;
@@ -128,7 +127,7 @@ public class MavenArtifactResolvingHelper implements ArtifactResolvingHelper {
                                     new JavaScopeDeriver()
                             ), defaultExcludes
                     );
-            DependencyResult result = this.system.resolveDependencies(tempSession, new DependencyRequest(request, null));
+            CollectResult result = this.system.collectDependencies(tempSession, request);
             PreorderNodeListGenerator gen = new PreorderNodeListGenerator();
             result.getRoot().accept(gen);
             nodes = gen.getNodes();
@@ -156,7 +155,7 @@ public class MavenArtifactResolvingHelper implements ArtifactResolvingHelper {
                             artifact.getVersion(),
                             artifact.getExtension(),
                             artifact.getClassifier(),
-                            artifact.getFile());
+                            null);
                 })
                 .map(this::resolve)
                 .filter(Objects::nonNull)


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

The examples and uberjar build is broken. The change that might have caused this was a recent change to use resolveDependencies instead of collectDependencies.
## Modifications

Using system.collectDependencies as before and setting the artifact file to null as before
## Result

The examples/uber-jar builds should work
