### PR TITLE
SWARM-800: Upgrade to Vert.x 3.3.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <version.org.openshift.ping>1.0.0.Beta7-swarm-1</version.org.openshift.ping>
     <version.org.jgroups>3.6.10.Final</version.org.jgroups>
 
-    <version.vertx>3.3.2</version.vertx>
+    <version.vertx>3.3.3</version.vertx>
 
     <version.keycloak>2.1.0.Final</version.keycloak>
     <version.keycloak-secretstore>1.0.4.Final</version.keycloak-secretstore>


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

---
## Motivation

Upgrade the Vert.x fraction to use 3.3.3
## Modifications

The parent vert.x version was changed to 3.3.3
## Result

The Vert.x fraction depends on Vert.x 3.3.3
