### PR TITLE
SWARM-715: Enhanced JAX-RS Client API

### DIFF
--- a/fractions/cdi-extensions/cdi-jaxrsapi/module.conf
+++ b/fractions/cdi-extensions/cdi-jaxrsapi/module.conf
@@ -1,0 +1,12 @@
+javax.enterprise.api
+org.wildfly.swarm.spi
+org.wildfly.swarm.spi:runtime
+org.wildfly.swarm.container:runtime export=true
+
+javax.enterprise.concurrent.api
+
+org.ow2.asm
+org.jboss.jandex
+
+org.wildfly.swarm.jaxrs
+org.jboss.resteasy.resteasy-jaxrs

--- a/fractions/cdi-extensions/cdi-jaxrsapi/pom.xml
+++ b/fractions/cdi-extensions/cdi-jaxrsapi/pom.xml
@@ -15,58 +15,50 @@
   </parent>
 
   <groupId>org.wildfly.swarm</groupId>
-  <artifactId>jaxrs-cdi</artifactId>
+  <artifactId>cdi-jaxrsapi</artifactId>
 
-  <name>JAX-RS with CDI</name>
-  <description>Provide CDI injection into RESTful services</description>
+  <name>CDI JAX-RS API Enhancements</name>
+  <description>CDI JAX-RS API Enhancements</description>
 
   <packaging>jar</packaging>
 
   <properties>
-    <swarm.fraction.bootstrap>true</swarm.fraction.bootstrap>
-    <swarm.fraction.stability>stable</swarm.fraction.stability>
-    <swarm.fraction.tags>JavaEE,Web</swarm.fraction.tags>
+    <swarm.fraction.stability>unstable</swarm.fraction.stability>
   </properties>
 
-  <build>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
-  </build>
-
   <dependencies>
-    <!-- Fraction Dependencies -->
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>container</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>jaxrs</artifactId>
     </dependency>
+
+    <!-- Provided APIs -->
     <dependency>
-      <groupId>org.wildfly.swarm</groupId>
-      <artifactId>cdi</artifactId>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.wildfly.swarm</groupId>
-      <artifactId>cdi-jaxrsapi</artifactId>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.wildfly.core</groupId>
+      <artifactId>wildfly-server</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.wildfly.core</groupId>
       <artifactId>wildfly-core-feature-pack</artifactId>
-      <type>zip</type>
-      <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.wildfly</groupId>
-      <artifactId>wildfly-servlet-feature-pack</artifactId>
       <type>zip</type>
       <scope>provided</scope>
       <exclusions>
@@ -88,6 +80,48 @@
         </exclusion>
       </exclusions>
     </dependency>
+
+    <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-servlet-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+
   </dependencies>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+
+    <plugins>
+      <plugin>
+        <groupId>org.jboss.jandex</groupId>
+        <artifactId>jandex-maven-plugin</artifactId>
+        <version>1.0.4</version>
+        <executions>
+          <execution>
+            <id>make-index</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>jandex</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+
+  </build>
 
 </project>

--- a/fractions/cdi-extensions/cdi-jaxrsapi/pom.xml
+++ b/fractions/cdi-extensions/cdi-jaxrsapi/pom.xml
@@ -23,7 +23,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <swarm.fraction.stability>unstable</swarm.fraction.stability>
+    <swarm.fraction.stability>experimental</swarm.fraction.stability>
     <swarm.fraction.tags>JavaEE,Service Discovery</swarm.fraction.tags>
   </properties>
 

--- a/fractions/cdi-extensions/cdi-jaxrsapi/pom.xml
+++ b/fractions/cdi-extensions/cdi-jaxrsapi/pom.xml
@@ -18,12 +18,13 @@
   <artifactId>cdi-jaxrsapi</artifactId>
 
   <name>CDI JAX-RS API Enhancements</name>
-  <description>CDI JAX-RS API Enhancements</description>
+  <description>Generates implementation of external service from interface which can then be injected to call that service.</description>
 
   <packaging>jar</packaging>
 
   <properties>
     <swarm.fraction.stability>unstable</swarm.fraction.stability>
+    <swarm.fraction.tags>JavaEE,Service Discovery</swarm.fraction.tags>
   </properties>
 
   <dependencies>

--- a/fractions/cdi-extensions/cdi-jaxrsapi/src/main/java/org/wildfly/swarm/cdi/jaxrsapi/CDIJAXRSFraction.java
+++ b/fractions/cdi-extensions/cdi-jaxrsapi/src/main/java/org/wildfly/swarm/cdi/jaxrsapi/CDIJAXRSFraction.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.cdi.jaxrsapi;
+
+import org.wildfly.swarm.spi.api.Fraction;
+import org.wildfly.swarm.spi.api.annotations.DeploymentModule;
+
+/**
+ * @author Ken Finnigan
+ */
+@DeploymentModule(name = "org.wildfly.swarm.cdi.jaxrsapi", slot = "deployment", export = true)
+public class CDIJAXRSFraction implements Fraction<CDIJAXRSFraction> {
+}

--- a/fractions/cdi-extensions/cdi-jaxrsapi/src/main/java/org/wildfly/swarm/cdi/jaxrsapi/Service.java
+++ b/fractions/cdi-extensions/cdi-jaxrsapi/src/main/java/org/wildfly/swarm/cdi/jaxrsapi/Service.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.cdi.jaxrsapi;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Ken Finnigan
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE})
+public @interface Service {
+    String baseUrl() default "";
+}

--- a/fractions/cdi-extensions/cdi-jaxrsapi/src/main/java/org/wildfly/swarm/cdi/jaxrsapi/ServiceClient.java
+++ b/fractions/cdi-extensions/cdi-jaxrsapi/src/main/java/org/wildfly/swarm/cdi/jaxrsapi/ServiceClient.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.cdi.jaxrsapi;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import javax.enterprise.concurrent.ManagedExecutorService;
+import javax.naming.InitialContext;
+
+/**
+ * @author Ken Finnigan
+ */
+public interface ServiceClient<T> {
+
+    default <U> void exec(Supplier<U> restMethod, Consumer<U> handler, Consumer<Throwable> exceptionHandler) throws Exception {
+        chainableExec(restMethod, exceptionHandler)
+                .thenAccept(handler)
+                .exceptionally(t -> {
+                    exceptionHandler.accept(t);
+                    return null;
+                });
+    }
+
+    default <U> CompletableFuture<U> chainableExec(Supplier<U> restMethod, Consumer<Throwable> exceptionHandler) throws Exception {
+        return CompletableFuture
+                .supplyAsync(restMethod, executorService())
+                .exceptionally(t -> {
+                    exceptionHandler.accept(t);
+                    return null;
+                });
+    }
+
+    default ManagedExecutorService executorService() throws Exception {
+        InitialContext ctx = new InitialContext();
+        return (ManagedExecutorService) ctx.lookup("java:jboss/ee/concurrency/executor/default");
+    }
+}

--- a/fractions/cdi-extensions/cdi-jaxrsapi/src/main/java/org/wildfly/swarm/cdi/jaxrsapi/deployment/ProxyBuilder.java
+++ b/fractions/cdi-extensions/cdi-jaxrsapi/src/main/java/org/wildfly/swarm/cdi/jaxrsapi/deployment/ProxyBuilder.java
@@ -1,0 +1,147 @@
+package org.wildfly.swarm.cdi.jaxrsapi.deployment;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Set;
+
+import javax.ws.rs.Path;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.client.jaxrs.ProxyConfig;
+import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
+import org.jboss.resteasy.client.jaxrs.i18n.Messages;
+import org.jboss.resteasy.client.jaxrs.internal.proxy.ClientInvoker;
+import org.jboss.resteasy.client.jaxrs.internal.proxy.ClientProxy;
+import org.jboss.resteasy.client.jaxrs.internal.proxy.MethodInvoker;
+import org.jboss.resteasy.client.jaxrs.internal.proxy.ResteasyClientProxy;
+import org.jboss.resteasy.client.jaxrs.internal.proxy.SubResourceInvoker;
+import org.jboss.resteasy.util.IsHttpMethod;
+
+/**
+ * Borrowed from RESTEasy for initial work
+ */
+public class ProxyBuilder<T> {
+    private static final Class<?>[] cClassArgArray = {Class.class};
+
+    private final Class<T> iface;
+    private final ResteasyWebTarget webTarget;
+    private ClassLoader loader = Thread.currentThread().getContextClassLoader();
+    private MediaType serverConsumes;
+    private MediaType serverProduces;
+
+    public static <T> ProxyBuilder<T> builder(Class<T> iface, WebTarget webTarget)
+    {
+        return new ProxyBuilder<T>(iface, (ResteasyWebTarget)webTarget);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T proxy(final Class<T> iface, WebTarget base, final ProxyConfig config)
+    {
+        if (iface.isAnnotationPresent(Path.class))
+        {
+            Path path = iface.getAnnotation(Path.class);
+            if (!path.value().equals("") && !path.value().equals("/"))
+            {
+                base = base.path(path.value());
+            }
+        }
+        HashMap<Method, MethodInvoker> methodMap = new HashMap<Method, MethodInvoker>();
+        for (Method method : iface.getMethods())
+        {
+            // ignore the as method to allow declaration in client interfaces
+            if ("as".equals(method.getName()) && Arrays.equals(method.getParameterTypes(), cClassArgArray))
+            {
+                continue;
+            }
+
+            // Added by Ken Finnigan
+            // Ignore default methods
+            if (method.isDefault()) {
+                continue;
+            }
+
+            MethodInvoker invoker;
+            Set<String> httpMethods = IsHttpMethod.getHttpMethods(method);
+            if ((httpMethods == null || httpMethods.size() == 0) && method.isAnnotationPresent(Path.class) && method.getReturnType().isInterface())
+            {
+                invoker = new SubResourceInvoker((ResteasyWebTarget)base, method, config);
+            }
+            else
+            {
+                invoker = createClientInvoker(iface, method, (ResteasyWebTarget)base, config);
+            }
+            methodMap.put(method, invoker);
+        }
+
+        Class<?>[] intfs =
+                {
+                        iface, ResteasyClientProxy.class
+                };
+
+        ClientProxy clientProxy = new ClientProxy(methodMap, base, config);
+        // this is done so that equals and hashCode work ok. Adding the proxy to a
+        // Collection will cause equals and hashCode to be invoked. The Spring
+        // infrastructure had some problems without this.
+        clientProxy.setClazz(iface);
+
+        return (T) Proxy.newProxyInstance(config.getLoader(), intfs, clientProxy);
+    }
+
+    private static <T> ClientInvoker createClientInvoker(Class<T> clazz, Method method, ResteasyWebTarget base, ProxyConfig config)
+    {
+        Set<String> httpMethods = IsHttpMethod.getHttpMethods(method);
+        if (httpMethods == null || httpMethods.size() != 1)
+        {
+            throw new RuntimeException(Messages.MESSAGES.mustUseExactlyOneHttpMethod(method.toString()));
+        }
+        ClientInvoker invoker = new ClientInvoker(base, clazz, method, config);
+        invoker.setHttpMethod(httpMethods.iterator().next());
+        return invoker;
+    }
+
+    private ProxyBuilder(Class<T> iface, ResteasyWebTarget webTarget)
+    {
+        this.iface = iface;
+        this.webTarget = webTarget;
+    }
+
+    public ProxyBuilder<T> classloader(ClassLoader cl)
+    {
+        this.loader = cl;
+        return this;
+    }
+
+    public ProxyBuilder<T> defaultProduces(MediaType type)
+    {
+        this.serverProduces = type;
+        return this;
+    }
+
+    public ProxyBuilder<T> defaultConsumes(MediaType type)
+    {
+        this.serverConsumes = type;
+        return this;
+    }
+
+    public ProxyBuilder<T> defaultProduces(String type)
+    {
+        this.serverProduces = MediaType.valueOf(type);
+        return this;
+    }
+
+    public ProxyBuilder<T> defaultConsumes(String type)
+    {
+        this.serverConsumes = MediaType.valueOf(type);
+        return this;
+    }
+    public T build()
+    {
+        return proxy(iface, webTarget, new ProxyConfig(loader, serverConsumes, serverProduces));
+    }
+
+
+
+}

--- a/fractions/cdi-extensions/cdi-jaxrsapi/src/main/java/org/wildfly/swarm/cdi/jaxrsapi/runtime/ServiceClientProcessor.java
+++ b/fractions/cdi-extensions/cdi-jaxrsapi/src/main/java/org/wildfly/swarm/cdi/jaxrsapi/runtime/ServiceClientProcessor.java
@@ -1,0 +1,201 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.cdi.jaxrsapi.runtime;
+
+import java.util.List;
+
+import javax.inject.Singleton;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.wildfly.swarm.cdi.jaxrsapi.ServiceClient;
+import org.wildfly.swarm.jaxrs.JAXRSArchive;
+import org.wildfly.swarm.spi.api.ArchiveMetadataProcessor;
+
+/**
+ * @author Ken Finnigan
+ */
+@Singleton
+public class ServiceClientProcessor implements ArchiveMetadataProcessor {
+    @Override
+    public void processArchive(Archive<?> archive, Index index) {
+        List<ClassInfo> serviceClients = index.getKnownDirectImplementors((DotName.createSimple(ServiceClient.class.getName())));
+
+        serviceClients.forEach(info -> {
+            String name = info.name().toString() + "_generated";
+            String path = "WEB-INF/classes/" + name.replace('.', '/') + ".class";
+            archive.as(JAXRSArchive.class).add(new ByteArrayAsset(ClientServiceFactory.createImpl(name, info)), path);
+        });
+    }
+
+    private static class ClientServiceFactory implements Opcodes {
+        static byte[] createImpl(String implName, ClassInfo classInfo) {
+            ClassWriter cw = new ClassWriter(0);
+            MethodVisitor mv;
+            AnnotationVisitor av0;
+
+            cw.visit(V1_8, ACC_PUBLIC + ACC_SUPER,
+                     implName.replace('.', '/'),
+                     null,
+                     "java/lang/Object",
+                     new String[]{classInfo.name().toString().replace('.', '/')}
+            );
+
+            int lastDot = implName.lastIndexOf('.');
+            String simpleName = implName.substring(lastDot + 1);
+
+            cw.visitSource(simpleName + ".java", null);
+            {
+                av0 = cw.visitAnnotation("Ljavax/enterprise/context/ApplicationScoped;", true);
+                av0.visitEnd();
+            }
+            cw.visitInnerClass("javax/ws/rs/client/Invocation$Builder", "javax/ws/rs/client/Invocation", "Builder", ACC_PUBLIC + ACC_STATIC + ACC_ABSTRACT + ACC_INTERFACE);
+
+            {
+                mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+                mv.visitCode();
+                Label l0 = new Label();
+                mv.visitLabel(l0);
+                mv.visitLineNumber(14, l0);
+                mv.visitVarInsn(ALOAD, 0);
+                mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+                Label l1 = new Label();
+                mv.visitLabel(l1);
+                mv.visitLineNumber(15, l1);
+                mv.visitInsn(RETURN);
+                Label l2 = new Label();
+                mv.visitLabel(l2);
+                mv.visitLocalVariable("this",
+                                      buildTypeDef(implName),
+                                      null,
+                                      l0,
+                                      l2,
+                                      0);
+                mv.visitMaxs(1, 1);
+                mv.visitEnd();
+            }
+
+            List<AnnotationInstance> annotations = classInfo.annotations().get(DotName.createSimple("org.wildfly.swarm.cdi.jaxrsapi.Service"));
+            String baseUrl = (String) annotations.get(0).value("baseUrl").value();
+            int lineNum = 18;
+
+            classInfo.asClass().methods()
+                    .stream()
+                    .forEachOrdered(method -> {
+                        createMethod(cw, implName, classInfo.name().toString(), method, lineNum, baseUrl);
+                    });
+            cw.visitEnd();
+
+            return cw.toByteArray();
+        }
+
+        static void createMethod(ClassWriter cw, String implName, String clientInterfaceName, MethodInfo method, int lineNum, String baseUrl) {
+            MethodVisitor mv;
+
+            {
+                mv = cw.visitMethod(ACC_PUBLIC, method.name(), buildMethodDef(method), null, null);
+                mv.visitCode();
+                Label l0 = new Label();
+                mv.visitLabel(l0);
+                mv.visitLineNumber(lineNum++, l0);
+                mv.visitLdcInsn(Type.getType(buildTypeDef(clientInterfaceName)));
+                mv.visitTypeInsn(NEW, "org/jboss/resteasy/client/jaxrs/ResteasyClientBuilder");
+                mv.visitInsn(DUP);
+                mv.visitMethodInsn(INVOKESPECIAL, "org/jboss/resteasy/client/jaxrs/ResteasyClientBuilder", "<init>", "()V", false);
+                mv.visitMethodInsn(INVOKEVIRTUAL, "org/jboss/resteasy/client/jaxrs/ResteasyClientBuilder", "build", "()Lorg/jboss/resteasy/client/jaxrs/ResteasyClient;", false);
+                mv.visitLdcInsn(baseUrl);
+                Label l1 = new Label();
+                mv.visitLabel(l1);
+                mv.visitLineNumber(lineNum++, l1);
+                mv.visitMethodInsn(INVOKEVIRTUAL, "org/jboss/resteasy/client/jaxrs/ResteasyClient", "target", "(Ljava/lang/String;)Lorg/jboss/resteasy/client/jaxrs/ResteasyWebTarget;", false);
+                Label l2 = new Label();
+                mv.visitLabel(l2);
+                mv.visitLineNumber(lineNum - 2, l2);
+                mv.visitMethodInsn(INVOKESTATIC, "org/wildfly/swarm/cdi/jaxrsapi/deployment/ProxyBuilder", "builder", "(Ljava/lang/Class;Ljavax/ws/rs/client/WebTarget;)Lorg/wildfly/swarm/cdi/jaxrsapi/deployment/ProxyBuilder;", false);
+                Label l3 = new Label();
+                mv.visitLabel(l3);
+                mv.visitLineNumber(lineNum++, l3);
+                mv.visitMethodInsn(INVOKEVIRTUAL, "org/wildfly/swarm/cdi/jaxrsapi/deployment/ProxyBuilder", "build", "()Ljava/lang/Object;", false);
+                mv.visitTypeInsn(CHECKCAST, clientInterfaceName.replace('.', '/'));
+                for (int i = 1; i <= method.parameters().size(); i++) {
+                    mv.visitVarInsn(ALOAD, i);
+                }
+                Label l4 = new Label();
+                mv.visitLabel(l4);
+                mv.visitLineNumber(lineNum++, l4);
+                mv.visitMethodInsn(INVOKEINTERFACE, clientInterfaceName.replace('.', '/'), method.name(), buildMethodDef(method), true);
+                Label l5 = new Label();
+                mv.visitLabel(l5);
+                if (method.returnType().kind().equals(org.jboss.jandex.Type.Kind.VOID)) {
+                    mv.visitLineNumber(lineNum++, l5);
+                    mv.visitInsn(RETURN);
+                } else {
+                    mv.visitLineNumber(lineNum - 4, l5);
+                    mv.visitInsn(ARETURN);
+                }
+                Label l6 = new Label();
+                mv.visitLabel(l6);
+                int methodParams = 0;
+                mv.visitLocalVariable("this", buildTypeDef(implName), null, l0, l6, methodParams++);
+                for (AnnotationInstance anno : method.annotations()) {
+                    if (anno.name().toString().contains("QueryParam") || anno.name().toString().contains("PathParam")) {
+                        short position = anno.target().asMethodParameter().position();
+                        org.jboss.jandex.Type parameterType = anno.target().asMethodParameter().method().parameters().get(position);
+                        mv.visitLocalVariable(String.valueOf(anno.value().value()), buildTypeDef(parameterType.name().toString()), null, l0, l6, methodParams++);
+                    }
+                }
+                mv.visitMaxs(3, methodParams);
+                lineNum += 4;
+                mv.visitEnd();
+            }
+        }
+
+        static String buildTypeDef(String name) {
+            return "L" + name.replace('.', '/') + ";";
+        }
+
+        static String buildMethodDef(MethodInfo method) {
+            StringBuilder builder = new StringBuilder();
+
+            // Method Parameters
+            builder.append("(");
+            for (org.jboss.jandex.Type type : method.parameters()) {
+                builder.append(buildTypeDef(type.name().toString()));
+            }
+            builder.append(")");
+
+            // Method Return Type
+            if (method.returnType().kind().equals(org.jboss.jandex.Type.Kind.VOID)) {
+                builder.append("V");
+            } else {
+                builder.append(buildTypeDef(method.returnType().name().toString()));
+            }
+
+            return builder.toString();
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -973,6 +973,11 @@
         <artifactId>cdi-config</artifactId>
         <version>2016.11.0-SNAPSHOT</version>
       </dependency>
+      <dependency>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>cdi-jaxrsapi</artifactId>
+        <version>2016.11.0-SNAPSHOT</version>
+      </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
@@ -1171,6 +1176,7 @@
     <module>fractions/zipkin-jaxrs</module>
 
     <module>fractions/cdi-extensions/cdi-config</module>
+    <module>fractions/cdi-extensions/cdi-jaxrsapi</module>
 
     <module>fractions/etc/jgroups-module</module>
 

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -75,7 +75,6 @@
   <modules>
     <module>testsuite-batch-jberet</module>
     <module>testsuite-buildtool</module>
-    <module>testsuite-cdi</module>
     <module>testsuite-camel-cdi</module>
     <module>testsuite-camel-cxf</module>
     <module>testsuite-camel-ejb</module>
@@ -83,6 +82,8 @@
     <module>testsuite-camel-jmx</module>
     <module>testsuite-camel-jpa</module>
     <module>testsuite-camel-other</module>
+    <module>testsuite-cdi</module>
+    <module>testsuite-cdi-jaxrsapi</module>
     <module>testsuite-connector</module>
     <module>testsuite-container</module>
     <module>testsuite-datasources</module>

--- a/testsuite/testsuite-cdi-jaxrsapi/pom.xml
+++ b/testsuite/testsuite-cdi-jaxrsapi/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>testsuite</artifactId>
+    <version>2016.11.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>testsuite-cdi-jaxrsapi</artifactId>
+
+  <name>Test Suite: CDI extensions to JAX-RS</name>
+  <description>Test Suite: CDI extensions to JAX-RS</description>
+
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>jaxrs-cdi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>cdi-jaxrsapi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>arquillian</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.junit</groupId>
+      <artifactId>arquillian-junit-container</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/testsuite/testsuite-cdi-jaxrsapi/src/main/java/org/wildfly/swarm/cdi/jaxrsapi/MessageResource.java
+++ b/testsuite/testsuite-cdi-jaxrsapi/src/main/java/org/wildfly/swarm/cdi/jaxrsapi/MessageResource.java
@@ -1,0 +1,73 @@
+package org.wildfly.swarm.cdi.jaxrsapi;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+
+/**
+ * @author Ken Finnigan
+ */
+@Path("/messages")
+@ApplicationScoped
+public class MessageResource {
+
+    public static final String MESSAGE_PREFIX = "The date and time is ";
+
+    @Inject
+    TimeService timeService;
+
+    @GET
+    @Path("/sync")
+    public String getMessageSync2Sync() throws Exception {
+        String time = timeService.getTime();
+        if (time != null) {
+            return message(time);
+        } else {
+            return "Time service unavailable";
+        }
+    }
+
+    @GET
+    @Path("/async")
+    public void getMessageAsync2Sync(@Suspended final AsyncResponse asyncResponse) throws Exception {
+        timeService.exec(() -> timeService.getTime(),
+                         s -> asyncResponse.resume(this.message(s)),
+                         asyncResponse::resume);
+    }
+
+    @GET
+    @Path("/asyncZone")
+    public void getMessageAsync2AsyncOffset(@Suspended final AsyncResponse asyncResponse, @QueryParam("zoneId") String zoneId) throws Exception {
+        timeService.exec(() -> timeService.getTimeForZone(zoneId),
+                         s -> asyncResponse.resume(this.message(s)),
+                         asyncResponse::resume);
+    }
+
+    @GET
+    @Path("/timeMessage")
+    public void getTimeMessage(@Suspended final AsyncResponse asyncResponse) throws Exception {
+        timeService.chainableExec(timeService::getTime, asyncResponse::resume)
+                .thenApply((s) -> timeService.addMessage(s))
+                .thenAccept(asyncResponse::resume)
+                .exceptionally(t -> {
+                    asyncResponse.resume(t);
+                    return null;
+                });
+    }
+
+    @GET
+    @Path("/hello/{name}")
+    public String hello(@PathParam("name") String name) throws Exception {
+        return timeService.hello(name);
+    }
+
+    private String message(String time) {
+        System.err.println("Time received is: " + time);
+        return MESSAGE_PREFIX + time;
+    }
+}

--- a/testsuite/testsuite-cdi-jaxrsapi/src/main/java/org/wildfly/swarm/cdi/jaxrsapi/TimeResource.java
+++ b/testsuite/testsuite-cdi-jaxrsapi/src/main/java/org/wildfly/swarm/cdi/jaxrsapi/TimeResource.java
@@ -1,0 +1,51 @@
+package org.wildfly.swarm.cdi.jaxrsapi;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * @author Ken Finnigan
+ */
+@Path("/time")
+public class TimeResource {
+    public final static String INTRO_MESSAGE = "Howdy at ";
+
+    public static final String MESSAGE_HELLO = "Hello to ";
+
+    @GET
+    @Path("/default")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getTime() {
+        return ZonedDateTime.now().format(DateTimeFormatter.RFC_1123_DATE_TIME);
+    }
+
+    @GET
+    @Path("/tz")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String getTimeForZone(@QueryParam("zoneId") String zoneId) {
+        return ZonedDateTime.of(LocalDateTime.now(), ZoneId.of(zoneId)).format(DateTimeFormatter.RFC_1123_DATE_TIME);
+    }
+
+    @GET
+    @Path("/message")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String addMessage(@QueryParam("time") String time) {
+        return INTRO_MESSAGE + time;
+    }
+
+    @GET
+    @Path("/hello/{name}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String hello(@PathParam("name") String name) throws Exception {
+        return MESSAGE_HELLO + name;
+    }
+}

--- a/testsuite/testsuite-cdi-jaxrsapi/src/main/java/org/wildfly/swarm/cdi/jaxrsapi/TimeService.java
+++ b/testsuite/testsuite-cdi-jaxrsapi/src/main/java/org/wildfly/swarm/cdi/jaxrsapi/TimeService.java
@@ -1,0 +1,35 @@
+package org.wildfly.swarm.cdi.jaxrsapi;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * @author Ken Finnigan
+ */
+@Path("time")
+@Service(baseUrl = "http://localhost:8080/")
+public interface TimeService extends ServiceClient<TimeService> {
+    @GET
+    @Path("default")
+    @Produces(MediaType.TEXT_PLAIN)
+    String getTime();
+
+    @GET
+    @Path("tz")
+    @Produces(MediaType.TEXT_PLAIN)
+    String getTimeForZone(@QueryParam("zoneId") String zoneId);
+
+    @GET
+    @Path("message")
+    @Produces(MediaType.TEXT_PLAIN)
+    String addMessage(@QueryParam("time") String time);
+
+    @GET
+    @Path("hello/{name}")
+    @Produces(MediaType.TEXT_PLAIN)
+    String hello(@PathParam("name") String name);
+}

--- a/testsuite/testsuite-cdi-jaxrsapi/src/test/java/org/wildfly/swarm/cdi/jaxrsapi/JAXRSApiTest.java
+++ b/testsuite/testsuite-cdi-jaxrsapi/src/test/java/org/wildfly/swarm/cdi/jaxrsapi/JAXRSApiTest.java
@@ -1,0 +1,66 @@
+package org.wildfly.swarm.cdi.jaxrsapi;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.WebDriver;
+import org.wildfly.swarm.jaxrs.JAXRSArchive;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Ken Finnigan
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class JAXRSApiTest {
+
+    @Drone
+    WebDriver browser;
+
+    @Deployment
+    public static Archive createDeployment() {
+        JAXRSArchive deployment = ShrinkWrap.create(JAXRSArchive.class);
+        deployment.addPackage(MessageResource.class.getPackage());
+        return deployment;
+    }
+
+    @Test
+    public void syncCall() throws Exception {
+        browser.navigate().to("http://localhost:8080/messages/sync");
+        assertThat(browser.getPageSource()).contains(MessageResource.MESSAGE_PREFIX);
+    }
+
+    @Test
+    public void asyncCall() throws Exception {
+        browser.navigate().to("http://localhost:8080/messages/async");
+        String pageSource = browser.getPageSource();
+        assertThat(pageSource).contains(MessageResource.MESSAGE_PREFIX);
+        assertThat(pageSource).doesNotContain("null");
+    }
+
+    @Test
+    public void zoneCall() throws Exception {
+        browser.navigate().to("http://localhost:8080/messages/asyncZone?zoneId=America/New_York");
+        String pageSource = browser.getPageSource();
+        assertThat(pageSource).contains(MessageResource.MESSAGE_PREFIX);
+        assertThat(pageSource).doesNotContain("null");
+    }
+
+    @Test
+    public void timeCall() throws Exception {
+        browser.navigate().to("http://localhost:8080/messages/timeMessage");
+        assertThat(browser.getPageSource()).contains(TimeResource.INTRO_MESSAGE);
+    }
+
+    @Test
+    public void hello() throws Exception {
+        browser.navigate().to("http://localhost:8080/messages/hello/james");
+        assertThat(browser.getPageSource()).contains(TimeResource.MESSAGE_HELLO + "james");
+    }
+}

--- a/testsuite/testsuite-cdi-jaxrsapi/src/test/resources/arquillian.xml
+++ b/testsuite/testsuite-cdi-jaxrsapi/src/test/resources/arquillian.xml
@@ -1,0 +1,7 @@
+<arquillian>
+
+  <extension qualifier="webdriver">
+    <property name="browser">phantomjs</property>
+  </extension>
+
+</arquillian>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
Allow a developer to define an interface that maps to an external service they need to call, such as:

```
@Service(baseUrl = "http://localhost:8081/time")
public interface TimeService extends ServiceClient<TimeService> {
  @GET
  @Path("tz")
  @Produces(MediaType.TEXT_PLAIN)
  String getTimeForZone(@QueryParam("zoneId") String zoneId);
}
```

You can then access the generated service by:

```
public class MyResource {

  @Inject
  TimeService timeService;

...
  timeService.getTimeForZone(zoneId);
...
}
```

Modifications
-------------
Added new cdi-jaxrsapi fraction that generates the implentation of an interface that extends ServiceClient.

Added a new testsuite to validate it works as expected.

Result
------
No impact on existing functionality. Adds ability to generate client of external service.