### PR TITLE
SWARM-809 - Better waiting for Swarm processes to start.

### DIFF
--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
@@ -237,7 +237,7 @@ public class UberjarSimpleContainer implements SimpleContainer {
         this.process = executor.execute();
         this.process.getOutputStream().close();
 
-        this.process.awaitDeploy(2, TimeUnit.MINUTES);
+        this.process.awaitReadiness(2, TimeUnit.MINUTES);
 
         if (!this.process.isAlive()) {
             throw new DeploymentException("Process failed to start");

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/Main.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/Main.java
@@ -15,15 +15,6 @@
  */
 package org.wildfly.swarm.bootstrap;
 
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.net.URISyntaxException;
-
-import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
-import org.jboss.modules.ModuleLoadException;
 import org.wildfly.swarm.bootstrap.env.ApplicationEnvironment;
 import org.wildfly.swarm.bootstrap.modules.BootModuleLoader;
 import org.wildfly.swarm.bootstrap.util.BootstrapProperties;
@@ -50,35 +41,12 @@ public class Main {
 
     public void run() throws Throwable {
         setupBootModuleLoader();
-        invoke(getMainClass());
+        new MainInvoker( ApplicationEnvironment.get().getMainClassName(), this.args ).invoke();
     }
 
     public void setupBootModuleLoader() {
         System.setProperty("boot.module.loader", BootModuleLoader.class.getName());
     }
 
-    public Class<?> getMainClass() throws IOException, URISyntaxException, ModuleLoadException, ClassNotFoundException {
-        String mainClassName = ApplicationEnvironment.get().getMainClassName();
-        Module module = Module.getBootModuleLoader().loadModule(ModuleIdentifier.create("swarm.application"));
-        return module.getClassLoader().loadClass(mainClassName);
-    }
-
-    public String getMainClassName() {
-        return ApplicationEnvironment.get().getMainClassName();
-    }
-
-    public void invoke(Class<?> mainClass) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        final Method mainMethod = mainClass.getMethod("main", String[].class);
-
-        final int modifiers = mainMethod.getModifiers();
-        if (!Modifier.isStatic(modifiers)) {
-            throw new NoSuchMethodException("Main method is not static for " + mainClass);
-        }
-
-        mainMethod.invoke(null, new Object[]{this.args});
-    }
-
     private final String[] args;
-
-
 }

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/MainInvoker.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/MainInvoker.java
@@ -1,0 +1,105 @@
+package org.wildfly.swarm.bootstrap;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.jboss.modules.Module;
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.modules.ModuleLoadException;
+import org.wildfly.swarm.bootstrap.modules.BootModuleLoader;
+
+/**
+ * @author Bob McWhirter
+ */
+public class MainInvoker {
+
+    public MainInvoker(Method mainMethod, String... args) {
+        this.mainMethod = mainMethod;
+        this.args = args;
+        System.setProperty("boot.module.loader", BootModuleLoader.class.getName());
+    }
+
+    public MainInvoker(Class<?> mainClass, String... args) throws Exception {
+        this(getMainMethod(mainClass), args);
+    }
+
+    public MainInvoker(String mainClassName, String... args) throws Exception {
+        this(getMainMethod(getMainClass(mainClassName)), args);
+    }
+
+    public void invoke() throws Exception {
+        this.mainMethod.invoke(null, new Object[]{this.args});
+        emitReady();
+    }
+
+    protected void emitReady() throws Exception {
+        Module module = Module.getBootModuleLoader().loadModule(ModuleIdentifier.create("swarm.container"));
+        Class<?> messagesClass = module.getClassLoader().loadClass("org.wildfly.swarm.internal.SwarmMessages");
+        Field field = messagesClass.getDeclaredField("MESSAGES");
+
+        Object messages = field.get(null);
+
+        Method ready = messages.getClass().getMethod( "wildflySwarmIsReady" );
+        ready.invoke( messages );
+    }
+
+    public static void main(String... args) throws Exception {
+        System.setProperty("boot.module.loader", BootModuleLoader.class.getName());
+        List<String> argList = Arrays.asList(args);
+
+        if (argList.isEmpty()) {
+            throw new RuntimeException("Invalid usage of MainWrapper; actual main-class must be specified");
+        }
+
+        String mainClassName = argList.get(0);
+        List<String> actualArgs = argList.subList(1, argList.size());
+
+        Class<?> mainClass = getMainClass(mainClassName);
+
+        Method mainMethod = getMainMethod(mainClass);
+
+        MainInvoker wrapper = new MainInvoker(mainMethod, actualArgs.toArray(new String[]{}));
+        wrapper.invoke();
+    }
+
+    public static Class<?> getMainClass(String mainClassName) throws IOException, URISyntaxException, ModuleLoadException, ClassNotFoundException {
+        Class<?> mainClass = null;
+        try {
+            Module module = Module.getBootModuleLoader().loadModule(ModuleIdentifier.create("swarm.application"));
+            ClassLoader cl = module.getClassLoader();
+            mainClass = cl.loadClass(mainClassName);
+        } catch (ClassNotFoundException | ModuleLoadException e) {
+            ClassLoader cl = ClassLoader.getSystemClassLoader();
+            mainClass = cl.loadClass(mainClassName);
+        }
+
+        if ( mainClass == null ) {
+            throw new ClassNotFoundException( mainClassName );
+        }
+        return mainClass;
+    }
+
+    public static Method getMainMethod(Class<?> mainClass) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        final Method mainMethod = mainClass.getMethod("main", String[].class);
+
+        if ( mainMethod == null ) {
+            throw new NoSuchMethodException("No method main() found" );
+        }
+
+        final int modifiers = mainMethod.getModifiers();
+        if (!Modifier.isStatic(modifiers)) {
+            throw new NoSuchMethodException("Main method is not static for " + mainClass);
+        }
+        return mainMethod;
+    }
+
+    private final Method mainMethod;
+
+    private final String[] args;
+}

--- a/core/container/src/main/java/org/wildfly/swarm/internal/SwarmMessages.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/SwarmMessages.java
@@ -168,4 +168,9 @@ public interface SwarmMessages extends BasicLogger {
     @Message(id = 36, value = "Error installing user-space CDI extension: %s")
     void errorInstallingUserSpaceExtension(String factoryClassName);
 
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 99999, value = "WildFly Swarm is Ready")
+    void wildflySwarmIsReady();
+
+
 }

--- a/plugin/src/main/java/org/wildfly/swarm/plugin/maven/MultiStartMojo.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/maven/MultiStartMojo.java
@@ -163,7 +163,7 @@ public class MultiStartMojo extends AbstractSwarmMojo {
 
         try {
             SwarmProcess launched = executor.execute();
-            launched.awaitDeploy(30, TimeUnit.SECONDS);
+            launched.awaitReadiness(30, TimeUnit.SECONDS);
             procs.add(launched);
         } catch (IOException | InterruptedException e) {
             throw new MojoFailureException("Unable to execute: " + artifact, e);

--- a/plugin/src/main/java/org/wildfly/swarm/plugin/maven/StartMojo.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/maven/StartMojo.java
@@ -26,7 +26,6 @@ import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
-import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.Artifact;
@@ -132,7 +131,7 @@ public class StartMojo extends AbstractSwarmMojo {
                 }
             }));
 
-            process.awaitDeploy(2, TimeUnit.MINUTES);
+            process.awaitReadiness(2, TimeUnit.MINUTES);
 
             if (!process.isAlive()) {
                 throw new MojoFailureException("Process failed to start");

--- a/tools/src/main/java/org/wildfly/swarm/tools/exec/IOBridge.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/exec/IOBridge.java
@@ -81,7 +81,7 @@ public class IOBridge implements Runnable, Closeable {
             fileOut.newLine();
             fileOut.flush();
         }
-        if (line.contains("WFLYSRV0010")) {
+        if (line.contains("WFSWARM99999")) {
             this.latch.countDown();
         }
     }

--- a/tools/src/main/java/org/wildfly/swarm/tools/exec/MainClass.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/exec/MainClass.java
@@ -15,8 +15,10 @@
  */
 package org.wildfly.swarm.tools.exec;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
+
+import org.wildfly.swarm.bootstrap.MainInvoker;
 
 /**
  * @author Bob McWhirter
@@ -29,7 +31,10 @@ public class MainClass implements Executable {
 
     @Override
     public List<? extends String> toArguments() {
-        return Collections.singletonList(this.className);
+        List<String> args = new ArrayList<>();
+        args.add( MainInvoker.class.getName());
+        args.add( this.className );
+        return args;
     }
 
     private final String className;

--- a/tools/src/main/java/org/wildfly/swarm/tools/exec/SwarmExecutor.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/exec/SwarmExecutor.java
@@ -244,7 +244,6 @@ public class SwarmExecutor {
         cli.addAll(this.executable.toArguments());
         cli.addAll(this.arguments);
 
-
         final ProcessBuilder processBuilder = new ProcessBuilder(cli)
                 .directory(this.workingDirectory.toFile());
         processBuilder.environment().putAll(environment);

--- a/tools/src/main/java/org/wildfly/swarm/tools/exec/SwarmProcess.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/exec/SwarmProcess.java
@@ -87,7 +87,7 @@ public class SwarmProcess {
         return process.exitValue();
     }
 
-    public void awaitDeploy(long timeout, TimeUnit timeUnit) throws InterruptedException {
+    public void awaitReadiness(long timeout, TimeUnit timeUnit) throws InterruptedException {
         this.latch.await(timeout, timeUnit);
     }
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------

In some examples our tests would be fooled by the first
deployed item, which sometimes was an implicit or otherwise
non-primary deployment.  This caused tests to run before
the actual code-to-be-tested was ready.

Modifications
-------------

Added a hook to display a better log message once the
default or user-provided main() had completed its work
and wire that to SwarmProcess.awaitReadiness() instead
of watching for any particular deployment.

Result
------

Better testing.