### PR TITLE
SWARM-688: Hide internal fractions on container startup

### DIFF
--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/FractionManifest.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/FractionManifest.java
@@ -31,6 +31,8 @@ public class FractionManifest {
 
     private String stabilityLevel;
 
+    private boolean internal;
+
     private List<String> dependencies = new ArrayList<>();
 
     public FractionManifest() {
@@ -61,6 +63,10 @@ public class FractionManifest {
         setArtifactId((String) data.get("artifactId"));
         setVersion((String) data.get("version"));
         setDependencies((Collection<String>) data.get("dependencies"));
+        Object internal = data.get("internal");
+        if (internal != null) {
+            setInternal((Boolean) internal);
+        }
         Map stability = (Map) data.get("stability");
         if ( stability != null ) {
             setStabilityIndex((Integer) stability.get("index"));
@@ -98,6 +104,14 @@ public class FractionManifest {
 
     public void setStabilityLevel(String stabilityLevel) {
         this.stabilityLevel = stabilityLevel;
+    }
+
+    public boolean isInternal() {
+        return internal;
+    }
+
+    public void setInternal(boolean internal) {
+        this.internal = internal;
     }
 
     public void setDependencies(Collection<String> dependencies) {

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/ServerBootstrapImpl.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/ServerBootstrapImpl.java
@@ -139,11 +139,15 @@ public class ServerBootstrapImpl implements ServerBootstrap {
     }
 
     protected void logFraction(FractionManifest manifest) {
-        int stabilityIndex = manifest.getStabilityIndex();
-        if ( stabilityIndex < 3 ) {
-            LOG.warn(SwarmMessages.MESSAGES.availableFraction(manifest.getName(), manifest.getStabilityLevel(), manifest.getGroupId(), manifest.getArtifactId(), manifest.getVersion()));
+        if (manifest.isInternal()) {
+            LOG.debug(SwarmMessages.MESSAGES.availableFraction(manifest.getName(), manifest.getStabilityLevel(), manifest.getGroupId(), manifest.getArtifactId(), manifest.getVersion()));
         } else {
-            LOG.info(SwarmMessages.MESSAGES.availableFraction(manifest.getName(), manifest.getStabilityLevel(), manifest.getGroupId(), manifest.getArtifactId(), manifest.getVersion()));
+            int stabilityIndex = manifest.getStabilityIndex();
+            if (stabilityIndex < 3) {
+                LOG.warn(SwarmMessages.MESSAGES.availableFraction(manifest.getName(), manifest.getStabilityLevel(), manifest.getGroupId(), manifest.getArtifactId(), manifest.getVersion()));
+            } else {
+                LOG.info(SwarmMessages.MESSAGES.availableFraction(manifest.getName(), manifest.getStabilityLevel(), manifest.getGroupId(), manifest.getArtifactId(), manifest.getVersion()));
+            }
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   </scm>
 
   <properties>
-    <version.wildfly.swarm.fraction.plugin>37</version.wildfly.swarm.fraction.plugin>
+    <version.wildfly.swarm.fraction.plugin>38</version.wildfly.swarm.fraction.plugin>
 
     <version.cdi2>2.0.Alpha4</version.cdi2>
     <version.org.snakeyaml>1.17</version.org.snakeyaml>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
By default, don't log internal fractions on container startup.

Only log internal fractions when DEBUG enabled

Modifications
-------------
Add `internal` onto FractionManifest and log them as DEBUG on startup

Result
------
Internal fractions logged at startup only visible when logging set to DEBUG