### PR TITLE
SWARM-825: Container :api, :runtime modules incorrect paths

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/core/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -58,22 +58,21 @@ import org.jboss.shrinkwrap.impl.base.importer.zip.ZipImporterImpl;
 import org.jboss.shrinkwrap.impl.base.spec.JavaArchiveImpl;
 import org.jboss.shrinkwrap.impl.base.spec.WebArchiveImpl;
 import org.wildfly.swarm.bootstrap.env.ApplicationEnvironment;
+import org.wildfly.swarm.bootstrap.logging.BackingLoggerManager;
 import org.wildfly.swarm.bootstrap.logging.BootstrapLogger;
 import org.wildfly.swarm.bootstrap.modules.BootModuleLoader;
 import org.wildfly.swarm.bootstrap.util.BootstrapProperties;
 import org.wildfly.swarm.cli.CommandLine;
 import org.wildfly.swarm.container.DeploymentException;
+import org.wildfly.swarm.container.cdi.ProjectStageFactory;
 import org.wildfly.swarm.container.internal.Server;
 import org.wildfly.swarm.container.internal.ServerBootstrap;
 import org.wildfly.swarm.container.internal.WeldShutdown;
-import org.wildfly.swarm.container.runtime.cdi.ProjectStageFactory;
-import org.wildfly.swarm.container.runtime.logging.JBossLoggingManager;
 import org.wildfly.swarm.internal.ArtifactManager;
 import org.wildfly.swarm.internal.OutboundSocketBindingRequest;
 import org.wildfly.swarm.internal.SocketBindingRequest;
 import org.wildfly.swarm.internal.SwarmMessages;
 import org.wildfly.swarm.spi.api.ArtifactLookup;
-import org.wildfly.swarm.spi.api.DependenciesContainer;
 import org.wildfly.swarm.spi.api.Fraction;
 import org.wildfly.swarm.spi.api.OutboundSocketBinding;
 import org.wildfly.swarm.spi.api.ProjectStage;
@@ -148,7 +147,7 @@ public class Swarm {
             Module.setModuleLogger(new StreamModuleLogger(System.err));
         }
 
-        System.setProperty(SwarmInternalProperties.VERSION, ( VERSION == null ? "unknown" : VERSION ) );
+        System.setProperty(SwarmInternalProperties.VERSION, (VERSION == null ? "unknown" : VERSION));
 
         setArgs(args);
         this.debugBootstrap = debugBootstrap;
@@ -164,7 +163,8 @@ public class Swarm {
                 System.setProperty("org.jboss.logmanager.configurator", "org.wildfly.swarm.container.runtime.wildfly.LoggingConfigurator");
                 //force logging init
                 LogManager.getLogManager();
-                BootstrapLogger.setBackingLoggerManager(new JBossLoggingManager());
+                Class<?> logManagerClass = loggingModule.getClassLoader().loadClass("org.wildfly.swarm.container.runtime.logging.JBossLoggingManager");
+                BootstrapLogger.setBackingLoggerManager((BackingLoggerManager) logManagerClass.newInstance());
             } finally {
                 Thread.currentThread().setContextClassLoader(originalCl);
             }

--- a/core/container/src/main/java/org/wildfly/swarm/container/cdi/ProjectStageFactory.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/cdi/ProjectStageFactory.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.swarm.container.runtime.cdi;
+package org.wildfly.swarm.container.cdi;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/core/container/src/main/java/org/wildfly/swarm/container/cdi/ProjectStageImpl.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/cdi/ProjectStageImpl.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.swarm.container.runtime.cdi;
+package org.wildfly.swarm.container.cdi;
 
 import java.util.HashMap;
 import java.util.List;

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/ProjectStageProducingExtension.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/ProjectStageProducingExtension.java
@@ -24,6 +24,7 @@ import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.Extension;
 
 import org.jboss.weld.literal.DefaultLiteral;
+import org.wildfly.swarm.container.cdi.ProjectStageImpl;
 import org.wildfly.swarm.spi.api.ProjectStage;
 import org.wildfly.swarm.spi.api.StageConfig;
 

--- a/core/container/src/main/resources/modules/org/wildfly/swarm/container/api/module.xml
+++ b/core/container/src/main/resources/modules/org/wildfly/swarm/container/api/module.xml
@@ -12,6 +12,7 @@
         <include-set>
           <path name="META-INF"/>
           <path name="org/wildfly/swarm"/>
+          <path name="org/wildfly/swarm/cdi"/>
           <path name="org/wildfly/swarm/cli"/>
           <path name="org/wildfly/swarm/container"/>
           <path name="org/wildfly/swarm/container/internal"/>
@@ -19,15 +20,15 @@
           <path name="org/wildfly/swarm/internal"/>
         </include-set>
         <exclude-set>
-          <path name="org/wildfly/container/runtime"/>
-          <path name="org/wildfly/container/runtime/cdi"/>
-          <path name="org/wildfly/container/runtime/cli"/>
-          <path name="org/wildfly/container/runtime/config"/>
-          <path name="org/wildfly/container/runtime/deployments"/>
-          <path name="org/wildfly/container/runtime/logging"/>
-          <path name="org/wildfly/container/runtime/marshal"/>
-          <path name="org/wildfly/container/runtime/wildfly"/>
-          <path name="org/wildfly/container/runtime/xmlconfig"/>
+          <path name="org/wildfly/swarm/container/runtime"/>
+          <path name="org/wildfly/swarm/container/runtime/cdi"/>
+          <path name="org/wildfly/swarm/container/runtime/cli"/>
+          <path name="org/wildfly/swarm/container/runtime/config"/>
+          <path name="org/wildfly/swarm/container/runtime/deployments"/>
+          <path name="org/wildfly/swarm/container/runtime/logging"/>
+          <path name="org/wildfly/swarm/container/runtime/marshal"/>
+          <path name="org/wildfly/swarm/container/runtime/wildfly"/>
+          <path name="org/wildfly/swarm/container/runtime/xmlconfig"/>
         </exclude-set>
       </filter>
     </artifact>

--- a/core/container/src/main/resources/modules/org/wildfly/swarm/container/main/module.xml
+++ b/core/container/src/main/resources/modules/org/wildfly/swarm/container/main/module.xml
@@ -11,6 +11,7 @@
     <system export="true">
       <paths>
         <path name="org/wildfly/swarm"/>
+        <path name="org/wildfly/swarm/cdi"/>
         <path name="org/wildfly/swarm/cli"/>
         <path name="org/wildfly/swarm/container"/>
         <path name="org/wildfly/swarm/container/internal"/>
@@ -21,6 +22,7 @@
     <module name="org.wildfly.swarm.container" slot="api" services="import" export="true">
       <imports>
         <include path="**"/>
+        <include path="org/wildfly/swarm/cdi"/>
         <include path="org/wildfly/swarm/cli"/>
         <include path="org/wildfly/swarm/container"/>
         <include path="org/wildfly/swarm/container/internal"/>

--- a/core/container/src/main/resources/modules/org/wildfly/swarm/container/runtime/module.xml
+++ b/core/container/src/main/resources/modules/org/wildfly/swarm/container/runtime/module.xml
@@ -10,18 +10,19 @@
     <artifact name="org.wildfly.swarm:container:${project.version}">
       <filter>
         <include-set>
-          <path name="org/wildfly/container/runtime"/>
-          <path name="org/wildfly/container/runtime/cdi"/>
-          <path name="org/wildfly/container/runtime/cli"/>
-          <path name="org/wildfly/container/runtime/config"/>
-          <path name="org/wildfly/container/runtime/deployments"/>
-          <path name="org/wildfly/container/runtime/logging"/>
-          <path name="org/wildfly/container/runtime/marshal"/>
-          <path name="org/wildfly/container/runtime/wildfly"/>
-          <path name="org/wildfly/container/runtime/xmlconfig"/>
+          <path name="org/wildfly/swarm/container/runtime"/>
+          <path name="org/wildfly/swarm/container/runtime/cdi"/>
+          <path name="org/wildfly/swarm/container/runtime/cli"/>
+          <path name="org/wildfly/swarm/container/runtime/config"/>
+          <path name="org/wildfly/swarm/container/runtime/deployments"/>
+          <path name="org/wildfly/swarm/container/runtime/logging"/>
+          <path name="org/wildfly/swarm/container/runtime/marshal"/>
+          <path name="org/wildfly/swarm/container/runtime/wildfly"/>
+          <path name="org/wildfly/swarm/container/runtime/xmlconfig"/>
         </include-set>
         <exclude-set>
           <path name="org/wildfly/swarm"/>
+          <path name="org/wildfly/swarm/cdi"/>
           <path name="org/wildfly/swarm/cli"/>
           <path name="org/wildfly/swarm/container"/>
           <path name="org/wildfly/swarm/container/internal"/>

--- a/core/container/src/test/java/org/wildfly/swarm/container/ProjectStageTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/container/ProjectStageTest.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.wildfly.swarm.container.runtime.cdi.ProjectStageFactory;
+import org.wildfly.swarm.container.cdi.ProjectStageFactory;
 import org.wildfly.swarm.spi.api.ProjectStage;
 import org.wildfly.swarm.spi.api.StageConfig;
 

--- a/testsuite/testsuite-container/src/test/java/org/wildfly/swarm/container/test/ProjectStagesTest.java
+++ b/testsuite/testsuite-container/src/test/java/org/wildfly/swarm/container/test/ProjectStagesTest.java
@@ -17,7 +17,7 @@ package org.wildfly.swarm.container.test;
 
 import org.junit.*;
 import org.wildfly.swarm.Swarm;
-import org.wildfly.swarm.container.runtime.cdi.ProjectStageFactory;
+import org.wildfly.swarm.container.cdi.ProjectStageFactory;
 import org.wildfly.swarm.spi.api.ProjectStage;
 import org.wildfly.swarm.spi.api.StageConfig;
 import org.wildfly.swarm.spi.api.SwarmProperties;


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
The :api and :runtime modules for container incorrectly specify the runtime classes package structure that should be excluded from :api and included in :runtime.

It currently specifies `org/wildfly/container` instead of `org/wildfly/swarm/container`.

Modifications
-------------
Correctly specify runtime packages within container module.xml's.

Fix usage of runtime only classes within `Swarm`. Use of JBossLogManager needed to be loaded via module and ProjectStages could be moved to api side.

Result
------
Should fix unexpected behavior when dealing with container runtime classes.