### PR TITLE
SWARM-714: Hide `jaxrs-cdi` fraction from developer

### DIFF
--- a/fraction-list/src/main/resources/org/wildfly/swarm/fractionlist/fraction-packages.properties
+++ b/fraction-list/src/main/resources/org/wildfly/swarm/fractionlist/fraction-packages.properties
@@ -10,7 +10,6 @@ ejb-remote=javax.ejb:Remote
 infinispan=org.infinispan
 javafx=javafx*
 jaxrs=javax.ws.rs
-jaxrs-cdi=javax.ws.rs+javax.inject
 jaxrs-jaxb=javax.ws.rs+javax.xml.bind*
 jaxrs-jsonp=javax.ws.rs+javax.json
 jaxrs-validator=javax.ws.rs+javax.validation*

--- a/fractions/javaee/jaxrs-cdi/module-rewrite.conf
+++ b/fractions/javaee/jaxrs-cdi/module-rewrite.conf
@@ -1,0 +1,3 @@
+module: org.jboss.resteasy.resteasy-cdi
+  optional: org.jboss.weld.core
+  optional: org.jboss.weld.spi

--- a/fractions/javaee/jaxrs-cdi/pom.xml
+++ b/fractions/javaee/jaxrs-cdi/pom.xml
@@ -38,18 +38,9 @@
   </build>
 
   <dependencies>
-    <!-- Fraction Dependencies -->
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
-      <artifactId>jaxrs</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.wildfly.swarm</groupId>
-      <artifactId>cdi</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.wildfly.swarm</groupId>
-      <artifactId>cdi-jaxrsapi</artifactId>
+      <artifactId>container</artifactId>
     </dependency>
 
     <dependency>

--- a/fractions/javaee/jaxrs-cdi/pom.xml
+++ b/fractions/javaee/jaxrs-cdi/pom.xml
@@ -24,6 +24,7 @@
 
   <properties>
     <swarm.fraction.bootstrap>true</swarm.fraction.bootstrap>
+    <swarm.fraction.internal>true</swarm.fraction.internal>
     <swarm.fraction.stability>stable</swarm.fraction.stability>
     <swarm.fraction.tags>JavaEE,Web</swarm.fraction.tags>
   </properties>

--- a/fractions/javaee/jaxrs/pom.xml
+++ b/fractions/javaee/jaxrs/pom.xml
@@ -49,6 +49,10 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>security</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>jaxrs-cdi</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>javax.inject</groupId>

--- a/fractions/microprofile/pom.xml
+++ b/fractions/microprofile/pom.xml
@@ -40,7 +40,11 @@
     <!-- Fraction Dependencies -->
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
-      <artifactId>jaxrs-cdi</artifactId>
+      <artifactId>jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>cdi</artifactId>
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>

--- a/testsuite/testsuite-cdi-jaxrsapi/pom.xml
+++ b/testsuite/testsuite-cdi-jaxrsapi/pom.xml
@@ -25,7 +25,11 @@
   <dependencies>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
-      <artifactId>jaxrs-cdi</artifactId>
+      <artifactId>jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>cdi</artifactId>
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
Having to know to include a new dependency just because an application uses jaxrs and cdi is not a good developer experience.

We want such a combination to be implicitly included

Modifications
-------------
Due to its small size, added jaxrs-cdi fraction into jaxrs by default but modified the module.xml rules to exclude weld modules as they will be brought in if cdi dependency is chosen.

Result
------
No longer necessary to select jaxrs-cdi dependency when already including jaxrs and cdi.