### PR TITLE
SWARM-610: The wildfly-self-contained.d directory lingers

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
@@ -209,6 +209,7 @@ public class RuntimeServer implements Server {
     public void stop() throws Exception {
 
         this.container.stop();
+        this.container=null;
         this.client = null;
         this.deployer = null;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     <version.org.jboss.msc.jboss-msc>1.2.6.Final</version.org.jboss.msc.jboss-msc>
     <version.jboss-logmanager-ext>1.0.0.Alpha3</version.jboss-logmanager-ext>
 
+
     <version.org.arquillian>1.1.10.Final</version.org.arquillian>
     <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>
     <version.org.jboss.arquillian.drone>2.0.1.Final</version.org.jboss.arquillian.drone>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
Motivation
Some files lingers in the tmp directory when the process stops

Modifications

Change the WF Core StandaloneContainer to manage the tmp directory explicitly and provide a stop() to shutdown the container.

Result

All allocated tmp files will be properly removed when Swarm stops.