### PR TITLE
SWARM-612: jboss-cli reload results in 404 / no deployment

### DIFF
--- a/core/container/pom.xml
+++ b/core/container/pom.xml
@@ -139,6 +139,11 @@
       <artifactId>wildfly-logging</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.wildfly.core</groupId>
+      <artifactId>wildfly-controller</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.wildfly.core</groupId>

--- a/core/container/src/main/java/org/wildfly/swarm/container/internal/Deployer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/internal/Deployer.java
@@ -18,6 +18,7 @@ package org.wildfly.swarm.container.internal;
 import java.nio.file.Path;
 import java.util.Collection;
 
+import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.Archive;
 import org.wildfly.swarm.container.DeploymentException;
 

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeDeployer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeDeployer.java
@@ -73,10 +73,12 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HAS
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PERSISTENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUNTIME_NAME;
 
 /**
  * @author Bob McWhirter
+ * @author Heiko Braun
  */
 @Singleton
 public class RuntimeDeployer implements Deployer {
@@ -250,6 +252,7 @@ public class RuntimeDeployer implements Deployer {
         deploymentAdd.get(OP_ADDR).set("deployment", deployment.getName());
         deploymentAdd.get(RUNTIME_NAME).set(deployment.getName());
         deploymentAdd.get(ENABLED).set(true);
+        deploymentAdd.get(PERSISTENT).set(true);
 
         int deploymentTimeout = Integer.getInteger(SwarmProperties.DEPLOYMENT_TIMEOUT, 300);
 

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/BootstrapConfiguration.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/BootstrapConfiguration.java
@@ -1,0 +1,13 @@
+package org.wildfly.swarm.container.runtime.xmlconfig;
+
+import java.util.List;
+
+import org.jboss.dmr.ModelNode;
+
+/**
+ * @author Heiko Braun
+ * @since 14/09/16
+ */
+public interface BootstrapConfiguration {
+    List<ModelNode> get();
+}

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/BootstrapPersister.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/BootstrapPersister.java
@@ -1,0 +1,112 @@
+package org.wildfly.swarm.container.runtime.xmlconfig;
+
+import java.io.File;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Executors;
+
+import javax.xml.namespace.QName;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.RunningMode;
+import org.jboss.as.controller.RunningModeControl;
+import org.jboss.as.controller.extension.ExtensionRegistry;
+import org.jboss.as.controller.parsing.Namespace;
+import org.jboss.as.controller.persistence.ConfigurationPersistenceException;
+import org.jboss.as.controller.persistence.ConfigurationPersister;
+import org.jboss.as.controller.persistence.ExtensibleConfigurationPersister;
+import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
+import org.jboss.as.controller.persistence.XmlConfigurationPersister;
+import org.jboss.as.server.parsing.StandaloneXml;
+import org.jboss.dmr.ModelNode;
+import org.jboss.modules.Module;
+import org.jboss.staxmapper.XMLElementWriter;
+
+/**
+ * Bootstrap from a precomputed set of operations and then switch to an XML based storage model.
+ * In the later stages the XML config will be store in the java.io.tmpdir as <code>swarm-config-UUID.xml</code>.
+ * This step leverages the default Wildfly components for persistence, in particular the {@link XmlConfigurationPersister}
+ *
+ * @author Heiko Braun
+ * @since 14/09/16
+ *
+ */
+public class BootstrapPersister implements ExtensibleConfigurationPersister {
+
+    private final File configurationFile;
+
+    private final XmlConfigurationPersister delegate;
+
+    private BootstrapConfiguration bootstrapConfig;
+
+    public BootstrapPersister(BootstrapConfiguration bootstrapConfig, File configurationFile) {
+        this.bootstrapConfig = bootstrapConfig;
+        this.configurationFile = configurationFile;
+        this.delegate = createDelegate(configurationFile);
+    }
+
+    @Override
+    public PersistenceResource store(ModelNode model, Set<PathAddress> affectedAddresses) throws ConfigurationPersistenceException {
+        return delegate.store(model, affectedAddresses);
+    }
+
+    @Override
+    public void marshallAsXml(ModelNode model, OutputStream output) throws ConfigurationPersistenceException {
+        delegate.marshallAsXml(model, output);
+    }
+
+    @Override
+    public List<ModelNode> load() throws ConfigurationPersistenceException {
+        if(!configurationFile.exists()) {
+            return bootstrapConfig.get();
+        } else {
+            return delegate.load();
+        }
+    }
+
+    @Override
+    public void successfulBoot() throws ConfigurationPersistenceException {
+
+    }
+
+    @Override
+    public String snapshot() throws ConfigurationPersistenceException {
+        return null;
+    }
+
+    @Override
+    public SnapshotInfo listSnapshots() {
+        return ConfigurationPersister.NULL_SNAPSHOT_INFO;
+    }
+
+    @Override
+    public void deleteSnapshot(String name) {
+
+    }
+
+    @Override
+    public void registerSubsystemWriter(String name, XMLElementWriter<SubsystemMarshallingContext> writer) {
+        delegate.registerSubsystemWriter(name, writer);
+    }
+
+    @Override
+    public void unregisterSubsystemWriter(String name) {
+        delegate.unregisterSubsystemWriter(name);
+    }
+
+    private XmlConfigurationPersister createDelegate(File configFile) {
+
+        QName rootElement = new QName(Namespace.CURRENT.getUriString(), "server");
+        ExtensionRegistry extensionRegistry = new ExtensionRegistry(ProcessType.SELF_CONTAINED, new RunningModeControl(RunningMode.NORMAL));
+        StandaloneXml parser = new StandaloneXml(Module.getBootModuleLoader(), Executors.newSingleThreadExecutor(), extensionRegistry);
+
+        XmlConfigurationPersister persister = new XmlConfigurationPersister(
+                configFile, rootElement, parser, parser, false
+        );
+
+        return persister;
+
+    }
+}

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/StandaloneXMLParser.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/StandaloneXMLParser.java
@@ -73,6 +73,7 @@ public class StandaloneXMLParser {
         }, ParsingOption.IGNORE_SUBSYSTEM_FAILURES);
 
         xmlMapper = XMLMapper.Factory.create();
+        xmlMapper.registerRootElement(new QName(Namespace.CURRENT.getUriString(), "server"), parserDelegate);
 
         QName serverElementName = new QName("urn:jboss:domain:4.0", "server");
         this.recognizedNames.add( serverElementName );

--- a/core/container/src/main/resources/modules/org/wildfly/swarm/container/api/module.xml
+++ b/core/container/src/main/resources/modules/org/wildfly/swarm/container/api/module.xml
@@ -36,6 +36,9 @@
   <dependencies>
     <module name="org.wildfly.swarm.configuration" export="true"/>
     <module name="org.wildfly.swarm.spi" export="true" services="export"/>
+    <module name="org.jboss.as.server"/>
+    <module name="org.jboss.as.controller" export="true"/>
+    <module name="org.jboss.as.server"/>
     <module name="org.jboss.modules" export="true"/>
     <module name="org.jboss.shrinkwrap" export="true"/>
     <module name="org.jboss.shrinkwrap.descriptors" export="true"/>
@@ -48,5 +51,10 @@
     <module name="javax.enterprise.api"/>
     <module name="javax.inject.api"/>
     <module name="javax.annotation.api" export="true"/>
+
+    <!-- the following have been added to support xml parsing -->
+    <module name="javax.api" export="true"/>
+    <module name="org.jboss.staxmapper" export="true"/>
+    <module name="org.jboss.as.logging" export="true"/>
   </dependencies>
 </module>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
Motivation

Using the management tools to :reload a live Swarm instance, caused the deployment to disappear.

Modifications

Swarm does now, like WildFly, keep a copy of the server configuration around, that it can read back when the server reloads.

Result

Start a server, :reload it using the CLI and the deployment is still registered with the node.