### PR TITLE
SWARM-833: bad default mod_cluster multicast address

### DIFF
--- a/fractions/mod_cluster/src/main/java/org/wildfly/swarm/mod_cluster/runtime/ModclusterSocketBindingCustomizer.java
+++ b/fractions/mod_cluster/src/main/java/org/wildfly/swarm/mod_cluster/runtime/ModclusterSocketBindingCustomizer.java
@@ -35,7 +35,7 @@ public class ModclusterSocketBindingCustomizer implements Customizer {
     public void customize() {
 
         if ( this.address == null ) {
-            this.address = "224.01.105";
+            this.address = "224.0.1.105";
         }
 
         if ( this.port == null ) {


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
The default mod_cluster multicast address is configured to 224.01.105,
which obviously isn't a valid IP address. Comparing to WildFly, it's
clear that it's a typo, it should be 224.0.1.105.

Modifications
-------------
Changed the default mod_cluster multicast address to 224.0.1.105.

Result
------
Default configuration for mod_cluster is more sensible.