### PR TITLE
SWARM-723: Fraction for FluentD to integrate with EFK stack

### DIFF
--- a/fractions/fluentd/module.conf
+++ b/fractions/fluentd/module.conf
@@ -1,0 +1,3 @@
+org.jboss.logmanager
+org.wildfly.swarm.logging
+org.fluentd export=true

--- a/fractions/fluentd/pom.xml
+++ b/fractions/fluentd/pom.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+~
+~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>wildfly-swarm</artifactId>
+    <version>2016.12.0-SNAPSHOT</version>
+    <relativePath>../../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>fluentd</artifactId>
+
+  <name>Fluentd</name>
+  <description>Write log entries to Fluentd</description>
+
+  <packaging>jar</packaging>
+
+  <properties>
+    <swarm.fraction.stability>experimental</swarm.fraction.stability>
+    <swarm.fraction.tags>Logging, Openshift</swarm.fraction.tags>
+    <fluentd.version>0.3.2</fluentd.version>
+  </properties>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>container</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>spi</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss</groupId>
+      <artifactId>staxmapper</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.fluentd</groupId>
+      <artifactId>fluent-logger</artifactId>
+      <version>${fluentd.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.logmanager</groupId>
+      <artifactId>jboss-logmanager-ext</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.wildfly.core</groupId>
+      <artifactId>wildfly-core-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-servlet-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+  </dependencies>
+
+
+</project>

--- a/fractions/fluentd/src/main/java/org/wildfly/swarm/fluentd/FluentdFraction.java
+++ b/fractions/fluentd/src/main/java/org/wildfly/swarm/fluentd/FluentdFraction.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.fluentd;
+
+import org.wildfly.swarm.config.logging.Level;
+import org.wildfly.swarm.spi.api.Fraction;
+
+/**
+ * @author Heiko Braun
+ */
+public class FluentdFraction implements Fraction<FluentdFraction> {
+
+    public FluentdFraction() {
+        this.hostname = "localhost";
+        this.port = 24224;
+        this.level = Level.INFO;
+    }
+
+    public static Fraction createDefaultFluentdFraction() {
+        return new FluentdFraction();
+    }
+
+    public FluentdFraction level(Level level) {
+        this.level = level;
+        return this;
+    }
+
+    public Level level() {
+        return this.level;
+    }
+
+    public FluentdFraction hostname(String hostname) {
+        this.hostname = hostname;
+        return this;
+    }
+
+    public String hostname() {
+        return this.hostname;
+    }
+
+    public FluentdFraction port(int port) {
+        this.port = port;
+        return this;
+    }
+
+    public int port() {
+        return this.port;
+    }
+
+    public String getTag() {
+        return tag;
+    }
+
+    private String hostname;
+
+    private int port;
+
+    private Level level;
+
+    private String tag = "local";
+
+}

--- a/fractions/fluentd/src/main/java/org/wildfly/swarm/fluentd/FluentdProperties.java
+++ b/fractions/fluentd/src/main/java/org/wildfly/swarm/fluentd/FluentdProperties.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.fluentd;
+
+public class FluentdProperties {
+    //public
+    public static final String HOSTNAME = "swarm.fluentd.hostname";
+
+    //public
+    public static final String PORT = "swarm.fluentd.port";
+
+}

--- a/fractions/fluentd/src/main/java/org/wildfly/swarm/fluentd/runtime/FluentdCustomizer.java
+++ b/fractions/fluentd/src/main/java/org/wildfly/swarm/fluentd/runtime/FluentdCustomizer.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.fluentd.runtime;
+
+import java.util.Optional;
+import java.util.Properties;
+
+import javax.enterprise.inject.Any;
+import javax.inject.Inject;
+
+import org.wildfly.swarm.config.logging.CustomHandler;
+import org.wildfly.swarm.config.logging.Level;
+import org.wildfly.swarm.fluentd.FluentdFraction;
+import org.wildfly.swarm.fluentd.FluentdProperties;
+import org.wildfly.swarm.logging.LoggingFraction;
+import org.wildfly.swarm.spi.api.Customizer;
+import org.wildfly.swarm.spi.runtime.annotations.ConfigurationValue;
+import org.wildfly.swarm.spi.runtime.annotations.Post;
+
+/**
+ * @author Heiko Braun
+ */
+@Post
+public class FluentdCustomizer implements Customizer {
+
+    @Inject
+    @Any
+    private FluentdFraction fluentdFraction;
+
+    @Inject
+    @Any
+    private LoggingFraction loggingFraction;
+
+    @Inject
+    @ConfigurationValue(FluentdProperties.HOSTNAME)
+    private Optional<String> hostname;
+
+    @Inject
+    @ConfigurationValue(FluentdProperties.PORT)
+    private Optional<Integer> port;
+
+    @Override
+    public void customize() {
+        try {
+            String hostname = this.hostname.orElse(this.fluentdFraction.hostname());
+            int port = this.port.orElse(this.fluentdFraction.port());
+
+            if (hostname != null) {
+                Properties handlerProps = new Properties();
+
+                handlerProps.put("hostname", hostname);
+                handlerProps.put("port", "" + port);
+                handlerProps.put("tag", this.fluentdFraction.getTag());
+
+                final CustomHandler<?> fluentd = new CustomHandler<>("fluentd-handler")
+                        .module("org.wildfly.swarm.fluentd:runtime")
+                        .attributeClass(FluentdHandler.class.getName())
+                        .properties(handlerProps);
+
+                final Level level = this.fluentdFraction.level();
+
+                this.loggingFraction
+                        //.consoleHandler(level, LoggingFraction.COLOR_PATTERN)
+                        .customHandler(fluentd)
+                        .rootLogger(level, LoggingFraction.CONSOLE, fluentd.getKey());
+            } else {
+                throw new IllegalArgumentException("Not enabling fluentd, no host set");
+            }
+        } catch (Throwable t) {
+            t.printStackTrace();
+        }
+    }
+}

--- a/fractions/fluentd/src/main/java/org/wildfly/swarm/fluentd/runtime/FluentdHandler.java
+++ b/fractions/fluentd/src/main/java/org/wildfly/swarm/fluentd/runtime/FluentdHandler.java
@@ -1,0 +1,141 @@
+package org.wildfly.swarm.fluentd.runtime;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.ErrorManager;
+import java.util.logging.Logger;
+
+import org.fluentd.logger.sender.RawSocketSender;
+import org.jboss.logmanager.ExtHandler;
+import org.jboss.logmanager.ExtLogRecord;
+
+/**
+ * @author Heiko Braun
+ * @since 14/11/2016
+ */
+public class FluentdHandler extends ExtHandler {
+
+    public enum Key {
+        EXCEPTION("exception"),
+        LEVEL("level"),
+        LOGGER_CLASS_NAME("loggerClassName"),
+        LOGGER_NAME("loggerName"),
+        MDC("mdc"),
+        MESSAGE("message"),
+        NDC("ndc"),
+        RECORD("record"),
+        SEQUENCE("sequence"),
+        THREAD_ID("threadId"),
+        THREAD_NAME("threadName"),
+        TIMESTAMP("timestamp");
+
+        private final String key;
+
+        Key(final String key) {
+            this.key = key;
+        }
+
+        /**
+         * Returns the name of the key for the structure.
+         *
+         * @return the name of they key
+         */
+        public String getKey() {
+            return key;
+        }
+    }
+
+    public FluentdHandler() {
+        setAutoFlush(false);
+    }
+
+    public void setHostname(String hostname) {
+        this.hostname = hostname;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public void setTag(String tag) {
+        this.tag = tag;
+    }
+
+    @Override
+    protected void doPublish(ExtLogRecord record) {
+
+        synchronized (this) {
+            if(!initialized) {
+                try {
+                    initialize();
+                } catch (Exception e) {
+                    reportError("Error creating fluentd connection", e, ErrorManager.OPEN_FAILURE);
+                    setEnabled(false);
+                }
+            }
+        }
+
+        if(initialized) {
+            Map<String, Object> entries = new HashMap<>();
+
+            entries.put(Key.SEQUENCE.getKey(), record.getSequenceNumber());
+            entries.put(Key.LEVEL.getKey(), record.getLevel().getName());
+            entries.put(Key.THREAD_NAME.getKey(), record.getThreadName());
+            entries.put(Key.MESSAGE.getKey(), record.getFormattedMessage());
+            entries.put(Key.THREAD_ID.getKey(), record.getThreadID());
+            entries.put(Key.MDC.getKey(), record.getMdcCopy());
+            entries.put(Key.NDC.getKey(), record.getNdc());
+
+            this.sender.emit(this.tag, record.getMillis(), entries);
+        }
+
+    }
+
+    private void initialize() {
+        try {
+            this.sender = new RawSocketSender(hostname, port);
+            this.initialized = true;
+            log.info("Connected to fluentd daemon");
+        } catch (Throwable t) {
+            throw new RuntimeException("Failed to initialise fluentd connection", t);
+        }
+    }
+
+    @Override
+    public void flush() {
+        // should not happen
+    }
+
+    @Override
+    public void close() {
+        super.close();
+        log.info("Disconnect from fluentd daemon ...");
+        synchronized (this) {
+            safeClose(this.sender);
+            this.sender = null;
+            this.initialized = false;
+        }
+    }
+
+    private void safeClose(RawSocketSender c) {
+        try {
+            if (c != null) c.close();
+        } catch (Exception e) {
+            reportError("Error closing resource", e, ErrorManager.CLOSE_FAILURE);
+        } catch (Throwable ignored) {
+        }
+    }
+
+    private static final java.util.logging.Logger log = Logger.getLogger("org.wildfly.swarm.fluentd");
+
+    private String hostname;
+
+    private int port;
+
+    private boolean initialized;
+
+    private RawSocketSender sender;
+
+    private String tag;
+
+}

--- a/fractions/fluentd/src/main/resources/modules/org/fluentd/main/module.xml
+++ b/fractions/fluentd/src/main/resources/modules/org/fluentd/main/module.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+
+<module xmlns="urn:jboss:module:1.3" name="org.fluentd">
+
+  <resources>
+    <artifact name="org.fluentd:fluent-logger:${fluentd.version}"/>
+    <artifact name="org.msgpack:msgpack:0.6.8"/>
+    <artifact name="com.googlecode.json-simple:json-simple:1.1.1"/>
+    <artifact name="org.javassist:javassist:3.18.1-GA"/>
+    <artifact name="org.slf4j:slf4j-api:1.7.7.jbossorg-1"/>
+    <artifact name="org.jboss.logmanager:jboss-logmanager-ext:${version.jboss-logmanager-ext}"/>
+  </resources>
+
+  <dependencies>
+    <module name="org.jboss.logmanager"/>
+    <module name="javax.json.api"/>
+    <module name="javax.xml.stream.api"/>
+  </dependencies>
+</module>

--- a/fractions/fluentd/src/main/resources/provided-dependencies.txt
+++ b/fractions/fluentd/src/main/resources/provided-dependencies.txt
@@ -1,0 +1,1 @@
+javax.json:javax.json-api

--- a/pom.xml
+++ b/pom.xml
@@ -1168,6 +1168,7 @@
     <module>fractions/databases/mysql</module>
     <module>fractions/databases/postgresql</module>
     <module>fractions/drools-server</module>
+    <module>fractions/fluentd</module>
     <module>fractions/flyway</module>
     <module>fractions/hibernate-search</module>
     <module>fractions/hibernate-validator</module>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

# Motivation

Allow logging to fluentd daemon

# Modification

Added new fraction `"fluentd"` that tweaks logging to add a custom fluentd log handler

# Result

With the fraction enabled, logs go to system out and fluentd