### PR TITLE
SWARM-844: Gradle project dependencies with 2 colons are resolved as …

### DIFF
--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/GradleDependencyAdapter.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/GradleDependencyAdapter.java
@@ -90,6 +90,9 @@ public class GradleDependencyAdapter {
                     line = line.substring(0, line.indexOf(SUFFIX));
                 }
 
+                if(line.startsWith("project")) // Always skip 'project' dependencies.
+                    continue;
+
                 String[] coords = line.split(":");
                 if(3==coords.length) {
                     String version = coords[2];


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

SWARM-844: Gradle project dependencies with 2 colons are resolved as jar dependencies

Motivation
----------
Gradle project dependencies containing 2 colons are handled like jar dependencies.
This leads to an error when trying to resolve a Maven artifact with a name like project(:a:b)

Modifications
-------------
Skip dependencies starting with project.

Result
------
Gradle project dependencies are handled correctly now.