### PR TITLE
SWARM-846: TopologyProxyService is never started

### DIFF
--- a/fractions/topology-webapp/src/main/java/org/wildfly/swarm/topology/webapp/TopologyProxyService.java
+++ b/fractions/topology-webapp/src/main/java/org/wildfly/swarm/topology/webapp/TopologyProxyService.java
@@ -44,7 +44,7 @@ import org.wildfly.swarm.topology.TopologyListener;
 
 public class TopologyProxyService implements Service<TopologyProxyService>, TopologyListener {
 
-    public static final ServiceName SERVICE_NAME = ServiceName.of("swarm.topology.proxy");
+    public static final ServiceName SERVICE_NAME = ServiceName.parse("swarm.topology.proxy");
 
     public TopologyProxyService(Set<String> serviceNames) {
         this.serviceNames = serviceNames;

--- a/fractions/topology-webapp/src/main/java/org/wildfly/swarm/topology/webapp/runtime/TopologyWebAppActivator.java
+++ b/fractions/topology-webapp/src/main/java/org/wildfly/swarm/topology/webapp/runtime/TopologyWebAppActivator.java
@@ -15,8 +15,12 @@
  */
 package org.wildfly.swarm.topology.webapp.runtime;
 
+import java.util.Collections;
 import java.util.Set;
 
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import io.undertow.server.HttpHandler;
@@ -25,20 +29,24 @@ import org.jboss.msc.service.ServiceActivatorContext;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceRegistryException;
 import org.jboss.msc.service.ServiceTarget;
-import org.wildfly.swarm.topology.TopologyConnector;
 import org.wildfly.swarm.topology.runtime.TopologyManagerActivator;
 import org.wildfly.swarm.topology.webapp.TopologyProxyService;
+import org.wildfly.swarm.topology.webapp.TopologyWebAppFraction;
 
 @Singleton
 public class TopologyWebAppActivator implements ServiceActivator {
 
-    public TopologyWebAppActivator(Set<String> serviceNames) {
-        this.serviceNames = serviceNames;
-    }
+    @Inject
+    @Any
+    private Instance<TopologyWebAppFraction> topologyWebAppFractionInstance;
 
     @Override
     public void activate(ServiceActivatorContext context) throws ServiceRegistryException {
         ServiceTarget target = context.getServiceTarget();
+
+        if (!topologyWebAppFractionInstance.isUnsatisfied()) {
+            serviceNames = topologyWebAppFractionInstance.get().proxiedServiceMappings().keySet();
+        }
 
         TopologyProxyService proxyService = new TopologyProxyService(serviceNames);
         ServiceBuilder<TopologyProxyService> serviceBuilder = target
@@ -51,5 +59,5 @@ public class TopologyWebAppActivator implements ServiceActivator {
         serviceBuilder.install();
     }
 
-    private final Set<String> serviceNames;
+    private Set<String> serviceNames = Collections.emptySet();
 }

--- a/testsuite/testsuite-topology-webapp/pom.xml
+++ b/testsuite/testsuite-topology-webapp/pom.xml
@@ -29,6 +29,10 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>topology-jgroups</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>logging</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
TopologyWebAppActivator is not triggering the installation of the TopologyProxyService which means there is no way to map between a proxy URL and the underlying topology service when a main() uses TopologyWebAppFraction.proxyService().

This bug currently prevents Booker from looking up services.

Modifications
-------------
Modified TopologyWebAppActivator to be picked up by Weld and added as a ServiceActivator into runtime.

TopologyProzyService was creating service name with .of() instead of .parse() which caused quotes to be part of service name.

Modified topology-webapp test to check for presence of appropriate MSC services related to proxies.

Result
------
Product behavior corrected from failing silently.