### PR TITLE
SWARM-848: ServiceName ClassLoading issue with TopologyWebAppActivator

### DIFF
--- a/fractions/topology-webapp/src/main/java/org/wildfly/swarm/topology/webapp/runtime/TopologyProxyService.java
+++ b/fractions/topology-webapp/src/main/java/org/wildfly/swarm/topology/webapp/runtime/TopologyProxyService.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.swarm.topology.webapp;
+package org.wildfly.swarm.topology.webapp.runtime;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -41,6 +41,7 @@ import org.jboss.msc.value.InjectedValue;
 import org.wildfly.extension.undertow.deployment.GlobalRequestControllerHandler;
 import org.wildfly.swarm.topology.Topology;
 import org.wildfly.swarm.topology.TopologyListener;
+import org.wildfly.swarm.topology.webapp.TopologyWebAppFraction;
 
 public class TopologyProxyService implements Service<TopologyProxyService>, TopologyListener {
 

--- a/fractions/topology-webapp/src/main/java/org/wildfly/swarm/topology/webapp/runtime/TopologyWebAppActivator.java
+++ b/fractions/topology-webapp/src/main/java/org/wildfly/swarm/topology/webapp/runtime/TopologyWebAppActivator.java
@@ -30,7 +30,6 @@ import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceRegistryException;
 import org.jboss.msc.service.ServiceTarget;
 import org.wildfly.swarm.topology.runtime.TopologyManagerActivator;
-import org.wildfly.swarm.topology.webapp.TopologyProxyService;
 import org.wildfly.swarm.topology.webapp.TopologyWebAppFraction;
 
 @Singleton


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
Linkage error because ServiceName is loaded from different classloader instances.

Modifications
-------------
Moved TopologyProxyService into runtime package/module as its not needed on api side.

Result
------
Ribbon Example passes as ServiceName is referenced from same classloader.