### PR TITLE
SWARM-693, SWARM-514: Health check updates

### DIFF
--- a/fractions/io/src/main/java/org/wildfly/swarm/io/IOFraction.java
+++ b/fractions/io/src/main/java/org/wildfly/swarm/io/IOFraction.java
@@ -30,7 +30,11 @@ import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
 public class IOFraction extends IO<IOFraction> implements Fraction<IOFraction> {
 
     public IOFraction applyDefaults() {
-        return worker(new Worker("default"))
+        return worker(
+                "default", w -> {
+                    w.ioThreads(100);
+                    w.taskMaxThreads(20);
+                })
                 .bufferPool(new BufferPool("default"));
     }
 }

--- a/fractions/monitor/module.conf
+++ b/fractions/monitor/module.conf
@@ -19,3 +19,4 @@ org.jboss.as.domain-management
 org.jboss.as.domain-http-interface
 
 org.jboss.logging
+io.undertow.servlet

--- a/fractions/monitor/module.conf
+++ b/fractions/monitor/module.conf
@@ -12,6 +12,10 @@ javax.ws.rs.api
 javax.api
 
 io.undertow.core
+org.jboss.xnio
+org.jboss.xnio.nio
 
 org.jboss.as.domain-management
 org.jboss.as.domain-http-interface
+
+org.jboss.logging

--- a/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/CompositeHealthStatus.java
+++ b/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/CompositeHealthStatus.java
@@ -22,10 +22,11 @@ import java.util.Optional;
 import org.jboss.dmr.ModelNode;
 
 /**
+ * TODO: remove
  * @author Heiko Braun
  * @since 23/03/16
  */
-public class CompositeHealthStatus implements Status {
+class CompositeHealthStatus implements Status {
 
     private final Policy policy;
 
@@ -105,5 +106,10 @@ public class CompositeHealthStatus implements Status {
     public interface Policy {
         State apply(List<HealthStatus> states);
         Optional<String> message(List<HealthStatus> states);
+    }
+
+    @Override
+    public String toJson() {
+        return null;
     }
 }

--- a/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/Health.java
+++ b/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/Health.java
@@ -27,10 +27,4 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 public @interface Health {
 
-    /**
-     * By default all health endpoints will inherit the security of the implicit '/health' endpoint.
-     * This method allows to exclude certain endpoints from that policy.
-     * @return
-     */
-    boolean inheritSecurity() default true;
 }

--- a/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/HealthStatus.java
+++ b/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/HealthStatus.java
@@ -25,19 +25,34 @@ import org.jboss.dmr.ModelNode;
  */
 public class HealthStatus implements Status {
 
+    private final String name;
+
     private Optional<ModelNode> message = Optional.empty();
-    private final State state;
+    private State state;
 
-    HealthStatus(State state) {
-        this.state = state;
+    HealthStatus(String name) {
+        this.name = name;
     }
 
-    public static HealthStatus up() {
-        return new HealthStatus(State.UP);
+    public static HealthStatus named(String name)
+    {
+        return new HealthStatus(name);
     }
 
-    public static HealthStatus down() {
-        return new HealthStatus(State.DOWN);
+    public HealthStatus up() {
+        assertNamed();
+        this.state = State.UP;
+        return this;
+    }
+
+    private void assertNamed() {
+        if(null==this.name)
+            throw new IllegalStateException("HealthStatus need to be named");
+    }
+
+    public HealthStatus down() {
+        this.state = State.DOWN;
+        return this;
     }
 
     public HealthStatus withAttribute(String key, String value) {
@@ -70,5 +85,16 @@ public class HealthStatus implements Status {
 
     public State getState() {
         return state;
+    }
+
+    @Override
+    public String toJson() {
+        ModelNode wrapper = new ModelNode();
+        wrapper.get("id").set(name);
+        wrapper.get("result").set(state.name());
+        if(message.isPresent()) {
+            wrapper.get("data").set(message.get());
+        }
+        return wrapper.toJSONString(false);
     }
 }

--- a/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/Status.java
+++ b/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/Status.java
@@ -23,6 +23,8 @@ import java.util.Optional;
  */
 public interface Status {
 
+    String toJson();
+
     enum State {UP,DOWN}
 
     State getState();

--- a/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/BufferingSinkConduit.java
+++ b/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/BufferingSinkConduit.java
@@ -1,0 +1,96 @@
+package org.wildfly.swarm.monitor.runtime;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.xnio.IoUtils;
+import org.xnio.channels.StreamSourceChannel;
+import org.xnio.conduits.AbstractStreamSinkConduit;
+import org.xnio.conduits.ConduitWritableByteChannel;
+import org.xnio.conduits.Conduits;
+import org.xnio.conduits.StreamSinkConduit;
+
+/**
+ * Conduit that saves all the data that is written through it
+ *
+ * @author Heiko Braun
+ */
+public class BufferingSinkConduit extends AbstractStreamSinkConduit<StreamSinkConduit> {
+
+    private final List<byte[]> data = new CopyOnWriteArrayList<>();
+
+    /**
+     * Construct a new instance.
+     *
+     * @param next the delegate conduit to set
+     */
+    public BufferingSinkConduit(StreamSinkConduit next) {
+        super(next);
+    }
+
+    @Override
+    public int write(ByteBuffer src) throws IOException {
+        int pos = src.position();
+        int res = super.write(src);
+        if (res > 0) {
+            byte[] d = new byte[res];
+            for (int i = 0; i < res; ++i) {
+                d[i] = src.get(i + pos);
+            }
+            data.add(d);
+        }
+        return res;
+    }
+
+    @Override
+    public long write(ByteBuffer[] dsts, int offs, int len) throws IOException {
+        for (int i = offs; i < len; ++i) {
+            if (dsts[i].hasRemaining()) {
+                return write(dsts[i]);
+            }
+        }
+        return 0;
+    }
+
+    @Override
+    public long transferFrom(final FileChannel src, final long position, final long count) throws IOException {
+        return src.transferTo(position, count, new ConduitWritableByteChannel(this));
+    }
+
+    @Override
+    public long transferFrom(final StreamSourceChannel source, final long count, final ByteBuffer throughBuffer) throws IOException {
+        return IoUtils.transfer(source, count, throughBuffer, new ConduitWritableByteChannel(this));
+    }
+
+    @Override
+    public int writeFinal(ByteBuffer src) throws IOException {
+        return Conduits.writeFinalBasic(this, src);
+    }
+
+    @Override
+    public long writeFinal(ByteBuffer[] srcs, int offset, int length) throws IOException {
+        return Conduits.writeFinalBasic(this, srcs, offset, length);
+    }
+
+    @Override
+    public void terminateWrites() throws IOException {
+        super.terminateWrites();
+        data.clear();
+    }
+
+    public void flushTo(StringBuffer sb) {
+        if (!data.isEmpty()) {
+            for (int i = 0; i < data.size(); ++i) {
+                try {
+                    sb.append(new String(data.get(i), "UTF-8"));  // TODO retrieve the encoding from the http response headers
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+}
+

--- a/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/HealthResponseFilter.java
+++ b/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/HealthResponseFilter.java
@@ -33,10 +33,7 @@ public class HealthResponseFilter implements ContainerResponseFilter {
             Status status = (Status) resp.getEntity();
             int code = (Status.State.UP == status.getState()) ? 200 : 503;
             resp.setStatus(code);
-            if (status.getMessage().isPresent())
-                resp.setEntity(status.getMessage().get());
-            else
-                resp.setEntity("{ \"status\": \"" + status.getState().name() + "\"}");
+            resp.setEntity(status.toJson());
         }
     }
 

--- a/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/HttpContexts.java
+++ b/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/HttpContexts.java
@@ -15,20 +15,44 @@
  */
 package org.wildfly.swarm.monitor.runtime;
 
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import javax.enterprise.inject.Vetoed;
 import javax.naming.NamingException;
 
 import io.undertow.attribute.ReadOnlyAttributeException;
 import io.undertow.attribute.RelativePathAttribute;
+import io.undertow.client.ClientCallback;
+import io.undertow.client.ClientConnection;
+import io.undertow.client.ClientExchange;
+import io.undertow.client.ClientRequest;
+import io.undertow.client.ClientResponse;
+import io.undertow.client.UndertowClient;
+import io.undertow.server.DefaultByteBufferPool;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
-import io.undertow.util.Headers;
+import io.undertow.util.AttachmentKey;
+import io.undertow.util.HttpString;
+import io.undertow.util.Protocols;
+import io.undertow.util.SameThreadExecutor;
 import io.undertow.util.StatusCodes;
+import io.undertow.util.StringReadChannelListener;
 import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
 import org.wildfly.swarm.monitor.HealthMetaData;
+import org.xnio.ChannelListeners;
+import org.xnio.OptionMap;
+import org.xnio.Options;
+import org.xnio.Xnio;
+import org.xnio.XnioWorker;
+import org.xnio.channels.StreamSinkChannel;
 
 /**
  * The actual monitoring HTTP endpoints. These are wrapped by {@link SecureHttpContexts}.
@@ -39,6 +63,20 @@ import org.wildfly.swarm.monitor.HealthMetaData;
 class HttpContexts implements HttpHandler {
 
     public HttpContexts(HttpHandler next) {
+
+        try {
+            this.worker = Xnio.getInstance().createWorker(
+                    OptionMap.builder()
+                            .set(Options.WORKER_IO_THREADS, 5)
+                            .set(Options.WORKER_TASK_CORE_THREADS, 5)
+                            .set(Options.WORKER_TASK_MAX_THREADS, 10)
+                            .set(Options.TCP_NODELAY, true)
+                            .getMap()
+            );
+
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to create worker pool");
+        }
         this.next = next;
 
         try {
@@ -61,70 +99,171 @@ class HttpContexts implements HttpHandler {
         } else if (THREADS.equals(exchange.getRequestPath())) {
             threads(exchange);
             return;
-        } else if (Queries.isDirectAccessToHealthEndpoint(monitor, exchange.getRelativePath())) {
-            exchange.setStatusCode(StatusCodes.MOVED_PERMANENTLY);
-            exchange.getResponseHeaders().put(Headers.LOCATION, HEALTH + exchange.getRelativePath());
-            return;
         } else if (HEALTH.equals(exchange.getRequestPath())) {
-            listHealtSubresources(exchange);
+            proxyRequests(exchange);
             return;
-        } else if (exchange.getRelativePath().startsWith(HEALTH)) {
-            healthRedirect(exchange);
-            if(exchange.isResponseStarted()) // allow the redirect handler to proceed
-                return;
         }
 
         next.handleRequest(exchange);
     }
 
-    private void listHealtSubresources(HttpServerExchange exchange) {
+    private void proxyRequests(HttpServerExchange exchange) {
+
         if(monitor.getHealthURIs().isEmpty()) {
             noHealthEndpoints(exchange);
+        } else {
+
+            Runnable r = new Runnable() {
+                @Override
+                public void run() {
+
+                    try {
+
+                        final UndertowClient client = UndertowClient.getInstance();
+                        final List<ClientResponse> responses = new ArrayList();
+
+                        ClientConnection connection =
+                                client.connect(
+                                        new URL("http://" + exchange.getHostAndPort()).toURI(),
+                                        worker,
+                                        new DefaultByteBufferPool(false, 1024, 100, 12),
+                                        OptionMap.EMPTY
+                                ).get();
+
+                        //  probe each health endpoint
+                        for(HealthMetaData healthCheck : monitor.getHealthURIs()) {
+
+                            try {
+                                ClientRequest request = new ClientRequest();
+                                request.setProtocol(Protocols.HTTP_1_1);
+                                request.setPath(healthCheck.getWebContext());
+                                request.getRequestHeaders().add(X_SWARM_HEALTH_TOKEN, EPHEMERAL_TOKEN);
+                                final CountDownLatch latch = new CountDownLatch(1);
+                                connection.sendRequest(request, createClientCallback(responses, latch));
+                                latch.await(monitor.getProbeTimeoutSeconds(), TimeUnit.SECONDS);
+
+                                if(latch.getCount()>0)
+                                    throw new Exception("Probing "+healthCheck.getWebContext() + " timed out");
+
+                            } catch (Exception e) {
+                                connection.close();
+                                throw new RuntimeException("Failed to process health check "+ healthCheck.getWebContext(), e);
+                            }
+                        }
+
+                        // process responses
+                        boolean failed = false;
+                        if (!responses.isEmpty()) {
+
+                            StringBuffer sb = new StringBuffer("{");
+                            sb.append("\"checks\": [\n");
+
+                            int i=0;
+                            for(ClientResponse resp : responses) {
+                                if(200==resp.getResponseCode()) {
+                                    sb.append(resp.getAttachment(RESPONSE_BODY));
+                                } else if(503==resp.getResponseCode()){
+                                    sb.append(resp.getAttachment(RESPONSE_BODY));
+                                    failed = true;
+                                } else {
+                                    throw new RuntimeException("Unexpected status code: "+resp.getResponseCode());
+                                }
+                                if(i<responses.size()-1)
+                                    sb.append(",\n");
+                                i++;
+                            }
+                            sb.append("],\n");
+
+                            String outcome = failed ? "DOWN":"UP"; // we don't have policies yet, so keep it simple
+                            sb.append("\"outcome\": \""+outcome+"\"\n");
+                            sb.append("}\n");
+
+                            // send a response
+                            if(failed)
+                                exchange.setStatusCode(503);
+                            exchange.getResponseSender().send(sb.toString());
+
+                        } else {
+                            exchange.setStatusCode(204);
+                        }
+
+                        connection.close();
+                        exchange.endExchange();
+
+                    } catch (Throwable t) {
+                        LOG.error("Health check failed", t);
+
+                        if(!exchange.isResponseStarted())
+                            exchange.setStatusCode(500);
+                        exchange.endExchange();
+                    }
+                }
+            };
+
+            exchange.dispatch(exchange.isInIoThread() ? SameThreadExecutor.INSTANCE : exchange.getIoThread(), r);
+
         }
-        else
-        {
-            ModelNode payload = new ModelNode();
-            for (HealthMetaData endpoint : monitor.getHealthURIs()) {
-                payload.get("links").add(HEALTH + endpoint.getWebContext());
+
+    }
+
+    private static final AttachmentKey<String> RESPONSE_BODY = AttachmentKey.create(String.class);
+
+    private ClientCallback<ClientExchange> createClientCallback(final List<ClientResponse> responses, CountDownLatch latch) {
+
+        return new ClientCallback<ClientExchange>() {
+            @Override
+            public void completed(final ClientExchange result) {
+                result.setResponseListener(new ClientCallback<ClientExchange>() {
+                    @Override
+                    public void completed(final ClientExchange result) {
+                        responses.add(result.getResponse());
+                        new StringReadChannelListener(result.getConnection().getBufferPool()) {
+
+                            @Override
+                            protected void stringDone(String string) {
+                                result.getResponse().putAttachment(RESPONSE_BODY, string);
+                                latch.countDown();
+                            }
+
+                            @Override
+                            protected void error(IOException e) {
+                                LOG.error("Failed to read response", e);
+                                latch.countDown();
+
+                            }
+                        }.setup(result.getResponseChannel());
+                    }
+
+                    @Override
+                    public void failed(IOException e) {
+                        LOG.error("Failed to read response", e);
+                        latch.countDown();
+                    }
+                });
+
+                try {
+                    result.getRequestChannel().shutdownWrites();
+                    if(!result.getRequestChannel().flush()) {
+                        result.getRequestChannel().getWriteSetter().set(ChannelListeners.<StreamSinkChannel>flushingChannelListener(null, null));
+                        result.getRequestChannel().resumeWrites();
+                    }
+                } catch (IOException e) {
+                    LOG.error("Failed to read response", e);
+                    latch.countDown();
+                }
             }
 
-            exchange.setStatusCode(200);
-            exchange.getResponseSender().send(payload.toJSONString(false));
-        }
-
+            @Override
+            public void failed(IOException e) {
+                LOG.error("Probe invocation failed", e);
+                latch.countDown();
+            }
+        };
     }
 
     private void noHealthEndpoints(HttpServerExchange exchange) {
         exchange.setStatusCode(204);
-        exchange.getResponseSender().send("No health endpoints configured!");
-    }
-
-    private void healthRedirect(HttpServerExchange exchange) {
-        if(monitor.getHealthURIs().isEmpty()) {
-            noHealthEndpoints(exchange);
-        }
-        else {
-
-            String rel = exchange.getRelativePath();
-            String subresource = rel.substring(HEALTH.length(), rel.length());
-            boolean matches = false;
-            for (HealthMetaData metaData : monitor.getHealthURIs()) {
-                if(metaData.getWebContext().equals(subresource)) {
-                    matches = true;
-                    break;
-                }
-            }
-            if(matches) {
-                try {
-                    RelativePathAttribute.INSTANCE.writeAttribute(exchange, subresource);
-                } catch (ReadOnlyAttributeException e) {
-                    e.printStackTrace();
-                }
-            }
-            else {
-                exchange.setStatusCode(404);
-            }
-        }
+        exchange.setReasonPhrase("No health endpoints configured!");
     }
 
     private void nodeInfo(HttpServerExchange exchange) {
@@ -144,6 +283,8 @@ class HttpContexts implements HttpHandler {
         return contexts;
     };
 
+    private static Logger LOG = Logger.getLogger("org.wildfly.swarm.monitor.health");
+
     public static final String NODE = "/node";
 
     public static final String HEAP = "/heap";
@@ -151,6 +292,10 @@ class HttpContexts implements HttpHandler {
     public static final String THREADS = "/threads";
 
     public static final String HEALTH = "/health";
+
+    final static String EPHEMERAL_TOKEN = UUID.randomUUID().toString();
+
+    static final HttpString X_SWARM_HEALTH_TOKEN = HttpString.tryFromString("X_SWARM_HEALTH_TOKEN");
 
     private final Monitor monitor;
 
@@ -175,4 +320,6 @@ class HttpContexts implements HttpHandler {
     private final HttpHandler next;
 
     private RoundRobin roundRobin;
+
+    private XnioWorker worker;
 }

--- a/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/HttpContexts.java
+++ b/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/HttpContexts.java
@@ -58,7 +58,8 @@ import org.xnio.channels.StreamSinkChannel;
 class HttpContexts implements HttpHandler {
 
     protected ThreadLocal<CountDownLatch> dispatched = new ThreadLocal<>();
-    private AttachmentKey RESPONSES = AttachmentKey.create(List.class);
+    private AttachmentKey<List> RESPONSES = AttachmentKey.create(List.class);
+    static AttachmentKey<String> TOKEN = AttachmentKey.create(String.class);
 
     public HttpContexts(HttpHandler next) {
 
@@ -202,7 +203,7 @@ class HttpContexts implements HttpHandler {
             mockExchange.setRequestPath(delegateContext);
             mockExchange.setRelativePath(delegateContext);
             mockExchange.getRequestHeaders().add(Headers.HOST, exchange.getRequestHeaders().get(Headers.HOST).getFirst());
-            mockExchange.getRequestHeaders().add(X_SWARM_HEALTH_TOKEN, EPHEMERAL_TOKEN);
+            mockExchange.putAttachment(TOKEN, EPHEMERAL_TOKEN);
             mockExchange.putAttachment(RESPONSES, responses);
             connection.addCloseListener(new ServerConnection.CloseListener() {
                 @Override
@@ -317,8 +318,6 @@ class HttpContexts implements HttpHandler {
     public static final String HEALTH = "/health";
 
     final static String EPHEMERAL_TOKEN = UUID.randomUUID().toString();
-
-    static final HttpString X_SWARM_HEALTH_TOKEN = HttpString.tryFromString("X_SWARM_HEALTH_TOKEN");
 
     private final Monitor monitor;
 

--- a/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/InVMConnection.java
+++ b/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/InVMConnection.java
@@ -1,0 +1,253 @@
+package org.wildfly.swarm.monitor.runtime;
+
+import java.io.IOException;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.util.LinkedList;
+import java.util.List;
+
+import io.undertow.UndertowLogger;
+import io.undertow.UndertowMessages;
+import io.undertow.conduits.EmptyStreamSourceConduit;
+import io.undertow.connector.ByteBufferPool;
+import io.undertow.server.DefaultByteBufferPool;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.server.HttpUpgradeListener;
+import io.undertow.server.SSLSessionInfo;
+import io.undertow.server.ServerConnection;
+import io.undertow.server.XnioBufferPoolAdaptor;
+import io.undertow.util.PooledAdaptor;
+import org.jboss.logging.Logger;
+import org.xnio.ChannelListener;
+import org.xnio.Option;
+import org.xnio.OptionMap;
+import org.xnio.Pool;
+import org.xnio.StreamConnection;
+import org.xnio.XnioIoThread;
+import org.xnio.XnioWorker;
+import org.xnio.channels.Configurable;
+import org.xnio.channels.ConnectedChannel;
+import org.xnio.conduits.BufferedStreamSinkConduit;
+import org.xnio.conduits.ConduitStreamSinkChannel;
+import org.xnio.conduits.ConduitStreamSourceChannel;
+import org.xnio.conduits.NullStreamSinkConduit;
+import org.xnio.conduits.StreamSinkConduit;
+
+/**
+ * An Undertow in vm http connection
+ *
+ * @author Heiko Braun
+ */
+final class InVMConnection extends ServerConnection {
+
+    private static Logger LOG = Logger.getLogger(InVMConnection.class);
+
+    private final ByteBufferPool bufferPool;
+    private final XnioWorker worker;
+
+    private SSLSessionInfo sslSessionInfo;
+    private XnioBufferPoolAdaptor poolAdaptor;
+    private BufferingSinkConduit bufferSink;
+
+    protected final List<CloseListener> closeListeners = new LinkedList<>();
+
+    InVMConnection(XnioWorker worker) {
+        this.bufferPool = new DefaultByteBufferPool(false, 1024, 0, 0);
+        this.worker = worker;
+    }
+
+    public void flushTo(StringBuffer sb) {
+        bufferSink.flushTo(sb);
+    }
+
+    @Override
+    public Pool<ByteBuffer> getBufferPool() {
+        if(poolAdaptor == null) {
+            poolAdaptor = new XnioBufferPoolAdaptor(getByteBufferPool());
+        }
+        return poolAdaptor;
+    }
+
+    @Override
+    public ByteBufferPool getByteBufferPool() {
+        return bufferPool;
+    }
+
+    @Override
+    public XnioWorker getWorker() {
+        return null;
+    }
+
+    @Override
+    public XnioIoThread getIoThread() {
+        return null;
+    }
+
+    @Override
+    public HttpServerExchange sendOutOfBandResponse(HttpServerExchange exchange) {
+        throw UndertowMessages.MESSAGES.outOfBandResponseNotSupported();
+    }
+
+    @Override
+    public boolean isContinueResponseSupported() {
+        return false;
+    }
+
+    @Override
+    public void terminateRequestChannel(HttpServerExchange exchange) {
+        LOG.trace("Terminate Mock exchange");
+    }
+
+    @Override
+    public boolean isOpen() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsOption(Option<?> option) {
+        return false;
+    }
+
+    @Override
+    public <T> T getOption(Option<T> option) throws IOException {
+        return null;
+    }
+
+    @Override
+    public <T> T setOption(Option<T> option, T value) throws IllegalArgumentException, IOException {
+        return null;
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+
+    @Override
+    public SocketAddress getPeerAddress() {
+        return null;
+    }
+
+    @Override
+    public <A extends SocketAddress> A getPeerAddress(Class<A> type) {
+        return null;
+    }
+
+    @Override
+    public ChannelListener.Setter<? extends ConnectedChannel> getCloseSetter() {
+        return null;
+    }
+
+    @Override
+    public SocketAddress getLocalAddress() {
+        return null;
+    }
+
+    @Override
+    public <A extends SocketAddress> A getLocalAddress(Class<A> type) {
+        return null;
+    }
+
+    @Override
+    public OptionMap getUndertowOptions() {
+        return OptionMap.EMPTY;
+    }
+
+    @Override
+    public int getBufferSize() {
+        return 1024;
+    }
+
+    @Override
+    public SSLSessionInfo getSslSessionInfo() {
+        return sslSessionInfo;
+    }
+
+    @Override
+    public void setSslSessionInfo(SSLSessionInfo sessionInfo) {
+        sslSessionInfo = sessionInfo;
+    }
+
+    @Override
+    public void addCloseListener(CloseListener listener) {
+        this.closeListeners.add(listener);
+    }
+
+    @Override
+    public StreamConnection upgradeChannel() {
+        return null;
+    }
+
+    @Override
+    public ConduitStreamSinkChannel getSinkChannel() {
+
+        ConduitStreamSinkChannel sinkChannel = new ConduitStreamSinkChannel(
+                Configurable.EMPTY,
+                new BufferedStreamSinkConduit(
+                        new NullStreamSinkConduit(worker.getIoThread()),
+                        new PooledAdaptor(bufferPool.allocate())
+                )
+        );
+        sinkChannel.setCloseListener(new ChannelListener<ConduitStreamSinkChannel>() {
+            @Override
+            public void handleEvent(ConduitStreamSinkChannel conduitStreamSinkChannel) {
+                try {
+                    for (CloseListener l : closeListeners) {
+                        try {
+                            l.closed(InVMConnection.this);
+                        } catch (Throwable e) {
+                            UndertowLogger.REQUEST_LOGGER.exceptionInvokingCloseListener(l, e);
+                        }
+                    }
+                } finally {
+                }
+            }
+        });
+        return sinkChannel;
+    }
+
+    @Override
+    public ConduitStreamSourceChannel getSourceChannel() {
+        return new ConduitStreamSourceChannel(Configurable.EMPTY, new EmptyStreamSourceConduit(worker.getIoThread()));
+    }
+
+    @Override
+    protected StreamSinkConduit getSinkConduit(HttpServerExchange exchange, StreamSinkConduit conduit) {
+        bufferSink = new BufferingSinkConduit(conduit);
+        return bufferSink;
+    }
+
+    @Override
+    protected boolean isUpgradeSupported() {
+        return false;
+    }
+
+    @Override
+    protected boolean isConnectSupported() {
+        return false;
+    }
+
+    @Override
+    protected void exchangeComplete(HttpServerExchange exchange) {
+        LOG.trace("InVM exchange complete");
+    }
+
+    @Override
+    protected void setUpgradeListener(HttpUpgradeListener upgradeListener) {
+        //ignore
+    }
+
+    @Override
+    protected void setConnectListener(HttpUpgradeListener connectListener) {
+        //ignore
+    }
+
+    @Override
+    protected void maxEntitySizeUpdated(HttpServerExchange exchange) {
+    }
+
+    @Override
+    public String getTransportProtocol() {
+        return "mock";
+    }
+
+}

--- a/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/Monitor.java
+++ b/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/Monitor.java
@@ -51,4 +51,10 @@ public interface Monitor {
     List<HealthMetaData> getHealthURIs();
 
     Optional<SecurityRealm> getSecurityRealm();
+
+    /**
+     * The timeout in seconds
+     * @return
+     */
+    long getProbeTimeoutSeconds();
 }

--- a/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/MonitorService.java
+++ b/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/MonitorService.java
@@ -60,6 +60,11 @@ public class MonitorService implements Monitor, Service<MonitorService> {
     }
 
     @Override
+    public long getProbeTimeoutSeconds() {
+        return DEFAULT_PROBE_TIMEOUT_SECONDS;
+    }
+
+    @Override
     public void start(StartContext startContext) throws StartException {
         executorService = Executors.newSingleThreadExecutor();
         serverEnvironment = serverEnvironmentValue.getValue();
@@ -193,6 +198,8 @@ public class MonitorService implements Monitor, Service<MonitorService> {
     public Injector<SecurityRealm> getSecurityRealmInjector() {
         return this.securityRealmServiceValue;
     }
+
+    private static final long DEFAULT_PROBE_TIMEOUT_SECONDS = 2;
 
     private final InjectedValue<ServerEnvironment> serverEnvironmentValue = new InjectedValue<ServerEnvironment>();
 

--- a/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/Queries.java
+++ b/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/Queries.java
@@ -38,6 +38,12 @@ class Queries {
         });
     }
 
+    public final static boolean isAggregatorEndpoint(Monitor monitor, String relativePath) {
+        return query(monitor, metaData -> {
+            return relativePath.equals(HttpContexts.HEALTH);
+        });
+    }
+
     public final static boolean isDirectAccessToHealthEndpoint(Monitor monitor, String relativePath) {
         return query(monitor, metaData -> {
             return relativePath.equals(metaData.getWebContext());

--- a/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/SecureHttpContexts.java
+++ b/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/SecureHttpContexts.java
@@ -135,8 +135,8 @@ public class SecureHttpContexts implements HttpHandler {
 
     private boolean hasTokenAuth(HttpServerExchange exchange) {
 
-        HeaderValues token = exchange.getRequestHeaders().get(HttpContexts.X_SWARM_HEALTH_TOKEN);
-        return token != null && HttpContexts.EPHEMERAL_TOKEN.equals(token.getFirst());
+        String token = exchange.getAttachment(HttpContexts.TOKEN);
+        return token != null && HttpContexts.EPHEMERAL_TOKEN.equals(token);
     }
 
     private static AuthenticationMechanism wrap(final AuthenticationMechanism toWrap, final AuthMechanism mechanism) {

--- a/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/UndertowFilterCustomizer.java
+++ b/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/UndertowFilterCustomizer.java
@@ -15,8 +15,6 @@
  */
 package org.wildfly.swarm.monitor.runtime;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import javax.inject.Singleton;

--- a/fractions/monitor/src/test/java/org/wildfly/swarm/monitor/MonitorTest.java
+++ b/fractions/monitor/src/test/java/org/wildfly/swarm/monitor/MonitorTest.java
@@ -28,7 +28,8 @@ public class MonitorTest {
     @Test
     public void testAttributes() {
 
-        HealthStatus healthStatus = HealthStatus.up()
+        HealthStatus healthStatus = HealthStatus.named("test")
+                .up()
                 .withAttribute("a", "b")
                 .withAttribute("c", "d");
 

--- a/testsuite/testsuite-jaxrs/src/main/java/org/wildfly/swarm/jaxrs/FailedChecks.java
+++ b/testsuite/testsuite-jaxrs/src/main/java/org/wildfly/swarm/jaxrs/FailedChecks.java
@@ -1,0 +1,28 @@
+package org.wildfly.swarm.jaxrs;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.wildfly.swarm.monitor.Health;
+import org.wildfly.swarm.monitor.HealthStatus;
+
+/**
+ * @author Heiko Braun
+ */
+@Path("/failed")
+public class FailedChecks {
+
+    @GET
+    @Health
+    @Path("/first")
+    public HealthStatus checkHealth() {
+        return HealthStatus.named("first").down();
+    }
+
+    @GET
+    @Health
+    @Path("/second")
+    public HealthStatus checkHealthInsecure() {
+        return HealthStatus.named("second").up().withAttribute("time", System.currentTimeMillis());
+    }
+}

--- a/testsuite/testsuite-jaxrs/src/main/java/org/wildfly/swarm/jaxrs/SuccessfulChecks.java
+++ b/testsuite/testsuite-jaxrs/src/main/java/org/wildfly/swarm/jaxrs/SuccessfulChecks.java
@@ -24,21 +24,21 @@ import org.wildfly.swarm.monitor.HealthStatus;
 /**
  * @author Heiko Braun
  */
-@Path("/monitor")
-public class HealthCheckResource {
+@Path("/success")
+public class SuccessfulChecks {
 
 
     @GET
     @Health
-    @Path("/health-secure")
+    @Path("/first")
     public HealthStatus checkHealth() {
-        return HealthStatus.up().withAttribute("status", "UP");
+        return HealthStatus.named("first").up();
     }
 
     @GET
-    @Health(inheritSecurity = false)
-    @Path("/health-insecure")
+    @Health
+    @Path("/second")
     public HealthStatus checkHealthInsecure() {
-        return HealthStatus.up().withAttribute("status", "UP");
+        return HealthStatus.named("second").up().withAttribute("time", System.currentTimeMillis());
     }
 }

--- a/testsuite/testsuite-jaxrs/src/test/java/org/wildfly/swarm/jaxrs/JAXRSArquillianTest.java
+++ b/testsuite/testsuite-jaxrs/src/test/java/org/wildfly/swarm/jaxrs/JAXRSArquillianTest.java
@@ -40,7 +40,7 @@ public class JAXRSArquillianTest {
     @Deployment(testable = false)
     public static Archive createDeployment() throws Exception {
         JAXRSArchive deployment = ShrinkWrap.create(JAXRSArchive.class, "myapp.war");
-        deployment.addClass(HealthCheckResource.class);
+        deployment.addClass(SuccessfulChecks.class);
         deployment.addClass(CustomJsonProvider.class);
         deployment.addClass(MyResource.class);
         deployment.setContextRoot("rest");
@@ -56,7 +56,7 @@ public class JAXRSArquillianTest {
     @Test
     @RunAsClient
     public void testResource() {
-        browser.navigate().to("http://localhost:8080/health/rest/monitor/health-secure");
+        browser.navigate().to("http://localhost:8080/rest/success/first");
         assertThat(browser.getPageSource()).contains("UP");
     }
 

--- a/testsuite/testsuite-jaxrs/src/test/java/org/wildfly/swarm/jaxrs/MonitorPayloadTest.java
+++ b/testsuite/testsuite-jaxrs/src/test/java/org/wildfly/swarm/jaxrs/MonitorPayloadTest.java
@@ -1,0 +1,82 @@
+package org.wildfly.swarm.jaxrs;
+
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.arquillian.CreateSwarm;
+import org.wildfly.swarm.monitor.MonitorFraction;
+
+/**
+ * @author Heiko Braun
+ */
+@RunWith(Arquillian.class)
+public class MonitorPayloadTest extends SimpleHttp {
+
+    @Deployment
+    public static Archive getDeployment() throws Exception {
+        JAXRSArchive deployment = ShrinkWrap.create(JAXRSArchive.class, "myapp.war");
+        deployment.addClass(SimpleHttp.class);
+        deployment.addClass(JaxRsActivator.class);
+        deployment.addClass(FailedChecks.class);
+        deployment.addAllDependencies();
+        deployment.setContextRoot("rest");
+        return deployment;
+    }
+
+    @CreateSwarm
+    public static Swarm getContainer() throws Exception {
+        Swarm container = new Swarm();
+        container.fraction(new JAXRSFraction());
+        container.fraction(new MonitorFraction());
+        return container;
+    }
+
+    @Test
+    @RunAsClient
+    public void testHealthIntegration() throws Exception {
+
+        // aggregator / with auth
+        Response response = getUrlContents("http://localhost:8080/health");
+        System.out.println(response.getBody());
+        Assert.assertTrue(
+                response.getBody().contains("first") &&
+                        response.getBody().contains("second")
+        );
+
+        // direct / failure
+        response = getUrlContents("http://localhost:8080/rest/v1/failed/first", false);
+        Assert.assertEquals("Expected 503", 503, response.getStatus());
+
+        // direct / sucess
+        response = getUrlContents("http://localhost:8080/rest/v1/failed/second", false);
+        Assert.assertEquals("Expected 200", 200, response.getStatus());
+
+        // aggregator / failed
+        response = getUrlContents("http://localhost:8080/health", true);
+        Assert.assertEquals("Expected 503", 503, response.getStatus());
+        Assert.assertTrue(response.getBody().contains("first") && response.getBody().contains("UP"));
+
+    }
+}


### PR DESCRIPTION
Motivation
----------

Simplify the health check procedurs and update to health check spec 1.0

Modifications
-------------

- common entry point /health (SWARM-514)
- aggregation of results (SWARM-693)
- simplified security

Result
------

User can now provide health checks as before, but an invocation to /health will gather the results from all checks. If security is applied, then it is enforced across all monitoring endpoints and jaxrs resources that act as health checks.