### PR TITLE
SWARM-854: fraction autodetection is hard to debug

### DIFF
--- a/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/PackageTask.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/PackageTask.java
@@ -90,6 +90,11 @@ public class PackageTask extends DefaultTask {
                         .collect(Collectors.toList()))
                 .logger(new BuildTool.SimpleLogger() {
                     @Override
+                    public void debug(String msg) {
+                        getLogger().debug(msg);
+                    }
+
+                    @Override
                     public void info(String msg) {
                         getLogger().info(msg);
                     }

--- a/plugin/src/main/java/org/wildfly/swarm/plugin/maven/PackageMojo.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/maven/PackageMojo.java
@@ -116,6 +116,11 @@ public class PackageMojo extends AbstractSwarmMojo {
                 .hollow(hollow)
                 .logger(new BuildTool.SimpleLogger() {
                     @Override
+                    public void debug(String msg) {
+                        getLog().debug(msg);
+                    }
+
+                    @Override
                     public void info(String msg) {
                         getLog().info(msg);
                     }

--- a/swarmtool/src/main/java/org/wildfly/swarm/swarmtool/Main.java
+++ b/swarmtool/src/main/java/org/wildfly/swarm/swarmtool/Main.java
@@ -67,6 +67,9 @@ public class Main {
     private static final OptionSpec<Void> EXECUTABLE_OPT =
             OPT_PARSER.accepts("executable", "make the swarm jar executable");
 
+    private static final OptionSpec<Void> DEBUG_LOGGING =
+            OPT_PARSER.accepts("debug", "enable debug logging");
+
     private static final OptionSpec<String> FRACTIONS_OPT =
             OPT_PARSER.acceptsAll(asList("f", "fractions"), "swarm fractions to include")
                     .withRequiredArg()
@@ -233,6 +236,9 @@ public class Main {
         }
         if (foundOptions.has(MODULES_OPT)) {
             tool.additionalModules(foundOptions.valuesOf(MODULES_OPT));
+        }
+        if (foundOptions.has(DEBUG_LOGGING)) {
+            tool.logger(BuildTool.STD_LOGGER_WITH_DEBUG);
         }
 
         addSwarmFractions(tool, foundOptions.valuesOf(FRACTIONS_OPT));

--- a/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
@@ -276,6 +276,7 @@ public class BuildTool {
         tmpFile.deleteOnExit();
         this.projectAsset.getArchive().as(ZipExporter.class).exportTo(tmpFile, true);
         final FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer(this.fractionList)
+                .logger(log)
                 .source(tmpFile);
 
         resolvedDependencies.getDependencies().stream()
@@ -539,7 +540,11 @@ public class BuildTool {
         archive.add(new FileAsset(artifact.file), artifactPath.toString());
     }
 
-    private static SimpleLogger STD_LOGGER = new SimpleLogger() {
+    public static final SimpleLogger STD_LOGGER = new SimpleLogger() {
+        @Override
+        public void debug(String msg) {
+        }
+
         @Override
         public void info(String msg) {
             System.out.println(msg);
@@ -557,7 +562,50 @@ public class BuildTool {
         }
     };
 
+    public static final SimpleLogger STD_LOGGER_WITH_DEBUG = new SimpleLogger() {
+        @Override
+        public void debug(String msg) {
+            System.out.println(msg);
+        }
+
+        @Override
+        public void info(String msg) {
+            System.out.println(msg);
+        }
+
+        @Override
+        public void error(String msg) {
+            System.err.println(msg);
+        }
+
+        @Override
+        public void error(String msg, Throwable t) {
+            error(msg);
+            t.printStackTrace();
+        }
+    };
+
+    public static final SimpleLogger NOP_LOGGER = new SimpleLogger() {
+        @Override
+        public void debug(String msg) {
+        }
+
+        @Override
+        public void info(String msg) {
+        }
+
+        @Override
+        public void error(String msg) {
+        }
+
+        @Override
+        public void error(String msg, Throwable t) {
+        }
+    };
+
     public interface SimpleLogger {
+        void debug(String msg);
+
         void info(String msg);
 
         void error(String msg);

--- a/tools/src/main/java/org/wildfly/swarm/tools/ClassAndPackageDetector.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/ClassAndPackageDetector.java
@@ -46,6 +46,11 @@ import org.objectweb.asm.signature.SignatureVisitor;
 
 public class ClassAndPackageDetector {
 
+    public ClassAndPackageDetector logger(BuildTool.SimpleLogger log) {
+        this.log = log;
+        return this;
+    }
+
     public ClassAndPackageDetector detect(final List<File> files) throws IOException {
         for (File f : files) {
             detect(f);
@@ -55,6 +60,8 @@ public class ClassAndPackageDetector {
     }
 
     public ClassAndPackageDetector detect(final File file) throws IOException {
+        log.debug("Scanning " + file);
+
         if (file.isDirectory()) {
             detectInDir(file);
         } else if (file.getName().endsWith(".jar") || file.getName().endsWith(".war")) {
@@ -125,6 +132,8 @@ public class ClassAndPackageDetector {
     }
 
     final private PackageCollector visitor = new PackageCollector();
+
+    private BuildTool.SimpleLogger log = BuildTool.NOP_LOGGER;
 
     static class PackageCollector extends ClassVisitor {
 

--- a/tools/src/main/java/org/wildfly/swarm/tools/FractionUsageAnalyzer.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/FractionUsageAnalyzer.java
@@ -50,13 +50,20 @@ public class FractionUsageAnalyzer {
         return this;
     }
 
+    public FractionUsageAnalyzer logger(final BuildTool.SimpleLogger log) {
+        this.log = log;
+        return this;
+    }
+
     public Set<FractionDescriptor> detectNeededFractions() throws IOException {
         if (this.fractionList == null) {
 
             return Collections.emptySet();
         }
         final Set<FractionDescriptor> specs = new HashSet<>();
-        final ClassAndPackageDetector detector = new ClassAndPackageDetector().detect(this.sources);
+        final ClassAndPackageDetector detector = new ClassAndPackageDetector()
+                .logger(log)
+                .detect(this.sources);
         final Set<String> detectables = new HashSet<>(detector.packages());
         detectables.addAll(detector.classes().stream()
                                    .map(FractionUsageAnalyzer::asClassNameMatch)
@@ -115,6 +122,7 @@ public class FractionUsageAnalyzer {
 
     private final FractionList fractionList;
 
+    private BuildTool.SimpleLogger log = BuildTool.NOP_LOGGER;
 
     private static class StatefulMatcher {
         StatefulMatcher(FractionDescriptor desc, String... matchSpecs) {


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
Currently, fraction autodetection is very opaque process.
One can only see its output, the list of detected fractions.
If the list looks wrong, there's no way to figure out how
the autodetection process came up with it. If the list
of files/directories being scanned would be provided
in a debug log, that would help.

Modifications
-------------
The `BuildTool.SimpleLogger` interface gained a `debug` method.
This is currently only called from `ClassAndPackageDetector.detect`,
but can be possibly used elsewhere too.

The Maven plugin and the Gradle plugin correctly wire up
`SimpleLogger.debug` with their native logging. The Swarmtool
gained a new `--debug` argument to enable debug logging
on standard output.

Result
------
Fraction autodetection can log the input set, which aids debugging.