### PR TITLE
SWARM-857: Secured Ribbon client CNFE

### DIFF
--- a/fractions/netflix/ribbon-secured/src/main/resources/modules/org/wildfly/swarm/netflix/ribbon/secured/client/module.xml
+++ b/fractions/netflix/ribbon-secured/src/main/resources/modules/org/wildfly/swarm/netflix/ribbon/secured/client/module.xml
@@ -5,7 +5,7 @@
 
   <dependencies>
     <module name="org.wildfly.swarm.netflix.ribbon"/>
-    <module name="org.wildfly.swarm.keycloak" slot="runtime"/>
+    <module name="org.wildfly.swarm.keycloak" slot="deployment"/>
     <module name="org.keycloak.keycloak-core"/>
     <module name="com.netflix.ribbon"/>
     <module name="io.reactivex.rxnetty"/>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
Using the secured Ribbon client gets a ClassNotFoundException for KeycloakSecurityContextAssociation when attempting to propagate the Bearer Token from Keycloak to a subsequent call.

This results in the security context not being present on a subsequent call.

Modifications
-------------
ribbon.secured:client module incorrectly had a dependency on swarm.keycloak:runtime instead of :deployment.

Result
------
No longer an exception when propagating bearer token between calls and security context is available.