### PR TITLE
SWARM-853 and SWARM-864

### DIFF
--- a/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/DriverInfo.java
+++ b/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/DriverInfo.java
@@ -17,9 +17,13 @@ package org.wildfly.swarm.datasources.runtime;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.jar.JarFile;
 
@@ -189,6 +193,8 @@ public abstract class DriverInfo {
                 locationStr = locationStr.substring(0, bangLoc);
             }
 
+            locationStr = getPlatformPath(locationStr);
+
             File locationFile = Paths.get(locationStr).toFile();
 
             return locationFile;
@@ -197,6 +203,19 @@ public abstract class DriverInfo {
         }
 
         return null;
+    }
+
+    protected String getPlatformPath(String path) {
+        if (!isWindows()) {
+            return path;
+        }
+
+        URI uri = URI.create("file://" + path);
+        return Paths.get(uri).toString();
+    }
+
+    protected boolean isWindows() {
+        return System.getProperty("os.name").toLowerCase().contains("win");
     }
 
     public boolean isInstalled() {
@@ -214,4 +233,5 @@ public abstract class DriverInfo {
             config.accept(ds);
         });
     }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   </scm>
 
   <properties>
-    <version.wildfly.swarm.fraction.plugin>38</version.wildfly.swarm.fraction.plugin>
+    <version.wildfly.swarm.fraction.plugin>39</version.wildfly.swarm.fraction.plugin>
 
     <version.cdi2>2.0.Alpha4</version.cdi2>
     <version.org.snakeyaml>1.17</version.org.snakeyaml>


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----

SWARM-853 - Make @DefaultDeployment work on Windows.
SWARM-864 - BYO JDBC and Windows paths.

Motivation
----------

Because some non-zero percentage of the world uses Windows,
we should ensure our slash-handling is generally well-behaved.

Modifications
-------------

Handle Windows file: URLs better in conversion from code source
location to things-on-disk.  Additionally, handle the correcting
of slashes to java-centric when dictating the final location
within the @DefaultDeployment archive.

Result
------

@DefaultDeployment and BYO JDBC driver now work on Windows.