### PR TITLE
SWARM-843: Wrong default port number for the legacy remoting connector

### DIFF
--- a/fractions/javaee/remoting/src/main/java/org/wildfly/swarm/remoting/RemotingFraction.java
+++ b/fractions/javaee/remoting/src/main/java/org/wildfly/swarm/remoting/RemotingFraction.java
@@ -63,5 +63,5 @@ public class RemotingFraction extends Remoting<RemotingFraction> implements Frac
     public int port() {
         return this.port.get();
     }
-    private Defaultable<Integer> port = integer(4777);
+    private Defaultable<Integer> port = integer(4447);
 }

--- a/fractions/javaee/remoting/src/main/java/org/wildfly/swarm/remoting/runtime/RemotingLegacyConnectorCustomizer.java
+++ b/fractions/javaee/remoting/src/main/java/org/wildfly/swarm/remoting/runtime/RemotingLegacyConnectorCustomizer.java
@@ -19,7 +19,7 @@ import org.wildfly.swarm.spi.runtime.annotations.Post;
  * <p>In the event {@link RemotingFraction#requireLegacyConnector(boolean)}</p> has been
  * set to <code>true</code> or if configuration property <code>swarm.remoting.port</code>
  * is set to any value, this customizer will install a socket-binding named
- * <code>legacy-remoting</code> for port <code>4777</code> or whatever value
+ * <code>legacy-remoting</code> for port <code>4447</code> or whatever value
  * configuration property <code>swarm.remoting.port</code> is set to.</p>
  *
  * @author Bob McWhirter
@@ -40,7 +40,7 @@ public class RemotingLegacyConnectorCustomizer implements Customizer {
     @Override
     public void customize() {
         if (this.remoting.isRequireLegacyConnector() ) {
-            LOG.info("Remoting installed but Undertnow not available. Enabled legacy connector on port 4777.");
+            LOG.info("Remoting installed but Undertnow not available. Enabled legacy connector on port 4447.");
             this.remoting.connector("legacy", (connector) -> {
                 connector.socketBinding("legacy-remoting");
             });

--- a/fractions/javaee/remoting/src/main/java/org/wildfly/swarm/remoting/runtime/RemotingLegacyConnectorCustomizer.java
+++ b/fractions/javaee/remoting/src/main/java/org/wildfly/swarm/remoting/runtime/RemotingLegacyConnectorCustomizer.java
@@ -40,7 +40,7 @@ public class RemotingLegacyConnectorCustomizer implements Customizer {
     @Override
     public void customize() {
         if (this.remoting.isRequireLegacyConnector() ) {
-            LOG.info("Remoting installed but Undertnow not available. Enabled legacy connector on port 4447.");
+            LOG.info("Remoting installed but Undertow not available. Enabled legacy connector on port 4447.");
             this.remoting.connector("legacy", (connector) -> {
                 connector.socketBinding("legacy-remoting");
             });

--- a/testsuite/testsuite-jmx-remote-remoting/src/test/java/org/wildfly/swarm/jmx/JMXRemoteManagementAutoEndpointArquillianTest.java
+++ b/testsuite/testsuite-jmx-remote-remoting/src/test/java/org/wildfly/swarm/jmx/JMXRemoteManagementAutoEndpointArquillianTest.java
@@ -60,7 +60,7 @@ public class JMXRemoteManagementAutoEndpointArquillianTest {
     @Test
     @RunAsClient
     public void testRemoteConnection() throws Exception {
-        String urlString = "service:jmx:remote://localhost:4777";
+        String urlString = "service:jmx:remote://localhost:4447";
 
         JMXServiceURL serviceURL = new JMXServiceURL(urlString);
         JMXConnector jmxConnector = JMXConnectorFactory.connect(serviceURL, null);

--- a/testsuite/testsuite-jmx-remote-remoting/src/test/java/org/wildfly/swarm/jmx/JMXRemoteNonManagementEndpointArquillianTest.java
+++ b/testsuite/testsuite-jmx-remote-remoting/src/test/java/org/wildfly/swarm/jmx/JMXRemoteNonManagementEndpointArquillianTest.java
@@ -63,7 +63,7 @@ public class JMXRemoteNonManagementEndpointArquillianTest {
     @Test
     @RunAsClient
     public void testRemoteConnection() throws Exception {
-        String urlString = "service:jmx:remote://localhost:4777";
+        String urlString = "service:jmx:remote://localhost:4447";
 
         JMXServiceURL serviceURL = new JMXServiceURL(urlString);
         JMXConnector jmxConnector = JMXConnectorFactory.connect(serviceURL, null);


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
The remoting connector used wrong port for legacy systems

Modifications
-------------
Update the port number and java docs

Result
------
The legacy connector uses 4447 as the port number