### PR TITLE
SWARM-779 - Classes in **.deployment.* being warned about by Weld.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   </scm>
 
   <properties>
-    <version.wildfly.swarm.fraction.plugin>39</version.wildfly.swarm.fraction.plugin>
+    <version.wildfly.swarm.fraction.plugin>40</version.wildfly.swarm.fraction.plugin>
 
     <version.cdi2>2.0.Alpha4</version.cdi2>
     <version.org.snakeyaml>1.17</version.org.snakeyaml>


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------

The warnings are loud, and useless.

Modifications
-------------

Pre-create the jandex index from the fraction plugin, and
explicitly exclude the .deployment.* package when indexing.
Weld then trusts us.

Result
------

Less noise!  Better performance! Clearer skin!  You may or
may not become taller.