### PR TITLE
SWARM-879: Maven is missing auth. for mirrors

### DIFF
--- a/plugin/src/main/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelper.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelper.java
@@ -194,7 +194,18 @@ public class MavenArtifactResolvingHelper implements ArtifactResolvingHelper {
         RemoteRepository mirror = session.getMirrorSelector().getMirror(repository);
 
         if (mirror != null) {
-            repository = mirror;
+            builder = new RemoteRepository.Builder(mirror);
+          
+            // the authentication is not automatically copied to the mirror
+            if (auth != null
+                && auth.getUsername() != null
+                && auth.getPassword() != null) {
+                builder.setAuthentication(new AuthenticationBuilder()
+                        .addUsername(auth.getUsername())
+                        .addPassword(auth.getPassword()).build());
+            }
+        
+            repository = builder.build();
         }
 
         Proxy proxy = session.getProxySelector().getProxy(repository);


### PR DESCRIPTION
Motivation
----------
Maven builds with mirrors that need authentication are failing since
release 2016.11.0.

Modifications
-------------
Maven plugin mirror resolution, especially the authentication part.

Result
------
Maven builds with mirrors that need authentication are working again.