### PR TITLE
SWARM-817: wildfly-swarm:run does not work for dependencies added with DependenciesContainer.addAllDependencies()

### DIFF
--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/GradleDependencyAdapter.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/GradleDependencyAdapter.java
@@ -20,16 +20,29 @@ import java.nio.file.Path;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Scanner;
+import java.util.Stack;
 
 import org.gradle.tooling.GradleConnector;
 import org.gradle.tooling.ProjectConnection;
 import org.gradle.tooling.model.GradleProject;
+import org.wildfly.swarm.tools.ArtifactSpec;
+import org.wildfly.swarm.tools.DeclaredDependencies;
 
 /**
+ * A very naive way to get access the gradle dependency information.
+ *
  * @author Heiko Braun
  * @since 19/10/16
  */
 public class GradleDependencyAdapter {
+
+    private static final String PREFIX1 = "+---";
+
+    private static final String PREFIX2 = "\\---";
+
+    private static final String PROJECT = "project";
+
+    private static final String COLON = ":";
 
     /**
      * A gradle build configuration reference
@@ -53,11 +66,7 @@ public class GradleDependencyAdapter {
         this.rootPath = projectDir;
     }
 
-    public List<String> parseDependencies() {
-        return parseDependencies(Configuration.RUNTIME);
-    }
-
-    public List<String> parseDependencies(Configuration configuration) {
+    public DeclaredDependencies parseDependencies(Configuration configuration) {
         System.out.println(rootPath);
 
         GradleConnector connector = GradleConnector.newConnector()
@@ -76,49 +85,76 @@ public class GradleDependencyAdapter {
 
 
         // parse
+        DeclaredDependencies declaredDependencies = new DeclaredDependencies();
 
         String deps = new String(bout.toByteArray());
-        List<String> coordinates = new LinkedList<String>();
+
         Scanner scanner = new Scanner(deps);
 
         while (scanner.hasNextLine()) {
             String line = scanner.nextLine();
-            if(line.contains(PREFIX)) {
-                line = line.substring(line.indexOf(PREFIX) + PREFIX.length(), line.length());
 
-                if(line.endsWith(SUFFIX)) {
-                    line = line.substring(0, line.indexOf(SUFFIX));
-                }
+            // top level deps
+            if(line.startsWith(PREFIX1)
+                    || line.startsWith(PREFIX2)) {
 
-                if(line.startsWith("project")) // Always skip 'project' dependencies.
+                if(stack.size()>0)
+                    stack.pop();
+
+                // parse
+                line = parseLine(line);
+                String coord = parseCoordinate(line);
+                ArtifactSpec parent = DeclaredDependencies.createSpec(coord);
+                declaredDependencies.add(parent);
+                stack.push(parent);
+            }
+
+            // transient
+            else if(line.contains(PREFIX)) {
+                line = parseLine(line);
+
+                if(line.startsWith(PROJECT)) // Always skip 'project' dependencies.
                     continue;
 
-                String[] coords = line.split(":");
-                if(3==coords.length) {
-                    String version = coords[2];
-                    if(version.contains(VERSION_UP)) {
-                        String s = coords[0]+":"+coords[1]+":"+ version.substring(version.indexOf(VERSION_UP)+VERSION_UP.length(), version.length());
-                        coordinates.add(s);
-                    } else {
-                        coordinates.add(line);
-                    }
-                } else {
-                    throw new IllegalArgumentException("Unexpected input format");
-                }
-
-
+                String coord = parseCoordinate(line);
+                declaredDependencies.add(stack.peek(), DeclaredDependencies.createSpec(coord));
 
             }
         }
 
         scanner.close();
 
-        return coordinates;
+        return declaredDependencies;
+    }
+
+    private String parseCoordinate(String line) {
+        String[] coords = line.split(COLON);
+        if(3==coords.length) {
+            String version = coords[2];
+            if(version.contains(VERSION_UP)) {
+                String s = coords[0]+":"+coords[1]+":"+ version.substring(version.indexOf(VERSION_UP)+VERSION_UP.length(), version.length());
+                return s;
+            } else {
+                return line;
+            }
+        } else {
+            throw new IllegalArgumentException("Unexpected input format");
+        }
+    }
+
+    private String parseLine(String line) {
+        line = line.substring(line.indexOf(PREFIX) + PREFIX.length(), line.length());
+
+        if(line.endsWith(SUFFIX)) {
+            line = line.substring(0, line.indexOf(SUFFIX));
+        }
+        return line;
     }
 
     private static final String PREFIX = "--- ";
     private static final String SUFFIX = " (*)";
     private static final String VERSION_UP = "-> ";
 
+    private Stack<ArtifactSpec> stack = new Stack<>();
     private Path rootPath;
 }

--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/GradleDependencyDeclarationFactory.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/GradleDependencyDeclarationFactory.java
@@ -16,9 +16,6 @@
 package org.wildfly.swarm.arquillian.adapter;
 
 import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.wildfly.swarm.arquillian.resolver.ShrinkwrapArtifactResolvingHelper;
 import org.wildfly.swarm.internal.FileSystemLayout;
@@ -37,23 +34,13 @@ public class GradleDependencyDeclarationFactory extends DependencyDeclarationFac
 
     @Override
     public DeclaredDependencies create(ShrinkwrapArtifactResolvingHelper resolvingHelper) {
-        DeclaredDependencies declaredDependencies = new DeclaredDependencies();
 
         GradleDependencyAdapter gradleAdapter = new GradleDependencyAdapter(fsLayout.getRootPath());
 
-        List<String> coordinates = gradleAdapter.parseDependencies(GradleDependencyAdapter.Configuration.TEST_RUNTIME);
-        List<ArtifactSpec> specs = coordinates.stream()
-                .map(c -> ArtifactSpec.fromMscGav(c))
-                .collect(Collectors.toList());
+        DeclaredDependencies declaredDependencies = gradleAdapter.parseDependencies(GradleDependencyAdapter.Configuration.TEST_RUNTIME);
 
-        Set<ArtifactSpec> artifactSpecs = resolvingHelper.resolveAll(new HashSet<ArtifactSpec>(specs), false, false);
-
-        for (ArtifactSpec artefact : artifactSpecs) {
-            if(null==artefact.file)
-                throw new RuntimeException("Artifact file not resolved");
-            declaredDependencies.addExplicitDependency(artefact);
-            //dependency.presolvedDependency(artefact);
-        }
+        // resolve to local files
+        resolvingHelper.resolveAll(new HashSet<ArtifactSpec>(declaredDependencies.getTransientDependencies()), false, false);
 
         return declaredDependencies;
     }

--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
@@ -250,6 +250,7 @@ public class UberjarSimpleContainer implements SimpleContainer {
     private void munge(DependenciesContainer depContainer, DeclaredDependencies declaredDependencies) {
 
         for(ArtifactSpec artifact : declaredDependencies.getExplicitDependencies()) { // [hb] TODO: this should actually be transient deps
+            assert artifact.file!=null : "artifact.file cannot be null at this point: "+artifact;
             depContainer.addAsLibraries(artifact.file);
         }
 

--- a/arquillian/arquillian/pom.xml
+++ b/arquillian/arquillian/pom.xml
@@ -38,6 +38,7 @@
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>container</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/DependencyTree.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/DependencyTree.java
@@ -1,0 +1,53 @@
+package org.wildfly.swarm.bootstrap.env;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Each direct dependency (parent) keeps a bucket of transient dependencies (children)
+ * so we can infer the origin (parent) for each transient dependency.
+ *
+ * @author Heiko Braun
+ * @since 05/12/2016
+ */
+public class DependencyTree<T> {
+
+    /**
+     * A transient dependencies linked ot a parent (origin)
+     * @param parent
+     */
+    public void add(T parent, T child) {
+        if(!depTree.keySet().contains(parent)) {
+            depTree.put(parent, new HashSet<>());
+        }
+        if(!child.equals(parent))
+            depTree.get(parent).add(child);
+    }
+
+
+    /**
+     * Direct dep without any transient dependencies
+     * @param parent
+     */
+    public void add(T parent) {
+        if(!depTree.keySet().contains(parent)) {
+            depTree.put(parent, new HashSet<>());
+        }
+    }
+
+    public Set<T> getDirectDeps() {
+        return depTree.keySet();
+    }
+
+    public Set<T> getTransientDeps(T parent) {
+        Set<T> deps = depTree.get(parent);
+        if(null==deps)
+            throw new IllegalArgumentException("Unknown dependency "+parent);
+        return deps;
+    }
+
+    protected Map<T,Set<T>> depTree = new HashMap<>();
+
+}

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/SystemDependencyResolution.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/SystemDependencyResolution.java
@@ -11,7 +11,6 @@ import java.util.stream.Collectors;
 
 
 /**
- * [hb] TODO: rename to SystemDependencies
  * @author Heiko Braun
  * @since 18/07/16
  */
@@ -19,9 +18,6 @@ public class SystemDependencyResolution implements DependencyResolution {
 
 
     public SystemDependencyResolution() {
-
-        System.out.println("<< Thread - SystemDependencyResolution : "+Thread.currentThread()+">>");
-
         final String classpathProp = System.getProperty("java.class.path");
         final String javaHomProp = System.getProperty("java.home");
         final String userDirProp = System.getProperty("user.dir");
@@ -32,13 +28,6 @@ public class SystemDependencyResolution implements DependencyResolution {
 
         this.pwd = userDirProp;
         this.javaHome = javaHomProp.endsWith(JRE) ? javaHomProp.substring(0, javaHomProp.lastIndexOf(JRE)) : javaHomProp;
-    }
-
-    SystemDependencyResolution(List<String> classpath, String javaHome, String pwd, List<String> testClasspath) {
-        this.classpath = classpath;
-        this.pwd = pwd;
-        this.javaHome = javaHome.endsWith(JRE) ? javaHome.substring(0, javaHome.lastIndexOf(JRE)) : javaHome;
-        this.testClasspath = testClasspath;
     }
 
     @Override
@@ -99,4 +88,5 @@ public class SystemDependencyResolution implements DependencyResolution {
     final String pwd;
 
     final List<String> testClasspath;
+
 }

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/util/MavenArtifactDescriptor.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/util/MavenArtifactDescriptor.java
@@ -67,7 +67,10 @@ public class MavenArtifactDescriptor implements Comparable<MavenArtifactDescript
             return new MavenArtifactDescriptor(parts[0], parts[1], parts[2], null, parts[3]);
         } else if (parts.length == 5) {
             return new MavenArtifactDescriptor(parts[0], parts[1], parts[2], parts[3], parts[4]);
-        } else {
+        } else if (parts.length == 6) {
+            return new MavenArtifactDescriptor(parts[0], parts[1], parts[2], parts[3], parts[4]);
+        }
+        else {
             throw new IOException("Invalid gav: " + gav);
         }
 

--- a/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
@@ -329,7 +329,7 @@ public class BuildTool {
                                       .sorted()
                                       .collect(Collectors.toList())));
 
-        allFractions.forEach(f -> this.declaredDependencies.addExplicitDependency(f));
+        allFractions.forEach(f -> this.declaredDependencies.add(f));
         analyzeDependencies(true);
     }
 

--- a/tools/src/main/java/org/wildfly/swarm/tools/DependencyManager.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/DependencyManager.java
@@ -189,7 +189,7 @@ public class DependencyManager implements ResolvedDependencies {
 
     }
 
-    private void analyzeModuleDependencies(DeclaredDependencies artifactReport) {
+    private void analyzeModuleDependencies(DeclaredDependencies declaredDependencies) {
         this.dependencies.stream()
                 .filter(e -> e.type().equals(JAR))
                 .map(e -> e.file)
@@ -202,6 +202,9 @@ public class DependencyManager implements ResolvedDependencies {
         this.moduleDependencies.addAll(analyzer.getDependencies());
     }
 
+    /**
+     * Removable are basically all dependencies that are brought in by fractions.
+     */
     private void analyzeRemovableDependencies(DeclaredDependencies declaredDependencies) throws Exception {
 
         Set<ArtifactSpec> bootstrapDeps = this.dependencies.stream()
@@ -227,7 +230,7 @@ public class DependencyManager implements ResolvedDependencies {
 
     }
 
-    private void analyzeFractionManifests(DeclaredDependencies artifactReport) {
+    private void analyzeFractionManifests(DeclaredDependencies declaredDependencies) {
         this.dependencies.stream()
                 .map(e -> fractionManifest(e.file))
                 .filter(e -> e != null)

--- a/tools/src/test/java/org/wildfly/swarm/tools/DependencyManagerTest.java
+++ b/tools/src/test/java/org/wildfly/swarm/tools/DependencyManagerTest.java
@@ -50,12 +50,9 @@ public class DependencyManagerTest {
     public void testNoSwarmJars() throws Exception {
         // Explicitly asked-for dependencies are also the full resolved tree
         DeclaredDependencies declaredDependencies = new DeclaredDependencies();
-        declaredDependencies.addExplicitDependency(JAXRS_SPEC);
-        declaredDependencies.addExplicitDependency(COMMON_DEP);
 
-        declaredDependencies.addTransientDependency(JAXRS_SPEC);
-        declaredDependencies.addTransientDependency(COMMON_DEP);
-        declaredDependencies.addTransientDependency(SERVLET_SPEC);
+        declaredDependencies.add(JAXRS_SPEC, SERVLET_SPEC);
+        declaredDependencies.add(COMMON_DEP);
 
         manager.analyzeDependencies(false, declaredDependencies);
         assertThat(manager.getRemovableDependencies()).isEmpty();
@@ -78,16 +75,14 @@ public class DependencyManagerTest {
     public void testAutodetectedSwarmJar() throws Exception {
         // Explicitly asked-for dependencies are also the full resolved tree
         DeclaredDependencies declaredDependencies = new DeclaredDependencies();
-        declaredDependencies.addExplicitDependency(JAXRS_SPEC);
-        declaredDependencies.addExplicitDependency(COMMON_DEP);
 
-        // auto-detected, not pre-solved
-        declaredDependencies.addExplicitDependency(JAXRS_FRACTION);
+        declaredDependencies.add(JAXRS_SPEC, SERVLET_SPEC);
+        declaredDependencies.add(COMMON_DEP);
 
-        declaredDependencies.addTransientDependency(UNDERTOW_FRACTION);
-        declaredDependencies.addTransientDependency(JAXRS_SPEC);
-        declaredDependencies.addTransientDependency(SERVLET_SPEC);
-        declaredDependencies.addTransientDependency(COMMON_DEP);
+        declaredDependencies.add(JAXRS_FRACTION, JAXRS_SPEC);
+        declaredDependencies.add(JAXRS_FRACTION, COMMON_DEP);
+        declaredDependencies.add(JAXRS_FRACTION, UNDERTOW_FRACTION);
+        declaredDependencies.add(JAXRS_SPEC, SERVLET_SPEC);
 
         manager.analyzeDependencies(true, declaredDependencies);
         assertThat(manager.getRemovableDependencies()).containsOnly(JAXRS_FRACTION, UNDERTOW_FRACTION);
@@ -109,17 +104,14 @@ public class DependencyManagerTest {
     public void testAutodetectedSwarmJarNoExplicitCommon() throws Exception {
         // Explicitly asked-for dependencies are also the full resolved tree
         DeclaredDependencies declaredDependencies = new DeclaredDependencies();
-        declaredDependencies.addExplicitDependency(JAXRS_SPEC);
 
-        // auto-detected, not pre-solved
-        declaredDependencies.addExplicitDependency(JAXRS_FRACTION);
+        declaredDependencies.add(JAXRS_SPEC, SERVLET_SPEC);
 
-        declaredDependencies.addTransientDependency(UNDERTOW_FRACTION);
-        declaredDependencies.addTransientDependency(SERVLET_SPEC);
-        declaredDependencies.addTransientDependency(COMMON_DEP);
+        declaredDependencies.add(JAXRS_FRACTION, JAXRS_SPEC);
+        declaredDependencies.add(JAXRS_FRACTION, COMMON_DEP);
+        declaredDependencies.add(JAXRS_FRACTION, UNDERTOW_FRACTION);
+        declaredDependencies.add(JAXRS_SPEC, SERVLET_SPEC);
 
-        declaredDependencies.addTransientDependency(JAXRS_SPEC);
-        declaredDependencies.addTransientDependency(SERVLET_SPEC);
 
         manager.analyzeDependencies(true, declaredDependencies);
         assertThat(manager.getRemovableDependencies()).containsOnly(JAXRS_FRACTION, UNDERTOW_FRACTION, COMMON_DEP);
@@ -138,13 +130,12 @@ public class DependencyManagerTest {
     public void testWithSwarmJarBeingOnlyUserOfDep() throws Exception {
         // Only :jaxrs is the explicit resolved tree, but brings in jaxrs-spec and common dep
         DeclaredDependencies declaredDependencies = new DeclaredDependencies();
-        declaredDependencies.addExplicitDependency(JAXRS_FRACTION);
 
-        declaredDependencies.addTransientDependency(JAXRS_FRACTION);
-        declaredDependencies.addTransientDependency(JAXRS_SPEC);
-        declaredDependencies.addTransientDependency(UNDERTOW_FRACTION);
-        declaredDependencies.addTransientDependency(SERVLET_SPEC);
-        declaredDependencies.addTransientDependency(COMMON_DEP);
+        declaredDependencies.add(JAXRS_FRACTION, JAXRS_SPEC);
+        declaredDependencies.add(JAXRS_FRACTION, COMMON_DEP);
+        declaredDependencies.add(JAXRS_FRACTION, UNDERTOW_FRACTION);
+        declaredDependencies.add(JAXRS_FRACTION, SERVLET_SPEC);
+
         manager.analyzeDependencies(false, declaredDependencies);
 
         assertThat(manager.getRemovableDependencies()).containsOnly(JAXRS_FRACTION, JAXRS_SPEC, UNDERTOW_FRACTION, SERVLET_SPEC, COMMON_DEP);
@@ -161,14 +152,14 @@ public class DependencyManagerTest {
     public void testWithApplicationAlsoUsingDep() throws Exception {
         // :jaxrs and common dep are explicit, implying application needs common
         DeclaredDependencies declaredDependencies = new DeclaredDependencies();
-        declaredDependencies.addExplicitDependency(JAXRS_FRACTION);
-        declaredDependencies.addExplicitDependency(COMMON_DEP);
 
-        declaredDependencies.addTransientDependency(JAXRS_FRACTION);
-        declaredDependencies.addTransientDependency(JAXRS_SPEC);
-        declaredDependencies.addTransientDependency(UNDERTOW_FRACTION);
-        declaredDependencies.addTransientDependency(SERVLET_SPEC);
-        declaredDependencies.addTransientDependency(COMMON_DEP);
+        declaredDependencies.add(JAXRS_FRACTION, JAXRS_SPEC);
+        declaredDependencies.add(JAXRS_FRACTION, COMMON_DEP);
+        declaredDependencies.add(JAXRS_FRACTION, UNDERTOW_FRACTION);
+        declaredDependencies.add(JAXRS_FRACTION, SERVLET_SPEC);
+
+        declaredDependencies.add(COMMON_DEP);
+
 
         manager.analyzeDependencies(false, declaredDependencies);
         assertThat(manager.getRemovableDependencies()).containsOnly(JAXRS_FRACTION, JAXRS_SPEC, UNDERTOW_FRACTION, SERVLET_SPEC);


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

- Shared dependency information between maven plugin and process started from process builder (i.e swarm:run)
- Use a bucket based approach to declared dependencies (easier to reason about the origin of a transient dep)