### PR TITLE
SWARM-884: Dependencies with a classifier are found by ApplicationModuleFinder

### DIFF
--- a/core/bootstrap/pom.xml
+++ b/core/bootstrap/pom.xml
@@ -104,6 +104,12 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.2.28</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/core/bootstrap/pom.xml
+++ b/core/bootstrap/pom.xml
@@ -104,12 +104,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>2.2.28</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
 </project>

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/ApplicationModuleFinder.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/ApplicationModuleFinder.java
@@ -157,7 +157,7 @@ public class ApplicationModuleFinder extends AbstractSingleModuleFinder {
                     if ( parts.length == 4 ) {
                         coords = new ArtifactCoordinates( parts[0], parts[1], parts[3] );
                     } else if ( parts.length == 5 ) {
-                        coords = new ArtifactCoordinates( parts[0], parts[1], parts[3], parts[4] );
+                        coords = new ArtifactCoordinates( parts[0], parts[1], parts[4], parts[3] );
                     }
                     try {
                         File artifact = MavenResolvers.get().resolveJarArtifact(coords);

--- a/core/bootstrap/src/test/java/org/wildfly/swarm/bootstrap/modules/ApplicationModuleFinderTest.java
+++ b/core/bootstrap/src/test/java/org/wildfly/swarm/bootstrap/modules/ApplicationModuleFinderTest.java
@@ -1,0 +1,49 @@
+package org.wildfly.swarm.bootstrap.modules;
+
+import java.util.Collections;
+
+import org.jboss.modules.ModuleSpec;
+import org.junit.Test;
+import org.wildfly.swarm.bootstrap.env.ApplicationEnvironment;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test {@link ApplicationModuleFinder}
+ *
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+public class ApplicationModuleFinderTest {
+
+    @Test
+    public void testDependency() {
+        // Mocks
+        ApplicationEnvironment env = mock(ApplicationEnvironment.class);
+        when(env.getDependencies()).thenReturn(Collections.singletonList("org.jboss.forge.addon:ui-spi:jar:3.4.0.Final"));
+
+        ModuleSpec.Builder builder = mock(ModuleSpec.Builder.class);
+
+        ApplicationModuleFinder sut = new ApplicationModuleFinder();
+        sut.addDependencies(builder, env);
+
+        verify(builder, times(1)).addResourceRoot(any());
+    }
+
+    @Test
+    public void testDependencyHasClassifier() {
+        // Mocks
+        ApplicationEnvironment env = mock(ApplicationEnvironment.class);
+        when(env.getDependencies()).thenReturn(Collections.singletonList("org.jboss.forge.addon:ui-spi:jar:forge-addon:3.4.0.Final"));
+
+        ModuleSpec.Builder builder = mock(ModuleSpec.Builder.class);
+
+        ApplicationModuleFinder sut = new ApplicationModuleFinder();
+        sut.addDependencies(builder, env);
+
+        verify(builder, times(1)).addResourceRoot(any());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
     <version.org.objectweb.asm>5.0.4</version.org.objectweb.asm>
     <version.fest-assert>1.4</version.fest-assert>
     <version.junit>4.12</version.junit>
+    <version.mockito>2.2.28</version.mockito>
 
     <version.jolokia>1.3.4</version.jolokia>
     <version.io.swagger>1.5.5</version.io.swagger>
@@ -230,6 +231,11 @@
       <artifactId>fest-assert</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <dependencyManagement>
@@ -335,6 +341,12 @@
         <groupId>org.easytesting</groupId>
         <artifactId>fest-assert</artifactId>
         <version>${version.fest-assert}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${version.mockito}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
Having a project with a dependency containing a classifier outputs the following error when starting up :

    Tue Dec 06 10:58:18 BRST 2016 ERROR [org.wildfly.swarm.modules.application] (main) Unable to find artifact for org.jboss.forge.addon:ui-spi:forge-addon:3.4.0.Final

Modifications
-------------
ApplicationModuleFinder is assigning the wrong values to the ArtifactCoordinates(final String groupId, final String artifactId, final String version, final String classifier) constructor

Result
------
Error message is no longer shown.