### PR TITLE
SWARM-882: Generate keycloak.json from System properties

### DIFF
--- a/fractions/keycloak/module.conf
+++ b/fractions/keycloak/module.conf
@@ -1,9 +1,12 @@
 org.wildfly.swarm.undertow
 io.undertow.servlet
 io.undertow.core
+org.keycloak.keycloak-core
 org.keycloak.keycloak-undertow-adapter
 org.keycloak.keycloak-adapter-subsystem
 org.keycloak.keycloak-jboss-adapter-core
 org.keycloak.keycloak-wildfly-adapter
 javax.servlet.api
+com.fasterxml.jackson.core.jackson-databind
+com.fasterxml.jackson.core.jackson-annotations
 

--- a/fractions/keycloak/src/main/java/org/wildfly/swarm/keycloak/internal/KeycloakJsonGenerator.java
+++ b/fractions/keycloak/src/main/java/org/wildfly/swarm/keycloak/internal/KeycloakJsonGenerator.java
@@ -1,0 +1,103 @@
+package org.wildfly.swarm.keycloak.internal;
+
+import java.beans.IntrospectionException;
+import java.beans.PropertyDescriptor;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.keycloak.representations.adapters.config.AdapterConfig;
+import org.keycloak.representations.adapters.config.BaseAdapterConfig;
+import org.keycloak.representations.adapters.config.BaseRealmConfig;
+
+class KeycloakJsonGenerator {
+
+    static final String PREFIX = "swarm.keycloak.adapter-config.";
+
+    private static final Set<String> REQUESTED_ADAPTER_CONFIGS;
+
+    static {
+        REQUESTED_ADAPTER_CONFIGS = System.getProperties().keySet().stream()
+                .map(Object::toString)
+                .filter(key -> key.startsWith(PREFIX))
+                .map(key -> key.substring(PREFIX.length()))
+                .collect(Collectors.toSet());
+    }
+
+    static InputStream generate() {
+        byte[] keycloakJson = null;
+        try {
+            keycloakJson = new ObjectMapper()
+                    .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                    .writeValueAsBytes(setupAdapterConfig());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return new ByteArrayInputStream(keycloakJson);
+    }
+
+    private static AdapterConfig setupAdapterConfig() throws IntrospectionException, InvocationTargetException, IllegalAccessException {
+        AdapterConfig adapterConfig = new AdapterConfig();
+
+        for (Map.Entry<String, Field> config : populateAllAdapterConfigs().entrySet()) {
+            String json = config.getKey();
+            Field field = config.getValue();
+
+            PropertyDescriptor property = new PropertyDescriptor(field.getName(), adapterConfig.getClass());
+            set(adapterConfig, json, field.getType(), property.getWriteMethod());
+        }
+
+        return adapterConfig;
+    }
+
+    private static Map<String, Field> populateAllAdapterConfigs() {
+        Map<String, Field> allAdapterConfigs = new HashMap<>();
+
+        Arrays.asList(BaseRealmConfig.class, BaseAdapterConfig.class, AdapterConfig.class).forEach(config -> {
+            for (Field field : config.getDeclaredFields()) {
+                allAdapterConfigs.put(field.getAnnotation(JsonProperty.class).value(), field);
+            }
+        });
+
+        return allAdapterConfigs;
+    }
+
+    private static void set(AdapterConfig adapterConfig, String json, Class<?> type, Method setter) throws IllegalAccessException, InvocationTargetException {
+        if (! REQUESTED_ADAPTER_CONFIGS.contains(json)) {
+            return;
+        }
+
+        if (type == boolean.class || type == Boolean.class) {
+            setter.invoke(adapterConfig, Boolean.valueOf(System.getProperty(PREFIX + json)));
+            return;
+        }
+
+        if (type == int.class  || type == Integer.class) {
+            setter.invoke(adapterConfig, Integer.valueOf(System.getProperty(PREFIX + json)));
+            return;
+        }
+
+        if (type == Map.class) {
+            String[] pairs = System.getProperty(PREFIX + json).split(",");
+            Map<String, Object> map = new HashMap<>();
+            for (String pair : pairs) {
+                map.put(pair.split("=")[0].trim(), pair.split("=")[1].trim());
+            }
+            setter.invoke(adapterConfig, map);
+            return;
+        }
+
+        setter.invoke(adapterConfig, System.getProperty(PREFIX + json));
+    }
+
+}

--- a/fractions/keycloak/src/main/java/org/wildfly/swarm/keycloak/internal/SecuredImpl.java
+++ b/fractions/keycloak/src/main/java/org/wildfly/swarm/keycloak/internal/SecuredImpl.java
@@ -95,8 +95,8 @@ public class SecuredImpl extends AssignableBase<ArchiveBase<?>> implements Secur
 
         if (keycloakJson != null) {
             getArchive().as(JARArchive.class).add(createAsset(keycloakJson), "WEB-INF/keycloak.json");
-        } else {
-            // not adding it.
+        } else if (Boolean.valueOf(System.getProperty(KeycloakJsonGenerator.PREFIX + "generated"))) {
+            getArchive().as(JARArchive.class).add(createAsset(KeycloakJsonGenerator.generate()), "WEB-INF/keycloak.json");
         }
     }
 

--- a/fractions/keycloak/src/test/java/org/wildfly/swarm/keycloak/internal/KeycloakJsonGeneratorTest.java
+++ b/fractions/keycloak/src/test/java/org/wildfly/swarm/keycloak/internal/KeycloakJsonGeneratorTest.java
@@ -1,0 +1,52 @@
+package org.wildfly.swarm.keycloak.internal;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.keycloak.representations.adapters.config.AdapterConfig;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.wildfly.swarm.keycloak.internal.KeycloakJsonGenerator.PREFIX;
+
+public class KeycloakJsonGeneratorTest {
+
+    private static final String REALM = PREFIX + "realm";
+    private static final String CREDENTIALS = PREFIX + "credentials";
+    private static final String CONNECTION_POOL_SIZE = PREFIX + "connection-pool-size";
+    private static final String ENABLE_CORS = PREFIX + "enable-cors";
+
+    @Before
+    public void setUp() throws Exception {
+        System.setProperty(REALM, "booker");
+        System.setProperty(CREDENTIALS, "secret=deec63e4-d242-4180-b402-80fba0a9187e");
+        System.setProperty(CONNECTION_POOL_SIZE, "100");
+        System.setProperty(ENABLE_CORS, "true");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.clearProperty(REALM);
+        System.clearProperty(CREDENTIALS);
+        System.clearProperty(CONNECTION_POOL_SIZE);
+        System.clearProperty(ENABLE_CORS);
+    }
+
+    @Test
+    public void test_generated_keycloak_json_from_properties() throws Exception {
+        StringBuilder keycloakJson = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(KeycloakJsonGenerator.generate()))) {
+            reader.lines().forEach(keycloakJson::append);
+        }
+        AdapterConfig result = new ObjectMapper().readValue(keycloakJson.toString(), AdapterConfig.class);
+
+        assertThat(result.getRealm()).isEqualTo("booker");
+        assertThat(result.getCredentials().get("secret")).isEqualTo("deec63e4-d242-4180-b402-80fba0a9187e");
+        assertThat(result.getConnectionPoolSize()).isEqualTo(100);
+        assertThat(result.isCors()).isEqualTo(true);
+    }
+
+}


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
It'd be useful that generating keycloak.json from System properties on
runtime. We don't have to re-build app when re-writing each property of
keycloak.json.

Modifications
-------------
Add KeycloakJsonGenerator and expose some depdencies(keycloak-core, jackson)

Result
------
You can generate keycloak.json on runtime.