### PR TITLE
SWARM-863 - control-C'd processes don't stop.

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/ServerBootstrapImpl.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/ServerBootstrapImpl.java
@@ -134,6 +134,7 @@ public class ServerBootstrapImpl implements ServerBootstrap {
                 weld.addBeanClass(each);
             }
 
+            weld.property("org.jboss.weld.se.shutdownHook", false);
             WeldContainer weldContainer = weld.initialize();
 
             RuntimeServer server = weldContainer.select(RuntimeServer.class).get();


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------

When executing an UberJar via `java -jar ...` on Windows,
executing control-C to stop the process attempts to shutdown
WildFly but never successfully exits.

Modifications
-------------

Disable our core Weld-SE's shutdown hook.  It still seems to
shutdown later, but this helps the ordering to allow WildFly
to completely shutdown before we stop the core WildFly Swarm bits
wrapped around it.

Lifecycle should, and now seems to be:

a) Start WildFly Swarm Core
b) Start WildFly
...
c) Stop WildFly
d) Stop WildFly Swarm Core

Result
------

UberJars on Windows can now be successfully stopped using
control-C, instead of forcing a taskkill on the process.