### PR TITLE
SWARM-903 - HTTP2 isn't always enablable on HTTPS listeners.

### DIFF
--- a/fractions/javaee/undertow/src/test/java/org/wildfly/swarm/undertow/runtime/HTTP2CustomizerTest.java
+++ b/fractions/javaee/undertow/src/test/java/org/wildfly/swarm/undertow/runtime/HTTP2CustomizerTest.java
@@ -1,0 +1,37 @@
+package org.wildfly.swarm.undertow.runtime;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+import org.wildfly.swarm.config.undertow.Server;
+import org.wildfly.swarm.config.undertow.server.HttpsListener;
+import org.wildfly.swarm.undertow.UndertowFraction;
+import org.wildfly.swarm.undertow.UndertowProperties;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Bob McWhirter
+ */
+public class HTTP2CustomizerTest {
+
+    @Test
+    public void testHTTP2Enabled() {
+
+        HTTP2Customizer customizer = new HTTP2Customizer();
+        customizer.undertow = new UndertowFraction().applyDefaults();
+        Server server = customizer.undertow.subresources().server(UndertowProperties.DEFAULT_SERVER);
+
+        AtomicReference<HttpsListener> listener = new AtomicReference<>();
+        server.httpsListener("default-https", (config) -> {
+            listener.set(config);
+        });
+
+        assertThat(listener.get()).isNotNull();
+
+        assertThat(listener.get().enableHttp2()).isNull();
+        customizer.customize();
+        assertThat(listener.get().enableHttp2()).isTrue();
+
+    }
+}


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------

Apparently some environment lack enough ciphers to effectively
do HTTP2 in a way that some browsers can appreciate.

Modifications
-------------

Promote the same strong-cipher checking from Undertow/WildFly11
to WildFly Swarm until we rebase against that version of protected
WildFly.

Result
------

Should only enable HTTP2 if there's a strong-enough cipher to
avoid irritating browsers.