### PR TITLE
SWARM-903: Display a warning when HTTP/2 is not supported in an environment

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/internal/SwarmMessages.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/SwarmMessages.java
@@ -172,6 +172,11 @@ public interface SwarmMessages extends BasicLogger {
     @Message(id = 37, value = "Configuration:\n%s")
     void configuration(String configuration);
 
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 38, value = "HTTP/2 is not supported in this environment. " +
+            "Are the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files for JDK/JRE 8 installed?")
+    void http2NotSupported();
+
     // ------------------------------------------------------------------------
     // ------------------------------------------------------------------------
 

--- a/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/runtime/HTTP2Customizer.java
+++ b/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/runtime/HTTP2Customizer.java
@@ -23,6 +23,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 
 import org.wildfly.swarm.config.undertow.Server;
+import org.wildfly.swarm.internal.SwarmMessages;
 import org.wildfly.swarm.spi.api.Customizer;
 import org.wildfly.swarm.spi.runtime.annotations.Post;
 import org.wildfly.swarm.undertow.UndertowFraction;
@@ -41,6 +42,7 @@ public class HTTP2Customizer implements Customizer {
     @Override
     public void customize() {
         if (!supportsHTTP2()) {
+            SwarmMessages.MESSAGES.http2NotSupported();
             return;
         }
         for (Server server : undertow.subresources().servers()) {


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
HTTP/2 may not work in environments where a given cipher is not supported.

Modifications
-------------
When the required cipher is not supported, display a warning message saying that HTTP/2 is not being enabled and propose a solution.

Result
------
A warning message is displayed when HTTP/2 is not enabled because it's running in an unsupported environment.