### PR TITLE
SWARM-911: insufficient rules for fraction autodetection

### DIFF
--- a/fraction-list/src/main/resources/org/wildfly/swarm/fractionlist/fraction-packages.properties
+++ b/fraction-list/src/main/resources/org/wildfly/swarm/fractionlist/fraction-packages.properties
@@ -2,23 +2,23 @@
 # can be mixed and matched: some-fraction=foo+bar,baz, with + taking precedence
 # If the package ends with *, it is checked as a prefix
 # specific-class matchers can be specified with foo.bar:ClassName
-batch-jberet=javax.batch
+batch-jberet=javax.batch*
 bean-validation=javax.validation*
 cdi=javax.inject,javax.enterprise.inject,javax.enterprise.context,javax.enterprise.event
 ejb=javax.ejb
 ejb-remote=javax.ejb:Remote
 infinispan=org.infinispan
 javafx=javafx*
-jaxrs=javax.ws.rs
-jaxrs-jaxb=javax.ws.rs+javax.xml.bind*
-jaxrs-jsonp=javax.ws.rs+javax.json
-jaxrs-validator=javax.ws.rs+javax.validation*
-jpa=javax.persistence
+jaxrs=javax.ws.rs*
+jaxrs-jaxb=javax.ws.rs*+javax.xml.bind*
+jaxrs-jsonp=javax.ws.rs*+javax.json*
+jaxrs-validator=javax.ws.rs*+javax.validation*
+jpa=javax.persistence*
 jsf=javax.faces*
-mail=javax.mail
+mail=javax.mail*
 messaging=javax.jms
 spring=org.springframework*
 swagger=io.swagger.annotations
-transactions=javax.transaction
-undertow=javax.servlet
-webservices=javax.jws
+transactions=javax.transaction*
+undertow=javax.servlet*,javax.websocket*
+webservices=javax.jws*,javax.xml.ws*


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
The rules for fraction autodetection are insufficient for some
Java EE components. Most importantly, the rule for the `batch-jberet`
fraction can't possibly work, because there are no classes in the
`javax.batch` package, they are all in the subpackages.

Modifications
-------------
Modified the rules for:

- `batch-jberet`
- `jaxrs` and `jaxrs-*`
- `jpa`
- `mail`
- `transactions`
- `undertow`
- `webservices`

Result
------
More precise fraction autodetection. Autodetecting the `batch-jberet`
fraction is actually possible.