### PR TITLE
SWARM-911 -- Auto-detection rule for javax.sql* datasources fraction.

### DIFF
--- a/fraction-list/src/main/resources/org/wildfly/swarm/fractionlist/fraction-packages.properties
+++ b/fraction-list/src/main/resources/org/wildfly/swarm/fractionlist/fraction-packages.properties
@@ -5,6 +5,7 @@
 batch-jberet=javax.batch*
 bean-validation=javax.validation*
 cdi=javax.inject,javax.enterprise.inject,javax.enterprise.context,javax.enterprise.event
+datasources=javax.sql*
 ejb=javax.ejb
 ejb-remote=javax.ejb:Remote
 infinispan=org.infinispan


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------

We should be able to detect usage of a DataSource.

Modifications
-------------

Add a detection rule for javax.sql*.

Result
------

We can auto-detect DataSource usage now.