### PR TITLE
SWARM-916: default security subsystem configuration different from WildFly

### DIFF
--- a/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/runtime/WebSecurityCustomizer.java
+++ b/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/runtime/WebSecurityCustomizer.java
@@ -13,44 +13,41 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.swarm.ejb.runtime;
+package org.wildfly.swarm.undertow.runtime;
 
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import org.wildfly.swarm.config.Security;
 import org.wildfly.swarm.config.security.Flag;
 import org.wildfly.swarm.config.security.SecurityDomain;
 import org.wildfly.swarm.config.security.security_domain.ClassicAuthorization;
 import org.wildfly.swarm.config.security.security_domain.authorization.PolicyModule;
-import org.wildfly.swarm.security.SecurityFraction;
 import org.wildfly.swarm.spi.api.Customizer;
 import org.wildfly.swarm.spi.runtime.annotations.Post;
 
-/**
- * @author Ken Finnigan
- */
 @Post
 @Singleton
-public class EJBSecurityCustomizer implements Customizer {
+public class WebSecurityCustomizer implements Customizer {
 
     @Inject
-    private Instance<SecurityFraction> securityInstance;
+    private Instance<Security> securityInstance;
 
     @Override
     public void customize() {
         if (!securityInstance.isUnsatisfied()) {
-            SecurityFraction security = securityInstance.get();
+            Security security = securityInstance.get();
 
-            SecurityDomain ejbPolicy = security.subresources().securityDomains().stream().filter((e) -> e.getKey().equals("jboss-ejb-policy")).findFirst().orElse(null);
-            if (ejbPolicy == null) {
-                ejbPolicy = new SecurityDomain("jboss-ejb-policy")
+            SecurityDomain webPolicy = security.subresources().securityDomains().stream().filter((e) -> e.getKey().equals("jboss-web-policy")).findFirst().orElse(null);
+            if (webPolicy == null) {
+                webPolicy = new SecurityDomain("jboss-web-policy")
                         .cacheType(SecurityDomain.CacheType.DEFAULT)
                         .classicAuthorization(new ClassicAuthorization()
                                                       .policyModule(new PolicyModule("Delegating")
                                                                             .code("Delegating")
                                                                             .flag(Flag.REQUIRED)));
-                security.securityDomain(ejbPolicy);
+                security.securityDomain(webPolicy);
             }
         }
     }

--- a/fractions/wildfly/security/src/main/java/org/wildfly/swarm/security/SecurityFraction.java
+++ b/fractions/wildfly/security/src/main/java/org/wildfly/swarm/security/SecurityFraction.java
@@ -23,7 +23,12 @@ import org.wildfly.swarm.config.Security;
 import org.wildfly.swarm.config.security.Flag;
 import org.wildfly.swarm.config.security.SecurityDomain;
 import org.wildfly.swarm.config.security.security_domain.ClassicAuthentication;
+import org.wildfly.swarm.config.security.security_domain.ClassicAuthorization;
+import org.wildfly.swarm.config.security.security_domain.JaspiAuthentication;
+import org.wildfly.swarm.config.security.security_domain.authentication.AuthModule;
 import org.wildfly.swarm.config.security.security_domain.authentication.LoginModule;
+import org.wildfly.swarm.config.security.security_domain.authentication.LoginModuleStack;
+import org.wildfly.swarm.config.security.security_domain.authorization.PolicyModule;
 import org.wildfly.swarm.spi.api.Fraction;
 import org.wildfly.swarm.spi.api.annotations.MarshalDMR;
 import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
@@ -45,7 +50,8 @@ public class SecurityFraction extends Security<SecurityFraction> implements Frac
     }
 
     public SecurityFraction applyDefaults() {
-        return securityDomain(new SecurityDomain("other")
+        securityDomain(new SecurityDomain("other")
+                .cacheType(SecurityDomain.CacheType.DEFAULT)
                 .classicAuthentication(new ClassicAuthentication()
                         .loginModule(new LoginModule("RealmDirect")
                                 .code("RealmDirect")
@@ -55,6 +61,23 @@ public class SecurityFraction extends Security<SecurityFraction> implements Frac
                                 }})
 
                         )));
+
+        securityDomain(new SecurityDomain("jaspitest")
+                .cacheType(SecurityDomain.CacheType.DEFAULT)
+                .jaspiAuthentication(new JaspiAuthentication()
+                        .loginModuleStack(new LoginModuleStack("dummy")
+                                .loginModule(new LoginModule("Dummy")
+                                        .code("Dummy")
+                                        .flag(Flag.OPTIONAL)
+                                )
+                        )
+                        .authModule(new AuthModule("Dummy")
+                                .code("Dummy")
+                        )
+                )
+        );
+
+        return this;
     }
 
 }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
The default configuration of the `security` subsystem as created
by `SecurityFraction.applyDefaults` only contains a subset
of WildFly's default. Most of WildFly's default configuration
also applies to Swarm, perhaps with the exception of the `Remoting`
login module.

Modifications
-------------
Modified `SecurityFraction.applyDefaults` to match the default
configuration of WildFly, with the exception of the `Remoting`
login module.

Result
------
Default configuration is closer to WildFly.