### PR TITLE
SWARM-863 - Shutting down a -swarm.jar on Windows

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/core/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -429,6 +429,9 @@ public class Swarm {
         if (this.server == null) {
             throw SwarmMessages.MESSAGES.containerNotStarted("stop()");
         }
+        
+        this.server.stop();
+        this.server = null;
 
         Module module = Module.getBootModuleLoader().loadModule(ModuleIdentifier.create("swarm.container"));
         Class<?> shutdownClass = module.getClassLoader().loadClass("org.wildfly.swarm.container.runtime.WeldShutdownImpl");
@@ -436,8 +439,6 @@ public class Swarm {
         WeldShutdown shutdown = (WeldShutdown) shutdownClass.newInstance();
         shutdown.shutdown();
 
-        this.server.stop();
-        this.server = null;
         return this;
     }
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------

While control-C works, ultimately calling swarm.stop() doesn't.

It should.

Modifications
-------------

Once again, finding another shutdown lifecycle path (this one
rooted at swarm.stop()), we discover that we are shutting down weld
before stopping the rest of the WildFly and Swarm core.  Don't do that.

Reverse the ordering, to shutdown everything before Weld-SE and
now a programatic stop() on Windows seems to work.

Result
------

You can swarm.stop() on Windows without a hang.