### PR TITLE
SWARM-938: Examples resolve wrong artifact version

### DIFF
--- a/core/bootstrap/src/test/java/org/wildfly/swarm/bootstrap/Test.java
+++ b/core/bootstrap/src/test/java/org/wildfly/swarm/bootstrap/Test.java
@@ -1,0 +1,23 @@
+package org.wildfly.swarm.bootstrap;
+
+import org.jboss.modules.maven.ArtifactCoordinates;
+
+/**
+ * @author Heiko Braun
+ * @since 14/12/2016
+ */
+public class Test {
+    public static void main(String[] args) throws Exception {
+        String dep = "org.wildfly.swarm:request-controller:2017.1.0-20161214.105737-22";
+        String[] parts = dep.split(":");
+        ArtifactCoordinates coords = null;
+
+        if ( parts.length == 4 ) {
+            coords = new ArtifactCoordinates( parts[0], parts[1], parts[3] );
+        } else if ( parts.length == 5 ) {
+            coords = new ArtifactCoordinates( parts[0], parts[1], parts[3], parts[4] );
+        }
+
+        System.out.println(coords);
+    }
+}


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
Examples fail when using timestamped snapshots

Modifications
-------------
Rely on `Artifact.getBaseVersion()`, rather than `Artifact.getVersion()`

Result
------
The correct artifact version is resolved, even if timestamped artifacts are at play.