### PR TITLE
SWARM-938: Examples resolve wrong artifact version

### DIFF
--- a/plugin/src/main/java/org/wildfly/swarm/plugin/maven/AbstractSwarmMojo.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/maven/AbstractSwarmMojo.java
@@ -191,7 +191,7 @@ public abstract class AbstractSwarmMojo extends AbstractMojo {
                             artifact.getScope(),
                             artifact.getGroupId(),
                             artifact.getArtifactId(),
-                            artifact.getVersion(),
+                            artifact.getBaseVersion(),
                             artifact.getType(),
                             artifact.getClassifier(),
                             artifact.getFile()


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
Examples fail when using timestamped snapshots

Modifications
-------------
Rely on `Artifact.getBaseVersion()`, rather than `Artifact.getVersion()`

Result
------
The correct artifact version is resolved, even if timestamped artifacts are at play.