### PR TITLE
SWARM-893 & SWARM-939 - Improved handling of Configurables

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/core/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -429,7 +429,7 @@ public class Swarm {
         if (this.server == null) {
             throw SwarmMessages.MESSAGES.containerNotStarted("stop()");
         }
-        
+
         this.server.stop();
         this.server = null;
 

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/configurable/ConfigurableExtension.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/configurable/ConfigurableExtension.java
@@ -28,7 +28,6 @@ import javax.enterprise.inject.spi.Extension;
 import javax.enterprise.inject.spi.ProcessInjectionTarget;
 import javax.inject.Singleton;
 
-import org.jboss.msc.service.ServiceActivator;
 import org.wildfly.swarm.container.runtime.ConfigurableManager;
 import org.wildfly.swarm.spi.api.ArchiveMetadataProcessor;
 import org.wildfly.swarm.spi.api.ArchivePreparer;

--- a/core/spi/src/main/java/org/wildfly/swarm/spi/api/StageConfig.java
+++ b/core/spi/src/main/java/org/wildfly/swarm/spi/api/StageConfig.java
@@ -173,7 +173,7 @@ public class StageConfig {
          * @param <N> The value type to coerce to.
          * @return A new resolver capable of coercing to the given type.
          */
-        <N> Resolver<N> as(Class<N> clazz, Converter<T> converter);
+        <N> Resolver<N> as(Class<N> clazz, Converter<N> converter);
     }
 
     /** Converter capable of converting a native {@code String} value to a specific type.
@@ -197,7 +197,7 @@ public class StageConfig {
         }
 
         @Override
-        public <N> Resolver<N> as(Class<N> clazz, Converter<T> converter) {
+        public <N> Resolver<N> as(Class<N> clazz, Converter<N> converter) {
             targetType = clazz;
             this.converter = converter;
             return (Resolver<N>) this;
@@ -314,6 +314,6 @@ public class StageConfig {
 
         private T defaultValue;
 
-        private Converter<T> converter;
+        private Converter<?> converter;
     }
 }

--- a/testsuite/testsuite-security/pom.xml
+++ b/testsuite/testsuite-security/pom.xml
@@ -27,6 +27,10 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>arquillian</artifactId>
       <scope>test</scope>
     </dependency>

--- a/testsuite/testsuite-security/src/main/java/org/wildfly/swarm/security/Dummy.java
+++ b/testsuite/testsuite-security/src/main/java/org/wildfly/swarm/security/Dummy.java
@@ -1,0 +1,7 @@
+package org.wildfly.swarm.security;
+
+/**
+ * @author Bob McWhirter
+ */
+public class Dummy {
+}

--- a/testsuite/testsuite-security/src/main/resources/project-stages.yml
+++ b/testsuite/testsuite-security/src/main/resources/project-stages.yml
@@ -1,0 +1,19 @@
+swarm:
+  logging:
+    root-logger:
+      level: DEBUG
+    console-handlers:
+      CONSOLE:
+        level: DEBUG
+  security:
+    security-domains:
+      controle-despesas:
+        classic-authentication:
+          login-modules:
+            defaultRoleDatabaseModule:
+              code: org.jboss.security.auth.spi.DatabaseServerLoginModule
+              flag: optional
+              module-options:
+                dsJndiName: java:jboss/datasources/CustomDS
+                password-stacking: useFirstPass
+

--- a/testsuite/testsuite-security/src/test/java/org/wildfly/swarm/security/SecurityArquillianTest.java
+++ b/testsuite/testsuite-security/src/test/java/org/wildfly/swarm/security/SecurityArquillianTest.java
@@ -17,20 +17,14 @@ package org.wildfly.swarm.security;
 
 import java.util.concurrent.TimeoutException;
 
-import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistry;
-import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.swarm.Swarm;
-import org.wildfly.swarm.arquillian.CreateSwarm;
-import org.wildfly.swarm.spi.api.JARArchive;
+import org.wildfly.swarm.arquillian.DefaultDeployment;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -38,19 +32,8 @@ import static org.junit.Assert.assertNotNull;
  * @author Bob McWhirter
  */
 @RunWith(Arquillian.class)
+@DefaultDeployment
 public class SecurityArquillianTest {
-
-    @Deployment//(testable = false)
-    public static Archive createDeployment() {
-        JARArchive deployment = ShrinkWrap.create(JARArchive.class);
-        deployment.add(EmptyAsset.INSTANCE, "nothing");
-        return deployment;
-    }
-
-    @CreateSwarm
-    public static Swarm newSwarm() throws Exception {
-        return new Swarm().fraction(new SecurityFraction());
-    }
 
     @ArquillianResource
     public ServiceRegistry registry;


### PR DESCRIPTION
Motivation
----------

Some configurable items are non-scalars.  This includes
configurable things that are ultimately Maps, Properties,
or Java enums.  This notably affects:

  - Security module-options
  - Logging levels

Modifications
-------------

Improve handling of configurable items which have non-scalar
values.

Result
------

You can now set Map-like configuration items, such as
a security-domain's module-options.

You can also set Enum-based configuration items, such
as logging levels.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
