### PR TITLE
SWARM-957 - Empty maven.repo.local fails ARQ tests

### DIFF
--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
@@ -148,10 +148,14 @@ public class UberjarSimpleContainer implements SimpleContainer {
             executor.withProperty(AnnotationBasedMain.ANNOTATED_CLASS_NAME, this.testClass.getName());
         }
 
-        final String additionalRepos = System.getProperty(SwarmInternalProperties.BUILD_REPOS);
+        String additionalRepos = System.getProperty(SwarmInternalProperties.BUILD_REPOS);
         if (additionalRepos != null) {
-            executor.withProperty("remote.maven.repo", additionalRepos);
+            additionalRepos = additionalRepos + ",";
+        } else {
+            additionalRepos = "";
         }
+        additionalRepos = additionalRepos + "http://repository.jboss.org/nexus/content/groups/public/";
+        executor.withProperty("remote.maven.repo", additionalRepos);
 
 
         // project dependencies
@@ -224,6 +228,12 @@ public class UberjarSimpleContainer implements SimpleContainer {
         File executable = File.createTempFile("arquillian", "-swarm.jar");
         wrapped.as(ZipExporter.class).exportTo(executable, true);
         executable.deleteOnExit();
+
+        String mavenRepoLocal = System.getProperty("maven.repo.local" );
+
+        if ( mavenRepoLocal != null ) {
+            executor.withProperty( "maven.repo.local", mavenRepoLocal );
+        }
 
         executor.withProperty("java.net.preferIPv4Stack", "true");
         executor.withJVMArguments(getJavaVmArgumentsList());


### PR DESCRIPTION
Motivation
----------

When CI'ing, sometimes we have an empty repository.  It should
work.

Modifications
-------------

Ensure that the JBoss Nexus Repository is part of the remote
repositories for when dependencies aren't bundled within
the uberjar and when the uberjar is executed by Arquillian.

Result
------

Using an empty maven.repo.local should work.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
