### PR TITLE
SWARM-918 Arquillian should be aware of the empirical context-root.

### DIFF
--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/WildFlySwarmContainer.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/WildFlySwarmContainer.java
@@ -72,7 +72,7 @@ public class WildFlySwarmContainer extends DaemonDeployableContainerBase<DaemonC
         }
 
 
-        this.delegateContainer = new UberjarSimpleContainer(this.containerContext.get(), this.testClass);
+        this.delegateContainer = new UberjarSimpleContainer(this.containerContext.get(), this.deploymentContext.get(), this.testClass);
 
         try {
             this.delegateContainer

--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/resources/ContextRoot.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/resources/ContextRoot.java
@@ -1,0 +1,17 @@
+package org.wildfly.swarm.arquillian.adapter.resources;
+
+/**
+ * @author Bob McWhirter
+ */
+public class ContextRoot {
+
+    private final String context;
+
+    public ContextRoot(String context) {
+        this.context = context;
+    }
+
+    public String context() {
+        return this.context;
+    }
+}

--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/resources/SwarmURLResourceProvider.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/resources/SwarmURLResourceProvider.java
@@ -22,6 +22,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 
 import org.jboss.arquillian.container.spi.Container;
+import org.jboss.arquillian.container.spi.context.DeploymentContext;
 import org.jboss.arquillian.container.test.impl.enricher.resource.OperatesOnDeploymentAwareProvider;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
@@ -29,6 +30,9 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.wildfly.swarm.spi.api.SwarmProperties;
 
 public class SwarmURLResourceProvider extends OperatesOnDeploymentAwareProvider {
+
+    @Inject
+    private Instance<DeploymentContext> deploymentContext;
 
     @Inject
     Instance<Container> containerInstance;
@@ -84,8 +88,18 @@ public class SwarmURLResourceProvider extends OperatesOnDeploymentAwareProvider 
         }
 
         String contextPath = System.getProperty(SwarmProperties.CONTEXT_PATH);
-        if (contextPath == null) {
+        if ( this.deploymentContext.get() != null ) {
+            if (this.deploymentContext.get().getObjectStore().get(ContextRoot.class) != null) {
+                contextPath = this.deploymentContext.get().getObjectStore().get(ContextRoot.class).context();
+            }
+        }
+
+        if ( contextPath == null ) {
             contextPath = "/";
+        }
+
+        if ( ! contextPath.startsWith("/" ) ) {
+            contextPath = "/" + contextPath;
         }
 
         try {

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -143,6 +143,7 @@
     <module>testsuite-topology-webapp</module>
     <module>testsuite-transactions</module>
     <module>testsuite-undertow</module>
+    <module>testsuite-undertow-context</module>
     <module>testsuite-vertx</module>
     <module>testsuite-webservices</module>
     <module>testsuite-zipkin-jaxrs</module>

--- a/testsuite/testsuite-undertow-context/pom.xml
+++ b/testsuite/testsuite-undertow-context/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>testsuite</artifactId>
+    <version>2017.1.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>testsuite-undertow-context</artifactId>
+
+  <name>Test Suite: Undertow with Context</name>
+  <description>Test Suite: Undertow with Context</description>
+
+  <packaging>jar</packaging>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/webapp</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>undertow</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>management</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>arquillian</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.junit</groupId>
+      <artifactId>arquillian-junit-container</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/testsuite/testsuite-undertow-context/src/main/java/org/wildfly/swarm/undertow/test/Misc.java
+++ b/testsuite/testsuite-undertow-context/src/main/java/org/wildfly/swarm/undertow/test/Misc.java
@@ -1,0 +1,7 @@
+package org.wildfly.swarm.undertow.test;
+
+/**
+ * @author Bob McWhirter
+ */
+public class Misc {
+}

--- a/testsuite/testsuite-undertow-context/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/testsuite/testsuite-undertow-context/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss-web>
+  <context-root>/customroot/</context-root>
+</jboss-web>

--- a/testsuite/testsuite-undertow-context/src/test/java/org/wildfly/swarm/undertow/test/UndertowCustomArquillianTest.java
+++ b/testsuite/testsuite-undertow-context/src/test/java/org/wildfly/swarm/undertow/test/UndertowCustomArquillianTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.undertow.test;
+
+import java.net.URL;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.arquillian.DefaultDeployment;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Bob McWhirter
+ */
+@RunWith(Arquillian.class)
+@DefaultDeployment(type = DefaultDeployment.Type.WAR)
+public class UndertowCustomArquillianTest {
+
+    @ArquillianResource
+    URL context;
+
+    @Test
+    @RunAsClient
+    public void testContextRootExternally() {
+        assertEquals( context.getPath(), "/customroot/" );
+    }
+
+    @Test
+    public void testContextRootInternally() {
+        assertEquals( context.getPath(), "/customroot/" );
+    }
+
+}

--- a/testsuite/testsuite-undertow-context/src/test/resources/arquillian.xml
+++ b/testsuite/testsuite-undertow-context/src/test/resources/arquillian.xml
@@ -1,0 +1,14 @@
+<arquillian>
+
+  <extension qualifier="webdriver">
+    <property name="browser">phantomjs</property>
+  </extension>
+
+  <container qualifier="daemon" default="true">
+    <configuration>
+      <property name="host">localhost</property>
+      <property name="port">${swarm.arquillian.daemon.port:12345}</property>
+    </configuration>
+  </container>
+
+</arquillian>


### PR DESCRIPTION
Motivation
----------

If a test deployment contains some non-/ context-root set through
jboss-web.xml within the deployment, Arquillian should be aware
of it when injecting an @ArquillianResource of URL/URI.

Modifications
-------------

Make our UberJarSimpleContainer inspect the deployment to find
a jboss-web.xml if present.  If it is present, further inspect
its contents for any <context-root> element and communicate that
through the URL Provider.

Result
------

The correct context-root is injected into Arquillian tests
if a non-standard context is used.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
