### PR TITLE
SWARM-917 - Be less eager about generating JAXRS Applications

### DIFF
--- a/fractions/javaee/jaxrs/src/main/java/org/wildfly/swarm/jaxrs/JAXRSArchive.java
+++ b/fractions/javaee/jaxrs/src/main/java/org/wildfly/swarm/jaxrs/JAXRSArchive.java
@@ -20,6 +20,7 @@ import org.jboss.shrinkwrap.api.container.LibraryContainer;
 import org.jboss.shrinkwrap.api.container.ResourceContainer;
 import org.jboss.shrinkwrap.api.container.ServiceProviderContainer;
 import org.jboss.shrinkwrap.api.container.WebContainer;
+import org.wildfly.swarm.jaxrs.internal.JAXRSArchiveImpl;
 import org.wildfly.swarm.spi.api.DependenciesContainer;
 import org.wildfly.swarm.spi.api.JBossDeploymentStructureContainer;
 import org.wildfly.swarm.spi.api.MarkerContainer;
@@ -50,4 +51,7 @@ public interface JAXRSArchive extends
 
     JAXRSArchive addResource(Class<?> resource);
 
+    static boolean isJAXRS(Archive archive) {
+        return JAXRSArchiveImpl.isJAXRS(archive);
+    }
 }

--- a/fractions/javaee/jaxrs/src/main/java/org/wildfly/swarm/jaxrs/internal/ApplicationPathAnnotationSeekingClassVisitor.java
+++ b/fractions/javaee/jaxrs/src/main/java/org/wildfly/swarm/jaxrs/internal/ApplicationPathAnnotationSeekingClassVisitor.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.jaxrs.internal;
+
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Opcodes;
+
+/**
+ * @author Bob McWhirter
+ */
+public class ApplicationPathAnnotationSeekingClassVisitor extends AnnotationSeekingClassVisitor {
+
+    public ApplicationPathAnnotationSeekingClassVisitor() {
+        super("javax/ws/rs/ApplicationPath");
+    }
+}

--- a/fractions/javaee/jaxrs/src/main/java/org/wildfly/swarm/jaxrs/internal/DefaultJAXRSWarDeploymentFactory.java
+++ b/fractions/javaee/jaxrs/src/main/java/org/wildfly/swarm/jaxrs/internal/DefaultJAXRSWarDeploymentFactory.java
@@ -19,6 +19,7 @@ import javax.enterprise.context.ApplicationScoped;
 
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.wildfly.swarm.config.JAXRS;
 import org.wildfly.swarm.jaxrs.JAXRSArchive;
 import org.wildfly.swarm.undertow.internal.DefaultWarDeploymentFactory;
 
@@ -40,8 +41,14 @@ public class DefaultJAXRSWarDeploymentFactory extends DefaultWarDeploymentFactor
 
     @Override
     public Archive create() throws Exception {
-        JAXRSArchive archive = ShrinkWrap.create(JAXRSArchive.class, determineName());
-        setup(archive);
-        return archive.staticContent();
+        Archive archive = super.create();
+        // SWARM-917: only implicitly consider it a JAXRS archive if it happens to actually be one,
+        // in order to prevent gratuitous creation of @ApplicationPath stuff just because
+        // jaxrs-api classes are on the classpath.
+        if ( JAXRSArchive.isJAXRS( archive ) ) {
+            archive = archive.as(JAXRSArchive.class).staticContent();
+            setup(archive);
+        }
+        return archive;
     }
 }

--- a/fractions/javaee/jaxrs/src/main/java/org/wildfly/swarm/jaxrs/internal/JAXRSAnnotationSeekingClassVisitor.java
+++ b/fractions/javaee/jaxrs/src/main/java/org/wildfly/swarm/jaxrs/internal/JAXRSAnnotationSeekingClassVisitor.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.jaxrs.internal;
+
+/**
+ * @author Bob McWhirter
+ */
+public class JAXRSAnnotationSeekingClassVisitor extends AnnotationSeekingClassVisitor {
+
+    public JAXRSAnnotationSeekingClassVisitor() {
+        super("javax/ws/rs/*");
+    }
+}

--- a/fractions/javaee/jaxrs/src/test/java/org/wildfly/swarm/jaxrs/JAXRSArchiveTest.java
+++ b/fractions/javaee/jaxrs/src/test/java/org/wildfly/swarm/jaxrs/JAXRSArchiveTest.java
@@ -20,6 +20,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
+import org.wildfly.swarm.undertow.WARArchive;
 
 import static org.fest.assertions.Assertions.assertThat;
 
@@ -62,6 +63,27 @@ public class JAXRSArchiveTest {
 
         Node generated = archive.get(PATH);
         assertThat( generated ).isNull();
+    }
+
+    @Test
+    public void testDetectJAXRSness_isNot() {
+        WARArchive archive = ShrinkWrap.create( WARArchive.class );
+        archive.addClass( MyRandomClass.class );
+        assertThat( JAXRSArchive.isJAXRS( archive )).isFalse();
+    }
+
+    @Test
+    public void testDetectJAXRSness_classAnnotation() {
+        WARArchive archive = ShrinkWrap.create( WARArchive.class );
+        archive.addClass( MyResource.class );
+        assertThat( JAXRSArchive.isJAXRS( archive )).isTrue();
+    }
+
+    @Test
+    public void testDetectJAXRSness_methodAnnotation() {
+        WARArchive archive = ShrinkWrap.create( WARArchive.class );
+        archive.addClass( MyOtherResource.class );
+        assertThat( JAXRSArchive.isJAXRS( archive )).isTrue();
     }
 
 }

--- a/fractions/javaee/jaxrs/src/test/java/org/wildfly/swarm/jaxrs/MyOtherResource.java
+++ b/fractions/javaee/jaxrs/src/test/java/org/wildfly/swarm/jaxrs/MyOtherResource.java
@@ -1,0 +1,14 @@
+package org.wildfly.swarm.jaxrs;
+
+import javax.ws.rs.GET;
+
+/**
+ * @author Bob McWhirter
+ */
+public class MyOtherResource {
+
+    @GET
+    public void someMethod() {
+
+    }
+}

--- a/fractions/javaee/jaxrs/src/test/java/org/wildfly/swarm/jaxrs/MyRandomClass.java
+++ b/fractions/javaee/jaxrs/src/test/java/org/wildfly/swarm/jaxrs/MyRandomClass.java
@@ -1,0 +1,7 @@
+package org.wildfly.swarm.jaxrs;
+
+/**
+ * @author Bob McWhirter
+ */
+public class MyRandomClass {
+}

--- a/fractions/javaee/jaxrs/src/test/java/org/wildfly/swarm/jaxrs/MyResource.java
+++ b/fractions/javaee/jaxrs/src/test/java/org/wildfly/swarm/jaxrs/MyResource.java
@@ -1,0 +1,10 @@
+package org.wildfly.swarm.jaxrs;
+
+import javax.ws.rs.Path;
+
+/**
+ * @author Bob McWhirter
+ */
+@Path("/whatever")
+public class MyResource {
+}

--- a/testsuite/testsuite-maven-plugin/pom.xml
+++ b/testsuite/testsuite-maven-plugin/pom.xml
@@ -35,6 +35,13 @@
       <version>4.5.2</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>bom</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/testsuite/testsuite-maven-plugin/src/test/java/org/wildfly/swarm/maven/plugin/MavenPluginTest.java
+++ b/testsuite/testsuite-maven-plugin/src/test/java/org/wildfly/swarm/maven/plugin/MavenPluginTest.java
@@ -37,6 +37,7 @@ import org.jboss.shrinkwrap.api.GenericArchive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -188,6 +189,7 @@ public class MavenPluginTest {
         try {
             verifier.executeGoal(goal);
         } catch (VerificationException e) {
+            e.printStackTrace();
             if (testingProject.dependencies == Dependencies.JAVA_EE_APIS
                     && testingProject.autodetection == Autodetection.NEVER) {
                 // the only situation when build failure is expected


### PR DESCRIPTION
Motivation
----------

In the event a user paints with a wide brush and includes
the entire JavaEE API spec jar, auto-detection will mix in
JAX-RS.  While this would still be sub-par, we should protect
against then assuming that the user has actually created a
JAX-RS application.

Modifications
-------------

We only cast/coerce an Archive to a JAXRSArchive (and thus
optionally creating the @ApplicationPath annotated generated
Application class) if there is indeed usage of JAXRS annotations
within the application (or its dependencies).

Result
------

Just because the JAXRS fraction is detected doesn't necessarily
mean we actually truly need it, and now we look deeper into our
souls before committing ourselves to presuming JAXRS is actually
involved.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
