### PR TITLE
SWARM-892: swarm.context.path is not recognized

### DIFF
--- a/fractions/javaee/jaxrs/src/main/java/org/wildfly/swarm/jaxrs/internal/JAXRSArchiveImpl.java
+++ b/fractions/javaee/jaxrs/src/main/java/org/wildfly/swarm/jaxrs/internal/JAXRSArchiveImpl.java
@@ -52,7 +52,6 @@ public class JAXRSArchiveImpl extends WebContainerBase<JAXRSArchive> implements 
     public JAXRSArchiveImpl(Archive<?> delegate) {
         super(JAXRSArchive.class, delegate);
 
-        setDefaultContextRoot();
         addGeneratedApplication();
         addFaviconExceptionHandler();
     }

--- a/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/descriptors/JBossWebContainer.java
+++ b/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/descriptors/JBossWebContainer.java
@@ -18,36 +18,17 @@ package org.wildfly.swarm.undertow.descriptors;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.Node;
 import org.jboss.shrinkwrap.api.asset.Asset;
-import org.wildfly.swarm.spi.api.SwarmProperties;
 
-/** An archive mix-in supporting {@code jboss-web.xml} capabilities.
+/**
+ * An archive mix-in supporting {@code jboss-web.xml} capabilities.
  *
  * @author Bob McWhirter
  */
 public interface JBossWebContainer<T extends Archive<T>> extends Archive<T> {
     String JBOSS_WEB_PATH = "WEB-INF/jboss-web.xml";
 
-    /** Set the default content-root of this deployment.
-     *
-     * <p>This will set the context-root to be {@code /} instead of based upon the
-     * archive name.</p>
-     *
-     * @return This archive.
-     */
-    @SuppressWarnings("unchecked")
-    default T setDefaultContextRoot() {
-        JBossWebAsset asset = findJbossWebAsset();
-        if (asset.isRootSet()) {
-
-            return (T) this;
-        }
-
-        setContextRoot(System.getProperty(SwarmProperties.CONTEXT_PATH, "/"));
-
-        return (T) this;
-    }
-
-    /** Set the context root of this deployments.
+    /**
+     * Set the context root of this deployments.
      *
      * @param contextRoot The context root.
      * @return This archive.
@@ -59,7 +40,8 @@ public interface JBossWebContainer<T extends Archive<T>> extends Archive<T> {
         return (T) this;
     }
 
-    /** Retrieve the context root of this deployment.
+    /**
+     * Retrieve the context root of this deployment.
      *
      * @return The context root.
      */
@@ -67,7 +49,8 @@ public interface JBossWebContainer<T extends Archive<T>> extends Archive<T> {
         return findJbossWebAsset().getContextRoot();
     }
 
-    /** Retrieve the security domain of this deployment.
+    /**
+     * Retrieve the security domain of this deployment.
      *
      * @return The security domain.
      */
@@ -75,7 +58,8 @@ public interface JBossWebContainer<T extends Archive<T>> extends Archive<T> {
         return findJbossWebAsset().getSecurityDomain();
     }
 
-    /** Set the security domain of this deployment.
+    /**
+     * Set the security domain of this deployment.
      *
      * @param securityDomain The security domain.
      * @return This archive.
@@ -87,7 +71,8 @@ public interface JBossWebContainer<T extends Archive<T>> extends Archive<T> {
         return (T) this;
     }
 
-    /** Locate and load, or create a {@code jboss-web.xml} asset for this archive.
+    /**
+     * Locate and load, or create a {@code jboss-web.xml} asset for this archive.
      *
      * @return The existing or new {@code jboss-web.xml} asset.
      */

--- a/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/internal/WARArchiveImpl.java
+++ b/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/internal/WARArchiveImpl.java
@@ -42,7 +42,6 @@ public class WARArchiveImpl extends WebContainerBase<WARArchive> implements WARA
      */
     public WARArchiveImpl(Archive<?> delegate) {
         super(WARArchive.class, delegate);
-        setDefaultContextRoot();
         addFaviconExceptionHandler();
     }
 

--- a/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/runtime/ContextPathArchivePreparer.java
+++ b/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/runtime/ContextPathArchivePreparer.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.undertow.runtime;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.wildfly.swarm.spi.api.ArchivePreparer;
+import org.wildfly.swarm.spi.api.Defaultable;
+import org.wildfly.swarm.spi.api.annotations.Configurable;
+import org.wildfly.swarm.undertow.WARArchive;
+
+/**
+ * @author Ken Finnigan
+ */
+public class ContextPathArchivePreparer implements ArchivePreparer {
+
+    @Configurable("swarm.context.path")
+    Defaultable<String> contextPath = Defaultable.string("/");
+
+    @Override
+    public void prepareArchive(Archive<?> archive) {
+        WARArchive warArchive = archive.as(WARArchive.class);
+
+        if (warArchive.getContextRoot() == null) {
+            warArchive.setContextRoot(contextPath.get());
+        }
+    }
+}

--- a/fractions/javaee/undertow/src/test/java/org/wildfly/swarm/undertow/runtime/ContextPathArchivePreparerTest.java
+++ b/fractions/javaee/undertow/src/test/java/org/wildfly/swarm/undertow/runtime/ContextPathArchivePreparerTest.java
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.swarm.undertow;
+package org.wildfly.swarm.undertow.runtime;
 
 import org.junit.Test;
+import org.wildfly.swarm.undertow.WARArchive;
 import org.wildfly.swarm.undertow.internal.DefaultWarDeploymentFactory;
 
 import static org.fest.assertions.Assertions.assertThat;
@@ -23,10 +24,22 @@ import static org.fest.assertions.Assertions.assertThat;
 /**
  * @author Ken Finnigan
  */
-public class JbossWebContainerTest {
+public class ContextPathArchivePreparerTest {
 
     @Test
-    public void testSettingContextRoot() throws Exception {
+    public void testDefaultContextRoot() throws Exception {
+        WARArchive archive = DefaultWarDeploymentFactory.archiveFromCurrentApp();
+
+        assertThat(archive.getContextRoot()).isNull();
+
+        new ContextPathArchivePreparer().prepareArchive(archive);
+
+        assertThat(archive.getContextRoot()).isNotNull();
+        assertThat(archive.getContextRoot()).isEqualTo("/");
+    }
+
+    @Test
+    public void testDefaultContextRootWontOverride() throws Exception {
         WARArchive archive = DefaultWarDeploymentFactory.archiveFromCurrentApp();
 
         assertThat(archive.getContextRoot()).isNull();
@@ -35,18 +48,23 @@ public class JbossWebContainerTest {
         assertThat(archive.getContextRoot()).isNotNull();
         assertThat(archive.getContextRoot()).isEqualTo("myRoot");
 
-        archive.setContextRoot("/someRoot");
+        new ContextPathArchivePreparer().prepareArchive(archive);
+
         assertThat(archive.getContextRoot()).isNotNull();
-        assertThat(archive.getContextRoot()).isEqualTo("/someRoot");
+        assertThat(archive.getContextRoot()).isEqualTo("myRoot");
     }
 
     @Test
-    public void testSettingSecurityDomain() throws Exception {
+    public void testContextPathProperty() throws Exception {
         WARArchive archive = DefaultWarDeploymentFactory.archiveFromCurrentApp();
 
-        assertThat(archive.getSecurityDomain()).isNull();
+        assertThat(archive.getContextRoot()).isNull();
 
-        archive.setSecurityDomain("some-security-domain");
-        assertThat(archive.getSecurityDomain()).isEqualTo("some-security-domain");
+        ContextPathArchivePreparer preparer = new ContextPathArchivePreparer();
+        preparer.contextPath.set("/another-root");
+        preparer.prepareArchive(archive);
+
+        assertThat(archive.getContextRoot()).isNotNull();
+        assertThat(archive.getContextRoot()).isEqualTo("/another-root");
     }
 }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
swarm.context.path was only a system property, not it's modified to be a full configuration value that can be set in any configuration manner.

Modifications
-------------
Moved default context root setting from JBossWebContainer to ArchivePreparer where we can inject @Configurable("swarm.context.path")

Result
------
swarm.context.path is now a valid configuration key, not just a system property.

