### PR TITLE
SWARM-918: Follow up fix for inactive DeploymentContext

### DIFF
--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/resources/SwarmURLResourceProvider.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/resources/SwarmURLResourceProvider.java
@@ -88,7 +88,8 @@ public class SwarmURLResourceProvider extends OperatesOnDeploymentAwareProvider 
         }
 
         String contextPath = System.getProperty(SwarmProperties.CONTEXT_PATH);
-        if ( this.deploymentContext.get() != null ) {
+        DeploymentContext deploymentContext = this.deploymentContext.get();
+        if ( deploymentContext != null && deploymentContext.isActive() ) {
             if (this.deploymentContext.get().getObjectStore().get(ContextRoot.class) != null) {
                 contextPath = this.deploymentContext.get().getObjectStore().get(ContextRoot.class).context();
             }

--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/resources/SwarmURLResourceProvider.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/resources/SwarmURLResourceProvider.java
@@ -90,8 +90,8 @@ public class SwarmURLResourceProvider extends OperatesOnDeploymentAwareProvider 
         String contextPath = System.getProperty(SwarmProperties.CONTEXT_PATH);
         DeploymentContext deploymentContext = this.deploymentContext.get();
         if ( deploymentContext != null && deploymentContext.isActive() ) {
-            if (this.deploymentContext.get().getObjectStore().get(ContextRoot.class) != null) {
-                contextPath = this.deploymentContext.get().getObjectStore().get(ContextRoot.class).context();
+            if (deploymentContext.getObjectStore().get(ContextRoot.class) != null) {
+                contextPath = deploymentContext.getObjectStore().get(ContextRoot.class).context();
             }
         }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
If the DeploymentContext isn't active, the SwarmURLResourceProvider fails with an NPE instead of ignoring it not being active.

Modifications
-------------
Check whether the deploymentContext is active before retrieving the object store from it.

Result
------
Prevents tests from breaking when DeploymentContext not active
