### PR TITLE
SWARM-961: Place temporary files under build directory while running tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,7 @@
           <runOrder>alphabetical</runOrder>
           <failIfNoTests>false</failIfNoTests>
           <systemPropertyVariables>
+            <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
             <swarm.bind.address>127.0.0.1</swarm.bind.address>
             <project.version>${project.version}</project.version>
           </systemPropertyVariables>
@@ -164,6 +165,9 @@
             </goals>
             <configuration>
               <testSourceDirectory>src/it/java</testSourceDirectory>
+              <systemPropertyVariables>
+                <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
+              </systemPropertyVariables>
             </configuration>
           </execution>
         </executions>

--- a/tools/src/main/java/org/wildfly/swarm/tools/exec/SwarmExecutor.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/exec/SwarmExecutor.java
@@ -75,7 +75,8 @@ public class SwarmExecutor {
         Set<String> names = System.getProperties().stringPropertyNames();
 
         for (String name : names) {
-            if (name.startsWith("jboss") || name.startsWith("swarm") || name.startsWith("wildfly") || name.startsWith("maven")) {
+            if (name.startsWith("jboss") || name.startsWith("swarm") || name.startsWith("wildfly") || name.startsWith("maven")
+                    || name.equals("java.io.tmpdir")) {
                 String value = System.getProperty(name);
                 this.properties.put(name, value);
             }


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
WildFly Swarm creates a lot of temporary dirs/files and in some cases they are not deleted, causing the CI agent to crash with Insufficient Disk space errors after some time.

Modifications
-------------
java.io.tmpdir is set to the ${project.build.directory}.

Result
------
Temporary files created during a test execution are placed under target/ and deleted when the clean command is issued, leaving temporary dirs contained within the project