### PR TITLE
SWARM-940: NoClassDefFoundError for ServiceClient

### DIFF
--- a/fractions/cdi-extensions/cdi-jaxrsapi/module.conf
+++ b/fractions/cdi-extensions/cdi-jaxrsapi/module.conf
@@ -3,7 +3,7 @@ org.wildfly.swarm.spi
 org.wildfly.swarm.spi:runtime
 org.wildfly.swarm.container:runtime export=true
 
-javax.enterprise.concurrent.api
+org.wildfly.swarm.client.jaxrs export=true
 
 org.ow2.asm
 org.jboss.jandex

--- a/fractions/cdi-extensions/cdi-jaxrsapi/pom.xml
+++ b/fractions/cdi-extensions/cdi-jaxrsapi/pom.xml
@@ -50,6 +50,10 @@
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-client</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>jaxrs-client-api</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.wildfly.core</groupId>

--- a/fractions/cdi-extensions/cdi-jaxrsapi/src/main/java/org/wildfly/swarm/cdi/jaxrsapi/runtime/ServiceClientProcessor.java
+++ b/fractions/cdi-extensions/cdi-jaxrsapi/src/main/java/org/wildfly/swarm/cdi/jaxrsapi/runtime/ServiceClientProcessor.java
@@ -32,7 +32,7 @@ import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
-import org.wildfly.swarm.cdi.jaxrsapi.ServiceClient;
+import org.wildfly.swarm.client.jaxrs.ServiceClient;
 import org.wildfly.swarm.jaxrs.JAXRSArchive;
 import org.wildfly.swarm.spi.api.ArchiveMetadataProcessor;
 
@@ -99,7 +99,7 @@ public class ServiceClientProcessor implements ArchiveMetadataProcessor {
                 mv.visitEnd();
             }
 
-            List<AnnotationInstance> annotations = classInfo.annotations().get(DotName.createSimple("org.wildfly.swarm.cdi.jaxrsapi.Service"));
+            List<AnnotationInstance> annotations = classInfo.annotations().get(DotName.createSimple("org.wildfly.swarm.client.jaxrs.Service"));
             String baseUrl = (String) annotations.get(0).value("baseUrl").value();
             int lineNum = 18;
 

--- a/fractions/cdi-extensions/cdi-jaxrsapi/src/main/resources/modules/org/wildfly/swarm/client/jaxrs/main/module.xml
+++ b/fractions/cdi-extensions/cdi-jaxrsapi/src/main/resources/modules/org/wildfly/swarm/client/jaxrs/main/module.xml
@@ -1,0 +1,11 @@
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.swarm.client.jaxrs">
+  <resources>
+    <artifact name="org.wildfly.swarm:jaxrs-client-api:${project.version}"/>
+  </resources>
+
+  <dependencies>
+    <module name="javax.api"/>
+    <module name="javax.enterprise.concurrent.api"/>
+  </dependencies>
+
+</module>

--- a/jaxrs-client-api/pom.xml
+++ b/jaxrs-client-api/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>wildfly-swarm</artifactId>
+    <version>2017.1.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <artifactId>jaxrs-client-api</artifactId>
+
+  <name>Enhancements to JAX-RS Client API</name>
+  <description>Provide enhancements to JAX-RS Client API for microservice development</description>
+
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jboss.spec.javax.enterprise.concurrent</groupId>
+      <artifactId>jboss-concurrency-api_1.0_spec</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/jaxrs-client-api/src/main/java/org/wildfly/swarm/client/jaxrs/Service.java
+++ b/jaxrs-client-api/src/main/java/org/wildfly/swarm/client/jaxrs/Service.java
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.swarm.cdi.jaxrsapi;
+package org.wildfly.swarm.client.jaxrs;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/** Annotation for configuring a {@link ServiceClient} interface.
+/**
+ * Annotation for configuring a {@link ServiceClient} interface.
  *
  * @author Ken Finnigan
  */

--- a/jaxrs-client-api/src/main/java/org/wildfly/swarm/client/jaxrs/ServiceClient.java
+++ b/jaxrs-client-api/src/main/java/org/wildfly/swarm/client/jaxrs/ServiceClient.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.swarm.cdi.jaxrsapi;
+package org.wildfly.swarm.client.jaxrs;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -22,7 +22,8 @@ import java.util.function.Supplier;
 import javax.enterprise.concurrent.ManagedExecutorService;
 import javax.naming.InitialContext;
 
-/** Interface to extend to create a CDI-based JAXRS client.
+/**
+ * Interface to extend to create a CDI-based JAXRS client.
  *
  * @see Service
  *

--- a/pom.xml
+++ b/pom.xml
@@ -967,6 +967,11 @@
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
+        <artifactId>jaxrs-client-api</artifactId>
+        <version>2017.1.0-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly.swarm</groupId>
         <artifactId>cdi-jaxrsapi</artifactId>
         <version>2017.1.0-SNAPSHOT</version>
       </dependency>
@@ -976,7 +981,6 @@
         <artifactId>zipkin-jaxrs</artifactId>
         <version>2017.1.0-SNAPSHOT</version>
       </dependency>
-
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
@@ -1111,6 +1115,9 @@
     <module>core/bootstrap</module>
     <module>core/spi</module>
     <module>core/container</module>
+
+    <!-- other -->
+    <module>jaxrs-client-api</module>
 
     <!-- fractions -->
     <module>fractions/javaee/batch-jberet</module>

--- a/testsuite/testsuite-cdi-jaxrsapi/src/main/java/org/wildfly/swarm/cdi/jaxrsapi/TimeService.java
+++ b/testsuite/testsuite-cdi-jaxrsapi/src/main/java/org/wildfly/swarm/cdi/jaxrsapi/TimeService.java
@@ -7,6 +7,9 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import org.wildfly.swarm.client.jaxrs.Service;
+import org.wildfly.swarm.client.jaxrs.ServiceClient;
+
 /**
  * @author Ken Finnigan
  */


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
ServiceClient on the constructed interface was failing to be class loaded within the deployment.

Modifications
-------------
Modified cdi-jaxrsapi to have the API classes, ServiceClient and @Service, outside in a separate API jar which the fraction then has as a dependency and defines a module.xml for.

This brings it into line with how the Netflix libraries are brought in.

Result
------
Fixed CNFE for ServiceClient

