### PR TITLE
SWARM-973: add the java:/JmsXA JNDI binding

### DIFF
--- a/fractions/javaee/messaging/src/main/java/org/wildfly/swarm/messaging/EnhancedServer.java
+++ b/fractions/javaee/messaging/src/main/java/org/wildfly/swarm/messaging/EnhancedServer.java
@@ -16,6 +16,7 @@
 package org.wildfly.swarm.messaging;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -51,7 +52,7 @@ public class EnhancedServer extends org.wildfly.swarm.config.messaging.activemq.
                 .entries(Collections.singletonList("java:/ConnectionFactory")));
 
         pooledConnectionFactory(new PooledConnectionFactory("activemq-ra")
-                .entries(Collections.singletonList("java:jboss/DefaultJMSConnectionFactory"))
+                .entries(Arrays.asList("java:/JmsXA", "java:jboss/DefaultJMSConnectionFactory"))
                 .connectors(Collections.singletonList("in-vm"))
                 .transaction("xa"));
         return this;


### PR DESCRIPTION
Motivation
----------
The sample `jms/jms-xa` in Java EE 7 Samples requires
the `java:/JmsXA` JNDI binding to exist. This binding
doesn't exist in Swarm default configuration, but it
does exist in the default WildFly configuration.
Adding it will bring the Swarm default config
yet another bit closer to WildFly's.

Modifications
-------------
Modified the set of default JNDI bindings of the default
connection factory (in `EnhancedServer`) to be identical
to default WildFly config.

Result
------
Default config closer to WildFly. More Java EE 7 Samples
running out of the box. Noone should notice, unless they
bind something to this address (which they probably shouldn't).

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
