### PR TITLE
SWARM-982: Honor the existing root-logger level and handlers if enabled Logstash Fraction

### DIFF
--- a/fractions/logstash/src/main/java/org/wildfly/swarm/logstash/runtime/LogstashCustomizer.java
+++ b/fractions/logstash/src/main/java/org/wildfly/swarm/logstash/runtime/LogstashCustomizer.java
@@ -52,13 +52,16 @@ public class LogstashCustomizer implements Customizer {
                     .module("org.jboss.logmanager.ext")
                     .attributeClass("org.jboss.logmanager.ext.handlers.SocketHandler")
                     .namedFormatter("logstash")
-                    .properties(handlerProps);
+                    .properties(handlerProps)
+                    .level(this.logstash.level());
 
             this.logging
                     .customFormatter("logstash", "org.jboss.logmanager.ext", "org.jboss.logmanager.ext.formatters.LogstashFormatter",
                                      this.logstash.formatterProperties())
                     .customHandler(logstashHandler)
-                    .rootLogger(this.logstash.level(), logstashHandler.getKey());
+                    .subresources()
+                    .rootLogger()
+                    .handler(logstashHandler.getKey());
         }
     }
 }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
The existing root-logger level and handlers are overridden by
LogstashFraction level and a single logstash-handler.

Modifications
-------------
* Set LogstashFraction level as logstash-handler one
* Add logstash-handler to the existing root-logger handlers.

Result
------
It never overrides the existing root-logger level and handlers.
