### PR TITLE
SWARM-986: Non main() way to create Keycloak Security Constraints settings

### DIFF
--- a/fractions/keycloak/src/main/java/org/wildfly/swarm/keycloak/runtime/SecurityConstraintParser.java
+++ b/fractions/keycloak/src/main/java/org/wildfly/swarm/keycloak/runtime/SecurityConstraintParser.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.keycloak.runtime;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.wildfly.swarm.undertow.descriptors.SecurityConstraint;
+
+class SecurityConstraintParser {
+
+    private SecurityConstraintParser() {
+    }
+
+    /**
+     * Parse a String representation of SecurityConstraint from ProjectStage and return SecurityConstraint Instance.
+     *
+     * <p>If, for example, swarm.keycloak.security-constraints is provided as a set of list like below</p>
+     *
+     * <pre>
+     * swarm.keycloak.security-constraints:
+     *   - url-pattern: /secret
+     *     methods: [GET, POST]
+     *     roles: [admin]
+     * </pre>
+     *
+     * <p>StageConfig has it as the String like <code>{url-pattern=/secret, methods=[GET, POST], roles=[admin]}</code> .</p>
+     *
+     * <p>Then this method would parse the String and return SecurityConstraint instance.
+     *
+     * @param scAsString The String representation of SecurityConstraint from ProjectStage
+     * @return The SecurityConstraint instance
+     * @see SecurityConstraint
+     */
+    static SecurityConstraint parse(String scAsString) {
+        SecurityConstraint sc;
+
+        Matcher matcher = getMatcher(scAsString, "url-pattern=(.*?)[,}]");
+        if (matcher.find()) {
+            sc = new SecurityConstraint(matcher.group(1));
+        } else {
+            sc = new SecurityConstraint();
+        }
+
+        matcher = getMatcher(scAsString, "methods=\\[(.*?)\\]");
+        if (matcher.find()) {
+            sc.withMethod(trim(matcher.group(1).split(",")));
+        }
+
+        matcher = getMatcher(scAsString, "roles=\\[(.*?)\\]");
+        if (matcher.find()) {
+            sc.withRole(trim(matcher.group(1).split(",")));
+        }
+
+        return sc;
+    }
+
+    private static Matcher getMatcher(String scAsString, String exp) {
+        Pattern pattern = Pattern.compile(exp);
+        return pattern.matcher(scAsString);
+    }
+
+    private static String[] trim(String[] array) {
+        String[] trimmed = new String[array.length];
+
+        for (int i = 0; i < array.length; i++) {
+            trimmed[i] = array[i].trim();
+        }
+
+        return trimmed;
+    }
+
+}

--- a/fractions/keycloak/src/test/java/org/wildfly/swarm/keycloak/runtime/SecuredArchivePreparerTest.java
+++ b/fractions/keycloak/src/test/java/org/wildfly/swarm/keycloak/runtime/SecuredArchivePreparerTest.java
@@ -1,0 +1,123 @@
+package org.wildfly.swarm.keycloak.runtime;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathFactory;
+
+import com.sun.org.apache.xpath.internal.XPathAPI;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.traversal.NodeIterator;
+import org.wildfly.swarm.undertow.WARArchive;
+import org.wildfly.swarm.undertow.descriptors.WebXmlAsset;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class SecuredArchivePreparerTest {
+
+    private SecuredArchivePreparer preparer;
+    private WARArchive archive;
+
+    private DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+
+    @Before
+    public void setUp() {
+        preparer = new SecuredArchivePreparer();
+        archive = ShrinkWrap.create(WARArchive.class);
+    }
+
+    @Test
+    public void do_nothing_if_not_specified_security_constraints() throws Exception {
+        preparer.prepareArchive(archive);
+
+        assertThat(archive.get(WebXmlAsset.NAME)).isNull();
+    }
+
+    @Test
+    public void set_1_security_constraint() throws Exception {
+        preparer.securityConstraints = Collections.singletonList("{url-pattern=/aaa}");
+        preparer.prepareArchive(archive);
+
+        try (InputStream assetStream = archive.get(WebXmlAsset.NAME).getAsset().openStream()) {
+            Document document = factory.newDocumentBuilder().parse(assetStream);
+            XPath xpath = XPathFactory.newInstance().newXPath();
+
+            XPathExpression xpr = xpath.compile("count(//security-constraint)");
+            int securityConstraintsNum = ((Number) xpr.evaluate(document, XPathConstants.NUMBER)).intValue();
+            assertThat(securityConstraintsNum).isEqualTo(1);
+
+            xpr = xpath.compile("//url-pattern/text()");
+            String urlPattern = (String) xpr.evaluate(document, XPathConstants.STRING);
+            assertThat(urlPattern).isEqualTo("/aaa");
+        }
+    }
+
+    @Test
+    public void set_2_security_constraints() throws Exception {
+        preparer.securityConstraints = Arrays.asList("{url-pattern=/aaa}", "{url-pattern=/bbb");
+        preparer.prepareArchive(archive);
+
+        try (InputStream assetStream = archive.get(WebXmlAsset.NAME).getAsset().openStream()) {
+            Document document = factory.newDocumentBuilder().parse(assetStream);
+            XPath xpath = XPathFactory.newInstance().newXPath();
+
+            XPathExpression xpr = xpath.compile("count(//security-constraint)");
+            Number count = (Number) xpr.evaluate(document, XPathConstants.NUMBER);
+            assertThat(count.intValue()).isEqualTo(2);
+        }
+    }
+
+    @Test
+    public void set_1_method() throws Exception {
+        preparer.securityConstraints = Collections.singletonList("{methods=[GET]}");
+        preparer.prepareArchive(archive);
+
+        try (InputStream assetStream = archive.get(WebXmlAsset.NAME).getAsset().openStream()) {
+            Document document = factory.newDocumentBuilder().parse(assetStream);
+            XPath xpath = XPathFactory.newInstance().newXPath();
+
+            XPathExpression xpr  = xpath.compile("count(//http-method)");
+            int methodsNum = ((Number) xpr.evaluate(document, XPathConstants.NUMBER)).intValue();
+            assertThat(methodsNum).isEqualTo(1);
+
+            xpr = xpath.compile("//http-method/text()");
+            String urlPattern = (String) xpr.evaluate(document, XPathConstants.STRING);
+            assertThat(urlPattern).isEqualTo("GET");
+        }
+    }
+
+    @Test
+    public void set_2_methods() throws Exception {
+        preparer.securityConstraints = Collections.singletonList("{methods=[GET, POST]}");
+        preparer.prepareArchive(archive);
+
+        try (InputStream assetStream = archive.get(WebXmlAsset.NAME).getAsset().openStream()) {
+            Document document = factory.newDocumentBuilder().parse(assetStream);
+            XPath xpath = XPathFactory.newInstance().newXPath();
+
+            XPathExpression xpr  = xpath.compile("count(//http-method)");
+            int methodsNum = ((Number) xpr.evaluate(document, XPathConstants.NUMBER)).intValue();
+            assertThat(methodsNum).isEqualTo(2);
+
+            List<String> methods = new ArrayList<>();
+            NodeIterator it = XPathAPI.selectNodeIterator(document, "//http-method/text()");
+            Node node;
+            while ((node = it.nextNode()) != null) {
+                methods.add(node.getNodeValue());
+            }
+            assertThat(methods).contains("GET", "POST");
+        }
+    }
+
+}

--- a/fractions/keycloak/src/test/java/org/wildfly/swarm/keycloak/runtime/SecurityConstraintParserTest.java
+++ b/fractions/keycloak/src/test/java/org/wildfly/swarm/keycloak/runtime/SecurityConstraintParserTest.java
@@ -1,0 +1,61 @@
+package org.wildfly.swarm.keycloak.runtime;
+
+import org.junit.Test;
+import org.wildfly.swarm.undertow.descriptors.SecurityConstraint;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class SecurityConstraintParserTest {
+
+    @Test
+    public void set_url_pattern_and_methods_and_roles_explicitly() throws Exception {
+        String securityConstraint = "{url-pattern=/aaa, methods=[GET], roles=[role-a]}";
+
+        SecurityConstraint result = SecurityConstraintParser.parse(securityConstraint);
+
+        assertThat(result.urlPattern()).isEqualTo("/aaa");
+        assertThat(result.methods()).contains("GET");
+        assertThat(result.roles()).contains("role-a");
+    }
+
+    @Test
+    public void unconcerned_with_order_of_definition() throws Exception {
+        String securityConstraint = "{roles=[role-a], methods=[GET], url-pattern=/aaa}";
+
+        SecurityConstraint result = SecurityConstraintParser.parse(securityConstraint);
+
+        assertThat(result.urlPattern()).isEqualTo("/aaa");
+        assertThat(result.methods()).contains("GET");
+        assertThat(result.roles()).contains("role-a");
+    }
+
+    @Test
+    public void set_several_values_if_methods_or_roles_has_them() throws Exception {
+        String securityConstraint = "{url-pattern=/aaa, methods=[GET, PUT], roles=[role-a, role-b]}";
+
+        SecurityConstraint result = SecurityConstraintParser.parse(securityConstraint);
+
+        assertThat(result.methods()).contains("GET", "PUT");
+        assertThat(result.roles()).contains("role-a", "role-b");
+    }
+
+    @Test
+    public void set_wild_card_as_default_url_pattern() throws Exception {
+        String securityConstraint = "{methods=[GET], roles=[role-a]}";
+
+        SecurityConstraint result = SecurityConstraintParser.parse(securityConstraint);
+
+        assertThat(result.urlPattern()).isEqualTo("/*");
+    }
+
+    @Test
+    public void set_no_value_if_methods_or_roles_not_specified() throws Exception {
+        String securityConstraint = "{url-pattern=/aaa}";
+
+        SecurityConstraint result = SecurityConstraintParser.parse(securityConstraint);
+
+        assertThat(result.methods()).hasSize(0);
+        assertThat(result.roles()).hasSize(0);
+    }
+
+}


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
Currently Keyclaok Fraction Security Constraints settings requires a main().
It would be good if we could support it as Configurable.

Modifications
-------------
SecuredArchivePreparer set up the security constraints when provided 'swarm.keycloak.security-constraints'.

Result
------
You can now set Keycloak Security Constrains with project-stages.yml, no main().