### PR TITLE
SWARM-919 - Not all configurables appear in the log output.

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
@@ -163,6 +163,7 @@ public class RuntimeServer implements Server {
             each.customize();
         }
 
+        this.configurableManager.rescan();
         this.configurableManager.log();
         this.configurableManager.close();
 

--- a/fractions/javaee/ejb/src/main/java/org/wildfly/swarm/ejb/runtime/EJBSecurityCustomizer.java
+++ b/fractions/javaee/ejb/src/main/java/org/wildfly/swarm/ejb/runtime/EJBSecurityCustomizer.java
@@ -15,14 +15,11 @@
  */
 package org.wildfly.swarm.ejb.runtime;
 
-import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import org.wildfly.swarm.config.security.Flag;
 import org.wildfly.swarm.config.security.SecurityDomain;
-import org.wildfly.swarm.config.security.security_domain.ClassicAuthorization;
-import org.wildfly.swarm.config.security.security_domain.authorization.PolicyModule;
 import org.wildfly.swarm.security.SecurityFraction;
 import org.wildfly.swarm.spi.api.Customizer;
 import org.wildfly.swarm.spi.runtime.annotations.Post;
@@ -35,23 +32,23 @@ import org.wildfly.swarm.spi.runtime.annotations.Post;
 public class EJBSecurityCustomizer implements Customizer {
 
     @Inject
-    private Instance<SecurityFraction> securityInstance;
+    private SecurityFraction security;
 
     @Override
     public void customize() {
-        if (!securityInstance.isUnsatisfied()) {
-            SecurityFraction security = securityInstance.get();
-
-            SecurityDomain ejbPolicy = security.subresources().securityDomains().stream().filter((e) -> e.getKey().equals("jboss-ejb-policy")).findFirst().orElse(null);
-            if (ejbPolicy == null) {
-                ejbPolicy = new SecurityDomain("jboss-ejb-policy")
-                        .cacheType(SecurityDomain.CacheType.DEFAULT)
-                        .classicAuthorization(new ClassicAuthorization()
-                                                      .policyModule(new PolicyModule("Delegating")
-                                                                            .code("Delegating")
-                                                                            .flag(Flag.REQUIRED)));
-                security.securityDomain(ejbPolicy);
-            }
+        if (security.subresources().securityDomains().stream().anyMatch((e) -> e.getKey().equals("jboss-ejb-policy"))) {
+            return;
         }
+
+        this.security.securityDomain("jboss-ejb-policy", (policy) -> {
+            policy.cacheType(SecurityDomain.CacheType.DEFAULT);
+            policy.classicAuthorization((auth) -> {
+                auth.policyModule("Delegating", (module) -> {
+                    module.code("Delegating");
+                    module.flag(Flag.REQUIRED);
+                });
+            });
+        });
+
     }
 }


### PR DESCRIPTION
Motivation
----------

Some configuration items didn't make it to the log display of
configuration items.  This is bad.

Modifications
-------------

Introduced 2-phase scanning for configurables:

1) Scan when a configurable-holding item (such as a Fraction)
   is first produced, so that user-based properties can be
   applied as defaults.  All of these must be applied before
   any fraction customizers run because some of them look for
   the presence or absence of things to make customization
   decisions.

2) Post-customization, re-scan, to pick up anything added or
   altered by the customizers.

Phase (2) is the new addition.

Additionally, while in the code, cleaned up the config-api usage
as it relates to the SecurityFraction and the EJBSecurityCustomizer.
Prefer closures over constructors.

Since ConfigurableManager tracks objects it has scanned, also
modify it's own close() to clean up that list used to track the
objects.

Result
------

More complete display of configurable items in the log output.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
