### PR TITLE
SWARM-677 - Attempt ARQ test with non-remote-resolveable dependencies.

### DIFF
--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -113,6 +113,7 @@
     <module>testsuite-jsf</module>
     <module>testsuite-keycloak</module>
     <module>testsuite-keycloak-server</module>
+    <module>testsuite-local-dependencies</module>
     <module>testsuite-logging</module>
     <module>testsuite-logstash</module>
     <module>testsuite-mail</module>

--- a/testsuite/testsuite-local-dependencies/dep/pom.xml
+++ b/testsuite/testsuite-local-dependencies/dep/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>testsuite-local-dependencies</artifactId>
+    <version>2017.2.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>testsuite-local-dependencies-dep</artifactId>
+
+  <name>Test Suite: Local Dependencies - Dependency</name>
+  <description>Test Suite: Local Dependency - Dependency</description>
+
+  <packaging>jar</packaging>
+
+  <dependencies>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <configuration>
+          <skip>false</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/testsuite/testsuite-local-dependencies/dep/src/main/java/org/wildfly/swarm/local/dep/MyClass.java
+++ b/testsuite/testsuite-local-dependencies/dep/src/main/java/org/wildfly/swarm/local/dep/MyClass.java
@@ -1,0 +1,7 @@
+package org.wildfly.swarm.local.dep;
+
+/**
+ * @author Bob McWhirter
+ */
+public class MyClass {
+}

--- a/testsuite/testsuite-local-dependencies/pom.xml
+++ b/testsuite/testsuite-local-dependencies/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>testsuite</artifactId>
+    <version>2017.2.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>testsuite-local-dependencies</artifactId>
+
+  <name>Test Suite: Local Dependencies Parent</name>
+  <description>Test Suite: Local Dependencies Parent</description>
+
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>dep</module>
+    <module>test</module>
+  </modules>
+
+</project>

--- a/testsuite/testsuite-local-dependencies/test/pom.xml
+++ b/testsuite/testsuite-local-dependencies/test/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>testsuite-local-dependencies</artifactId>
+    <version>2017.2.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>testsuite-local-dependencies-test</artifactId>
+
+  <name>Test Suite: Local Dependencies - Test</name>
+  <description>Test Suite: Local Dependencies - Test</description>
+
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>testsuite-local-dependencies-dep</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>cdi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>arquillian</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/testsuite/testsuite-local-dependencies/test/src/main/java/org/wildfly/swarm/local/test/Cheddar.java
+++ b/testsuite/testsuite-local-dependencies/test/src/main/java/org/wildfly/swarm/local/test/Cheddar.java
@@ -1,0 +1,11 @@
+package org.wildfly.swarm.local.test;
+
+import javax.inject.Singleton;
+
+/**
+ * @author Bob McWhirter
+ */
+@Singleton
+public class Cheddar {
+
+}

--- a/testsuite/testsuite-local-dependencies/test/src/test/java/org/wildfly/swarm/local/test/ArqLocalDependenciesTest.java
+++ b/testsuite/testsuite-local-dependencies/test/src/test/java/org/wildfly/swarm/local/test/ArqLocalDependenciesTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.local.test;
+
+import javax.enterprise.inject.spi.CDI;
+import javax.inject.Inject;
+
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.arquillian.DefaultDeployment;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Bob McWhirter
+ */
+@RunWith(Arquillian.class)
+@DefaultDeployment
+public class ArqLocalDependenciesTest {
+
+    @Inject
+    private Cheddar cheddar;
+
+    @Test
+    public void testInjection() {
+        assertNotNull(cheddar);
+    }
+
+    @Test
+    public void testCDIContainerPresence() throws Exception {
+        assertNotNull(CDI.current());
+    }
+}


### PR DESCRIPTION
Motivation
----------

We should be able to run ARQ-based tests that involve local-only
dependencies.

Modifications
-------------

Added a test.

Result
------

Verified that the build does not fail with local-only dependencies.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
