### PR TITLE
SWARM-994 - @DefaultDeployment should default to WAR, not JAR. -- BRE…

### DIFF
--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/DefaultDeployment.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/DefaultDeployment.java
@@ -35,7 +35,7 @@ public @interface DefaultDeployment {
         }
     }
 
-    Type type() default Type.JAR;
+    Type type() default Type.WAR;
 
     boolean testable() default true;
 

--- a/testsuite/testsuite-batch-jberet/src/test/java/org/wildfly/swarm/batch/jberet/BatchArquillianTest.java
+++ b/testsuite/testsuite-batch-jberet/src/test/java/org/wildfly/swarm/batch/jberet/BatchArquillianTest.java
@@ -32,7 +32,7 @@ import org.wildfly.swarm.arquillian.DefaultDeployment;
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 @RunWith(Arquillian.class)
-@DefaultDeployment
+@DefaultDeployment(type = DefaultDeployment.Type.JAR)
 public class BatchArquillianTest {
 
     @Test

--- a/testsuite/testsuite-camel-cdi/src/test/java/org/wildfly/swarm/camel/test/cdi/CDIIntegrationTest.java
+++ b/testsuite/testsuite-camel-cdi/src/test/java/org/wildfly/swarm/camel/test/cdi/CDIIntegrationTest.java
@@ -25,7 +25,7 @@
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -61,7 +61,7 @@ import org.wildfly.swarm.camel.test.cdi.subA.RoutesContextC;
 import org.wildfly.swarm.camel.test.cdi.subA.RoutesContextD;
 
 @RunWith(Arquillian.class)
-@DefaultDeployment
+@DefaultDeployment(type = DefaultDeployment.Type.JAR)
 public class CDIIntegrationTest {
 
     @Resource(name = "java:jboss/camel/CamelContextRegistry")
@@ -70,12 +70,15 @@ public class CDIIntegrationTest {
     @Inject
     @ContextName("contextA")
     RoutesContextA routesA;
+
     @Inject
     @ContextName("contextB")
     RoutesContextB routesB;
+
     @Inject
     @ContextName("contextC")
     RoutesContextC routesC;
+
     @Inject
     @ContextName("contextD")
     RoutesContextD routesD;

--- a/testsuite/testsuite-camel-ejb/src/test/java/org/wildfly/swarm/camel/test/ejb/EjbIntegrationTest.java
+++ b/testsuite/testsuite-camel-ejb/src/test/java/org/wildfly/swarm/camel/test/ejb/EjbIntegrationTest.java
@@ -24,23 +24,18 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
-import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.extension.camel.CamelAware;
-import org.wildfly.swarm.Swarm;
-import org.wildfly.swarm.arquillian.CreateSwarm;
 import org.wildfly.swarm.arquillian.DefaultDeployment;
-import org.wildfly.swarm.camel.core.CamelCoreFraction;
-import org.wildfly.swarm.camel.test.ejb.subA.HelloBean;
-import org.wildfly.swarm.spi.api.JARArchive;
+
+import static org.wildfly.swarm.arquillian.DefaultDeployment.Type.JAR;
 
 @CamelAware
 @RunWith(Arquillian.class)
-@DefaultDeployment
+@DefaultDeployment(type=JAR)
 public class EjbIntegrationTest {
 
     @Test

--- a/testsuite/testsuite-camel-jms/src/test/java/org/wildfly/swarm/camel/test/jms/JMSIntegrationTest.java
+++ b/testsuite/testsuite-camel-jms/src/test/java/org/wildfly/swarm/camel/test/jms/JMSIntegrationTest.java
@@ -42,20 +42,12 @@ import org.apache.camel.PollingConsumer;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
-import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.extension.camel.CamelAware;
-import org.wildfly.swarm.Swarm;
-import org.wildfly.swarm.arquillian.CreateSwarm;
 import org.wildfly.swarm.arquillian.DefaultDeployment;
-import org.wildfly.swarm.camel.core.CamelCoreFraction;
-import org.wildfly.swarm.config.messaging.activemq.server.JMSQueue;
-import org.wildfly.swarm.messaging.MessagingFraction;
-import org.wildfly.swarm.spi.api.JARArchive;
 
 /**
  * Test routes that use the jms component in routes.
@@ -65,10 +57,14 @@ import org.wildfly.swarm.spi.api.JARArchive;
  */
 @CamelAware
 @RunWith(Arquillian.class)
-@DefaultDeployment(main = Main.class)
+@DefaultDeployment(
+        main = Main.class,
+        type = DefaultDeployment.Type.JAR
+)
 public class JMSIntegrationTest {
 
     static final String QUEUE_NAME = "camel-jms-queue";
+
     static final String QUEUE_JNDI_NAME = "java:/" + QUEUE_NAME;
 
     @Test
@@ -79,7 +75,7 @@ public class JMSIntegrationTest {
             @Override
             public void configure() throws Exception {
                 from("jms:queue:" + Main.QUEUE_NAME + "?connectionFactory=ConnectionFactory").
-                transform(body().prepend("Hello ")).to("direct:end");
+                        transform(body().prepend("Hello ")).to("direct:end");
             }
         });
 
@@ -113,8 +109,8 @@ public class JMSIntegrationTest {
             @Override
             public void configure() throws Exception {
                 from("direct:start").
-                transform(body().prepend("Hello ")).
-                to("jms:queue:" + Main.QUEUE_NAME + "?connectionFactory=ConnectionFactory");
+                        transform(body().prepend("Hello ")).
+                        to("jms:queue:" + Main.QUEUE_NAME + "?connectionFactory=ConnectionFactory");
             }
         });
 

--- a/testsuite/testsuite-camel-jmx/src/test/java/org/wildfly/swarm/camel/test/jmx/JMXIntegrationTest.java
+++ b/testsuite/testsuite-camel-jmx/src/test/java/org/wildfly/swarm/camel/test/jmx/JMXIntegrationTest.java
@@ -29,19 +29,13 @@ import org.apache.camel.ConsumerTemplate;
 import org.apache.camel.ServiceStatus;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
-import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.extension.camel.CamelAware;
 import org.wildfly.extension.camel.CamelContextRegistry;
-import org.wildfly.swarm.Swarm;
-import org.wildfly.swarm.arquillian.CreateSwarm;
 import org.wildfly.swarm.arquillian.DefaultDeployment;
-import org.wildfly.swarm.camel.core.CamelCoreFraction;
-import org.wildfly.swarm.spi.api.JARArchive;
 
 /**
  * Deploys a test which monitors an JMX attribute of a route.
@@ -51,7 +45,10 @@ import org.wildfly.swarm.spi.api.JARArchive;
  */
 @CamelAware
 @RunWith(Arquillian.class)
-@DefaultDeployment(main = Main.class)
+@DefaultDeployment(
+        main = Main.class,
+        type = DefaultDeployment.Type.JAR
+)
 public class JMXIntegrationTest {
 
     @Test

--- a/testsuite/testsuite-camel-jpa/src/test/java/org/wildfly/swarm/camel/test/jpa/JPATransactionManagerIntegrationTest.java
+++ b/testsuite/testsuite-camel-jpa/src/test/java/org/wildfly/swarm/camel/test/jpa/JPATransactionManagerIntegrationTest.java
@@ -36,7 +36,7 @@ import org.wildfly.swarm.arquillian.DefaultDeployment;
 import org.wildfly.swarm.camel.test.jpa.subA.Account;
 
 @RunWith(Arquillian.class)
-@DefaultDeployment
+@DefaultDeployment(type = DefaultDeployment.Type.JAR)
 public class JPATransactionManagerIntegrationTest {
 
     @Test
@@ -61,7 +61,7 @@ public class JPATransactionManagerIntegrationTest {
         Assert.assertEquals(account, result);
     }
 
-	private CamelContextRegistry getContextRegistry() throws NamingException {
-		return (CamelContextRegistry) new InitialContext().lookup("java:jboss/camel/CamelContextRegistry");
-	}
+    private CamelContextRegistry getContextRegistry() throws NamingException {
+        return (CamelContextRegistry) new InitialContext().lookup("java:jboss/camel/CamelContextRegistry");
+    }
 }

--- a/testsuite/testsuite-camel-other/src/test/java/org/wildfly/swarm/camel/test/ognl/OgnlIntegrationTest.java
+++ b/testsuite/testsuite-camel-other/src/test/java/org/wildfly/swarm/camel/test/ognl/OgnlIntegrationTest.java
@@ -28,7 +28,7 @@ import org.wildfly.swarm.arquillian.DefaultDeployment;
 
 @CamelAware
 @RunWith(Arquillian.class)
-@DefaultDeployment
+@DefaultDeployment(type = DefaultDeployment.Type.JAR)
 public class OgnlIntegrationTest {
 
     @Test
@@ -39,10 +39,10 @@ public class OgnlIntegrationTest {
             @Override
             public void configure() throws Exception {
                 from("direct:start")
-                .choice()
-                    .when()
+                        .choice()
+                        .when()
                         .ognl("request.body.name == 'Kermit'").transform(simple("Hello ${body.name}"))
-                    .otherwise()
+                        .otherwise()
                         .to("mock:dlq");
             }
         });

--- a/testsuite/testsuite-cdi/src/test/java/org/wildfly/swarm/cdi/CDIArquillianTest.java
+++ b/testsuite/testsuite-cdi/src/test/java/org/wildfly/swarm/cdi/CDIArquillianTest.java
@@ -22,7 +22,6 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.swarm.arquillian.DefaultDeployment;
-import org.wildfly.swarm.cdi.Cheddar;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -30,7 +29,7 @@ import static org.junit.Assert.assertNotNull;
  * @author Bob McWhirter
  */
 @RunWith(Arquillian.class)
-@DefaultDeployment
+@DefaultDeployment(type = DefaultDeployment.Type.JAR)
 public class CDIArquillianTest {
 
     @Inject

--- a/testsuite/testsuite-cdi/src/test/java/org/wildfly/swarm/cdi/ConfigValueProducerTest.java
+++ b/testsuite/testsuite-cdi/src/test/java/org/wildfly/swarm/cdi/ConfigValueProducerTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertNotNull;
  */
 @RunWith(Arquillian.class)
 @Ignore
-@DefaultDeployment
+@DefaultDeployment(type = DefaultDeployment.Type.JAR)
 public class ConfigValueProducerTest {
 
     @Test

--- a/testsuite/testsuite-cdi/src/test/java/org/wildfly/swarm/cdi/ConfigurationValueProducerTest.java
+++ b/testsuite/testsuite-cdi/src/test/java/org/wildfly/swarm/cdi/ConfigurationValueProducerTest.java
@@ -30,7 +30,7 @@ import org.wildfly.swarm.spi.runtime.annotations.ConfigurationValue;
  * @author George Gastaldi
  */
 @RunWith(Arquillian.class)
-@DefaultDeployment
+@DefaultDeployment(type = DefaultDeployment.Type.JAR)
 public class ConfigurationValueProducerTest {
 
     @Inject
@@ -40,7 +40,7 @@ public class ConfigurationValueProducerTest {
     @Test
     public void testServerAddressExists() {
         Assert.assertNotNull(loggerLevel);
-        Assert.assertEquals("DEBUG",loggerLevel.get());
+        Assert.assertEquals("DEBUG", loggerLevel.get());
     }
 
 }

--- a/testsuite/testsuite-connector/src/test/java/org/wildfly/swarm/connector/ConnectorArquillianTest.java
+++ b/testsuite/testsuite-connector/src/test/java/org/wildfly/swarm/connector/ConnectorArquillianTest.java
@@ -24,7 +24,7 @@ import org.wildfly.swarm.arquillian.DefaultDeployment;
  * @author Bob McWhirter
  */
 @RunWith(Arquillian.class)
-@DefaultDeployment
+@DefaultDeployment(type = DefaultDeployment.Type.JAR)
 public class ConnectorArquillianTest {
 
     @Test

--- a/testsuite/testsuite-container/src/test/java/org/wildfly/swarm/container/test/ProjectStagesArqTest.java
+++ b/testsuite/testsuite-container/src/test/java/org/wildfly/swarm/container/test/ProjectStagesArqTest.java
@@ -25,7 +25,10 @@ import org.wildfly.swarm.container.test.Main;
  * @author Heiko Braun
  */
 @RunWith(Arquillian.class)
-@DefaultDeployment(main=Main.class)
+@DefaultDeployment(
+        main = Main.class,
+        type = DefaultDeployment.Type.JAR
+)
 public class ProjectStagesArqTest {
 
     @Test

--- a/testsuite/testsuite-datasources-config/src/test/java/org/wildfly/swarm/datasources/test/DatasourcesArquillianTest.java
+++ b/testsuite/testsuite-datasources-config/src/test/java/org/wildfly/swarm/datasources/test/DatasourcesArquillianTest.java
@@ -28,7 +28,7 @@ import org.wildfly.swarm.arquillian.DefaultDeployment;
  * @author Bob McWhirter
  */
 @RunWith(Arquillian.class)
-@DefaultDeployment()
+@DefaultDeployment(type = DefaultDeployment.Type.JAR)
 public class DatasourcesArquillianTest {
 
     @ArquillianResource

--- a/testsuite/testsuite-datasources/src/test/java/org/wildfly/swarm/datasources/test/DatasourcesArquillianTest.java
+++ b/testsuite/testsuite-datasources/src/test/java/org/wildfly/swarm/datasources/test/DatasourcesArquillianTest.java
@@ -29,7 +29,8 @@ import org.wildfly.swarm.arquillian.DefaultDeployment;
  */
 @RunWith(Arquillian.class)
 @DefaultDeployment(
-        main = Main.class
+        main = Main.class,
+        type = DefaultDeployment.Type.JAR
 )
 public class DatasourcesArquillianTest {
 

--- a/testsuite/testsuite-ejb/src/test/java/org/wildfly/swarm/ejb/EJBArqSingletonTest.java
+++ b/testsuite/testsuite-ejb/src/test/java/org/wildfly/swarm/ejb/EJBArqSingletonTest.java
@@ -28,7 +28,7 @@ import org.wildfly.swarm.arquillian.DefaultDeployment;
  * @author Bob McWhirter
  */
 @RunWith(Arquillian.class)
-@DefaultDeployment
+@DefaultDeployment(type = DefaultDeployment.Type.JAR)
 public class EJBArqSingletonTest {
     @Test
     public void testHowdy() throws Exception {

--- a/testsuite/testsuite-ejb/src/test/java/org/wildfly/swarm/ejb/EJBArquillianTest.java
+++ b/testsuite/testsuite-ejb/src/test/java/org/wildfly/swarm/ejb/EJBArquillianTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertEquals;
  */
 @Ignore
 @RunWith(Arquillian.class)
-@DefaultDeployment
+@DefaultDeployment(type = DefaultDeployment.Type.JAR)
 public class EJBArquillianTest {
 
     @Test

--- a/testsuite/testsuite-infinispan/src/test/java/org/wildfly/swarm/infinispan/test/InfinispanRemoteTest.java
+++ b/testsuite/testsuite-infinispan/src/test/java/org/wildfly/swarm/infinispan/test/InfinispanRemoteTest.java
@@ -29,7 +29,7 @@ import org.wildfly.swarm.arquillian.DefaultDeployment;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(Arquillian.class)
-@DefaultDeployment
+@DefaultDeployment(type = DefaultDeployment.Type.JAR)
 public class InfinispanRemoteTest {
 
     @ArquillianResource

--- a/testsuite/testsuite-local-dependencies/test/src/test/java/org/wildfly/swarm/local/test/ArqLocalDependenciesTest.java
+++ b/testsuite/testsuite-local-dependencies/test/src/test/java/org/wildfly/swarm/local/test/ArqLocalDependenciesTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertNotNull;
  * @author Bob McWhirter
  */
 @RunWith(Arquillian.class)
-@DefaultDeployment
+@DefaultDeployment(type = DefaultDeployment.Type.JAR)
 public class ArqLocalDependenciesTest {
 
     @Inject

--- a/testsuite/testsuite-modules/src/test/java/org/wildfly/swarm/misc/modules/ArqModulesTest.java
+++ b/testsuite/testsuite-modules/src/test/java/org/wildfly/swarm/misc/modules/ArqModulesTest.java
@@ -36,7 +36,7 @@ import org.wildfly.swarm.arquillian.DefaultDeployment;
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 @RunWith(Arquillian.class)
-@DefaultDeployment
+@DefaultDeployment(type = DefaultDeployment.Type.JAR)
 public class ArqModulesTest {
 
     @Test
@@ -50,7 +50,7 @@ public class ArqModulesTest {
 
         URL resourceUrl = cl.getResource("subdir/stuff.txt");
 
-        assertNotNull( resourceUrl );
+        assertNotNull(resourceUrl);
 
         String content = null;
 
@@ -72,7 +72,7 @@ public class ArqModulesTest {
 
         URL resourceUrl = cl.getResource("root.txt");
 
-        assertNotNull( resourceUrl );
+        assertNotNull(resourceUrl);
 
         String content = null;
 
@@ -95,7 +95,7 @@ public class ArqModulesTest {
 
         URL resourceUrl = cl.getResource("another_subdir/stuff.txt");
 
-        assertNotNull( resourceUrl );
+        assertNotNull(resourceUrl);
 
         String content = null;
 

--- a/testsuite/testsuite-security/src/test/java/org/wildfly/swarm/security/SecurityArquillianTest.java
+++ b/testsuite/testsuite-security/src/test/java/org/wildfly/swarm/security/SecurityArquillianTest.java
@@ -32,7 +32,7 @@ import static org.junit.Assert.assertNotNull;
  * @author Bob McWhirter
  */
 @RunWith(Arquillian.class)
-@DefaultDeployment
+@DefaultDeployment(type= DefaultDeployment.Type.JAR)
 public class SecurityArquillianTest {
 
     @ArquillianResource


### PR DESCRIPTION
…AKING CHANGE

Motivation
----------

We encourage war-centric deployments, so we should make it easier.

Modifications
-------------

Changed the default from Type.JAR to Type.WAR.  Adjusted all
tests that used it with an implicit Type.JAR to be explicit about
Type.JAR.

Result
------

BREAKING CHANGE in the default behaviour of @DefaultDeployment.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
