### PR TITLE
SWARM-987 - Enable spatial capabilities.

### DIFF
--- a/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/drivers/PostgreSQLDriverInfo.java
+++ b/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/drivers/PostgreSQLDriverInfo.java
@@ -36,7 +36,8 @@ public class PostgreSQLDriverInfo extends DriverInfo {
     public static final String DEFAULT_PASSWORD = "postgres";
 
     public PostgreSQLDriverInfo() {
-        super("postgresql", ModuleIdentifier.create("org.postgresql"), "org.postgresql.Driver");
+        super("postgresql", ModuleIdentifier.create("org.postgresql"), "org.postgresql.Driver",
+                "org.postgis.DriverWrapper");
     }
 
     @Override

--- a/fractions/javaee/jpa-spatial/pom.xml
+++ b/fractions/javaee/jpa-spatial/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>wildfly-swarm</artifactId>
+    <version>2017.2.0-SNAPSHOT</version>
+    <relativePath>../../../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>jpa-spatial</artifactId>
+
+  <name>JPA Spatial Extensions</name>
+  <description>Java Persistence API with Spatial Extensions</description>
+
+  <properties>
+    <swarm.fraction.stability>experimental</swarm.fraction.stability>
+    <swarm.fraction.tags>JavaEE,Data,GIS,Spatial</swarm.fraction.tags>
+  </properties>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.vividsolutions</groupId>
+      <artifactId>jts</artifactId>
+      <version>1.13</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/fractions/javaee/jpa-spatial/src/main/java/org/wildfly/swarm/jpa/spatial/JPASpatialFraction.java
+++ b/fractions/javaee/jpa-spatial/src/main/java/org/wildfly/swarm/jpa/spatial/JPASpatialFraction.java
@@ -1,0 +1,11 @@
+package org.wildfly.swarm.jpa.spatial;
+
+import org.wildfly.swarm.spi.api.Fraction;
+import org.wildfly.swarm.spi.api.annotations.DeploymentModule;
+
+/**
+ * @author Bob McWhirter
+ */
+@DeploymentModule(name = "org.hibernate.spatial")
+public class JPASpatialFraction implements Fraction<JPASpatialFraction> {
+}

--- a/fractions/javaee/jpa-spatial/src/main/resources/modules/org/hibernate/spatial/main/module.xml
+++ b/fractions/javaee/jpa-spatial/src/main/resources/modules/org/hibernate/spatial/main/module.xml
@@ -1,0 +1,16 @@
+<module xmlns="urn:jboss:module:1.3" name="org.hibernate.spatial">
+  <resources>
+    <artifact name="org.hibernate:hibernate-spatial:${version.hibernate-spatial}"/>
+    <artifact name="org.geolatte:geolatte-geom:${version.geolatte}"/>
+    <artifact name="com.vividsolutions:jts:${version.vividsolutions-jts}"/>
+  </resources>
+
+  <dependencies>
+    <module name="org.hibernate"/>
+    <module name="org.jboss.logging"/>
+    <module name="org.dom4j"/>
+    <module name="org.slf4j"/>
+
+    <module name="org.postgresql" optional="true"/>
+  </dependencies>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,10 @@
     <version.swagger.javassist>3.18.2-GA</version.swagger.javassist>
     <version.swagger.commons.lang>3.2.1</version.swagger.commons.lang>
 
+    <version.hibernate-spatial>5.0.10.Final</version.hibernate-spatial>
+    <version.geolatte>1.0.1</version.geolatte>
+    <version.vividsolutions-jts>1.13</version.vividsolutions-jts>
+
     <version.eclipse.link>2.6.2</version.eclipse.link>
     <version.h2>1.4.187</version.h2>
     <version.mysql>5.1.39</version.mysql>
@@ -728,6 +732,12 @@
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
+        <artifactId>jpa-spatial</artifactId>
+        <version>2017.2.0-SNAPSHOT</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.wildfly.swarm</groupId>
         <artifactId>jpa-eclipselink</artifactId>
         <version>2017.2.0-SNAPSHOT</version>
       </dependency>
@@ -1182,6 +1192,7 @@
     <module>fractions/javaee/jca</module>
     <module>fractions/javaee/jmx</module>
     <module>fractions/javaee/jpa</module>
+    <module>fractions/javaee/jpa-spatial</module>
     <module>fractions/javaee/jpa-eclipselink</module>
     <module>fractions/javaee/jsf</module>
     <module>fractions/javaee/mail</module>


### PR DESCRIPTION
Motivation
----------

The world isn't flat.  People like maps.  Hibernate-spatial
exists.

Modifications
-------------

a) Provide jpa-spatial to bring in a new org.hibernate.spatial:main
module, which includes the spatial extensions to hibernate, plus
muckings to make them work with at least PostGIS.

b) Provide detection of PostGIS JDBC driver extensions on top
of the PostgreSQL detection.

Result
------

You can moderately use spatial JPA now.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
