### PR TITLE
SWARM-966: Resource root in module.xml not found running in IDE

### DIFF
--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/NestedJarResourceLoader.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/NestedJarResourceLoader.java
@@ -76,6 +76,11 @@ public class NestedJarResourceLoader {
                 }
             }
         } else if (urlString.startsWith("file:")) {
+            if (loaderName.endsWith(".jar") || loaderName.endsWith(".war")) {
+                return ResourceLoaders.createJarResourceLoader(
+                        loaderName,
+                        new JarFile(new File(new File(urlString.substring(5, urlString.length())), loaderPath)));
+            }
             return ResourceLoaders.createFileResourceLoader(
                     loaderPath,
                     new File(urlString.substring(5, urlString.length()))


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
When providing a custom module.xml, the jar within a <resource-root> element was not being found such that classes could be loaded from it.

Modifications
-------------
Create a ResourceLoader for Jars when we're dealing with a .jar or .war resource.

Result
------
<resource-root> jars are correctly loaded in a custom module.xml
