### PR TITLE
SWARM-1013: Add a default constructor to FractionDescriptor

### DIFF
--- a/tools/src/main/java/org/wildfly/swarm/tools/FractionDescriptor.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/FractionDescriptor.java
@@ -24,6 +24,20 @@ import java.util.Set;
  */
 public class FractionDescriptor {
 
+    /**
+     * Frameworks that proxy this class need a public constructor to perform adequately.
+     */
+    public FractionDescriptor() {
+        this.groupId = null;
+        this.artifactId = null;
+        this.version = null;
+        this.name = null;
+        this.description = null;
+        this.tags = null;
+        this.internal = false;
+        this.stability = null;
+    }
+
     public FractionDescriptor(String groupId, String artifactId, String version, String name, String description, String tags, boolean internal, FractionStability stability) {
         this.groupId = groupId;
         this.artifactId = artifactId;


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
FractionDescriptor is unproxyable because it doesn't have a default constructor.

Modifications
-------------
A default constructor was added with null values.

Result
------
Proxy frameworks can now successfully proxy this class.