### PR TITLE
SWARM-672 - Multiple sources of configuration

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/config/ClassLoaderConfigLocator.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/ClassLoaderConfigLocator.java
@@ -1,0 +1,56 @@
+package org.wildfly.swarm.container.config;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.jboss.modules.Module;
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.modules.ModuleLoadException;
+import org.wildfly.swarm.Swarm;
+
+/**
+ * @author Bob McWhirter
+ */
+public class ClassLoaderConfigLocator extends ConfigLocator {
+
+    public static ClassLoaderConfigLocator system() {
+        return new ClassLoaderConfigLocator(ClassLoader.getSystemClassLoader());
+    }
+
+    public static ClassLoaderConfigLocator forApplication() throws ModuleLoadException {
+        Module appModule = Module.getBootModuleLoader().loadModule(ModuleIdentifier.create(Swarm.APPLICATION_MODULE_NAME));
+        return new ClassLoaderConfigLocator(appModule.getClassLoader());
+    }
+
+    private ClassLoaderConfigLocator(ClassLoader classLoader) {
+        this.classLoader = classLoader;
+    }
+
+    @Override
+    public Stream<URL> locate(String profileName) throws IOException {
+        List<URL> located = new ArrayList<>();
+
+        Enumeration<URL> resources = this.classLoader.getResources(PROJECT_PREFIX + profileName + ".yml");
+
+        while (resources.hasMoreElements()) {
+            URL each = resources.nextElement();
+            located.add(each);
+        }
+
+        resources = this.classLoader.getResources(PROJECT_PREFIX + profileName + ".properties");
+
+        while (resources.hasMoreElements()) {
+            URL each = resources.nextElement();
+            located.add(each);
+        }
+
+        return located.stream();
+    }
+
+    private final ClassLoader classLoader;
+
+}

--- a/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigLocator.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigLocator.java
@@ -1,0 +1,19 @@
+package org.wildfly.swarm.container.config;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.stream.Stream;
+
+/**
+ * @author Bob McWhirter
+ */
+public abstract class ConfigLocator {
+
+    public static final String PROJECT_PREFIX = "project-";
+
+    public ConfigLocator() {
+    }
+
+    public abstract Stream<URL> locate(String profileName) throws IOException;
+
+}

--- a/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewFactory.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewFactory.java
@@ -18,10 +18,15 @@ package org.wildfly.swarm.container.config;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
 
 import javax.enterprise.inject.Vetoed;
 
+import org.jboss.modules.ModuleLoadException;
 import org.yaml.snakeyaml.Yaml;
 
 /**
@@ -31,25 +36,88 @@ import org.yaml.snakeyaml.Yaml;
 @Vetoed
 public class ConfigViewFactory {
 
+    private static final String STAGES = "stages";
+
     private final ConfigViewImpl configView;
+
+    public static ConfigViewFactory defaultFactory() throws ModuleLoadException {
+        return new ConfigViewFactory(
+                new FilesystemConfigLocator(),
+                ClassLoaderConfigLocator.system(),
+                ClassLoaderConfigLocator.forApplication()
+        );
+    }
 
     public ConfigViewFactory() {
         this.configView = new ConfigViewImpl();
+    }
+
+    public ConfigViewFactory(ConfigLocator... locators) {
+        this();
+        for (ConfigLocator locator : locators) {
+            addLocator(locator);
+        }
+    }
+
+    public void addLocator(ConfigLocator locator) {
+        this.locators.add(locator);
+    }
+
+    public ConfigViewFactory load(String profileName) {
+        this.locators
+                .stream()
+                .flatMap(locator -> {
+                    try {
+                        return locator.locate(profileName);
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                    return null;
+                })
+                .filter(Objects::nonNull)
+                .forEach(url -> {
+                    try {
+                        load(profileName, url);
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                });
+        return this;
+    }
+
+    public void load(String profileName, URL url) throws IOException {
+        if (url.getPath().endsWith(".properties")) {
+            loadProperties(profileName, url);
+        } else if (url.getPath().endsWith(".yml")) {
+            loadYaml(profileName, url);
+        }
+    }
+
+    protected void loadProperties(String profileName, URL url) throws IOException {
+        Properties props = new Properties();
+        props.load(url.openStream());
+        ConfigNode configNode = PropertiesConfigNodeFactory.load(props);
+        this.configView.register(profileName, configNode);
+    }
+
+    protected void loadYaml(String profileName, URL url) throws IOException {
+        if (profileName.equals(STAGES) || url.getPath().endsWith("-stages.yml")) {
+            loadProjectStages(url);
+            return;
+        }
+
+        loadYamlProjectConfig(profileName, url);
     }
 
     public ConfigViewImpl build() {
         return this.configView;
     }
 
-    public void loadProjectStages(URL url) throws IOException {
+    private void loadProjectStages(URL url) throws IOException {
         loadProjectStages(url.openStream());
     }
 
-    public void loadProjectConfig(String name, URL url) throws IOException {
-        loadProjectConfig(name, url.openStream());
-    }
-
-    public void loadProjectStages(InputStream inputStream) {
+    private void loadProjectStages(InputStream inputStream) {
         Yaml yaml = new Yaml();
         Iterable<Object> docs = yaml.loadAll(inputStream);
 
@@ -71,13 +139,19 @@ public class ConfigViewFactory {
         }
     }
 
-    public void loadProjectConfig(String name, InputStream inputStream) {
+    private void loadYamlProjectConfig(String name, URL url) throws IOException {
+        loadYamlProjectConfig(name, url.openStream());
+    }
+
+    private void loadYamlProjectConfig(String name, InputStream inputStream) {
         Yaml yaml = new Yaml();
         Map<String, ?> doc = (Map<String, ?>) yaml.load(inputStream);
 
         ConfigNode node = MapConfigNodeFactory.load(doc);
         this.configView.register(name, node);
     }
+
+    private List<ConfigLocator> locators = new ArrayList<>();
 
     private static final String PROJECT_PREFIX = "project";
 

--- a/core/container/src/main/java/org/wildfly/swarm/container/config/FilesystemConfigLocator.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/FilesystemConfigLocator.java
@@ -1,0 +1,45 @@
+package org.wildfly.swarm.container.config;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * @author Bob McWhirter
+ */
+public class FilesystemConfigLocator extends ConfigLocator {
+
+    public FilesystemConfigLocator() {
+        this(Paths.get("."));
+    }
+
+    public FilesystemConfigLocator(Path root) {
+        this.root = root;
+    }
+
+    @Override
+    public Stream<URL> locate(String profileName) throws IOException {
+        List<URL> located = new ArrayList<>();
+
+        Path path = this.root.resolve(PROJECT_PREFIX + profileName + ".yml");
+
+        if (Files.exists(path)) {
+            located.add(path.toUri().toURL());
+        }
+
+        path = this.root.resolve(PROJECT_PREFIX + profileName + ".properties");
+        if (Files.exists(path)) {
+            located.add(path.toUri().toURL());
+        }
+
+        return located.stream();
+    }
+
+    private final Path root;
+
+}


### PR DESCRIPTION
Motivation
----------

We may need to load configuration from various places.  While
we don't currently, we should have an architecture in place to
support it when/if required.  Plus we *do* currently load several
types of configuration (.yml and .properties) from several places
(filesystem, system classpath, swarm.application module).  So
we should clean up that code.

Modifications
-------------

Internal architectural changes to support strategies for locating
and loading .yml or .properties from various places.

Result
------

Softer skin.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
