### PR TITLE
SWARM-1020: Fix equal position checking of Option#parse

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/cli/Option.java
+++ b/core/container/src/main/java/org/wildfly/swarm/cli/Option.java
@@ -297,7 +297,7 @@ public class Option<T> {
         } else if (this.longArg != null && cur.startsWith(DOUBLE_HYPHEN + this.longArg)) {
             matchedArg = DOUBLE_HYPHEN + this.longArg;
             if (hasValue() && cur.length() >= this.longArg.length() + 3) {
-                if (cur.charAt(this.longArg.length() + 3) == '=') {
+                if (cur.charAt(this.longArg.length() + 2) == '=') {
                     value = cur.substring(this.longArg.length() + 3);
                 } else {
                     value = cur.substring(this.longArg.length() + 2);

--- a/core/container/src/test/java/org/wildfly/swarm/cli/CommandLineTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/cli/CommandLineTest.java
@@ -97,7 +97,7 @@ public class CommandLineTest {
     @Test
     public void testLongArgWithEqual() throws Exception {
         String fileName = "my.properties";
-        String expectedPath = "file:" + System.getProperty("user.dir") + File.separator + fileName;
+        String expectedPath = new URL(System.getProperty("user.dir") + File.separator + fileName).toString;
 
         CommandLine cmd = CommandLine.parse("--properties=" + fileName);
 
@@ -107,7 +107,7 @@ public class CommandLineTest {
     @Test
     public void testLongArgWithoutEqual() throws Exception {
         String fileName = "my.properties";
-        String expectedPath = "file:" + System.getProperty("user.dir") + File.separator + fileName;
+        String expectedPath = new URL(System.getProperty("user.dir") + File.separator + fileName).toString;
 
         CommandLine cmd = CommandLine.parse("--properties", fileName);
 

--- a/core/container/src/test/java/org/wildfly/swarm/cli/CommandLineTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/cli/CommandLineTest.java
@@ -98,7 +98,7 @@ public class CommandLineTest {
     @Test
     public void testLongArgWithEqual() throws Exception {
         String fileName = "my.properties";
-        String expectedPath = new URL(System.getProperty("user.dir") + File.separator + fileName).toString;
+        String expectedPath = new URL(System.getProperty("user.dir") + File.separator + fileName).toString();
 
         CommandLine cmd = CommandLine.parse("--properties=" + fileName);
 
@@ -108,7 +108,7 @@ public class CommandLineTest {
     @Test
     public void testLongArgWithoutEqual() throws Exception {
         String fileName = "my.properties";
-        String expectedPath = new URL(System.getProperty("user.dir") + File.separator + fileName).toString;
+        String expectedPath = new URL(System.getProperty("user.dir") + File.separator + fileName).toString();
 
         CommandLine cmd = CommandLine.parse("--properties", fileName);
 

--- a/core/container/src/test/java/org/wildfly/swarm/cli/CommandLineTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/cli/CommandLineTest.java
@@ -15,10 +15,14 @@
  */
 package org.wildfly.swarm.cli;
 
+import java.io.File;
+
 import org.junit.Test;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.wildfly.swarm.cli.CommandLine.HELP;
+import static org.wildfly.swarm.cli.CommandLine.PROFILES;
+import static org.wildfly.swarm.cli.CommandLine.PROPERTIES_URL;
 import static org.wildfly.swarm.cli.CommandLine.PROPERTY;
 import static org.wildfly.swarm.cli.CommandLine.VERSION;
 
@@ -88,6 +92,26 @@ public class CommandLineTest {
         assertThat(cmd.get(PROPERTY)).hasSize(2);
         assertThat(cmd.get(PROPERTY).get("foo")).isEqualTo("true");
         assertThat(cmd.get(PROPERTY).get("bar")).isEqualTo("cheese");
+    }
+
+    @Test
+    public void testLongArgWithEqual() throws Exception {
+        String fileName = "my.properties";
+        String expectedPath = "file:" + System.getProperty("user.dir") + File.separator + fileName;
+
+        CommandLine cmd = CommandLine.parse("--properties=" + fileName);
+
+        assertThat(cmd.get(PROPERTIES_URL).toString()).isEqualTo(expectedPath);
+    }
+
+    @Test
+    public void testLongArgWithoutEqual() throws Exception {
+        String fileName = "my.properties";
+        String expectedPath = "file:" + System.getProperty("user.dir") + File.separator + fileName;
+
+        CommandLine cmd = CommandLine.parse("--properties", fileName);
+
+        assertThat(cmd.get(PROPERTIES_URL).toString()).isEqualTo(expectedPath);
     }
 
     @Test

--- a/core/container/src/test/java/org/wildfly/swarm/cli/CommandLineTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/cli/CommandLineTest.java
@@ -16,6 +16,7 @@
 package org.wildfly.swarm.cli;
 
 import java.io.File;
+import java.net.URL;
 
 import org.junit.Test;
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
org.wildfly.swarm.cli.Option#parse returns a specified value of a long arg with equal
like --foo=bar but it returns the value included '='(e.g. =bar) because the '=' postion
check of the method is wrong.

Modifications
-------------
The check of the '=' position is fixed apploriately.

Result
------
Option#parse returns an expected value.