### PR TITLE
SWARM-839: Do not override user configured context root

### DIFF
--- a/fractions/swagger/src/main/java/org/wildfly/swarm/swagger/SwaggerArchive.java
+++ b/fractions/swagger/src/main/java/org/wildfly/swarm/swagger/SwaggerArchive.java
@@ -107,6 +107,13 @@ public interface SwaggerArchive extends Assignable {
     SwaggerArchive setContextRoot(String root);
 
     /**
+     * Determine if the archive has a context root configured
+     *
+     * @return true if the context root has been configured
+     */
+    boolean hasContextRoot();
+
+    /**
      * Sets whether the swagger.json will be pretty printed.
      *
      * @param prettyPrint if true swagger.json will be pretty printed

--- a/fractions/swagger/src/main/java/org/wildfly/swarm/swagger/internal/SwaggerArchiveImpl.java
+++ b/fractions/swagger/src/main/java/org/wildfly/swarm/swagger/internal/SwaggerArchiveImpl.java
@@ -112,6 +112,11 @@ public class SwaggerArchiveImpl extends AssignableBase<ArchiveBase<?>> implement
     }
 
     @Override
+    public boolean hasContextRoot() {
+        return getConfigurationAsset().getContextRoot() != null;
+    }
+
+    @Override
     public SwaggerArchive setPrettyPrint(boolean prettyPrint) {
         getConfigurationAsset().setPrettyPrint(prettyPrint);
         return this;

--- a/fractions/swagger/src/main/java/org/wildfly/swarm/swagger/internal/SwaggerConfigurationAsset.java
+++ b/fractions/swagger/src/main/java/org/wildfly/swarm/swagger/internal/SwaggerConfigurationAsset.java
@@ -105,6 +105,10 @@ public class SwaggerConfigurationAsset implements Asset {
         return this;
     }
 
+    public String getContextRoot() {
+        return (String) configuration.get(SwaggerConfig.Key.ROOT);
+    }
+
     public void setPrettyPrint(boolean prettyPrint) {
         configuration.put(SwaggerConfig.Key.PRETTY_PRINT, prettyPrint);
     }

--- a/fractions/swagger/src/main/java/org/wildfly/swarm/swagger/runtime/SwaggerArchivePreparer.java
+++ b/fractions/swagger/src/main/java/org/wildfly/swarm/swagger/runtime/SwaggerArchivePreparer.java
@@ -28,8 +28,11 @@ public class SwaggerArchivePreparer implements ArchivePreparer {
                 // Make the deployment a swagger archive
                 SwaggerArchive swaggerArchive = deployment.as(SwaggerArchive.class);
 
-                // Get the context root from the deployment and tell swagger about it
-                swaggerArchive.setContextRoot(deployment.getContextRoot());
+                // If the context root has not been configured
+                // get the context root from the deployment and tell swagger about it
+                if (!swaggerArchive.hasContextRoot()) {
+                    swaggerArchive.setContextRoot(deployment.getContextRoot());
+                }
 
                 // If the archive has not been configured with packages for swagger to scan
                 // try to be smart about it, and find the topmost package that's not in the

--- a/fractions/swagger/src/test/java/org/wildfly/swarm/swagger/SwaggerArchiveTest.java
+++ b/fractions/swagger/src/test/java/org/wildfly/swarm/swagger/SwaggerArchiveTest.java
@@ -74,5 +74,6 @@ public class SwaggerArchiveTest {
         assertThat(config.get(SwaggerConfig.Key.VERSION)).isEqualTo("1.0");
         assertThat(config.get(SwaggerConfig.Key.TERMS_OF_SERVICE_URL)).isEqualTo("http://myapplication.com/tos.txt");
         assertThat(Arrays.toString((String[])config.get(SwaggerConfig.Key.PACKAGES))).isEqualTo("[com.tester.resource, com.tester.other.resource]");
+        assertThat(config.get(SwaggerConfig.Key.ROOT)).isEqualTo("/tacos");
     }
 }


### PR DESCRIPTION
(Possible) fix for https://issues.jboss.org/browse/SWARM-839

The problem seems to be that SwaggerArchivePreparer always overrides the user configured context root (Swagger base path) with the context root from the deployment. 
This prevents the user from configuring their own basePath using SwaggerArchive.setContextRoot()

The example application at https://github.com/harrol/wildfly-swarm-swagger-test can be used to reproduce the bug in Wildfly Swarm 2017.1.1. The basePath is not set to '/context' as expected. When using the proposed fix the basePath is set.
