### PR TITLE
SWARM-1023: Arquillian auto added to all BOMs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   </scm>
 
   <properties>
-    <version.wildfly.swarm.fraction.plugin>40</version.wildfly.swarm.fraction.plugin>
+    <version.wildfly.swarm.fraction.plugin>41</version.wildfly.swarm.fraction.plugin>
     <version.wildfly.swarm.checkstyle>3</version.wildfly.swarm.checkstyle>
 
     <version.cdi2>2.0.Alpha4</version.cdi2>
@@ -1164,7 +1164,6 @@
   <modules>
     <!-- misc -->
     <module>tools</module>
-    <module>arquillian</module>
 
     <!-- base -->
     <module>core/bootstrap</module>
@@ -1245,12 +1244,14 @@
     <module>fractions/cdi-extensions/cdi-config</module>
     <module>fractions/cdi-extensions/cdi-jaxrsapi</module>
 
-    <module>testsuite</module>
-
     <module>fraction-list</module>
     <module>plugin</module>
-    <module>swarmtool</module>
     <module>boms</module>
+
+    <module>arquillian</module>
+    <module>swarmtool</module>
+
+    <module>testsuite</module>
 
     <module>standalone-servers</module>
   </modules>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
Arquillian is critical to be in all BOMs, so we've updated the fraction-plugin to auto add Arquillian and not include Arquillian as an auto discovered fraction when BOM building.

Also modify the build order to only build arquillian after all fractions and before testsuites.

Modifications
-------------
Reorder modules in pom.xml and upgrade to fraction-plugin 41.

Result
------
No change to product behavior.
