### PR TITLE
SWARM-891: Fraction autodetection with Arquillian tests

### DIFF
--- a/arquillian/adapter/pom.xml
+++ b/arquillian/adapter/pom.xml
@@ -39,6 +39,10 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>fraction-list</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>spi</artifactId>
     </dependency>
     <dependency>

--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/MavenDependencyDeclarationFactory.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/MavenDependencyDeclarationFactory.java
@@ -55,11 +55,15 @@ class MavenDependencyDeclarationFactory extends DependencyDeclarationFactory {
                     directDep.getCoordinate().getClassifier(),
                     directDep.asFile()
             );
-            MavenResolvedArtifact[] bucket = resolvingHelper.withResolver(r -> pom
-                    .resolve(parent.mavenGav())
-                    .withTransitivity()
-                    .asResolvedArtifact()
-            );
+            MavenResolvedArtifact[] bucket =
+                    resolvingHelper.withResolver(r -> {
+                                                     r.addDependency(resolvingHelper.createMavenDependency(parent));
+                                                     return pom
+                                                             .resolve()
+                                                             .withTransitivity()
+                                                             .asResolvedArtifact();
+                                                 }
+                    );
 
             for (MavenResolvedArtifact dep : bucket) {
 

--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
@@ -51,6 +51,7 @@ import org.wildfly.swarm.arquillian.CreateSwarm;
 import org.wildfly.swarm.arquillian.adapter.resources.ContextRoot;
 import org.wildfly.swarm.arquillian.resolver.ShrinkwrapArtifactResolvingHelper;
 import org.wildfly.swarm.bootstrap.util.BootstrapProperties;
+import org.wildfly.swarm.fractionlist.FractionList;
 import org.wildfly.swarm.internal.FileSystemLayout;
 import org.wildfly.swarm.spi.api.DependenciesContainer;
 import org.wildfly.swarm.spi.api.JARArchive;
@@ -152,7 +153,8 @@ public class UberjarSimpleContainer implements SimpleContainer {
         final ShrinkwrapArtifactResolvingHelper resolvingHelper = ShrinkwrapArtifactResolvingHelper.defaultInstance();
 
         BuildTool tool = new BuildTool(resolvingHelper)
-                .fractionDetectionMode(BuildTool.FractionDetectionMode.never)
+                .fractionDetectionMode(BuildTool.FractionDetectionMode.when_missing)
+                .fractionList(FractionList.get())
                 .bundleDependencies(false);
 
         String additionalModules = System.getProperty(SwarmInternalProperties.BUILD_MODULES);

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/DependencyTree.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/DependencyTree.java
@@ -1,15 +1,18 @@
 package org.wildfly.swarm.bootstrap.env;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Each direct dependency (parent) keeps a bucket of transient dependencies (children)
  * so we can infer the origin (parent) for each transient dependency.
  *
  * @author Heiko Braun
+ * @author Ken Finnigan
  * @since 05/12/2016
  */
 public class DependencyTree<T> {
@@ -40,11 +43,19 @@ public class DependencyTree<T> {
         }
     }
 
-    public Set<T> getDirectDeps() {
-        return depTree.keySet();
+    public Collection<T> getDirectDeps() {
+        return depTree
+                .keySet()
+                .stream()
+                .sorted(this::comparator)
+                .collect(Collectors.toList());
     }
 
-    public Set<T> getTransientDeps(T parent) {
+    protected int comparator(T first, T second) {
+        return 0;
+    }
+
+    public Collection<T> getTransientDeps(T parent) {
         Set<T> deps = depTree.get(parent);
         if (null == deps) {
             throw new IllegalArgumentException("Unknown dependency " + parent);

--- a/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/GradleArtifactResolvingHelper.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/GradleArtifactResolvingHelper.java
@@ -72,9 +72,9 @@ public class GradleArtifactResolvingHelper implements ArtifactResolvingHelper {
     }
 
     @Override
-    public Set<ArtifactSpec> resolveAll(final Set<ArtifactSpec> specs, boolean transitive, boolean defaultExcludes) throws Exception {
+    public Set<ArtifactSpec> resolveAll(final Collection<ArtifactSpec> specs, boolean transitive, boolean defaultExcludes) throws Exception {
         if (specs.isEmpty()) {
-            return specs;
+            return Collections.EMPTY_SET;
         }
 
         return doResolve(specs, transitive)

--- a/plugin/src/main/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelper.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelper.java
@@ -16,6 +16,8 @@
 package org.wildfly.swarm.plugin.maven;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -102,9 +104,9 @@ public class MavenArtifactResolvingHelper implements ArtifactResolvingHelper {
     }
 
     @Override
-    public Set<ArtifactSpec> resolveAll(Set<ArtifactSpec> specs, boolean transitive, boolean defaultExcludes) throws Exception {
+    public Set<ArtifactSpec> resolveAll(Collection<ArtifactSpec> specs, boolean transitive, boolean defaultExcludes) throws Exception {
         if (specs.isEmpty()) {
-            return specs;
+            return Collections.EMPTY_SET;
         }
         List<DependencyNode> nodes = null;
         if (transitive) {

--- a/tools/src/main/java/org/wildfly/swarm/tools/ArtifactResolver.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/ArtifactResolver.java
@@ -15,17 +15,18 @@
  */
 package org.wildfly.swarm.tools;
 
-import java.util.Set;
+import java.util.Collection;
 
 /**
  * @author Heiko Braun
+ * @author Ken Finnigan
  * @since 24/10/2016
  */
 public interface ArtifactResolver {
 
     ArtifactSpec resolveArtifact(ArtifactSpec spec) throws Exception;
 
-    Set<ArtifactSpec> resolveAllArtifactsTransitively(Set<ArtifactSpec> specs, boolean excludes) throws Exception;
+    Collection<ArtifactSpec> resolveAllArtifactsTransitively(Collection<ArtifactSpec> specs, boolean excludes) throws Exception;
 
-    Set<ArtifactSpec> resolveAllArtifactsNonTransitively(Set<ArtifactSpec> specs) throws Exception;
+    Collection<ArtifactSpec> resolveAllArtifactsNonTransitively(Collection<ArtifactSpec> specs) throws Exception;
 }

--- a/tools/src/main/java/org/wildfly/swarm/tools/ArtifactResolvingHelper.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/ArtifactResolvingHelper.java
@@ -15,10 +15,12 @@
  */
 package org.wildfly.swarm.tools;
 
+import java.util.Collection;
 import java.util.Set;
 
 /**
  * @author Bob McWhirter
+ * @author Ken Finnigan
  */
 public interface ArtifactResolvingHelper {
     /**
@@ -30,9 +32,9 @@ public interface ArtifactResolvingHelper {
      */
     ArtifactSpec resolve(ArtifactSpec spec) throws Exception;
 
-    default Set<ArtifactSpec> resolveAll(Set<ArtifactSpec> specs) throws Exception {
+    default Set<ArtifactSpec> resolveAll(Collection<ArtifactSpec> specs) throws Exception {
         return resolveAll(specs, true, false);
     }
 
-    Set<ArtifactSpec> resolveAll(Set<ArtifactSpec> specs, boolean transitive, boolean defaultExcludes) throws Exception;
+    Set<ArtifactSpec> resolveAll(Collection<ArtifactSpec> specs, boolean transitive, boolean defaultExcludes) throws Exception;
 }

--- a/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
@@ -27,10 +27,12 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TimeZone;
@@ -471,7 +473,7 @@ public class BuildTool {
     private void populateUberJarMavenRepository(Archive archive, ResolvedDependencies resolvedDependencies) throws Exception {
 
         Set<ArtifactSpec> alreadyResolved = new HashSet<>();
-        Set<ArtifactSpec> toBeResolved = new HashSet<>();
+        List<ArtifactSpec> toBeResolved = new ArrayList<>();
 
         for (ArtifactSpec dependency : resolvedDependencies.getDependencies()) {
 
@@ -498,7 +500,7 @@ public class BuildTool {
                                            resolvedDependencies.getDependencies().size()) + " artifacts");
 
         if (toBeResolved.size() > 0) {
-            Set<ArtifactSpec> newResolved = resolver.resolveAllArtifactsNonTransitively(toBeResolved);
+            Collection<ArtifactSpec> newResolved = resolver.resolveAllArtifactsNonTransitively(toBeResolved);
             alreadyResolved.addAll(newResolved);
         }
 
@@ -508,7 +510,7 @@ public class BuildTool {
     }
 
     private void populateUserMavenRepository(ResolvedDependencies resolvedDependencies) throws Exception {
-        Set<ArtifactSpec> toBeResolved = new HashSet<>();
+        List<ArtifactSpec> toBeResolved = new ArrayList<>();
 
         toBeResolved.addAll(
                 resolvedDependencies.getDependencies().stream()

--- a/tools/src/main/java/org/wildfly/swarm/tools/DeclaredDependencies.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/DeclaredDependencies.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -30,21 +31,12 @@ import org.wildfly.swarm.bootstrap.util.MavenArtifactDescriptor;
  * These maye be unresolved, which means you cannot assume they are available in any local repository.
  *
  * @author Heiko Braun
+ * @author Ken Finnigan
  * @since 24/10/2016
  */
 public class DeclaredDependencies extends DependencyTree<ArtifactSpec> {
 
-    @Deprecated
-    public void addExplicitDependency(ArtifactSpec artifactSpec) {
-        throw new IllegalArgumentException("To be removed");
-    }
-
-    @Deprecated
-    public void addTransientDependency(ArtifactSpec artifactSpec) {
-        throw new IllegalArgumentException("To be removed");
-    }
-
-    public Set<ArtifactSpec> getExplicitDependencies() {
+    public Collection<ArtifactSpec> getExplicitDependencies() {
         return getDirectDeps();
     }
 
@@ -58,7 +50,7 @@ public class DeclaredDependencies extends DependencyTree<ArtifactSpec> {
         return allTransient;
     }
 
-    public Set<ArtifactSpec> getTransientDependencies(ArtifactSpec artifact) {
+    public Collection<ArtifactSpec> getTransientDependencies(ArtifactSpec artifact) {
         return getTransientDeps(artifact);
     }
 
@@ -111,6 +103,16 @@ public class DeclaredDependencies extends DependencyTree<ArtifactSpec> {
         } catch (IOException e) {
             throw new RuntimeException("Failed to write dependency tree", e);
         }
+    }
+
+    @Override
+    protected int comparator(ArtifactSpec first, ArtifactSpec second) {
+        if (first.scope.equals("compile") || first.scope.equals("provided")) {
+            return -1;
+        } else if (second.scope.equals("compile") || second.scope.equals("provided")) {
+            return 1;
+        }
+        return 0;
     }
 
     private HashSet<ArtifactSpec> allTransient;

--- a/tools/src/main/java/org/wildfly/swarm/tools/DefaultArtifactResolver.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/DefaultArtifactResolver.java
@@ -15,10 +15,11 @@
  */
 package org.wildfly.swarm.tools;
 
-import java.util.Set;
+import java.util.Collection;
 
 /**
  * @author Heiko Braun
+ * @author Ken Finnigan
  * @since 24/10/2016
  */
 public class DefaultArtifactResolver implements ArtifactResolver {
@@ -41,11 +42,11 @@ public class DefaultArtifactResolver implements ArtifactResolver {
         return spec;
     }
 
-    public Set<ArtifactSpec> resolveAllArtifactsTransitively(Set<ArtifactSpec> specs, boolean defaultExcludes) throws Exception {
+    public Collection<ArtifactSpec> resolveAllArtifactsTransitively(Collection<ArtifactSpec> specs, boolean defaultExcludes) throws Exception {
         return this.resolver.resolveAll(specs, true, defaultExcludes);
     }
 
-    public Set<ArtifactSpec> resolveAllArtifactsNonTransitively(Set<ArtifactSpec> specs) throws Exception {
+    public Collection<ArtifactSpec> resolveAllArtifactsNonTransitively(Collection<ArtifactSpec> specs) throws Exception {
         return this.resolver.resolveAll(specs, false, false);
     }
 

--- a/tools/src/main/java/org/wildfly/swarm/tools/ResolvedDependencies.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/ResolvedDependencies.java
@@ -32,6 +32,7 @@ import org.jboss.shrinkwrap.api.Node;
  * Dependencies that have been resolved to local files.
  *
  * @author Heiko Braun
+ * @author Ken Finnigan
  * @since 26/10/2016
  */
 public interface ResolvedDependencies {
@@ -52,6 +53,8 @@ public interface ResolvedDependencies {
     ArtifactSpec findJBossModulesJar();
 
     ArtifactSpec findArtifact(String groupId, String artifactId, String version, String packaging, String classifier);
+
+    ArtifactSpec findArtifact(String groupId, String artifactId, String version, String packaging, String classifier, boolean includeTestScope);
 
     static boolean isExplodedBootstrap(ArtifactSpec dependency) {
         if (dependency.groupId().equals(JBOSS_MODULES_GROUP_ID) && dependency.artifactId().equals(JBOSS_MODULES_ARTIFACT_ID)) {


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
Currently there is no way for Arquillian tests to autodetect fractions when none are specified as Maven dependencies.

Modifications
-------------
Add fraction-list to arquillian and set autodetection to `when_missing` on BuildTool.

Modify Shrinkwrap resolving to add dependencies directly as opposed to passing a list of gavs into resolve() to ensure that the scope of each dependency is set to its actual value, as Shrinkwrap defaults to compile.

Modify the ordering of explicit deps from `DependencyTree` so that compile and provided dependencies come first. This ensures that when iterating to retrieve transitives for each of them, we're retrieving transitive compile dependencies first. Otherwise a test scoped dependency could take precedence over a compile one for the same gav.

Result
------
Arquillian tests are now able to utilize autodetection of fractions.
