### PR TITLE
SWARM-1017: Use Zip4J instead of java.util.zip

### DIFF
--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -59,6 +59,11 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
+    <dependency>
+      <groupId>net.lingala.zip4j</groupId>
+      <artifactId>zip4j</artifactId>
+      <version>1.3.2</version>
+    </dependency>
   </dependencies>
 
 

--- a/tools/src/main/java/org/wildfly/swarm/tools/ZipFileHeaderAsset.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/ZipFileHeaderAsset.java
@@ -1,0 +1,32 @@
+package org.wildfly.swarm.tools;
+
+import java.io.InputStream;
+
+import net.lingala.zip4j.core.ZipFile;
+import net.lingala.zip4j.exception.ZipException;
+import net.lingala.zip4j.model.FileHeader;
+import org.jboss.shrinkwrap.api.asset.Asset;
+
+/**
+ * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
+ */
+public class ZipFileHeaderAsset implements Asset {
+
+    private final ZipFile zipFile;
+
+    private final FileHeader fileHeader;
+
+    public ZipFileHeaderAsset(ZipFile zipFile, FileHeader fileHeader) {
+        this.zipFile = zipFile;
+        this.fileHeader = fileHeader;
+    }
+
+    @Override
+    public InputStream openStream() {
+        try {
+            return zipFile.getInputStream(fileHeader);
+        } catch (ZipException e) {
+            throw new RuntimeException("Could not open zip file stream", e);
+        }
+    }
+}


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
java.util.zip leaks refences when not closed. Zip4J does not

Modifications
-------------
Changed BuildTools to use Zip4J to avoid unclosed streams

Result
------
No changes in API.