### PR TITLE
SWARM-866 - Surface configurables through --config-help

### DIFF
--- a/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/UndertowFraction.java
+++ b/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/UndertowFraction.java
@@ -16,6 +16,7 @@
 package org.wildfly.swarm.undertow;
 
 import org.wildfly.swarm.config.Undertow;
+import org.wildfly.swarm.config.runtime.AttributeDocumentation;
 import org.wildfly.swarm.config.undertow.BufferCache;
 import org.wildfly.swarm.config.undertow.HandlerConfiguration;
 import org.wildfly.swarm.config.undertow.Server;
@@ -236,42 +237,50 @@ public class UndertowFraction extends Undertow<UndertowFraction> implements Frac
     }
 
     @Configurable("swarm.http.port")
+    @AttributeDocumentation("Set the port for the default HTTP listener")
     private Defaultable<Integer> httpPort = integer(DEFAULT_HTTP_PORT);
 
     @Configurable("swarm.https.port")
+    @AttributeDocumentation("Set the port for the default HTTPS listener")
     private Defaultable<Integer> httpsPort = integer(DEFAULT_HTTPS_PORT);
 
     @Configurable("swarm.ajp.port")
+    @AttributeDocumentation("Set the port for the default AJP listener")
     private Defaultable<Integer> ajpPort = integer(DEFAULT_AJP_PORT);
 
     /**
      * Path to the keystore.
      */
     @Configurable("swarm.http.keystore.path")
+    @AttributeDocumentation("Path to the server keystore")
     private String keystorePath;
 
     /**
      * Password for the keystore.
      */
     @Configurable("swarm.http.keystore.password")
+    @AttributeDocumentation("Password to the server keystore")
     private String keystorePassword;
 
     /**
      * Password for the key.
      */
     @Configurable("swarm.http.key.password")
+    @AttributeDocumentation("Password to the server certificate")
     private String keyPassword;
 
     /**
      * Server certificate alias.
      */
     @Configurable("swarm.http.certificate.alias")
+    @AttributeDocumentation("Alias to the server certificate")
     private String alias;
 
     /**
      * Whether or not enabling AJP
      */
     @Configurable("swarm.ajp.enable")
+    @AttributeDocumentation("Determine if AJP should be enabled")
     private Defaultable<Boolean> enableAJP = ifAnyExplicitlySet(this.ajpPort);
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   </scm>
 
   <properties>
-    <version.wildfly.swarm.fraction.plugin>41</version.wildfly.swarm.fraction.plugin>
+    <version.wildfly.swarm.fraction.plugin>43</version.wildfly.swarm.fraction.plugin>
     <version.wildfly.swarm.checkstyle>3</version.wildfly.swarm.checkstyle>
 
     <version.cdi2>2.0.Alpha4</version.cdi2>
@@ -38,9 +38,9 @@
     <version.jboss.management-console>2.8.25.Final</version.jboss.management-console>
 
     <version.maven.aether>3.2.5</version.maven.aether>
-    <version.wildfly.config-api>1.0.1.Final</version.wildfly.config-api>
+    <version.wildfly.config-api>1.0.2.Final</version.wildfly.config-api>
 
-    <version.keycloak.config-api>1.0.0.Final</version.keycloak.config-api>
+    <version.keycloak.config-api>1.0.1.Final</version.keycloak.config-api>
     <version.keycloak>2.5.0.Final</version.keycloak>
 
     <version.wildfly>10.1.0.Final</version.wildfly>

--- a/standalone-servers/keycloak/src/main/java/org/wildfly/swarm/servers/keycloak/KeycloakServer.java
+++ b/standalone-servers/keycloak/src/main/java/org/wildfly/swarm/servers/keycloak/KeycloakServer.java
@@ -11,6 +11,6 @@ public class KeycloakServer {
     }
 
     public static void main(String... args) throws Exception {
-        (new Swarm()).start();
+        (new Swarm(args)).start();
     }
 }


### PR DESCRIPTION
Motivation
----------

Consume the new bits produced by the fraction plugin
in order to provide --config-help.

Additionally, allow our standalone keycloak-server to
respect CLI arguments.

Modifications
-------------

Browse around for configuration-meta.properties and display
their contents when --config-help (all|<fraction>) is used
from the CLI.

Result
------

Lots of output.  Do not print.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
