### PR TITLE
NONE - Rev fraction-plugin to avoid file-already-exists causing unsta…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   </scm>
 
   <properties>
-    <version.wildfly.swarm.fraction.plugin>44</version.wildfly.swarm.fraction.plugin>
+    <version.wildfly.swarm.fraction.plugin>45</version.wildfly.swarm.fraction.plugin>
     <version.wildfly.swarm.checkstyle>3</version.wildfly.swarm.checkstyle>
 
     <version.cdi2>2.0.Alpha4</version.cdi2>


### PR DESCRIPTION
…ble builds.

Motivation
----------

Building cleanly and correctly is nice.

Modifications
-------------

Newer fraction-plugin which will REPLACE_EXISTING when adding the README.adoc
to the fraction.jar.

Result
------

Bob can now build HEAD.

- [ ] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
