### PR TITLE
SWARM-965 - Improve resource-loader under modules, particularly for n…

### DIFF
--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/ClasspathModuleFinder.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/ClasspathModuleFinder.java
@@ -18,6 +18,7 @@ package org.wildfly.swarm.bootstrap.modules;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Path;
 
 import org.jboss.modules.ModuleFinder;
 import org.jboss.modules.ModuleIdentifier;
@@ -76,12 +77,14 @@ public class ClasspathModuleFinder implements ModuleFinder {
 
             InputStream in = url.openStream();
 
+            Path explodedJar = NestedJarResourceLoader.explodedJar(base);
+
             ModuleSpec moduleSpec = null;
             try {
                 moduleSpec = ModuleXmlParser.parseModuleXml(
                         (rootPath, loaderPath, loaderName) -> NestedJarResourceLoader.loaderFor(base, rootPath, loaderPath, loaderName),
                         MavenResolvers.get(),
-                        "/",
+                        (explodedJar == null ? "/" : explodedJar.toAbsolutePath().toString()),
                         in,
                         path.toString(),
                         delegateLoader,


### PR DESCRIPTION
…ative library support.

Motivation
----------

Resource-loading in general is sub-par with our manipulation of jboss-modules.

Modifications
-------------

When we explode a module contained within a jar, it sometimes has resources
inside that we need to load.

Result
------

Better loading.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
