### PR TITLE
SWARM-1052: Wrong path is resolved in the HealthAnnotationProcessor.p…

### DIFF
--- a/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/HealthAnnotationProcessor.java
+++ b/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/HealthAnnotationProcessor.java
@@ -99,7 +99,7 @@ public class HealthAnnotationProcessor implements ArchiveMetadataProcessor {
                         if (methodInfo.hasAnnotation(PATH)) {
 
                             // the method level @Path
-                            sb.append(methodInfo.annotation(PATH).value().asString());
+                            safeAppend(sb, methodInfo.annotation(PATH).value().asString());
 
                             // the method level @Health
                             AnnotationInstance healthAnnotation = methodInfo.annotation(HEALTH);


### PR DESCRIPTION
…rocessArchive()

Motivation
----------
fix the wrong path resolved in the HealthAnnotationProcessor.processArchive()

Modifications
-------------
changed to use the safeAppend() for resolving the path declared on method level

Result
------
Now the path of Health endpoint could be resolved correctly(aligned with JAX-RS)

- [ ] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
