### PR TITLE
SWARM-1043: Show the logs of Configurable values defined in ArchivePreparer

### DIFF
--- a/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/UndertowFraction.java
+++ b/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/UndertowFraction.java
@@ -236,6 +236,15 @@ public class UndertowFraction extends Undertow<UndertowFraction> implements Frac
         return this.ajpPort.get();
     }
 
+    public String contextPath() {
+        return this.contextPath.get();
+    }
+
+    public UndertowFraction contextPath(String contextPath) {
+        this.contextPath.set(contextPath);
+        return this;
+    }
+
     @Configurable("swarm.http.port")
     @AttributeDocumentation("Set the port for the default HTTP listener")
     private Defaultable<Integer> httpPort = integer(DEFAULT_HTTP_PORT);
@@ -282,5 +291,12 @@ public class UndertowFraction extends Undertow<UndertowFraction> implements Frac
     @Configurable("swarm.ajp.enable")
     @AttributeDocumentation("Determine if AJP should be enabled")
     private Defaultable<Boolean> enableAJP = ifAnyExplicitlySet(this.ajpPort);
+
+    /**
+     * Context path
+     */
+    @Configurable("swarm.context.path")
+    @AttributeDocumentation("Set the context path")
+    private Defaultable<String> contextPath = Defaultable.string("/");
 
 }

--- a/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/runtime/ContextPathArchivePreparer.java
+++ b/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/runtime/ContextPathArchivePreparer.java
@@ -15,10 +15,11 @@
  */
 package org.wildfly.swarm.undertow.runtime;
 
+import javax.inject.Inject;
+
 import org.jboss.shrinkwrap.api.Archive;
 import org.wildfly.swarm.spi.api.ArchivePreparer;
-import org.wildfly.swarm.spi.api.Defaultable;
-import org.wildfly.swarm.spi.api.annotations.Configurable;
+import org.wildfly.swarm.undertow.UndertowFraction;
 import org.wildfly.swarm.undertow.WARArchive;
 
 /**
@@ -26,15 +27,15 @@ import org.wildfly.swarm.undertow.WARArchive;
  */
 public class ContextPathArchivePreparer implements ArchivePreparer {
 
-    @Configurable("swarm.context.path")
-    Defaultable<String> contextPath = Defaultable.string("/");
+    @Inject
+    UndertowFraction undertowFraction;
 
     @Override
     public void prepareArchive(Archive<?> archive) {
         WARArchive warArchive = archive.as(WARArchive.class);
 
         if (warArchive.getContextRoot() == null) {
-            warArchive.setContextRoot(contextPath.get());
+            warArchive.setContextRoot(undertowFraction.contextPath());
         }
     }
 }

--- a/fractions/javaee/undertow/src/test/java/org/wildfly/swarm/undertow/runtime/ContextPathArchivePreparerTest.java
+++ b/fractions/javaee/undertow/src/test/java/org/wildfly/swarm/undertow/runtime/ContextPathArchivePreparerTest.java
@@ -16,6 +16,7 @@
 package org.wildfly.swarm.undertow.runtime;
 
 import org.junit.Test;
+import org.wildfly.swarm.undertow.UndertowFraction;
 import org.wildfly.swarm.undertow.WARArchive;
 import org.wildfly.swarm.undertow.internal.DefaultWarDeploymentFactory;
 
@@ -32,7 +33,9 @@ public class ContextPathArchivePreparerTest {
 
         assertThat(archive.getContextRoot()).isNull();
 
-        new ContextPathArchivePreparer().prepareArchive(archive);
+        ContextPathArchivePreparer preparer = new ContextPathArchivePreparer();
+        preparer.undertowFraction = new UndertowFraction();
+        preparer.prepareArchive(archive);
 
         assertThat(archive.getContextRoot()).isNotNull();
         assertThat(archive.getContextRoot()).isEqualTo("/");
@@ -61,7 +64,7 @@ public class ContextPathArchivePreparerTest {
         assertThat(archive.getContextRoot()).isNull();
 
         ContextPathArchivePreparer preparer = new ContextPathArchivePreparer();
-        preparer.contextPath.set("/another-root");
+        preparer.undertowFraction = new UndertowFraction().contextPath("/another-root");
         preparer.prepareArchive(archive);
 
         assertThat(archive.getContextRoot()).isNotNull();

--- a/fractions/keycloak/src/main/java/org/wildfly/swarm/keycloak/KeycloakFraction.java
+++ b/fractions/keycloak/src/main/java/org/wildfly/swarm/keycloak/KeycloakFraction.java
@@ -15,7 +15,11 @@
  */
 package org.wildfly.swarm.keycloak;
 
+import java.util.List;
+
+import org.wildfly.swarm.config.runtime.AttributeDocumentation;
 import org.wildfly.swarm.spi.api.Fraction;
+import org.wildfly.swarm.spi.api.annotations.Configurable;
 import org.wildfly.swarm.spi.api.annotations.DeploymentModule;
 import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
 import org.wildfly.swarm.spi.api.annotations.WildFlySubsystem;
@@ -27,5 +31,31 @@ import org.wildfly.swarm.spi.api.annotations.WildFlySubsystem;
 @WildFlySubsystem("keycloak")
 @DeploymentModule(name = "org.keycloak.keycloak-core")
 public class KeycloakFraction implements Fraction<KeycloakFraction> {
+
+    @Configurable("swarm.keycloak.json.path")
+    @AttributeDocumentation("Set the external keycloak.json path. If this property specified, keycloak.json on classpath will be ignored")
+    String keycloakJsonPath;
+
+    @Configurable("swarm.keycloak.security.constraints")
+    @AttributeDocumentation("Set the Security Constraints to protect resources")
+    List<String> securityConstraints;
+
+    public String keycloakJsonPath() {
+        return keycloakJsonPath;
+    }
+
+    public KeycloakFraction keycloakJsonPath(String keycloakJsonPath) {
+        this.keycloakJsonPath = keycloakJsonPath;
+        return this;
+    }
+
+    public List<String> securityConstraints() {
+        return securityConstraints;
+    }
+
+    public KeycloakFraction securityConstraints(List<String> securityConstraints) {
+        this.securityConstraints = securityConstraints;
+        return this;
+    }
 
 }

--- a/fractions/keycloak/src/test/java/org/wildfly/swarm/keycloak/runtime/SecuredArchivePreparerTest.java
+++ b/fractions/keycloak/src/test/java/org/wildfly/swarm/keycloak/runtime/SecuredArchivePreparerTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.traversal.NodeIterator;
+import org.wildfly.swarm.keycloak.KeycloakFraction;
 import org.wildfly.swarm.undertow.WARArchive;
 import org.wildfly.swarm.undertow.descriptors.WebXmlAsset;
 
@@ -34,6 +35,7 @@ public class SecuredArchivePreparerTest {
     @Before
     public void setUp() {
         preparer = new SecuredArchivePreparer();
+        preparer.keycloakFraction = new KeycloakFraction();
         archive = ShrinkWrap.create(WARArchive.class);
     }
 
@@ -46,7 +48,7 @@ public class SecuredArchivePreparerTest {
 
     @Test
     public void set_1_security_constraint() throws Exception {
-        preparer.securityConstraints = Collections.singletonList("{url-pattern=/aaa}");
+        preparer.keycloakFraction.securityConstraints(Collections.singletonList("{url-pattern=/aaa}"));
         preparer.prepareArchive(archive);
 
         try (InputStream assetStream = archive.get(WebXmlAsset.NAME).getAsset().openStream()) {
@@ -65,7 +67,7 @@ public class SecuredArchivePreparerTest {
 
     @Test
     public void set_2_security_constraints() throws Exception {
-        preparer.securityConstraints = Arrays.asList("{url-pattern=/aaa}", "{url-pattern=/bbb");
+        preparer.keycloakFraction.securityConstraints(Arrays.asList("{url-pattern=/aaa}", "{url-pattern=/bbb"));
         preparer.prepareArchive(archive);
 
         try (InputStream assetStream = archive.get(WebXmlAsset.NAME).getAsset().openStream()) {
@@ -80,7 +82,7 @@ public class SecuredArchivePreparerTest {
 
     @Test
     public void set_1_method() throws Exception {
-        preparer.securityConstraints = Collections.singletonList("{methods=[GET]}");
+        preparer.keycloakFraction.securityConstraints(Collections.singletonList("{methods=[GET]}"));
         preparer.prepareArchive(archive);
 
         try (InputStream assetStream = archive.get(WebXmlAsset.NAME).getAsset().openStream()) {
@@ -99,7 +101,7 @@ public class SecuredArchivePreparerTest {
 
     @Test
     public void set_2_methods() throws Exception {
-        preparer.securityConstraints = Collections.singletonList("{methods=[GET, POST]}");
+        preparer.keycloakFraction.securityConstraints(Collections.singletonList("{methods=[GET, POST]}"));
         preparer.prepareArchive(archive);
 
         try (InputStream assetStream = archive.get(WebXmlAsset.NAME).getAsset().openStream()) {


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
 - https://issues.jboss.org/browse/SWARM-1043
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
It'd be good if showing the following Configuralble values defined in some ArchivePreparers.

* swarm.context.path
* swarm.keycloak.json.path
* swarm.keycloak.security.constraints

Modifications
-------------
Move these fields to each fraction(Undertow/Keycloak Fraction).

Result
------
You can see these values in the boot log.