### PR TITLE
SWARM-1004 - Too many warnings when CDI is involved.

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/ExtensionPreventionClassLoaderWrapper.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/ExtensionPreventionClassLoaderWrapper.java
@@ -1,0 +1,32 @@
+package org.wildfly.swarm.container.runtime;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Enumeration;
+
+/**
+ * @author Bob McWhirter
+ */
+public class ExtensionPreventionClassLoaderWrapper extends ClassLoader {
+
+    private static final String EXTENSION = "META-INF/services/javax.enterprise.inject.spi.Extension";
+
+    private final ClassLoader delegate;
+
+    public ExtensionPreventionClassLoaderWrapper(ClassLoader delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Enumeration<URL> getResources(String name) throws IOException {
+
+        if (name.equals(EXTENSION)) {
+            return Collections.emptyEnumeration();
+        }
+
+        return this.delegate.getResources(name);
+    }
+
+}
+


### PR DESCRIPTION
Motivation
----------

Noisy warnings in the log are noisy.

Modifications
-------------

The warning about InjectStageConfigView from [ServiceLoader]
category is actually coming from our internal Weld/CDI of
the container, not the CDI relevant to deployments.  It occurs
because when we crank up the internal Weld, it still checks
META-INF/services/... for any CDI Portable Extensions it can
find.  And it trips across the service-loader entry that is
indended only to be imported into a deployment, since it
references our extension that lives within a .deployment.*
package.

To prevent this, the TCCL is wrapped during our Weld initialization
to simply refuse to acknowledge any META-INF/services/... entries
related to CDI Portable Extensions. We explicitly set them up, so
no discovery is required.

Result
------

Less noise in the log.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
