### PR TITLE
SWARM-888: Gradle Plugin Hardcoded Modules resource directory

### DIFF
--- a/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/SwarmExtension.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/SwarmExtension.java
@@ -16,12 +16,16 @@
 package org.wildfly.swarm.plugin.gradle;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
 import groovy.lang.Closure;
 import groovy.util.ConfigObject;
+import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.Project;
 
@@ -29,6 +33,7 @@ import org.gradle.api.Project;
  * @author Bob McWhirter
  */
 public class SwarmExtension {
+    private static final String MODULE_DIR_NAME = "modules";
 
     private Project project;
 
@@ -50,7 +55,19 @@ public class SwarmExtension {
 
     public SwarmExtension(Project project) {
         this.project = project;
-        this.moduleDirs.add(new File(this.project.getBuildDir(), "resources/main/modules"));
+        Path resourcesOutputDir = project.getConvention()
+                .getPlugin(JavaPluginConvention.class)
+                .getSourceSets()
+                .findByName(SourceSet.MAIN_SOURCE_SET_NAME)
+                .getOutput()
+                .getResourcesDir()
+                .toPath()
+                .resolve(MODULE_DIR_NAME);
+        if (Files.isDirectory(resourcesOutputDir)) {
+            File moduleDir = resourcesOutputDir.toFile();
+
+            this.moduleDirs.add(moduleDir);
+        }
     }
 
     public void properties(Closure<Properties> closure) {


### PR DESCRIPTION
Motivation
----------
org.wildfly.swarm.plugin.gradle.SwarmExtension contains the below line:
this.moduleDirs.add(new File(this.project.getBuildDir(), "resources/main/modules"));

The output location is hardcoded. Gradle has the ability to modify the
resource output directory and this code will silently ignore modules
whenever the resource output directory is changed through Gradle.

Modifications
-------------
The hardcoded line was changed to utilize Gradle Main SourceSet output
directory. The solution still expects a "modules" directory under the output resource
directory.

Result
------
Changing Gradle resource output directory will no longer prevent the
loading of the modules.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
