### PR TITLE
SWARM-1009: Duplicates jars in M2FREPO and WEB-INF/lib

### DIFF
--- a/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
@@ -496,9 +496,11 @@ public class BuildTool {
 
         // removable deps define the ones that should not be in WEB-INF/lib
         // the ones excluded from M2_REPO is the inverse delta, aka all that belong to WEB-INF/lib
+        // NOTE: Care needs to be taken of those deps that belong to modules declaratiion. They are the exception to the rule
         Set<ArtifactSpec> excludeFromM2Repo = new HashSet<>(toBeResolved);
         excludeFromM2Repo.addAll(alreadyResolved);
         excludeFromM2Repo.removeAll(dependencyManager.getRemovableDependencies());
+        excludeFromM2Repo.removeAll(dependencyManager.getModuleDependencies());
 
         for (ArtifactSpec dependency : resolvedDependencies.getModuleDependencies()) {
             if (!dependency.isResolved()) {


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation:
Some jars end up in both M2REPO and WEB-INF/lib using more space then needed

Changes:
Exclude the inverse delta of removables from M2_REPO

Result:
The jars become smaller, but the overall availability project dependencies is still given