### PR TITLE
SWARM-1074: improve MavenPluginTest debuggability

### DIFF
--- a/testsuite/testsuite-maven-plugin/src/test/java/org/wildfly/swarm/maven/plugin/TestingProject.java
+++ b/testsuite/testsuite-maven-plugin/src/test/java/org/wildfly/swarm/maven/plugin/TestingProject.java
@@ -250,4 +250,28 @@ public final class TestingProject {
                 + ", technologies: " + includedTechnologies + ", additional dependency: " + additionalDependency
                 + ", additional fraction: " + additionalFraction;
     }
+
+    // ---
+
+    public String serialize() {
+        String technologies = includedTechnologies.stream()
+                .map(IncludedTechnology::toString)
+                .collect(Collectors.joining(","));
+        return packaging + ":" + dependencies + ":" + autodetection + ":" + technologies + ":" + additionalDependency
+                + ":" + additionalFraction;
+    }
+
+    public static TestingProject deserialize(String string) {
+        String[] parts = string.split(":");
+        Packaging packaging = Packaging.valueOf(parts[0]);
+        Dependencies dependencies = Dependencies.valueOf(parts[1]);
+        Autodetection autodetection = Autodetection.valueOf(parts[2]);
+        IncludedTechnology[] includedTechnologies = Arrays.stream(parts[3].split(","))
+                .map(IncludedTechnology::valueOf)
+                .toArray(IncludedTechnology[]::new);
+        AdditionalDependency additionalDependency = AdditionalDependency.valueOf(parts[4]);
+        AdditionalFraction additionalFraction = AdditionalFraction.valueOf(parts[5]);
+        return new TestingProject(packaging, dependencies, autodetection, includedTechnologies, additionalDependency,
+                                  additionalFraction);
+    }
 }


### PR DESCRIPTION
Motivation
----------
The `MavenPluginTest` is hard to debug in case of failures.

Modifications
-------------
The test:
- introduces a way to manually run a single testing combination,
  without modifying the test code, using a system property
- provides instructions how to use the facility for running
  a single combination, as a part of failing assertion message
- doesn't delete the working directory of the testing project
  when running in the single combination mode, because
  that directory is likely to be inspected manually

Result
------
Improved debuggability of the `MavenPluginTest`.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
