### PR TITLE
SWARM-1078: Explicitly lookup maven mirror authentication

### DIFF
--- a/plugin/src/main/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelper.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelper.java
@@ -193,21 +193,14 @@ public class MavenArtifactResolvingHelper implements ArtifactResolvingHelper {
 
         RemoteRepository repository = builder.build();
 
-        RemoteRepository mirror = session.getMirrorSelector().getMirror(repository);
+        final RemoteRepository mirror = session.getMirrorSelector().getMirror(repository);
 
         if (mirror != null) {
-            builder = new RemoteRepository.Builder(mirror);
-
-            // the authentication is not automatically copied to the mirror
-            if (auth != null
-                    && auth.getUsername() != null
-                    && auth.getPassword() != null) {
-                builder.setAuthentication(new AuthenticationBuilder()
-                                                  .addUsername(auth.getUsername())
-                                                  .addPassword(auth.getPassword()).build());
-            }
-
-            repository = builder.build();
+            final org.eclipse.aether.repository.Authentication mirrorAuth = session.getAuthenticationSelector()
+                    .getAuthentication(mirror);
+            repository = mirrorAuth != null
+                    ? new RemoteRepository.Builder(mirror).setAuthentication(mirrorAuth).build()
+                    : mirror;
         }
 
         Proxy proxy = session.getProxySelector().getProxy(repository);


### PR DESCRIPTION
Motivation
----------
The package goal of the maven plugin fails in case a mirror is specified in settings.xml that requires authentication.

Modifications
-------------
Instead of assuming the mirror uses the same credentials as the mirrored repo, lookup and use the (optional) mirror authentication from maven session.

Result
------
Mirror is accessed with the correct credentials from settings.xml (if any).

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
