### PR TITLE
SWARM-542: Can't run main() from IDE when using only Gradle, not Maven

### DIFF
--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/SystemDependencyResolution.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/SystemDependencyResolution.java
@@ -23,6 +23,9 @@ public class SystemDependencyResolution implements DependencyResolution {
         final String userDirProp = System.getProperty("user.dir");
         final String testClasspatProp = System.getProperty("swarm.test.dependencies");
 
+        //Dedect gradle cache
+        this.useGradleRepo = classpathProp.contains(File.separator + ".gradle");
+
         this.classpath = Arrays.asList(classpathProp.split(File.pathSeparator));
         this.testClasspath = testClasspatProp != null ? Arrays.asList(testClasspatProp.split(File.pathSeparator)) : Collections.EMPTY_LIST;
 
@@ -58,7 +61,7 @@ public class SystemDependencyResolution implements DependencyResolution {
                             .stream()
                             .map(e -> e.split(":"))
                             .map(e -> e[0] + File.separatorChar + e[1])
-                            .map(m -> m.replace('.', File.separatorChar))
+                            .map(m -> (useGradleRepo ? m : m.replace('.', File.separatorChar)))
                             .collect(Collectors.toList())
             );
 
@@ -88,5 +91,7 @@ public class SystemDependencyResolution implements DependencyResolution {
     final String pwd;
 
     final List<String> testClasspath;
+
+    final boolean useGradleRepo;
 
 }

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/SystemDependencyResolution.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/SystemDependencyResolution.java
@@ -60,7 +60,7 @@ public class SystemDependencyResolution implements DependencyResolution {
                     env.getRemovableDependencies()
                             .stream()
                             .map(e -> e.split(":"))
-                            .map(e -> e[0] + File.separatorChar + e[1])
+                            .map(e -> e[0] + File.separatorChar + e[1] + File.separatorChar)
                             .map(m -> (useGradleRepo ? m : m.replace('.', File.separatorChar)))
                             .collect(Collectors.toList())
             );
@@ -92,6 +92,6 @@ public class SystemDependencyResolution implements DependencyResolution {
 
     final List<String> testClasspath;
 
-    final boolean useGradleRepo;
+    private final boolean useGradleRepo;
 
 }

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/GradleResolver.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/GradleResolver.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.bootstrap.modules;
+
+import org.jboss.modules.maven.ArtifactCoordinates;
+import org.jboss.modules.maven.MavenResolver;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Collectors;
+
+/**
+ * @author Michael Fraefel
+ */
+public class GradleResolver implements MavenResolver {
+
+    private String gradleCachePath;
+
+    public GradleResolver(String gradleCachePath) {
+        this.gradleCachePath = gradleCachePath;
+    }
+
+    @Override
+    public File resolveArtifact(ArtifactCoordinates artifactCoordinates, String packaging) throws IOException {
+        //Search the matching artifact in a gradle cache.
+        String filter = toGradleArtifactFileName(artifactCoordinates, packaging);
+        Path artifactDirectory = Paths.get(gradleCachePath, artifactCoordinates.getGroupId(), artifactCoordinates.getArtifactId(), artifactCoordinates.getVersion());
+        for (Path hashDir :Files.list(artifactDirectory).collect(Collectors.toList())) {
+            for (Path artifact : Files.list(hashDir).collect(Collectors.toList())) {
+                if (artifact.endsWith(filter)) {
+                    return artifact.toFile();
+                }
+            }
+        }
+        return null;
+    }
+
+    private String toGradleArtifactFileName(ArtifactCoordinates artifactCoordinates, String packaging) {
+        StringBuilder sbFileFilter = new StringBuilder();
+        sbFileFilter
+                .append(artifactCoordinates.getArtifactId())
+                .append("-")
+                .append(artifactCoordinates.getVersion());
+        if (artifactCoordinates.getClassifier() != null && artifactCoordinates.getClassifier().length() > 0) {
+            sbFileFilter
+                    .append("-")
+                    .append(artifactCoordinates.getClassifier());
+        }
+        sbFileFilter
+                .append(".")
+                .append(packaging);
+        return sbFileFilter.toString();
+    }
+
+}

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/GradleResolver.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/GradleResolver.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
  */
 public class GradleResolver implements MavenResolver {
 
-    private String gradleCachePath;
+    private final String gradleCachePath;
 
     public GradleResolver(String gradleCachePath) {
         this.gradleCachePath = gradleCachePath;
@@ -51,7 +51,7 @@ public class GradleResolver implements MavenResolver {
         return null;
     }
 
-    private String toGradleArtifactFileName(ArtifactCoordinates artifactCoordinates, String packaging) {
+    String toGradleArtifactFileName(ArtifactCoordinates artifactCoordinates, String packaging) {
         StringBuilder sbFileFilter = new StringBuilder();
         sbFileFilter
                 .append(artifactCoordinates.getArtifactId())

--- a/core/bootstrap/src/test/java/org/wildfly/swarm/bootstrap/env/SystemDependencyResolutionTest.java
+++ b/core/bootstrap/src/test/java/org/wildfly/swarm/bootstrap/env/SystemDependencyResolutionTest.java
@@ -1,0 +1,83 @@
+package org.wildfly.swarm.bootstrap.env;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test {@link SystemDependencyResolution}
+ *
+ * @author Michael Fraefel
+ */
+public class SystemDependencyResolutionTest {
+
+
+    @Test
+    public void testResolve_withGradle() throws IOException {
+        String group = "org.wildfly.swarm";
+        String packaging = "jar";
+        String artifact1 = "test";
+        String artifact2 = "test2";
+        String version = "1.0";
+
+        String classpathFile1 = buildGradleClassPathEntry(group, artifact1, version, packaging);
+        String classpathFile2 = buildGradleClassPathEntry(group, artifact2, version, packaging);
+        String classpath = classpathFile1 + File.pathSeparator + classpathFile2;
+        System.setProperty("java.class.path", classpath);
+
+        ApplicationEnvironment env = ApplicationEnvironment.get();
+        env.getRemovableDependencies().add(group+":"+artifact1+":"+packaging+":"+version);
+
+        //WHEN
+        SystemDependencyResolution resolution = new SystemDependencyResolution();
+        Set<String> result = resolution.resolve(Collections.emptyList());
+
+        //THEN
+        assertEquals(1,result.size());
+        assertEquals(classpathFile2, result.iterator().next());
+
+    }
+
+    @Test
+    public void testResolve_withMaven() throws IOException {
+        String group = "org.wildfly.swarm";
+        String packaging = "jar";
+        String artifact1 = "test";
+        String artifact2 = "test2";
+        String version = "1.0";
+
+        String classpathFile1 = buildMavenClassPathEntry(group, artifact1, version, packaging);
+        String classpathFile2 = buildMavenClassPathEntry(group, artifact2, version, packaging);
+        String classpath = classpathFile1 + File.pathSeparator + classpathFile2;
+        System.setProperty("java.class.path", classpath);
+
+        ApplicationEnvironment env = ApplicationEnvironment.get();
+        env.getRemovableDependencies().add(group+":"+artifact1+":"+packaging+":"+version);
+
+        //WHEN
+        SystemDependencyResolution resolution = new SystemDependencyResolution();
+        Set<String> result = resolution.resolve(Collections.emptyList());
+
+        //THEN
+        assertEquals(1,result.size());
+        assertEquals(classpathFile2, result.iterator().next());
+
+    }
+
+
+    private String buildGradleClassPathEntry(String group, String artifact, String version, String packaging) {
+        return "path" + File.separator + ".gradle" + File.separator + group + File.separator + artifact +
+        File.separator + version + File.separator + "hash" + File.separator +artifact + "-" + version + "." + packaging;
+    }
+
+    private String buildMavenClassPathEntry(String group, String artifact, String version, String packaging) {
+        return "path" + File.separator + ".m2" + File.separator + "repository" + File.separator + group.replace('.', File.separatorChar) + File.separator + artifact +
+                File.separator + version + File.separator +artifact + "-" + version + "." + packaging;
+    }
+
+}

--- a/core/bootstrap/src/test/java/org/wildfly/swarm/bootstrap/modules/GradleResolverTest.java
+++ b/core/bootstrap/src/test/java/org/wildfly/swarm/bootstrap/modules/GradleResolverTest.java
@@ -1,0 +1,100 @@
+package org.wildfly.swarm.bootstrap.modules;
+
+import org.jboss.modules.maven.ArtifactCoordinates;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Test {@link GradleResolver}
+ *
+ * @author Michael Fraefel
+ */
+public class GradleResolverTest {
+
+    @Test
+    public void testToGradleArtifactFileName(){
+        //GIVEN
+        String group = "org.wildfly.swarm";
+        String packaging = "jar";
+        String artifact = "test";
+        String version = "1.0";
+        ArtifactCoordinates artifactCoordinates = new ArtifactCoordinates(group, artifact, version);
+
+        //WHEN
+        GradleResolver resolver = new GradleResolver(null);
+        String artifactFileName = resolver.toGradleArtifactFileName(artifactCoordinates, packaging);
+
+        //THEN
+        assertEquals(artifact + "-" + version + "." + packaging, artifactFileName);
+    }
+
+    @Test
+    public void testToGradleArtifactFileName_withClassifier(){
+        //GIVEN
+        String group = "org.wildfly.swarm";
+        String packaging = "jar";
+        String artifact = "test";
+        String version = "1.0";
+        String classifier = "sources";
+        ArtifactCoordinates artifactCoordinates = new ArtifactCoordinates(group, artifact, version, classifier);
+
+        //WHEN
+        GradleResolver resolver = new GradleResolver(null);
+        String artifactFileName = resolver.toGradleArtifactFileName(artifactCoordinates, packaging);
+
+        //THEN
+        assertEquals(artifact + "-" + version + "-"+ classifier + "." + packaging, artifactFileName);
+    }
+
+    @Test
+    public void testResolveArtifact() throws IOException {
+        //GIVEN
+        Path gradleCachePath = Files.createTempDirectory("gradle");
+        String group = "org.wildfly.swarm";
+        String packaging = "jar";
+        String artifact = "test";
+        String version = "1.0";
+        String classifier = "sources";
+        ArtifactCoordinates artifactCoordinates = new ArtifactCoordinates(group, artifact, version, classifier);
+
+        Path artifactDir = Files.createDirectories(gradleCachePath.resolve(group).resolve(artifact).resolve(version).resolve("hash"));
+        File artifactFile = Files.createFile(artifactDir.resolve(artifact + "-" + version + "-" + classifier + "." + packaging)).toFile();
+
+        //WHEN
+        GradleResolver resolver = new GradleResolver(gradleCachePath.toString());
+        File resolvedArtifactFile = resolver.resolveArtifact(artifactCoordinates, packaging);
+
+        //THEN
+        assertEquals(artifactFile, resolvedArtifactFile);
+    }
+
+    @Test
+    public void testResolveArtifact_notExists() throws IOException {
+        //GIVEN
+        Path gradleCachePath = Files.createTempDirectory("gradle");
+        String group = "org.wildfly.swarm";
+        String packaging = "jar";
+        String artifact = "test";
+        String version = "1.0";
+        String classifier = "sources";
+        ArtifactCoordinates artifactCoordinates = new ArtifactCoordinates(group, artifact, version, classifier);
+
+        Path artifactDir = Files.createDirectories(gradleCachePath.resolve(group).resolve(artifact).resolve(version).resolve("hash"));
+        File artifactFile = Files.createFile(artifactDir.resolve(artifact + "-" + version + "-" + classifier + ".pom")).toFile(); // Other packaging type
+
+        //WHEN
+        GradleResolver resolver = new GradleResolver(gradleCachePath.toString());
+        File resolvedArtifactFile = resolver.resolveArtifact(artifactCoordinates, packaging);
+
+        //THEN
+        assertNull(resolvedArtifactFile);
+    }
+
+}


### PR DESCRIPTION
Motivation
----------
When developing with gradle, it should be possible to work without the local maven repository.
[SWARM-542](https://issues.jboss.org/browse/SWARM-542)

Modifications
-------------
Detect when the IDE is using gradle. If gradle is used, respect the gradle cache format and use the gradle cache.

Result
------
The repository mavenLocal() isn't any more needed in the repository config.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
