### PR TITLE
SWARM-1063 - Do not try to process projects with pom packaging.

### DIFF
--- a/plugin/src/main/java/org/wildfly/swarm/plugin/maven/PackageMojo.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/maven/PackageMojo.java
@@ -87,6 +87,10 @@ public class PackageMojo extends AbstractSwarmMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (this.project.getPackaging().equals("pom")) {
+            getLog().info("Not processing project with pom packaging");
+            return;
+        }
         initProperties(false);
         final Artifact primaryArtifact = this.project.getArtifact();
         final String finalName = this.project.getBuild().getFinalName();
@@ -102,13 +106,13 @@ public class PackageMojo extends AbstractSwarmMojo {
 
         final BuildTool tool = new BuildTool(mavenArtifactResolvingHelper())
                 .projectArtifact(primaryArtifact.getGroupId(),
-                                 primaryArtifact.getArtifactId(),
-                                 primaryArtifact.getBaseVersion(),
-                                 type,
-                                 primaryArtifactFile,
-                                 finalName.endsWith("." + type) ?
-                                         finalName :
-                                         String.format("%s.%s", finalName, type))
+                        primaryArtifact.getArtifactId(),
+                        primaryArtifact.getBaseVersion(),
+                        type,
+                        primaryArtifactFile,
+                        finalName.endsWith("." + type) ?
+                                finalName :
+                                String.format("%s.%s", finalName, type))
                 .properties(this.properties)
                 .mainClass(this.mainClass)
                 .bundleDependencies(this.bundleDependencies)


### PR DESCRIPTION
Motivation
----------

Some folks like to put the wildfly-swarm-plugin configuration
in a parent pom. These parent poms, though, have no artifacts
to be packaged. And thus this fails.

Modifications
-------------

If the current project has pom packaging, quietly (with a log message)
not process it.

Result
------

Should be possible to configure the plugin in a parent pom without
breaking.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
