### PR TITLE
SWARM-1071 - Restore swarm.project.stage and swarm.project.stage.file

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigResolutionStrategy.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigResolutionStrategy.java
@@ -82,6 +82,12 @@ class ConfigResolutionStrategy {
         });
     }
 
+    private void deactivate(ConfigKey key) {
+        optionalValueOf(key).ifPresent((v) -> {
+            this.properties.clearProperty(key.name());
+        });
+    }
+
     /**
      * Retrieve the configuration value for a key.
      *

--- a/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewFactory.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewFactory.java
@@ -41,19 +41,24 @@ public class ConfigViewFactory {
     private final ConfigViewImpl configView;
 
     public static ConfigViewFactory defaultFactory() throws ModuleLoadException {
+        return defaultFactory(null);
+    }
+
+    public static ConfigViewFactory defaultFactory(Properties properties) throws ModuleLoadException {
         return new ConfigViewFactory(
+                properties,
                 new FilesystemConfigLocator(),
                 ClassLoaderConfigLocator.system(),
                 ClassLoaderConfigLocator.forApplication()
         );
     }
 
-    public ConfigViewFactory() {
-        this.configView = new ConfigViewImpl();
+    private ConfigViewFactory(Properties properties) {
+        this.configView = new ConfigViewImpl().withProperties(properties);
     }
 
-    public ConfigViewFactory(ConfigLocator... locators) {
-        this();
+    private ConfigViewFactory(Properties properties, ConfigLocator... locators) {
+        this(properties);
         for (ConfigLocator locator : locators) {
             addLocator(locator);
         }

--- a/core/container/src/main/java/org/wildfly/swarm/container/config/PropertiesManipulator.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/PropertiesManipulator.java
@@ -19,6 +19,8 @@ interface PropertiesManipulator {
 
     void setProperty(String name, String value);
 
+    void clearProperty(String name);
+
     Properties getProperties();
 
     class SystemPropertiesManipulator implements PropertiesManipulator {
@@ -37,6 +39,11 @@ interface PropertiesManipulator {
         @Override
         public void setProperty(String name, String value) {
             System.setProperty(name, value);
+        }
+
+        @Override
+        public void clearProperty(String name) {
+            System.clearProperty(name);
         }
 
         @Override
@@ -59,6 +66,11 @@ interface PropertiesManipulator {
         @Override
         public void setProperty(String name, String value) {
             this.properties.setProperty(name, value);
+        }
+
+        @Override
+        public void clearProperty(String name) {
+            this.properties.remove(name);
         }
 
         @Override

--- a/pom.xml
+++ b/pom.xml
@@ -1278,6 +1278,7 @@
     <module>testsuite/testsuite-monitor</module>
     <module>testsuite/testsuite-msc</module>
     <module>testsuite/testsuite-naming</module>
+    <module>testsuite/testsuite-project-stages</module>
     <module>testsuite/testsuite-remoting</module>
     <module>testsuite/testsuite-request-controller</module>
     <module>testsuite/testsuite-resource-adapters</module>

--- a/testsuite/testsuite-project-stages/pom.xml
+++ b/testsuite/testsuite-project-stages/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>testsuite</artifactId>
+    <version>2017.3.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>testsuite-project-stages</artifactId>
+
+  <name>Test Suite: Project Stages</name>
+  <description>Test Suite: Project Stages</description>
+
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>container</artifactId>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/ProjectStagesTest.java
+++ b/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/ProjectStagesTest.java
@@ -1,0 +1,66 @@
+package org.wildfly.swarm;
+
+import java.net.URL;
+import java.util.Properties;
+
+import org.junit.Test;
+import org.wildfly.swarm.spi.api.SwarmProperties;
+import org.wildfly.swarm.spi.api.config.ConfigView;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Bob McWhirter
+ */
+public class ProjectStagesTest {
+
+    @Test
+    public void testPropertyBasedConfigStagesFile() throws Exception {
+        try {
+            URL projectStages = getClass().getClassLoader().getResource("simple-project-stages.yml");
+            System.setProperty(SwarmProperties.PROJECT_STAGE_FILE, projectStages.toExternalForm());
+            Swarm swarm = new Swarm();
+            swarm.initializeConfigView(new Properties());
+
+            ConfigView view = swarm.configView();
+
+            assertThat(view.resolve("foo.bar.baz").getValue()).isEqualTo("cheddar");
+        } finally {
+            System.clearProperty(SwarmProperties.PROJECT_STAGE_FILE);
+        }
+    }
+
+    @Test
+    public void testPropertyBasedConfigStagesFileOnlyDefault() throws Exception {
+        try {
+            URL projectStages = getClass().getClassLoader().getResource("multi-project-stages.yml");
+            System.setProperty(SwarmProperties.PROJECT_STAGE_FILE, projectStages.toExternalForm());
+            Swarm swarm = new Swarm();
+            swarm.initializeConfigView(new Properties());
+
+            ConfigView view = swarm.configView();
+
+            assertThat(view.resolve("foo.bar.baz").getValue()).isEqualTo("cheddar");
+        } finally {
+            System.clearProperty(SwarmProperties.PROJECT_STAGE_FILE);
+        }
+    }
+
+    @Test
+    public void testPropertyBasedConfigStagesFileAndSelectedStage() throws Exception {
+        try {
+            URL projectStages = getClass().getClassLoader().getResource("multi-project-stages.yml");
+            System.setProperty(SwarmProperties.PROJECT_STAGE_FILE, projectStages.toExternalForm());
+            System.setProperty(SwarmProperties.PROJECT_STAGE, "production");
+            Swarm swarm = new Swarm();
+            swarm.initializeConfigView(new Properties());
+
+            ConfigView view = swarm.configView();
+
+            assertThat(view.resolve("foo.bar.baz").getValue()).isEqualTo("brie");
+        } finally {
+            System.clearProperty(SwarmProperties.PROJECT_STAGE_FILE);
+            System.clearProperty(SwarmProperties.PROJECT_STAGE);
+        }
+    }
+}

--- a/testsuite/testsuite-project-stages/src/test/resources/multi-project-stages.yml
+++ b/testsuite/testsuite-project-stages/src/test/resources/multi-project-stages.yml
@@ -1,0 +1,9 @@
+foo:
+  bar:
+    baz: cheddar
+---
+project:
+  stage: production
+foo:
+  bar:
+   baz: brie

--- a/testsuite/testsuite-project-stages/src/test/resources/simple-project-stages.yml
+++ b/testsuite/testsuite-project-stages/src/test/resources/simple-project-stages.yml
@@ -1,0 +1,3 @@
+foo:
+  bar:
+    baz: cheddar


### PR DESCRIPTION
Motivation
----------

In some environments, it's easier to set Java system properties than
to use command-line arguments (oddly).

Modifications
-------------

Restore previous support for project-stages.yml (multi-document type)
of YAML configuration via pointing to Files or URLs via a system property.
Additionally, allow activation of stage(s) via system property.

Result
------

Should work as it used to, and better on OpenShift.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
