### PR TITLE
SWARM-1086: Slim down supported fractions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1164,25 +1164,19 @@
     <module>core/spi</module>
     <module>core/container</module>
 
-    <!-- other -->
-    <module>jaxrs-client-api</module>
-
     <module>meta/meta-spi</module>
     <module>meta/fraction-metadata</module>
     <module>plugin</module>
     <module>boms</module>
 
     <module>arquillian</module>
-    <module>swarmtool</module>
 
-    <module>fractions/javaee/batch-jberet</module>
     <module>fractions/javaee/bean-validation</module>
     <module>fractions/javaee/cdi</module>
     <module>fractions/javaee/connector</module>
     <module>fractions/javaee/datasources</module>
     <module>fractions/javaee/ee</module>
     <module>fractions/javaee/ejb</module>
-    <module>fractions/javaee/ejb-remote</module>
     <module>fractions/javaee/jaxrs</module>
     <module>fractions/javaee/jaxrs-cdi</module>
     <module>fractions/javaee/jaxrs-jaxb</module>
@@ -1192,34 +1186,23 @@
     <module>fractions/javaee/jca</module>
     <module>fractions/javaee/jmx</module>
     <module>fractions/javaee/jpa</module>
-    <module>fractions/javaee/jpa-spatial</module>
-    <module>fractions/javaee/jpa-eclipselink</module>
     <module>fractions/javaee/jsf</module>
-    <module>fractions/javaee/mail</module>
-    <module>fractions/javaee/messaging</module>
     <module>fractions/javaee/naming</module>
     <module>fractions/javaee/remoting</module>
-    <module>fractions/javaee/resource-adapters</module>
     <module>fractions/javaee/transactions</module>
     <module>fractions/javaee/undertow</module>
-    <module>fractions/javaee/webservices</module>
 
     <module>fractions/wildfly/hibernate-search</module>
     <module>fractions/wildfly/hibernate-validator</module>
     <module>fractions/wildfly/infinispan</module>
     <module>fractions/wildfly/io</module>
-    <module>fractions/wildfly/jdr</module>
     <module>fractions/wildfly/jgroups</module>
     <module>fractions/wildfly/logging</module>
     <module>fractions/wildfly/management</module>
-    <module>fractions/wildfly/management-console</module>
     <module>fractions/wildfly/msc</module>
-    <module>fractions/wildfly/mod_cluster</module>
     <module>fractions/wildfly/request-controller</module>
     <module>fractions/wildfly/security</module>
-    
-    <module>fractions/fluentd</module>
-    <module>fractions/jolokia</module>
+
     <module>fractions/keycloak</module>
     <module>fractions/microprofile</module>
     <module>fractions/monitor</module>
@@ -1227,38 +1210,29 @@
     <module>fractions/topology</module>
     <module>fractions/topology-openshift</module>
     <module>fractions/topology-webapp</module>
-    <module>fractions/vertx</module>
-    <module>fractions/zipkin-jaxrs</module>
 
     <module>fractions/cdi-extensions/cdi-config</module>
-    <module>fractions/cdi-extensions/cdi-jaxrsapi</module>
 
     <module>standalone-servers/microprofile</module>
 
-    <module>testsuite/testsuite-batch-jberet</module>
     <module>testsuite/testsuite-buildtool</module>
     <module>testsuite/testsuite-cdi</module>
-    <module>testsuite/testsuite-cdi-jaxrsapi</module>
     <module>testsuite/testsuite-connector</module>
     <module>testsuite/testsuite-container</module>
     <module>testsuite/testsuite-datasources</module>
     <module>testsuite/testsuite-datasources-config</module>
     <module>testsuite/testsuite-ee</module>
     <module>testsuite/testsuite-ejb</module>
-    <module>testsuite/testsuite-ejb-remote</module>
     <module>testsuite/testsuite-hystrix</module>
     <module>testsuite/testsuite-infinispan</module>
     <module>testsuite/testsuite-io</module>
     <module>testsuite/testsuite-jaxrs</module>
     <module>testsuite/testsuite-jca</module>
-    <module>testsuite/testsuite-jdr</module>
     <module>testsuite/testsuite-jgroups</module>
     <module>testsuite/testsuite-jmx</module>
     <module>testsuite/testsuite-jmx-remote-remoting</module>
     <module>testsuite/testsuite-jmx-remote-management</module>
     <module>testsuite/testsuite-jmx-remote-undertow</module>
-    <module>testsuite/testsuite-jolokia</module>
-    <module>testsuite/testsuite-jolokia-keycloak</module>
     <module>testsuite/testsuite-jpa</module>
     <module>testsuite/testsuite-jpa-mysql</module>
     <module>testsuite/testsuite-jpa-postgresql</module>
@@ -1266,21 +1240,14 @@
     <module>testsuite/testsuite-keycloak</module>
     <module>testsuite/testsuite-local-dependencies</module>
     <module>testsuite/testsuite-logging</module>
-    <module>testsuite/testsuite-mail</module>
-    <module>testsuite/testsuite-mail-cdi</module>
     <module>testsuite/testsuite-management</module>
-    <module>testsuite/testsuite-management-console</module>
     <module>testsuite/testsuite-maven-plugin</module>
-    <module>testsuite/testsuite-messaging</module>
-    <module>testsuite/testsuite-messaging-remote</module>
-    <module>testsuite/testsuite-mod_cluster</module>
     <module>testsuite/testsuite-modules</module>
     <module>testsuite/testsuite-monitor</module>
     <module>testsuite/testsuite-msc</module>
     <module>testsuite/testsuite-naming</module>
     <module>testsuite/testsuite-remoting</module>
     <module>testsuite/testsuite-request-controller</module>
-    <module>testsuite/testsuite-resource-adapters</module>
     <module>testsuite/testsuite-ribbon</module>
     <module>testsuite/testsuite-ribbon-secured</module>
     <module>testsuite/testsuite-security</module>
@@ -1290,9 +1257,6 @@
     <module>testsuite/testsuite-transactions</module>
     <module>testsuite/testsuite-undertow</module>
     <module>testsuite/testsuite-undertow-context</module>
-    <module>testsuite/testsuite-vertx</module>
-    <module>testsuite/testsuite-webservices</module>
-    <module>testsuite/testsuite-zipkin-jaxrs</module>
   </modules>
 
   <profiles>
@@ -1304,22 +1268,46 @@
         </property>
       </activation>
       <modules>
-        <module>fractions/keycloak-server</module>
+        <module>jaxrs-client-api</module>
+
+        <module>swarmtool</module>
+
+        <module>fractions/javaee/batch-jberet</module>
+        <module>fractions/javaee/ejb-remote</module>
+        <module>fractions/javaee/jpa-spatial</module>
+        <module>fractions/javaee/jpa-eclipselink</module>
+        <module>fractions/javaee/mail</module>
+        <module>fractions/javaee/messaging</module>
+        <module>fractions/javaee/resource-adapters</module>
+        <module>fractions/javaee/webservices</module>
+
         <module>fractions/camel</module>
         <module>fractions/drools-server</module>
+        <module>fractions/fluentd</module>
         <module>fractions/flyway</module>
         <module>fractions/javafx</module>
+        <module>fractions/jolokia</module>
         <module>fractions/logstash</module>
+        <module>fractions/keycloak-server</module>
         <module>fractions/spring</module>
         <module>fractions/swagger</module>
         <module>fractions/swagger-webapp</module>
         <module>fractions/topology-consul</module>
         <module>fractions/topology-jgroups</module>
+        <module>fractions/vertx</module>
+        <module>fractions/zipkin-jaxrs</module>
+
+        <module>fractions/wildfly/jdr</module>
+        <module>fractions/wildfly/management-console</module>
+        <module>fractions/wildfly/mod_cluster</module>
+
+        <module>fractions/cdi-extensions/cdi-jaxrsapi</module>
 
         <module>standalone-servers/keycloak</module>
         <module>standalone-servers/management-console</module>
         <module>standalone-servers/swagger-ui</module>
 
+        <module>testsuite/testsuite-batch-jberet</module>
         <module>testsuite/testsuite-camel-cdi</module>
         <module>testsuite/testsuite-camel-core</module>
         <module>testsuite/testsuite-camel-cxf</module>
@@ -1328,17 +1316,32 @@
         <module>testsuite/testsuite-camel-jmx</module>
         <module>testsuite/testsuite-camel-jpa</module>
         <module>testsuite/testsuite-camel-other</module>
+        <module>testsuite/testsuite-cdi-jaxrsapi</module>
         <module>testsuite/testsuite-drools-server</module>
+        <module>testsuite/testsuite-ejb-remote</module>
         <module>testsuite/testsuite-flyway</module>
         <module>testsuite/testsuite-javafx</module>
+        <module>testsuite/testsuite-jdr</module>
+        <module>testsuite/testsuite-jolokia</module>
+        <module>testsuite/testsuite-jolokia-keycloak</module>
         <module>testsuite/testsuite-keycloak-server</module>
         <module>testsuite/testsuite-logstash</module>
+        <module>testsuite/testsuite-mail</module>
+        <module>testsuite/testsuite-mail-cdi</module>
+        <module>testsuite/testsuite-management-console</module>
+        <module>testsuite/testsuite-messaging</module>
+        <module>testsuite/testsuite-messaging-remote</module>
+        <module>testsuite/testsuite-mod_cluster</module>
+        <module>testsuite/testsuite-resource-adapters</module>
         <module>testsuite/testsuite-spring</module>
         <module>testsuite/testsuite-swagger</module>
         <module>testsuite/testsuite-swagger-webapp</module>
         <module>testsuite/testsuite-topology-consul</module>
         <module>testsuite/testsuite-topology-jgroups</module>
         <module>testsuite/testsuite-topology-webapp</module>
+        <module>testsuite/testsuite-vertx</module>
+        <module>testsuite/testsuite-webservices</module>
+        <module>testsuite/testsuite-zipkin-jaxrs</module>
       </modules>
     </profile>
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
Reduce the number of supported fractions for initial product version.

Modifications
-------------
Moved unsupported fractions and their testsuites into appropriate profile.

Result
------
Removes fractions from build when building for productization.
