### PR TITLE
SWARM-1068: StandaloneXmlParser incompatibility

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/StandaloneXMLParser.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/StandaloneXMLParser.java
@@ -43,6 +43,7 @@ import org.jboss.staxmapper.XMLMapper;
 
 /**
  * @author Heiko Braun
+ * @author Ken Finnigan
  * @since 27/11/15
  */
 @Vetoed
@@ -72,11 +73,10 @@ public class StandaloneXMLParser {
         }, ParsingOption.IGNORE_SUBSYSTEM_FAILURES);
 
         xmlMapper = XMLMapper.Factory.create();
-        xmlMapper.registerRootElement(new QName(Namespace.CURRENT.getUriString(), SERVER), parserDelegate);
 
-        QName serverElementName = new QName("urn:jboss:domain:4.0", SERVER);
-        this.recognizedNames.add(serverElementName);
-        xmlMapper.registerRootElement(serverElementName, parserDelegate);
+        addDelegate(new QName(Namespace.CURRENT.getUriString(), SERVER), parserDelegate);
+        addDelegate(new QName("urn:jboss:domain:4.1", SERVER), parserDelegate);
+        addDelegate(new QName("urn:jboss:domain:4.0", SERVER), parserDelegate);
     }
 
     /**


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
Hard coded reference to parser version is wrong, should be retrieving the current value.

Modifications
-------------
Modify code to use `CURRENT` to retrieve the appropriate version instead of hard coding.

Result
------
No longer issues with providing a standalone.xml with a version greater than 4.0.
