### PR TITLE
SWARM-1048 - Everybody loves StageConfig. Un-remove but deprecate.

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/core/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -78,6 +78,7 @@ import org.wildfly.swarm.spi.api.ArtifactLookup;
 import org.wildfly.swarm.spi.api.Fraction;
 import org.wildfly.swarm.spi.api.OutboundSocketBinding;
 import org.wildfly.swarm.spi.api.SocketBinding;
+import org.wildfly.swarm.spi.api.StageConfig;
 import org.wildfly.swarm.spi.api.SwarmProperties;
 import org.wildfly.swarm.spi.api.config.ConfigView;
 import org.wildfly.swarm.spi.api.internal.SwarmInternalProperties;
@@ -659,7 +660,22 @@ public class Swarm {
         }
     }
 
-    protected ConfigView configView() {
+    /** Retrieve the configuration view.
+     *
+     * @return The configuration view.
+     */
+    public ConfigView configView() {
+        return this.configView;
+    }
+
+    /** Retrieve the configuration view in a deprecated manner.
+     *
+     * @see #configView()
+     *
+     * @return The {@code ConfigView} through a deprecated interface.
+     */
+    @Deprecated
+    public StageConfig stageConfig() {
         return this.configView;
     }
 

--- a/core/spi/src/main/java/org/wildfly/swarm/spi/api/StageConfig.java
+++ b/core/spi/src/main/java/org/wildfly/swarm/spi/api/StageConfig.java
@@ -1,0 +1,14 @@
+package org.wildfly.swarm.spi.api;
+
+import org.wildfly.swarm.spi.api.config.Resolver;
+
+/**
+ * @author Bob McWhirter
+ */
+@Deprecated
+public interface StageConfig {
+    @Deprecated
+    default Resolver<String> resolve(String name) {
+        return null;
+    }
+}

--- a/core/spi/src/main/java/org/wildfly/swarm/spi/api/config/ConfigView.java
+++ b/core/spi/src/main/java/org/wildfly/swarm/spi/api/config/ConfigView.java
@@ -4,10 +4,12 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import org.wildfly.swarm.spi.api.StageConfig;
+
 /**
  * @author Bob McWhirter
  */
-public interface ConfigView {
+public interface ConfigView extends StageConfig {
 
     Object valueOf(ConfigKey key);
 

--- a/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/StageConfigTest.java
+++ b/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/StageConfigTest.java
@@ -1,0 +1,36 @@
+package org.wildfly.swarm;
+
+import java.net.URL;
+import java.util.Properties;
+
+import org.junit.Test;
+import org.wildfly.swarm.spi.api.StageConfig;
+import org.wildfly.swarm.spi.api.SwarmProperties;
+import org.wildfly.swarm.spi.api.config.ConfigView;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Bob McWhirter
+ */
+public class StageConfigTest {
+
+    @Test
+    public void testPropertyBasedConfigStagesFile() throws Exception {
+        try {
+            URL projectStages = getClass().getClassLoader().getResource("simple-project-stages.yml");
+            System.setProperty(SwarmProperties.PROJECT_STAGE_FILE, projectStages.toExternalForm());
+            Swarm swarm = new Swarm();
+            swarm.initializeConfigView(new Properties());
+
+            ConfigView view = swarm.configView();
+            assertThat(view.resolve("foo.bar.baz").getValue()).isEqualTo("cheddar");
+
+            StageConfig stageConfig = swarm.stageConfig();
+            assertThat(stageConfig.resolve("foo.bar.baz").getValue()).isEqualTo("cheddar");
+            
+        } finally {
+            System.clearProperty(SwarmProperties.PROJECT_STAGE_FILE);
+        }
+    }
+}


### PR DESCRIPTION
Motivation
----------

Folks are used to Swarm.stageConfig() which disappeared.

Modifications
-------------

Bring back a StageConfig (as an interface this time) and Swarm.stageConfig()
to access it from a main().  But, it's deprecated, and users should prefer
direct access to the ConfigView via Swarm.configView() instead.

Result
------

Less broken code.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
