### PR TITLE
SWARM-1047 - Allow injectability of complex @Configurable object trees

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewFactory.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewFactory.java
@@ -57,7 +57,7 @@ public class ConfigViewFactory {
         this.configView = new ConfigViewImpl().withProperties(properties);
     }
 
-    private ConfigViewFactory(Properties properties, ConfigLocator... locators) {
+    public ConfigViewFactory(Properties properties, ConfigLocator... locators) {
         this(properties);
         for (ConfigLocator locator : locators) {
             addLocator(locator);

--- a/core/container/src/test/java/org/wildfly/swarm/container/config/ConfigViewYamlTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/container/config/ConfigViewYamlTest.java
@@ -1,0 +1,42 @@
+package org.wildfly.swarm.container.config;
+
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Bob McWhirter
+ */
+public class ConfigViewYamlTest {
+
+    @Test
+    public void testYamlWithLiteralLists() throws Exception {
+        URL url = getClass().getClassLoader().getResource("project-lists.yml");
+
+        ConfigViewFactory factory = new ConfigViewFactory(new Properties());
+        factory.load("test", url);
+
+        ConfigViewImpl view = factory.build();
+        view.activate("test");
+
+        List<Map<?, ?>> constraints = view.resolve("swarm.keycloak.security.constraints").as(List.class).getValue();
+
+        assertThat(constraints).hasSize(1);
+        assertThat(constraints.get(0).get("url-pattern")).isEqualTo("/secured");
+
+        List<String> methods = (List<String>) constraints.get(0).get("methods");
+        assertThat(methods).hasSize(2);
+        assertThat(methods).containsExactly("GET", "POST");
+
+        List<String> roles = (List<String>) constraints.get(0).get("roles");
+        assertThat(roles).hasSize(1);
+        assertThat(roles).containsExactly("admin");
+
+
+    }
+}

--- a/core/container/src/test/resources/project-lists.yml
+++ b/core/container/src/test/resources/project-lists.yml
@@ -1,0 +1,7 @@
+swarm:
+  keycloak:
+    security:
+      constraints:
+        - url-pattern: /secured
+          methods: [GET, POST]
+          roles: [admin]

--- a/core/spi/src/main/java/org/wildfly/swarm/spi/api/config/Builder.java
+++ b/core/spi/src/main/java/org/wildfly/swarm/spi/api/config/Builder.java
@@ -2,6 +2,8 @@ package org.wildfly.swarm.spi.api.config;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.List;
+import java.util.Map;
 
 /**
  */
@@ -33,16 +35,28 @@ public class Builder<T> implements Resolver<T> {
     public T getValue() {
 
         Object originalValue = this.view.valueOf(this.key);
-        String valueStr = (originalValue != null ? originalValue.toString() : null);
 
-        try {
-            T value = convert(valueStr);
-            if (null == value) {
-                throw new RuntimeException("Stage config '" + key + "' is missing");
+        if (originalValue instanceof ConfigTree) {
+            if (List.class.isAssignableFrom(this.targetType)) {
+                return (T) ((ConfigTree) originalValue).asList();
+            } else if (Map.class.isAssignableFrom(this.targetType)) {
+                return (T) ((ConfigTree) originalValue).asMap();
+            } else {
+                return null;
             }
-            return value;
-        } catch (Throwable t) {
-            throw new RuntimeException(t);
+        } else {
+
+            String valueStr = (originalValue != null ? originalValue.toString() : null);
+
+            try {
+                T value = convert(valueStr);
+                if (null == value) {
+                    throw new RuntimeException("Stage config '" + key + "' is missing");
+                }
+                return value;
+            } catch (Throwable t) {
+                throw new RuntimeException(t);
+            }
         }
     }
 

--- a/core/spi/src/main/java/org/wildfly/swarm/spi/api/config/ConfigTree.java
+++ b/core/spi/src/main/java/org/wildfly/swarm/spi/api/config/ConfigTree.java
@@ -1,0 +1,14 @@
+package org.wildfly.swarm.spi.api.config;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Bob McWhirter
+ */
+public interface ConfigTree {
+
+    List asList();
+
+    Map asMap();
+}


### PR DESCRIPTION
Motivation
----------

Things like keycloak security constraints are hard to inject piecemeal.

Modifications
-------------

Allow to inject a Map or List, and get an object-shaped tree of collections
and scalars.

Result
------

More flexibility in injecting configurables beyond single scalars.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
