### PR TITLE
SWARM-870: specified fraction + auto detection finds none

### DIFF
--- a/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
@@ -277,7 +277,7 @@ public class BuildTool {
         this.archive.add(new WebInfLibFilteringArchiveAsset(this.projectAsset, this.dependencyManager));
     }
 
-    private boolean detectFractions() throws Exception {
+    private void detectFractions() throws Exception {
         final File tmpFile = File.createTempFile("buildtool", this.projectAsset.getName().replace("/", "_"));
         tmpFile.deleteOnExit();
         this.projectAsset.getArchive().as(ZipExporter.class).exportTo(tmpFile, true);
@@ -302,8 +302,6 @@ public class BuildTool {
         detectedFractions.stream()
                 .map(ArtifactSpec::fromFractionDescriptor)
                 .forEach(this::fraction);
-
-        return !detectedFractions.isEmpty();
     }
 
     static String strippedSwarmGav(MavenArtifactDescriptor desc) {
@@ -344,16 +342,13 @@ public class BuildTool {
 
             if (this.fractionDetectionMode == FractionDetectionMode.force || artifact == null) {
                 this.log.info("Scanning for needed WildFly Swarm fractions with mode: " + this.fractionDetectionMode);
+                detectFractions();
+            }
+        }
 
-                if (detectFractions()) {
-                    addFractions(resolvedDependencies);
-                }
-            }
-        } else {
-            // Ensure user added fractions have dependencies resolved when FractionDetectionMode.never
-            if (!this.fractions.isEmpty()) {
-                addFractions(resolvedDependencies);
-            }
+        // Ensure user added fractions have dependencies resolved
+        if (!this.fractions.isEmpty()) {
+            addFractions(resolvedDependencies);
         }
 
         artifact = this.dependencyManager.findWildFlySwarmBootstrapJar();


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
User should be able to specify a fraction and have it added when auto detection is force.

Modifications
-------------
Always add user specified additional fractions and resolve their dependencies irrespective of auto detection setting.

Result
------
Always add specified fractions to build.
