### PR TITLE
SWARM-1065 - Better logging granularity.

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/ConfigurableManager.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/ConfigurableManager.java
@@ -20,7 +20,7 @@ import org.jboss.logging.Logger;
 import org.wildfly.swarm.bootstrap.performance.Performance;
 import org.wildfly.swarm.config.runtime.Keyed;
 import org.wildfly.swarm.config.runtime.SubresourceInfo;
-import org.wildfly.swarm.internal.SwarmMessages;
+import org.wildfly.swarm.internal.SwarmConfigMessages;
 import org.wildfly.swarm.spi.api.Defaultable;
 import org.wildfly.swarm.spi.api.Fraction;
 import org.wildfly.swarm.spi.api.annotations.Configurable;
@@ -658,7 +658,7 @@ public class ConfigurableManager implements AutoCloseable {
                 e.printStackTrace();
             }
         }
-        SwarmMessages.MESSAGES.configuration(str.toString());
+        SwarmConfigMessages.MESSAGES.configuration(str.toString());
     }
 
     public void close() {

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/ServerBootstrapImpl.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/ServerBootstrapImpl.java
@@ -42,6 +42,7 @@ import org.wildfly.swarm.container.runtime.cli.CommandLineArgsExtension;
 import org.wildfly.swarm.internal.OutboundSocketBindingRequest;
 import org.wildfly.swarm.internal.SocketBindingRequest;
 import org.wildfly.swarm.internal.SwarmMessages;
+import org.wildfly.swarm.internal.SwarmMetricsMessages;
 import org.wildfly.swarm.spi.api.ClassLoading;
 import org.wildfly.swarm.spi.api.Fraction;
 import org.wildfly.swarm.spi.api.config.ConfigView;
@@ -151,7 +152,7 @@ public class ServerBootstrapImpl implements ServerBootstrap {
                 });
             });
         } finally {
-            SwarmMessages.MESSAGES.bootPerformance(Performance.dump());
+            SwarmMetricsMessages.MESSAGES.bootPerformance(Performance.dump());
         }
     }
 

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/marshal/ConfigViewPropertyMarshaller.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/marshal/ConfigViewPropertyMarshaller.java
@@ -23,7 +23,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.jboss.dmr.ModelNode;
-import org.wildfly.swarm.internal.SwarmMessages;
+import org.wildfly.swarm.internal.SwarmConfigMessages;
 import org.wildfly.swarm.spi.api.config.ConfigView;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
@@ -48,7 +48,7 @@ public class ConfigViewPropertyMarshaller implements ConfigurationMarshaller {
             if (!key.startsWith("jboss") && !key.startsWith("java")) {
                 String value = properties.getProperty(key);
                 if (value != null) {
-                    SwarmMessages.MESSAGES.marshalProjectStageProperty(key);
+                    SwarmConfigMessages.MESSAGES.marshalProjectStageProperty(key);
                     ModelNode modelNode = new ModelNode();
                     modelNode.get(OP).set(ADD);
                     modelNode.get(ADDRESS).set("system-property", key);

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/marshal/XMLMarshaller.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/marshal/XMLMarshaller.java
@@ -27,7 +27,7 @@ import javax.inject.Inject;
 import org.jboss.dmr.ModelNode;
 import org.wildfly.swarm.container.runtime.xmlconfig.StandaloneXMLParser;
 import org.wildfly.swarm.container.runtime.xmlconfig.XMLConfig;
-import org.wildfly.swarm.internal.SwarmMessages;
+import org.wildfly.swarm.internal.SwarmConfigMessages;
 
 /**
  * Marshals a collection of XML configurations (standalone.xml) to DMR.
@@ -63,7 +63,7 @@ public class XMLMarshaller implements ConfigurationMarshaller {
         seen.add(url);
         try {
             List<ModelNode> subList = this.parser.parse(url);
-            SwarmMessages.MESSAGES.marshalXml(url.toExternalForm(), subList.toString());
+            SwarmConfigMessages.MESSAGES.marshalXml(url.toExternalForm(), subList.toString());
             list.addAll(subList);
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/StandaloneXMLConfigProducer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/StandaloneXMLConfigProducer.java
@@ -23,7 +23,7 @@ import javax.enterprise.inject.Produces;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoadException;
-import org.wildfly.swarm.internal.SwarmMessages;
+import org.wildfly.swarm.internal.SwarmConfigMessages;
 
 /**
  * Produces auto-discovered XML configuration (standalone.xml) URLs.
@@ -43,7 +43,7 @@ public class StandaloneXMLConfigProducer {
             ClassLoader cl = app.getClassLoader();
             URL result = cl.getResource(STANDALONE_XML_FILE);
             if (result != null) {
-                SwarmMessages.MESSAGES.loadingStandaloneXml("'swarm.application' module", result.toExternalForm());
+                SwarmConfigMessages.MESSAGES.loadingStandaloneXml("'swarm.application' module", result.toExternalForm());
             }
             return result;
         } catch (ModuleLoadException e) {
@@ -58,7 +58,7 @@ public class StandaloneXMLConfigProducer {
         ClassLoader cl = ClassLoader.getSystemClassLoader();
         URL result = cl.getResource(STANDALONE_XML_FILE);
         if (result != null) {
-            SwarmMessages.MESSAGES.loadingStandaloneXml("system classloader", result.toExternalForm());
+            SwarmConfigMessages.MESSAGES.loadingStandaloneXml("system classloader", result.toExternalForm());
         }
         return result;
     }

--- a/core/container/src/main/java/org/wildfly/swarm/internal/SwarmConfigMessages.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/SwarmConfigMessages.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.swarm.internal;
+
+import java.net.URL;
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@MessageLogger(projectCode = "WFSWARM", length = 4)
+public interface SwarmConfigMessages extends BasicLogger {
+
+    SwarmConfigMessages MESSAGES = Logger.getMessageLogger(SwarmConfigMessages.class, "org.wildfly.swarm.config");
+
+    @Message(id = 1, value = "Stage config is not present.")
+    RuntimeException missingStageConfig();
+
+    @Message(id = 3, value = "Project stage '%s' cannot be found.")
+    RuntimeException stageNotFound(String stageName);
+
+    @Message(id = 10, value = "Failed to load stage configuration from URL : %s")
+    RuntimeException failedLoadingStageConfig(@Cause Throwable cause, URL url);
+
+    @Message(id = 11, value = "Missing stage 'default' in project-stages.yml")
+    RuntimeException missingDefaultStage();
+
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 20, value = "Stage Config found in %s at location: %s")
+    void stageConfigLocation(String configType, String configLocation);
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 21, value = "Failed to parse project stage URL reference, ignoring: %s")
+    void malformedStageConfigUrl(String error);
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 22, value = "Project stage superseded by external configuration %s")
+    void stageConfigSuperseded(String location);
+
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 24, value = "Using project stage: %s")
+    void usingProjectStage(String stageName);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 30, value = "Marshalling Project Stage property %s")
+    void marshalProjectStageProperty(String key);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 31, value = "Marshalling XML from %s as: \n %s")
+    void marshalXml(String location, String xml);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 32, value = "Load standalone.xml via %s from %s")
+    void loadingStandaloneXml(String loader, String location);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 37, value = "Configuration:\n%s")
+    void configuration(String configuration);
+
+}

--- a/core/container/src/main/java/org/wildfly/swarm/internal/SwarmMessages.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/SwarmMessages.java
@@ -19,7 +19,6 @@
 
 package org.wildfly.swarm.internal;
 
-import java.net.URL;
 import java.util.Collection;
 import java.util.List;
 
@@ -43,14 +42,8 @@ public interface SwarmMessages extends BasicLogger {
 
     SwarmMessages MESSAGES = Logger.getMessageLogger(SwarmMessages.class, "org.wildfly.swarm");
 
-    @Message(id = 1, value = "Stage config is not present.")
-    RuntimeException missingStageConfig();
-
     @Message(id = 2, value = "Cannot invoke %s on a container that has not been started.")
     IllegalStateException containerNotStarted(String method);
-
-    @Message(id = 3, value = "Project stage '%s' cannot be found.")
-    RuntimeException stageNotFound(String stageName);
 
     @Message(id = 4, value = "%s requires an argument.")
     RuntimeException argumentRequired(String arg);
@@ -69,12 +62,6 @@ public interface SwarmMessages extends BasicLogger {
 
     @Message(id = 9, value = "JavaArchive spec does not support Libraries")
     UnsupportedOperationException librariesNotSupported();
-
-    @Message(id = 10, value = "Failed to load stage configuration from URL : %s")
-    RuntimeException failedLoadingStageConfig(@Cause Throwable cause, URL url);
-
-    @Message(id = 11, value = "Missing stage 'default' in project-stages.yml")
-    RuntimeException missingDefaultStage();
 
     @Message(id = 12, value = "Fraction \"%s\" was configured using @WildFlyExtension with a module='',"
             + " but has multiple extension classes.  Please use classname='' to specify exactly one, or noClass=true to ignore all. %s")
@@ -101,25 +88,9 @@ public interface SwarmMessages extends BasicLogger {
     @Message(id = 19, value = "No deployments specified on the command-line")
     String noDeploymentsSpecified();
 
-    @LogMessage(level = Logger.Level.DEBUG)
-    @Message(id = 20, value = "Stage Config found in %s at location: %s")
-    void stageConfigLocation(String configType, String configLocation);
-
-    @LogMessage(level = Logger.Level.WARN)
-    @Message(id = 21, value = "Failed to parse project stage URL reference, ignoring: %s")
-    void malformedStageConfigUrl(String error);
-
-    @LogMessage(level = Logger.Level.WARN)
-    @Message(id = 22, value = "Project stage superseded by external configuration %s")
-    void stageConfigSuperseded(String location);
-
     @LogMessage(level = Logger.Level.ERROR)
     @Message(id = 23, value = "Unable to setup Shrinkwrap Domain")
     void shrinkwrapDomainSetupFailed(@Cause Throwable cause);
-
-    @LogMessage(level = Logger.Level.INFO)
-    @Message(id = 24, value = "Using project stage: %s")
-    void usingProjectStage(String stageName);
 
     @LogMessage(level = Logger.Level.DEBUG)
     @Message(id = 25, value = "Add deployment module: %s")
@@ -141,18 +112,6 @@ public interface SwarmMessages extends BasicLogger {
     @Message(id = 29, value = "Install MSC service for command line args: %s")
     void argsInstalled(List<String> args);
 
-    @LogMessage(level = Logger.Level.DEBUG)
-    @Message(id = 30, value = "Marshalling Project Stage property %s")
-    void marshalProjectStageProperty(String key);
-
-    @LogMessage(level = Logger.Level.DEBUG)
-    @Message(id = 31, value = "Marshalling XML from %s as: \n %s")
-    void marshalXml(String location, String xml);
-
-    @LogMessage(level = Logger.Level.DEBUG)
-    @Message(id = 32, value = "Load standalone.xml via %s from %s")
-    void loadingStandaloneXml(String loader, String location);
-
     @Message(id = 33, value = "HTTP/S is configured correctly, but org.wildfly.swarm:management is not available")
     RuntimeException httpsRequiresManagementFraction();
 
@@ -168,18 +127,10 @@ public interface SwarmMessages extends BasicLogger {
     @Message(id = 36, value = "Error installing user-space CDI extension: %s")
     void errorInstallingUserSpaceExtension(String factoryClassName);
 
-    @LogMessage(level = Logger.Level.INFO)
-    @Message(id = 37, value = "Configuration:\n%s")
-    void configuration(String configuration);
-
     @LogMessage(level = Logger.Level.WARN)
     @Message(id = 38, value = "HTTP/2 is not supported in this environment. " +
             "Are the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files for JDK/JRE 8 installed?")
     void http2NotSupported();
-
-    @LogMessage(level = Logger.Level.INFO)
-    @Message(id = 39, value = "Boot performance:\n%s")
-    void bootPerformance(String metrics);
 
 
     // ------------------------------------------------------------------------

--- a/core/container/src/main/java/org/wildfly/swarm/internal/SwarmMetricsMessages.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/SwarmMetricsMessages.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.swarm.internal;
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@MessageLogger(projectCode = "WFSWARM", length = 4)
+public interface SwarmMetricsMessages extends BasicLogger {
+
+    SwarmMetricsMessages MESSAGES = Logger.getMessageLogger(SwarmMetricsMessages.class, "org.wildfly.swarm.metrics");
+
+    @LogMessage(level = Logger.Level.TRACE)
+    @Message(id = 39, value = "Boot performance:\n%s")
+    void bootPerformance(String metrics);
+
+}


### PR DESCRIPTION
Motivation
----------

We need better control of what gets logged at which levels, and
be able to increase/decrease the output based on use-case.

Modifications
-------------

Split some SwarmMessages into Config and Metrics-related
messages.

Result
------

Somewhat less output by default.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
