### PR TITLE
Use HTTPS for jboss-public-repository-group

### DIFF
--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
@@ -188,7 +188,7 @@ public class UberjarSimpleContainer implements SimpleContainer {
         } else {
             additionalRepos = "";
         }
-        additionalRepos = additionalRepos + "http://repository.jboss.org/nexus/content/groups/public/";
+        additionalRepos = additionalRepos + "https://repository.jboss.org/nexus/content/groups/public/";
         executor.withProperty("remote.maven.repo", additionalRepos);
 
 

--- a/arquillian/resolver/src/main/java/org/wildfly/swarm/arquillian/resolver/ShrinkwrapArtifactResolvingHelper.java
+++ b/arquillian/resolver/src/main/java/org/wildfly/swarm/arquillian/resolver/ShrinkwrapArtifactResolvingHelper.java
@@ -67,7 +67,7 @@ public class ShrinkwrapArtifactResolvingHelper implements ArtifactResolvingHelpe
 
             MavenRemoteRepository jbossPublic =
                     MavenRemoteRepositories.createRemoteRepository("jboss-public-repository-group",
-                                                                   "http://repository.jboss.org/nexus/content/groups/public/",
+                                                                   "https://repository.jboss.org/nexus/content/groups/public/",
                                                                    "default");
             jbossPublic.setChecksumPolicy(MavenChecksumPolicy.CHECKSUM_POLICY_IGNORE);
             jbossPublic.setUpdatePolicy(MavenUpdatePolicy.UPDATE_POLICY_NEVER);

--- a/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/GradleArtifactResolvingHelper.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/GradleArtifactResolvingHelper.java
@@ -50,7 +50,7 @@ public class GradleArtifactResolvingHelper implements ArtifactResolvingHelper {
         this.projects = project.getRootProject().getAllprojects().stream().collect(Collectors.toMap(p -> p.getGroup() + ":" + p.getName() + ":" + p.getVersion(), p -> p));
         this.project.getRepositories().maven(repo -> {
             repo.setName("jboss-public");
-            repo.setUrl("http://repository.jboss.org/nexus/content/groups/public/");
+            repo.setUrl("https://repository.jboss.org/nexus/content/groups/public/");
         });
     }
 

--- a/plugin/src/main/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelper.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelper.java
@@ -66,7 +66,7 @@ public class MavenArtifactResolvingHelper implements ArtifactResolvingHelper {
         this.session = session;
         this.dependencyManagement = dependencyManagement;
         this.remoteRepositories.add(buildRemoteRepository("jboss-public-repository-group",
-                                                          "http://repository.jboss.org/nexus/content/groups/public/",
+                                                          "https://repository.jboss.org/nexus/content/groups/public/",
                                                           null));
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -1144,7 +1144,7 @@
     <repository>
       <id>jboss-public-repository-group</id>
       <name>JBoss Public Repository Group</name>
-      <url>http://repository.jboss.org/nexus/content/groups/public/</url>
+      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
       <releases>
         <enabled>true</enabled>
       </releases>
@@ -1158,7 +1158,7 @@
     <pluginRepository>
       <id>jboss-public-repository-group</id>
       <name>JBoss Public Repository Group</name>
-      <url>http://repository.jboss.org/nexus/content/groups/public/</url>
+      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
       <releases>
         <enabled>true</enabled>
       </releases>

--- a/swarmtool/src/main/java/org/wildfly/swarm/swarmtool/Main.java
+++ b/swarmtool/src/main/java/org/wildfly/swarm/swarmtool/Main.java
@@ -270,7 +270,7 @@ public class Main {
         final ConfigurableMavenResolverSystem resolver = Maven.configureResolver()
                 .withMavenCentralRepo(true)
                 .withRemoteRepo(MavenRemoteRepositories.createRemoteRepository("jboss-public-repository-group",
-                                                                               "http://repository.jboss.org/nexus/content/groups/public/",
+                                                                               "https://repository.jboss.org/nexus/content/groups/public/",
                                                                                "default")
                                         .setChecksumPolicy(MavenChecksumPolicy.CHECKSUM_POLICY_IGNORE)
                                         .setUpdatePolicy(MavenUpdatePolicy.UPDATE_POLICY_NEVER));


### PR DESCRIPTION
HTTP is not secure. Anyone on the way between the user
and the remote repo could forge the artifacts being download,
adding malicious code.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
