### PR TITLE
SWARM-1098: Incremental Build Support for Wildfly Swarm Gradle Plugin

### DIFF
--- a/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/PackagePlugin.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/PackagePlugin.java
@@ -31,10 +31,11 @@ import org.gradle.api.tasks.bundling.Jar;
 public class PackagePlugin implements Plugin<Project> {
 
     public static final String WILDFLY_SWARM_PACKAGE_TASK_NAME = "wildfly-swarm-package";
+    public static final String SWARM_EXTENSION = "swarm";
 
     @Override
     public void apply(Project project) {
-        project.getExtensions().create("swarm", SwarmExtension.class, project);
+        project.getExtensions().create(SWARM_EXTENSION, SwarmExtension.class, project);
         project.afterEvaluate(__ -> {
             final TaskContainer tasks = project.getTasks();
             final PackageTask packageTask = tasks.create(WILDFLY_SWARM_PACKAGE_TASK_NAME, PackageTask.class);

--- a/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
@@ -411,8 +411,12 @@ public class BuildTool {
 
     }
 
+    public static File getOutputFile(String baseName, Path directory) {
+        return new File(directory.toFile(), baseName + "-swarm.jar");
+    }
+
     private File createJar(String baseName, Path dir) throws IOException {
-        File out = new File(dir.toFile(), baseName + "-swarm.jar");
+        File out = getOutputFile(baseName, dir);
         if (!out.getParentFile().exists() && !out.getParentFile().mkdirs()) {
             this.log.error("Failed to create parent directory for: " + out.getAbsolutePath());
         }


### PR DESCRIPTION
Motivation
----------
The task 'wildfly-swarm-package' should only be executed, if the UberJar is not created yet,
the depending archive (jar,war) has changed or the 'swarm' extension properties for executing the task have changed.
Otherwise the task should be marked as UP-TO-DATE.

Modifications
-------------
Defining the inputs and outputs of the 'wildfly-swarm-package', so Gradle will automatically make an update-to-date check.

Result
------
The plugin will have the same behaviour on using. But running the tasks twice the second time should the task should be marked as UP-TO-DATE.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
