### PR TITLE
SWARM-1100: Swarmtool should support specifying additional dependencies

### DIFF
--- a/swarmtool/src/main/java/org/wildfly/swarm/swarmtool/Main.java
+++ b/swarmtool/src/main/java/org/wildfly/swarm/swarmtool/Main.java
@@ -80,6 +80,13 @@ public class Main {
                     .withValuesSeparatedBy(',')
                     .describedAs("undertow,jaxrs,...");
 
+    private static final OptionSpec<String> DEPENDENCIES_OPT =
+            OPT_PARSER.acceptsAll(asList("d", "dependencies"), "Maven coordinates (groupId:artifactId:version) of dependencies to include")
+                    .withRequiredArg()
+                    .ofType(String.class)
+                    .withValuesSeparatedBy(",")
+                    .describedAs("gav1,gav2,...");
+
     private static final OptionSpec<String> REPOS_OPT =
             OPT_PARSER.accepts("repos", "additional maven repos to resolve against")
                     .withRequiredArg()
@@ -217,6 +224,11 @@ public class Main {
                     properties.put(parts[0], parts[1]);
                 });
 
+        final DeclaredDependencies dependencies = new DeclaredDependencies();
+        foundOptions.valuesOf(DEPENDENCIES_OPT).stream()
+                .map(DeclaredDependencies::createSpec)
+                .forEach(dependencies::add);
+
         final String[] parts = source.getName().split("\\.(?=[^\\.]+$)");
         final String baseName = parts[0];
         final String type = parts[1] == null ? "jar" : parts[1];
@@ -225,7 +237,7 @@ public class Main {
         final String suffix = foundOptions.has(HOLLOW_OPT) ? "-hollow-swarm" : "-swarm";
         final BuildTool tool = new BuildTool(getResolvingHelper(foundOptions.valuesOf(REPOS_OPT)))
                 .projectArtifact("", baseName, "", type, source)
-                .declaredDependencies(new DeclaredDependencies())
+                .declaredDependencies(dependencies)
                 .fractionDetectionMode(foundOptions.has(DISABLE_AUTO_DETECT_OPT) ?
                                                BuildTool.FractionDetectionMode.never :
                                                BuildTool.FractionDetectionMode.force)


### PR DESCRIPTION
Motivation
----------
Swarmtool supports specifying additional fractions. In the same vein,
it should support specifying additional dependencies for things
like JDBC drivers.

Modifications
-------------
Added a cmdline option -d/--dependencies to Swarmtool. The option takes
a list of Maven GAVs and adds each of them as a "declared dependency",
similarly to how Swarm Maven plugin works.

Result
------
Swarmtool is now able to produce uberjars that contain JDBC drivers
that are detected by Swarm.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
