### PR TITLE
SWARM-898 - Unable to add ServiceActivator w/o main()

### DIFF
--- a/testsuite/testsuite-msc/pom.xml
+++ b/testsuite/testsuite-msc/pom.xml
@@ -29,6 +29,10 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>naming</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>arquillian</artifactId>
       <scope>test</scope>
     </dependency>

--- a/testsuite/testsuite-msc/src/main/java/org/wildfly/swarm/msc/test/MyServiceActivator.java
+++ b/testsuite/testsuite-msc/src/main/java/org/wildfly/swarm/msc/test/MyServiceActivator.java
@@ -1,0 +1,22 @@
+package org.wildfly.swarm.msc.test;
+
+import org.jboss.msc.service.ServiceActivator;
+import org.jboss.msc.service.ServiceActivatorContext;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistryException;
+import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.service.ValueService;
+import org.jboss.msc.value.ImmediateValue;
+
+/**
+ * @author Bob McWhirter
+ */
+public class MyServiceActivator implements ServiceActivator {
+
+    @Override
+    public void activate(ServiceActivatorContext context) throws ServiceRegistryException {
+        ServiceTarget target = context.getServiceTarget();
+        target.addService(ServiceName.of("swarm", "test", "cheese"), new ValueService<>(new ImmediateValue<>("cheddar")))
+                .install();
+    }
+}

--- a/testsuite/testsuite-msc/src/main/resources/META-INF/services/org.jboss.msc.service.ServiceActivator
+++ b/testsuite/testsuite-msc/src/main/resources/META-INF/services/org.jboss.msc.service.ServiceActivator
@@ -1,0 +1,1 @@
+org.wildfly.swarm.msc.test.MyServiceActivator

--- a/testsuite/testsuite-msc/src/main/resources/project-defaults.yml
+++ b/testsuite/testsuite-msc/src/main/resources/project-defaults.yml
@@ -1,0 +1,5 @@
+
+swarm:
+  msc:
+    service-activators:
+      org.wildfly.swarm.msc.test.MyServiceActivator

--- a/testsuite/testsuite-msc/src/test/java/org/wildfly/swarm/msc/MSCArquillianTest.java
+++ b/testsuite/testsuite-msc/src/test/java/org/wildfly/swarm/msc/MSCArquillianTest.java
@@ -15,40 +15,33 @@
  */
 package org.wildfly.swarm.msc;
 
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
+import javax.naming.NamingException;
+
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistry;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.swarm.Swarm;
-import org.wildfly.swarm.arquillian.CreateSwarm;
-import org.wildfly.swarm.spi.api.JARArchive;
+import org.wildfly.swarm.arquillian.DefaultDeployment;
+
+import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Bob McWhirter
  */
 @RunWith(Arquillian.class)
+@DefaultDeployment(type = DefaultDeployment.Type.JAR)
 public class MSCArquillianTest {
 
-    @Deployment(testable = false)
-    public static Archive createDeployment() {
-        JARArchive deployment = ShrinkWrap.create(JARArchive.class);
-        deployment.add(EmptyAsset.INSTANCE, "nothing");
-        return deployment;
-    }
-
-    @CreateSwarm
-    public static Swarm newSwarm() throws Exception {
-        return new Swarm().fraction(new MSCFraction());
-    }
+    @ArquillianResource
+    ServiceRegistry registry;
 
     @Test
-    @RunAsClient
-    public void testNothing() {
-
+    public void testNothing() throws NamingException {
+        ServiceController<?> service = registry.getService(ServiceName.of("swarm", "test", "cheese"));
+        assertNotNull(service);
     }
 
 }


### PR DESCRIPTION
Motivation
----------

Someone, somewhere, might have an MSC ServiceActivator they want
involved, even if they don't have a main().

Modifications
-------------

Added a test to prove that a non-main() method exists for adding
a ServiceActivator to a deployment.

Result
------

Proof is in the pudding.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
