### PR TITLE
SWARM-1104 - More eagerly setup project-config.

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/cli/CommandLine.java
+++ b/core/container/src/main/java/org/wildfly/swarm/cli/CommandLine.java
@@ -323,7 +323,7 @@ public class CommandLine {
      * @param swarm Swarm instance to configure.
      * @throws MalformedURLException If a URL is attempted to be read and fails.
      */
-    public void applyConfigurations(Swarm swarm) throws MalformedURLException {
+    public void applyConfigurations(Swarm swarm) throws IOException {
         if (get(SERVER_CONFIG) != null) {
             swarm.withXmlConfig(get(SERVER_CONFIG));
         }

--- a/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewFactory.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewFactory.java
@@ -103,6 +103,7 @@ public class ConfigViewFactory {
         props.load(url.openStream());
         ConfigNode configNode = PropertiesConfigNodeFactory.load(props);
         this.configView.register(profileName, configNode);
+        this.configView.withProfile(profileName);
     }
 
     protected void loadYaml(String profileName, URL url) throws IOException {
@@ -114,7 +115,12 @@ public class ConfigViewFactory {
         loadYamlProjectConfig(profileName, url);
     }
 
-    public ConfigViewImpl build() {
+    public ConfigViewImpl get() {
+        return this.configView;
+    }
+
+    public ConfigViewImpl get(boolean activate) {
+        this.configView.activate();
         return this.configView;
     }
 
@@ -154,6 +160,7 @@ public class ConfigViewFactory {
 
         ConfigNode node = MapConfigNodeFactory.load(doc);
         this.configView.register(name, node);
+        this.configView.withProfile(name);
     }
 
     private List<ConfigLocator> locators = new ArrayList<>();

--- a/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewImpl.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewImpl.java
@@ -33,7 +33,7 @@ public class ConfigViewImpl implements ConfigView {
      * Construct a new view.
      */
     public ConfigViewImpl() {
-
+        this.strategy = new ConfigResolutionStrategy();
     }
 
     /**
@@ -43,7 +43,10 @@ public class ConfigViewImpl implements ConfigView {
      * @return This view.
      */
     public ConfigViewImpl withProperties(Properties properties) {
-        this.properties = properties;
+        if (properties != null) {
+            this.properties = properties;
+            this.strategy.withProperties(properties);
+        }
         return this;
 
     }
@@ -55,7 +58,7 @@ public class ConfigViewImpl implements ConfigView {
      * @return This view.
      */
     public ConfigViewImpl withDefaults(ConfigNode defaultConfig) {
-        this.defaultConfig = defaultConfig;
+        this.strategy.defaults(defaultConfig);
         return this;
     }
 
@@ -103,9 +106,7 @@ public class ConfigViewImpl implements ConfigView {
      *
      * @param names The names to activate.
      */
-    public void activate(String... names) {
-        this.strategy = new ConfigResolutionStrategy(this.properties);
-
+    public void withProfile(String... names) {
         for (String name : names) {
             List<ConfigNode> nodes = this.registry.get(name);
             if (nodes != null) {
@@ -115,17 +116,15 @@ public class ConfigViewImpl implements ConfigView {
             }
         }
 
-        if (this.defaultConfig != null) {
-            this.strategy.add(this.defaultConfig);
-        }
+    }
 
+    public void withProfile(List<String> names) {
+        withProfile(names.toArray(new String[]{}));
+    }
+
+    public void activate() {
         this.strategy.activate();
     }
-
-    public void activate(List<String> names) {
-        activate(names.toArray(new String[]{}));
-    }
-
 
     // ------------------------------------------------------------------------
     // ------------------------------------------------------------------------
@@ -155,8 +154,6 @@ public class ConfigViewImpl implements ConfigView {
     }
 
     private Properties properties;
-
-    private ConfigNode defaultConfig;
 
     private Map<String, List<ConfigNode>> registry = new HashMap<>();
 

--- a/core/container/src/test/java/org/wildfly/swarm/container/config/ConfigViewTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/container/config/ConfigViewTest.java
@@ -122,7 +122,8 @@ public class ConfigViewTest {
         view.register("staging", staging);
         view.register("production", production);
 
-        view.activate("staging");
+        view.withProfile("staging");
+        view.activate();
 
         assertThat(view.valueOf(ConfigKey.parse("cheese"))).isEqualTo("velveeta");
         assertThat(view.valueOf(ConfigKey.parse("company.founded"))).isEqualTo("2017");
@@ -174,7 +175,8 @@ public class ConfigViewTest {
         view.register("cloud", cloud);
         view.register("production", production);
 
-        view.activate("cloud", "production");
+        view.withProfile("cloud", "production");
+        view.activate();
 
         assertThat(view.valueOf(ConfigKey.parse("cheese"))).isEqualTo("velveeta");
         assertThat(view.valueOf(ConfigKey.parse("company.founded"))).isEqualTo("2017");

--- a/core/container/src/test/java/org/wildfly/swarm/container/config/ConfigViewYamlTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/container/config/ConfigViewYamlTest.java
@@ -21,8 +21,8 @@ public class ConfigViewYamlTest {
         ConfigViewFactory factory = new ConfigViewFactory(new Properties());
         factory.load("test", url);
 
-        ConfigViewImpl view = factory.build();
-        view.activate("test");
+        ConfigViewImpl view = factory.get();
+        view.withProfile("test");
 
         List<Map<?, ?>> constraints = view.resolve("swarm.keycloak.security.constraints").as(List.class).getValue();
 

--- a/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/ProjectStagesTest.java
+++ b/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/ProjectStagesTest.java
@@ -19,9 +19,7 @@ public class ProjectStagesTest {
         try {
             URL projectStages = getClass().getClassLoader().getResource("simple-project-stages.yml");
             System.setProperty(SwarmProperties.PROJECT_STAGE_FILE, projectStages.toExternalForm());
-            Swarm swarm = new Swarm();
-            swarm.initializeConfigView(new Properties());
-
+            Swarm swarm = new Swarm(new Properties());
             ConfigView view = swarm.configView();
 
             assertThat(view.resolve("foo.bar.baz").getValue()).isEqualTo("cheddar");
@@ -35,8 +33,7 @@ public class ProjectStagesTest {
         try {
             URL projectStages = getClass().getClassLoader().getResource("multi-project-stages.yml");
             System.setProperty(SwarmProperties.PROJECT_STAGE_FILE, projectStages.toExternalForm());
-            Swarm swarm = new Swarm();
-            swarm.initializeConfigView(new Properties());
+            Swarm swarm = new Swarm(new Properties());
 
             ConfigView view = swarm.configView();
 
@@ -52,8 +49,7 @@ public class ProjectStagesTest {
             URL projectStages = getClass().getClassLoader().getResource("multi-project-stages.yml");
             System.setProperty(SwarmProperties.PROJECT_STAGE_FILE, projectStages.toExternalForm());
             System.setProperty(SwarmProperties.PROJECT_STAGE, "production");
-            Swarm swarm = new Swarm();
-            swarm.initializeConfigView(new Properties());
+            Swarm swarm = new Swarm(new Properties());
 
             ConfigView view = swarm.configView();
 
@@ -63,4 +59,22 @@ public class ProjectStagesTest {
             System.clearProperty(SwarmProperties.PROJECT_STAGE);
         }
     }
+
+    @Test
+    public void testSwarmAPIToLoadConfig() throws Exception {
+        Swarm swarm = new Swarm( new Properties());
+        swarm.withProfile("foo");
+        ConfigView view = swarm.configView();
+        assertThat(view.resolve("myname").getValue()).isEqualTo("foo");
+        swarm.withProfile("bar");
+        assertThat(view.resolve("myname").getValue()).isEqualTo("foo");
+    }
+
+    @Test
+    public void testCLIToLoadConfig() throws Exception {
+        Swarm swarm = new Swarm(new Properties(), "-Sfoo");
+        ConfigView view = swarm.configView();
+        assertThat(view.resolve("myname").getValue()).isEqualTo("foo");
+    }
+
 }

--- a/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/StageConfigTest.java
+++ b/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/StageConfigTest.java
@@ -20,15 +20,14 @@ public class StageConfigTest {
         try {
             URL projectStages = getClass().getClassLoader().getResource("simple-project-stages.yml");
             System.setProperty(SwarmProperties.PROJECT_STAGE_FILE, projectStages.toExternalForm());
-            Swarm swarm = new Swarm();
-            swarm.initializeConfigView(new Properties());
+            Swarm swarm = new Swarm(false, new Properties());
 
             ConfigView view = swarm.configView();
             assertThat(view.resolve("foo.bar.baz").getValue()).isEqualTo("cheddar");
 
             StageConfig stageConfig = swarm.stageConfig();
             assertThat(stageConfig.resolve("foo.bar.baz").getValue()).isEqualTo("cheddar");
-            
+
         } finally {
             System.clearProperty(SwarmProperties.PROJECT_STAGE_FILE);
         }

--- a/testsuite/testsuite-project-stages/src/test/resources/project-bar.yml
+++ b/testsuite/testsuite-project-stages/src/test/resources/project-bar.yml
@@ -1,0 +1,2 @@
+
+myname: bar

--- a/testsuite/testsuite-project-stages/src/test/resources/project-foo.yml
+++ b/testsuite/testsuite-project-stages/src/test/resources/project-foo.yml
@@ -1,0 +1,2 @@
+
+myname: foo


### PR DESCRIPTION
Motivation
----------

Since people want to be about to use the ConfigView from main(),
we should intiailize it progressively so that it's useful before
swarm.start() is called.

Modifications
-------------

Initialize the config-view pieces within the Swarm() ctor and
progressively as withConfig() and withProfile() are called.

Result
------

Users may use ConfigView in main() immediately after constructing
the Swarm, or after calling withConfig() or withProfile().

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
