### PR TITLE
SWARM-895 - Allow management fraction configuration via YAML

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/ConfigurableManager.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/ConfigurableManager.java
@@ -488,6 +488,7 @@ public class ConfigurableManager implements AutoCloseable {
                     .getTarget();
 
             return mh.invoke(this, itemPrefix);
+
         } catch (Throwable t) {
             throw new RuntimeException(t);
         }

--- a/core/container/src/main/resources/modules/org/wildfly/swarm/container/runtime/module.xml
+++ b/core/container/src/main/resources/modules/org/wildfly/swarm/container/runtime/module.xml
@@ -34,6 +34,7 @@
   </resources>
 
   <dependencies>
+    <module name="swarm.container" export="true" optional="true"/>
     <module name="org.wildfly.swarm.container" export="true"/>
     <module name="org.wildfly.swarm.bootstrap" optional="true"/>
     <module name="org.wildfly.swarm.configuration" export="true"/>

--- a/fractions/javaee/mail/src/main/java/org/wildfly/swarm/mail/EnhancedMailSessionConsumer.java
+++ b/fractions/javaee/mail/src/main/java/org/wildfly/swarm/mail/EnhancedMailSessionConsumer.java
@@ -20,5 +20,6 @@ import org.wildfly.swarm.config.mail.MailSessionConsumer;
 /**
  * @author Bob McWhirter
  */
+@FunctionalInterface
 public interface EnhancedMailSessionConsumer extends MailSessionConsumer<EnhancedMailSession> {
 }

--- a/fractions/javaee/mail/src/main/java/org/wildfly/swarm/mail/EnhancedSMTPServerConsumer.java
+++ b/fractions/javaee/mail/src/main/java/org/wildfly/swarm/mail/EnhancedSMTPServerConsumer.java
@@ -20,5 +20,6 @@ import org.wildfly.swarm.config.mail.mail_session.SMTPServerConsumer;
 /**
  * @author Bob McWhirter
  */
+@FunctionalInterface
 public interface EnhancedSMTPServerConsumer extends SMTPServerConsumer<EnhancedSMTPServer> {
 }

--- a/fractions/javaee/messaging/src/main/java/org/wildfly/swarm/messaging/EnhancedServerConsumer.java
+++ b/fractions/javaee/messaging/src/main/java/org/wildfly/swarm/messaging/EnhancedServerConsumer.java
@@ -20,6 +20,7 @@ import org.wildfly.swarm.config.messaging.activemq.ServerConsumer;
 /**
  * @author Bob McWhirter
  */
+@FunctionalInterface
 public interface EnhancedServerConsumer extends ServerConsumer<EnhancedServer> {
     default EnhancedServerConsumer then(EnhancedServerConsumer after) {
         return (c) -> {

--- a/fractions/wildfly/management-console/src/main/java/org/wildfly/swarm/management/console/ManagementConsoleFraction.java
+++ b/fractions/wildfly/management-console/src/main/java/org/wildfly/swarm/management/console/ManagementConsoleFraction.java
@@ -15,8 +15,12 @@
  */
 package org.wildfly.swarm.management.console;
 
+import org.wildfly.swarm.spi.api.Defaultable;
 import org.wildfly.swarm.spi.api.Fraction;
 import org.wildfly.swarm.spi.api.annotations.Configurable;
+
+import static org.wildfly.swarm.management.console.ManagementConsoleProperties.DEFAULT_CONTEXT;
+import static org.wildfly.swarm.spi.api.Defaultable.string;
 
 /**
  * Created by ggastald on 02/06/16.
@@ -29,15 +33,13 @@ public class ManagementConsoleFraction implements Fraction<ManagementConsoleFrac
     }
 
     public ManagementConsoleFraction contextRoot(String context) {
-        this.context = context;
+        this.context.set(context);
         return this;
     }
 
     public String contextRoot() {
-        return context;
+        return context.get();
     }
 
-    private static final String DEFAULT_CONTEXT = "/console";
-
-    private String context = DEFAULT_CONTEXT;
+    private Defaultable<String> context = string(DEFAULT_CONTEXT);
 }

--- a/fractions/wildfly/management-console/src/main/java/org/wildfly/swarm/management/console/ManagementConsoleProperties.java
+++ b/fractions/wildfly/management-console/src/main/java/org/wildfly/swarm/management/console/ManagementConsoleProperties.java
@@ -19,5 +19,5 @@ package org.wildfly.swarm.management.console;
  * @author Bob McWhirter
  */
 public interface ManagementConsoleProperties {
-    String CONTEXT = "swarm.management.console.context";
+    String DEFAULT_CONTEXT = "/console";
 }

--- a/fractions/wildfly/management-console/src/main/java/org/wildfly/swarm/management/console/runtime/ManagementConsoleDeploymentProducer.java
+++ b/fractions/wildfly/management-console/src/main/java/org/wildfly/swarm/management/console/runtime/ManagementConsoleDeploymentProducer.java
@@ -28,9 +28,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.importer.ZipImporter;
 import org.wildfly.swarm.management.console.ManagementConsoleFraction;
-import org.wildfly.swarm.management.console.ManagementConsoleProperties;
 import org.wildfly.swarm.spi.api.ArtifactLookup;
-import org.wildfly.swarm.spi.runtime.annotations.ConfigurationValue;
 import org.wildfly.swarm.undertow.WARArchive;
 
 /**
@@ -46,23 +44,14 @@ public class ManagementConsoleDeploymentProducer {
     @Any
     private ManagementConsoleFraction fraction;
 
-    @Inject
-    @ConfigurationValue(ManagementConsoleProperties.CONTEXT)
-    private String context;
-
     @Produces
     public Archive managementConsoleWar() throws Exception {
-        if (this.context == null) {
-            this.context = fraction.contextRoot();
-        }
-
         // Load the swagger-ui webjars.
         Module module = Module.getBootModuleLoader().loadModule(ModuleIdentifier.create("org.jboss.as.console"));
         URL resource = module.getExportedResource("jboss-as-console-resources.jar");
         WARArchive war = ShrinkWrap.create(WARArchive.class, "management-console-ui.war");
         war.as(ZipImporter.class).importFrom(resource.openStream());
-
-        war.setContextRoot(this.context);
+        war.setContextRoot(fraction.contextRoot());
 
         return war;
     }

--- a/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/EnhancedSecurityRealm.java
+++ b/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/EnhancedSecurityRealm.java
@@ -16,7 +16,6 @@
 package org.wildfly.swarm.management;
 
 import org.wildfly.swarm.config.management.SecurityRealm;
-import org.wildfly.swarm.config.management.SecurityRealmConsumer;
 
 /**
  * @author Bob McWhirter
@@ -30,7 +29,7 @@ public class EnhancedSecurityRealm extends SecurityRealm<EnhancedSecurityRealm> 
         plugIn("org.wildfly.swarm.management:runtime");
     }
 
-    public EnhancedSecurityRealm inMemoryAuthentication(InMemoryAuthentication.Consumer consumer) {
+    public EnhancedSecurityRealm inMemoryAuthentication(InMemoryAuthenticationConsumer consumer) {
         return plugInAuthentication((plugin) -> {
             plugin.name(IN_MEMORY_PLUGIN_NAME);
             InMemoryAuthentication authn = new InMemoryAuthentication(getKey(), plugin);
@@ -43,16 +42,12 @@ public class EnhancedSecurityRealm extends SecurityRealm<EnhancedSecurityRealm> 
         });
     }
 
-    public EnhancedSecurityRealm inMemoryAuthorization(InMemoryAuthorization.Consumer consumer) {
+    public EnhancedSecurityRealm inMemoryAuthorization(InMemoryAuthorizationConsumer consumer) {
         return plugInAuthorization((plugin) -> {
             plugin.name(IN_MEMORY_PLUGIN_NAME);
             InMemoryAuthorization authz = new InMemoryAuthorization(plugin);
             consumer.accept(authz);
         });
-    }
-
-    public static interface Consumer extends SecurityRealmConsumer<EnhancedSecurityRealm> {
-
     }
 
 }

--- a/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/EnhancedSecurityRealmConsumer.java
+++ b/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/EnhancedSecurityRealmConsumer.java
@@ -1,0 +1,11 @@
+package org.wildfly.swarm.management;
+
+import org.wildfly.swarm.config.management.SecurityRealmConsumer;
+
+/**
+ * @author Bob McWhirter
+ */
+@FunctionalInterface
+public interface EnhancedSecurityRealmConsumer extends SecurityRealmConsumer<EnhancedSecurityRealm> {
+
+}

--- a/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/InMemoryAuthentication.java
+++ b/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/InMemoryAuthentication.java
@@ -90,9 +90,4 @@ public class InMemoryAuthentication {
 
     private final PlugInAuthentication plugin;
 
-    @FunctionalInterface
-    public interface Consumer {
-        void accept(InMemoryAuthentication authn);
-    }
-
 }

--- a/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/InMemoryAuthenticationConsumer.java
+++ b/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/InMemoryAuthenticationConsumer.java
@@ -1,0 +1,9 @@
+package org.wildfly.swarm.management;
+
+/**
+ * @author Bob McWhirter
+ */
+@FunctionalInterface
+public interface InMemoryAuthenticationConsumer {
+    void accept(InMemoryAuthentication authn);
+}

--- a/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/InMemoryAuthorization.java
+++ b/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/InMemoryAuthorization.java
@@ -36,8 +36,4 @@ public class InMemoryAuthorization {
 
     private final PlugInAuthorization plugin;
 
-    @FunctionalInterface
-    public interface Consumer {
-        void accept(InMemoryAuthorization authz);
-    }
 }

--- a/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/InMemoryAuthorizationConsumer.java
+++ b/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/InMemoryAuthorizationConsumer.java
@@ -1,0 +1,9 @@
+package org.wildfly.swarm.management;
+
+/**
+ * @author Bob McWhirter
+ */
+@FunctionalInterface
+public interface InMemoryAuthorizationConsumer {
+    void accept(InMemoryAuthorization authz);
+}

--- a/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/ManagementFraction.java
+++ b/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/ManagementFraction.java
@@ -33,6 +33,7 @@ import static org.wildfly.swarm.spi.api.Defaultable.integer;
  * @author Bob McWhirter
  */
 @MarshalDMR
+@Configurable("swarm.management")
 public class ManagementFraction extends ManagementCoreService<ManagementFraction> implements Fraction<ManagementFraction> {
 
     public ManagementFraction() {
@@ -70,7 +71,7 @@ public class ManagementFraction extends ManagementCoreService<ManagementFraction
         });
     }
 
-    public ManagementFraction securityRealm(String childKey, EnhancedSecurityRealm.Consumer consumer) {
+    public ManagementFraction securityRealm(String childKey, EnhancedSecurityRealmConsumer consumer) {
         return securityRealm(() -> {
             EnhancedSecurityRealm realm = new EnhancedSecurityRealm(childKey);
             consumer.accept(realm);

--- a/testsuite/testsuite-management/src/main/java/org/wildfly/swarm/management/test/Dummy.java
+++ b/testsuite/testsuite-management/src/main/java/org/wildfly/swarm/management/test/Dummy.java
@@ -1,0 +1,7 @@
+package org.wildfly.swarm.management.test;
+
+/**
+ * @author Bob McWhirter
+ */
+public class Dummy {
+}

--- a/testsuite/testsuite-management/src/main/resources/project-defaults.yml
+++ b/testsuite/testsuite-management/src/main/resources/project-defaults.yml
@@ -1,0 +1,19 @@
+
+swarm:
+  management:
+    http-interface-management-interface:
+      security-realm: ManagementRealm
+    security-realms:
+      ManagementRealm:
+        plug-in-authentication:
+          name: swarm-in-memory
+          properties:
+            bob.hash:
+              value: 9b511b00aa7f2265621e38d2cf665f2f
+        plug-in-authorization:
+          name: swarm-in-memory
+          properties:
+            bob.roles:
+              value: admin
+
+

--- a/testsuite/testsuite-management/src/test/java/org/wildfly/swarm/management/test/ArqSecuredManagementInterfaceTest.java
+++ b/testsuite/testsuite-management/src/test/java/org/wildfly/swarm/management/test/ArqSecuredManagementInterfaceTest.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.management.test;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.arquillian.DefaultDeployment;
+import org.wildfly.swarm.management.AuthCallbackHandler;
+import org.wildfly.swarm.management.ManagementFraction;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Bob McWhirter
+ */
+@RunWith(Arquillian.class)
+@DefaultDeployment
+public class ArqSecuredManagementInterfaceTest {
+
+    /*
+    @Deployment(testable = false)
+    public static Archive createDeployment() {
+        JARArchive deployment = ShrinkWrap.create(JARArchive.class, "myapp.jar");
+        deployment.add(EmptyAsset.INSTANCE, "nothing");
+        return deployment;
+    }
+
+    public static Swarm newContainer() throws Exception {
+        return new Swarm()
+                .fraction(
+                        ManagementFraction.createDefaultFraction()
+                                .httpInterfaceManagementInterface((iface) -> {
+                                    iface.securityRealm("ManagementRealm");
+                                })
+                                .securityRealm("ManagementRealm", (realm) -> {
+                                    realm.inMemoryAuthentication((authn) -> {
+                                        authn.add("bob", "tacos!", true);
+                                    });
+                                    realm.inMemoryAuthorization((authz) -> {
+                                        authz.add("bob", "admin");
+                                    });
+                                })
+                );
+    }
+    */
+
+    @Test
+    @RunAsClient
+    public void testClient() throws Exception {
+
+        ModelControllerClient client = ModelControllerClient.Factory.create(
+                "localhost", 9990, new AuthCallbackHandler("bob", "tacos!")
+        );
+
+        ModelNode response = client.execute(Operations.createOperation("whoami"));
+
+        assertThat(response.get("outcome").asString()).isEqualTo("success");
+
+        ModelNode result = response.get("result");
+
+        assertThat(result).isNotNull();
+        assertThat(result.isDefined()).isTrue();
+
+        ModelNode identity = result.get("identity");
+
+        assertThat(identity).isNotNull();
+        assertThat(identity.isDefined()).isTrue();
+
+        assertThat(identity.get("username").asString()).isEqualTo("bob");
+
+        // ===
+
+        response = client.execute(Operations.createOperation("read-resource", PathAddress.pathAddress(PathElement.pathElement("deployment", "*")).toModelNode()));
+
+        assertThat(response.get("outcome").asString()).isEqualTo("success");
+
+        result = response.get("result");
+
+        assertThat(result).isNotNull();
+        assertThat(result.isDefined()).isTrue();
+        assertThat(result.getType()).isEqualTo(ModelType.LIST);
+        assertThat(result.asList()).hasSize(1);
+
+        ModelNode myapp = result.get(0);
+
+        assertThat(myapp).isNotNull();
+        assertThat(myapp.isDefined()).isTrue();
+
+        ModelNode myappResult = myapp.get("result");
+
+        assertThat(myappResult).isNotNull();
+        assertThat(myappResult.isDefined()).isTrue();
+
+        assertThat(myappResult.get("name").asString()).isEqualTo("ArqSecuredManagementInterfaceTest.war");
+
+    }
+
+}


### PR DESCRIPTION
Motivation
----------

We don't want to require main() usage.

Modifications
-------------

Mostly proving it works, but also solving a few bugs related to our
various Enhanced*Consumer usage and ConfigurableManager and some of
their lacking of @FunctionalInterface.

Result
------

You can now fully configure management interface using YAML or properties.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
