### PR TITLE
SWARM-1109: Follow normal WildFly default io subsystem configration

### DIFF
--- a/fractions/wildfly/io/src/main/java/org/wildfly/swarm/io/IOFraction.java
+++ b/fractions/wildfly/io/src/main/java/org/wildfly/swarm/io/IOFraction.java
@@ -17,6 +17,7 @@ package org.wildfly.swarm.io;
 
 import org.wildfly.swarm.config.IO;
 import org.wildfly.swarm.config.io.BufferPool;
+import org.wildfly.swarm.config.io.Worker;
 import org.wildfly.swarm.spi.api.Fraction;
 import org.wildfly.swarm.spi.api.annotations.MarshalDMR;
 import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
@@ -29,11 +30,7 @@ import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
 public class IOFraction extends IO<IOFraction> implements Fraction<IOFraction> {
 
     public IOFraction applyDefaults() {
-        return worker(
-                "default", w -> {
-                    w.ioThreads(100);
-                    w.taskMaxThreads(20);
-                })
+        return worker(new Worker("default"))
                 .bufferPool(new BufferPool("default"));
     }
 }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
 - https://issues.jboss.org/browse/SWARM-1109
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
IO Fraction worker default configuration is different from normal WildFly.

Modifications
-------------
Just new Worker("default") instead of specifying the
worker attributes(io-threads,task-max-threads) values.

Result
------
IO Fraction default configuration is closer to normal WildFly.
