### PR TITLE
SWARM-1112: Project with just the management-console fails to start

### DIFF
--- a/fractions/wildfly/management-console/pom.xml
+++ b/fractions/wildfly/management-console/pom.xml
@@ -31,7 +31,7 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>
-            <id>swagger-ui</id>
+            <id>management-ui</id>
             <phase>prepare-package</phase>
             <goals>
               <goal>copy-dependencies</goal>
@@ -67,6 +67,7 @@
       <artifactId>jboss-as-console</artifactId>
       <classifier>resources</classifier>
       <version>${version.jboss.management-console}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>

--- a/fractions/wildfly/management-console/src/main/java/org/wildfly/swarm/management/console/runtime/ManagementConsoleDeploymentProducer.java
+++ b/fractions/wildfly/management-console/src/main/java/org/wildfly/swarm/management/console/runtime/ManagementConsoleDeploymentProducer.java
@@ -46,7 +46,7 @@ public class ManagementConsoleDeploymentProducer {
 
     @Produces
     public Archive managementConsoleWar() throws Exception {
-        // Load the swagger-ui webjars.
+        // Load the management-ui webjars.
         Module module = Module.getBootModuleLoader().loadModule(ModuleIdentifier.create("org.jboss.as.console"));
         URL resource = module.getExportedResource("jboss-as-console-resources.jar");
         WARArchive war = ShrinkWrap.create(WARArchive.class, "management-console-ui.war");


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------

Error in the logs when starting a service with the management console fraction in place

Modifications
-------------

The fraction did declare the management console resources as a dependency, also in fact it's loaded as a module

Result
------

The error in the log is gone and the management UI resources will not be added through addAllDeps()

