### PR TITLE
SWARM-1014 - Quiet down boot logging

### DIFF
--- a/fractions/wildfly/management/module.conf
+++ b/fractions/wildfly/management/module.conf
@@ -1,2 +1,3 @@
 org.jboss.as.domain-management
 org.jboss.as.domain-http-interface
+org.jboss.as.domain-http-error-context

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   </scm>
 
   <properties>
-    <version.wildfly.swarm.fraction.plugin>51</version.wildfly.swarm.fraction.plugin>
+    <version.wildfly.swarm.fraction.plugin>52</version.wildfly.swarm.fraction.plugin>
     <version.wildfly.swarm.checkstyle>3</version.wildfly.swarm.checkstyle>
 
     <version.org.snakeyaml>1.17</version.org.snakeyaml>

--- a/testsuite/testsuite-cdi/src/main/java/org/wildfly/swarm/cdi/test/Cheddar.java
+++ b/testsuite/testsuite-cdi/src/main/java/org/wildfly/swarm/cdi/test/Cheddar.java
@@ -1,4 +1,4 @@
-package org.wildfly.swarm.cdi;
+package org.wildfly.swarm.cdi.test;
 
 import javax.inject.Singleton;
 

--- a/testsuite/testsuite-cdi/src/main/java/org/wildfly/swarm/cdi/test/ConfigAwareBean.java
+++ b/testsuite/testsuite-cdi/src/main/java/org/wildfly/swarm/cdi/test/ConfigAwareBean.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.swarm.cdi;
+package org.wildfly.swarm.cdi.test;
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;

--- a/testsuite/testsuite-cdi/src/test/java/org/wildfly/swarm/cdi/test/CDIArquillianTest.java
+++ b/testsuite/testsuite-cdi/src/test/java/org/wildfly/swarm/cdi/test/CDIArquillianTest.java
@@ -13,34 +13,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.swarm.cdi;
+package org.wildfly.swarm.cdi.test;
 
-import java.util.Optional;
-
+import javax.enterprise.inject.spi.CDI;
 import javax.inject.Inject;
 
 import org.jboss.arquillian.junit.Arquillian;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.swarm.arquillian.DefaultDeployment;
-import org.wildfly.swarm.spi.runtime.annotations.ConfigurationValue;
+
+import static org.junit.Assert.assertNotNull;
 
 /**
- * @author George Gastaldi
+ * @author Bob McWhirter
  */
 @RunWith(Arquillian.class)
 @DefaultDeployment(type = DefaultDeployment.Type.JAR)
-public class ConfigurationValueProducerTest {
+public class CDIArquillianTest {
 
     @Inject
-    @ConfigurationValue("logger.level")
-    private Optional<String> loggerLevel;
+    private Cheddar cheddar;
 
     @Test
-    public void testServerAddressExists() {
-        Assert.assertNotNull(loggerLevel);
-        Assert.assertEquals("DEBUG", loggerLevel.get());
+    public void testInjection() {
+        assertNotNull(cheddar);
     }
 
+    @Test
+    public void testCDIContainerPresence() throws Exception {
+        assertNotNull(CDI.current());
+    }
 }

--- a/testsuite/testsuite-cdi/src/test/java/org/wildfly/swarm/cdi/test/ConfigValueProducerTest.java
+++ b/testsuite/testsuite-cdi/src/test/java/org/wildfly/swarm/cdi/test/ConfigValueProducerTest.java
@@ -13,14 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.swarm.cdi;
+package org.wildfly.swarm.cdi.test;
 
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.swarm.arquillian.DefaultDeployment;
-import org.wildfly.swarm.cdi.ConfigAwareBean;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/testsuite/testsuite-cdi/src/test/java/org/wildfly/swarm/cdi/test/ConfigurationValueProducerTest.java
+++ b/testsuite/testsuite-cdi/src/test/java/org/wildfly/swarm/cdi/test/ConfigurationValueProducerTest.java
@@ -13,35 +13,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.swarm.cdi;
+package org.wildfly.swarm.cdi.test;
 
-import javax.enterprise.inject.spi.CDI;
+import java.util.Optional;
+
 import javax.inject.Inject;
 
 import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.swarm.arquillian.DefaultDeployment;
-
-import static org.junit.Assert.assertNotNull;
+import org.wildfly.swarm.spi.runtime.annotations.ConfigurationValue;
 
 /**
- * @author Bob McWhirter
+ * @author George Gastaldi
  */
 @RunWith(Arquillian.class)
 @DefaultDeployment(type = DefaultDeployment.Type.JAR)
-public class CDIArquillianTest {
+public class ConfigurationValueProducerTest {
 
     @Inject
-    private Cheddar cheddar;
+    @ConfigurationValue("logger.level")
+    private Optional<String> loggerLevel;
 
     @Test
-    public void testInjection() {
-        assertNotNull(cheddar);
+    public void testServerAddressExists() {
+        Assert.assertNotNull(loggerLevel);
+        Assert.assertEquals("DEBUG", loggerLevel.get());
     }
 
-    @Test
-    public void testCDIContainerPresence() throws Exception {
-        assertNotNull(CDI.current());
-    }
 }


### PR DESCRIPTION
Motivation
----------

Too much useless output when booting.

Modifications
-------------

Silence the error-context message by making sure the management fraction
has the error context.

Silence some messages we see in our own testsuite due to @DefaultDeployment
scraping cdi.jar.  This is accopmlished by changing the package name of the
test itself.

Rev the fraction-plugin also, to remove detect classes from the fractions.

Result
------

Yet quieter logs.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
