### PR TITLE
SWARM-1113: Infinispan-core is now a compile-time dependency.

### DIFF
--- a/fractions/wildfly/infinispan/pom.xml
+++ b/fractions/wildfly/infinispan/pom.xml
@@ -39,6 +39,11 @@
   <dependencies>
 
     <dependency>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>container</artifactId>
     </dependency>

--- a/testsuite/testsuite-infinispan/pom.xml
+++ b/testsuite/testsuite-infinispan/pom.xml
@@ -32,10 +32,6 @@
       <artifactId>jaxrs</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.infinispan</groupId>
-      <artifactId>infinispan-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>arquillian</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
Applications depending on the infinispan fraction can't use the infinispan classes.

Modifications
-------------
Added infinispan-core as a compile-time dependency to the infinispan fraction

Result
------
Infinispan-core classes are now available when a project depends on the infinispan fraction