### PR TITLE
SWARM-1117: fix non-UberJar deploy when zip dependency is involved

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeDeployer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeDeployer.java
@@ -190,13 +190,14 @@ public class RuntimeDeployer implements Deployer {
                             } else {
                                 Set<String> paths = appEnv.resolveDependencies(Collections.EMPTY_LIST);
                                 for (String path : paths) {
+                                    final File pathFile = new File(path);
                                     if (path.endsWith(".jar")) {
-                                        depContainer.addAsLibrary(new File(path));
-                                    } else {
+                                        depContainer.addAsLibrary(pathFile);
+                                    } else if (pathFile.isDirectory()) {
                                         depContainer
                                                 .merge(ShrinkWrap.create(GenericArchive.class)
                                                                 .as(ExplodedImporter.class)
-                                                                .importDirectory(path)
+                                                                .importDirectory(pathFile)
                                                                 .as(GenericArchive.class),
                                                         "/WEB-INF/classes",
                                                         Filters.includeAll());


### PR DESCRIPTION
Motivation
----------
RuntimeDeployer.deploy() fails when zip dependency is present because it treats all non-jars as directories.

Modifications
-------------
Added directory check to detect a directory dependency instead of making assumptions.

Result
------
RuntimeDeployer does not fail anymore when non-jar and non-directory dependencies are found.
Those dependencies (like zip dependencies) are simply skipped.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
