### PR TITLE
plugin version as variable in standalone-servers

### DIFF
--- a/standalone-servers/pom.xml
+++ b/standalone-servers/pom.xml
@@ -24,7 +24,7 @@
         <plugin>
           <groupId>org.wildfly.swarm</groupId>
           <artifactId>wildfly-swarm-plugin</artifactId>
-          <version>2017.3.0-SNAPSHOT</version>
+          <version>${project.version}</version>
           <executions>
             <execution>
               <id>package</id>
@@ -73,7 +73,7 @@
             <plugin>
               <groupId>org.wildfly.swarm</groupId>
               <artifactId>wildfly-swarm-plugin</artifactId>
-              <version>2017.3.0-SNAPSHOT</version>
+              <version>${project.version}</version>
               <executions>
                 <execution>
                   <id>start</id>


### PR DESCRIPTION
Motivation
----------
Adjust standalone-servers pom to allow successful processing by PME (http://release-engineering.github.io/pom-manipulation-ext/)

Modifications
-------------
Swarm plugin version has been changed from hardcoded to ${project.version}.

Result
------

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
