### PR TITLE
SWARM-1124 container.jar references terribly many module.xmls.

### DIFF
--- a/core/container/module-rewrite.conf
+++ b/core/container/module-rewrite.conf
@@ -1,3 +1,21 @@
 module: org.jboss.as.server
   optional: org.jboss.as.domain-http-interface
+  optional: org.jboss.as.jmx
+  optional: org.jboss.as.naming
+  optional: org.jboss.as.marshalling
+  optional: org.jboss.as.marshalling.river
+  optional: org.jboss.as.sasl
+  optional: org.jboss.as.protocol
+
+module: org.jboss.weld.core
+  optional: org.omg.api
+  optional: javax.ejb.api
+  optional: javax.persistence.api
+  optional: javax.servlet.api
+  optional: javax.transaction.api
+  optional: javax.validation.api
+  optional: javax.xml.rpc.api
+  optional: javax.rmi.api
+  optional: org.glassfish.javax.el
+  include: javax.xml.soap.api
 

--- a/fractions/camel/components/other/module.conf
+++ b/fractions/camel/components/other/module.conf
@@ -61,3 +61,6 @@ org.apache.camel.component.zipfile
 org.apache.camel.component.zipkin
 org.apache.camel.component.zookeeper
 org.wildfly.swarm.camel.core
+org.javassist
+com.fasterxml.jackson.dataformat.cbor
+com.fasterxml.jackson.dataformat.smile

--- a/fractions/javaee/cdi/src/main/resources/modules/org/jboss/weld/core/nonoptional/module.xml
+++ b/fractions/javaee/cdi/src/main/resources/modules/org/jboss/weld/core/nonoptional/module.xml
@@ -1,0 +1,15 @@
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.weld.core" slot="nonoptional">
+
+  <dependencies>
+    <module name="org.omg.api"/>
+    <module name="javax.ejb.api"/>
+    <module name="javax.persistence.api"/>
+    <module name="javax.servlet.api"/>
+    <module name="javax.transaction.api"/>
+    <module name="javax.validation.api"/>
+    <module name="javax.xml.rpc.api"/>
+    <module name="org.glassfish.javax.el"/>
+    <module name="javax.rmi.api"/>
+    <module name="javax.xml.soap.api"/>
+  </dependencies>
+</module>

--- a/testsuite/testsuite-camel-other/pom.xml
+++ b/testsuite/testsuite-camel-other/pom.xml
@@ -41,6 +41,11 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>jaxrs</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>arquillian</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Motivation
----------

We may not need all of these.  We should be tiny.

Modifications
-------------

Exclude many module dependencies (mark as optional).

Result
------

Smaller actual and implied container.jar.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
