### PR TITLE
SWARM-1029: Support Keycloak client config in yml

### DIFF
--- a/fractions/keycloak-server/module.conf
+++ b/fractions/keycloak-server/module.conf
@@ -3,7 +3,7 @@
 org.wildfly.swarm.infinispan
 org.wildfly.swarm.datasources
 
-org.wildfly.swarm.configuration.keycloak
+org.wildfly.swarm.configuration.keycloak.server
 
 io.undertow.servlet
 io.undertow.core

--- a/fractions/keycloak-server/pom.xml
+++ b/fractions/keycloak-server/pom.xml
@@ -63,7 +63,7 @@
 
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
-      <artifactId>keycloak-config-api</artifactId>
+      <artifactId>keycloak-server-config-api</artifactId>
     </dependency>
 
     <dependency>

--- a/fractions/keycloak/module.conf
+++ b/fractions/keycloak/module.conf
@@ -1,4 +1,7 @@
 org.wildfly.swarm.undertow
+
+org.wildfly.swarm.configuration.keycloak.client export=true
+
 io.undertow.servlet
 io.undertow.core
 org.keycloak.keycloak-undertow-adapter

--- a/fractions/keycloak/pom.xml
+++ b/fractions/keycloak/pom.xml
@@ -56,6 +56,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>keycloak-client-config-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
       <scope>provided</scope>

--- a/fractions/keycloak/src/main/java/org/wildfly/swarm/keycloak/KeycloakFraction.java
+++ b/fractions/keycloak/src/main/java/org/wildfly/swarm/keycloak/KeycloakFraction.java
@@ -15,8 +15,10 @@
  */
 package org.wildfly.swarm.keycloak;
 
+import org.wildfly.swarm.config.Keycloak;
 import org.wildfly.swarm.spi.api.Fraction;
 import org.wildfly.swarm.spi.api.annotations.DeploymentModule;
+import org.wildfly.swarm.spi.api.annotations.MarshalDMR;
 import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
 import org.wildfly.swarm.spi.api.annotations.WildFlySubsystem;
 
@@ -26,6 +28,7 @@ import org.wildfly.swarm.spi.api.annotations.WildFlySubsystem;
 @WildFlyExtension(module = "org.keycloak.keycloak-adapter-subsystem")
 @WildFlySubsystem("keycloak")
 @DeploymentModule(name = "org.keycloak.keycloak-core")
-public class KeycloakFraction implements Fraction<KeycloakFraction> {
+@MarshalDMR
+public class KeycloakFraction extends Keycloak<KeycloakFraction> implements Fraction {
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <version.maven.aether>3.2.5</version.maven.aether>
     <version.wildfly.config-api>1.0.2.Final</version.wildfly.config-api>
 
-    <version.keycloak.config-api>1.0.1.Final</version.keycloak.config-api>
+    <version.keycloak.config-api>1.0.2.Final</version.keycloak.config-api>
     <version.keycloak>2.5.0.Final</version.keycloak>
 
     <version.wildfly>10.1.0.Final</version.wildfly>
@@ -84,10 +84,6 @@
     <version.com.squareup.okio>1.8.0</version.com.squareup.okio>
 
     <version.vertx>3.3.3</version.vertx>
-
-<!--
-    <version.keycloak-secretstore>1.0.4.Final</version.keycloak-secretstore>
--->
 
     <version.org.kie>6.4.0.Final</version.org.kie>
 
@@ -376,7 +372,12 @@
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
-        <artifactId>keycloak-config-api</artifactId>
+        <artifactId>keycloak-server-config-api</artifactId>
+        <version>${version.keycloak.config-api}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>keycloak-client-config-api</artifactId>
         <version>${version.keycloak.config-api}</version>
       </dependency>
 
@@ -799,12 +800,6 @@
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-undertow-adapter</artifactId>
         <version>${version.keycloak}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.keycloak.secretstore</groupId>
-        <artifactId>secret-store</artifactId>
-        <version>${version.keycloak-secretstore}</version>
-        <type>war</type>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
Keycloak provides a means of defining a client adapter using a subsystem instead of a keycloak.json present within the deployment.

Enable the keycloak fraction to utilize subsystem configuration so that it can be set within project-defaults.yml.

Modifications
-------------
Update to config api 1.0.2.Final and update artifacts to indicate we now have separate client and server config apis.

Add @MarshalDMR to KeycloakFraction for subsystem support.

Result
------
Users can now replace keycloak.json content with values in project-defaults.yml
