### PR TITLE
SWARM-1125: Upgrade Keycloak to 2.5.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <version.wildfly.config-api>1.0.2.Final</version.wildfly.config-api>
 
     <version.keycloak.config-api>1.0.1.Final</version.keycloak.config-api>
-    <version.keycloak>2.5.0.Final</version.keycloak>
+    <version.keycloak>2.5.4.Final</version.keycloak>
 
     <version.wildfly>10.1.0.Final</version.wildfly>
     <version.org.wildfly.core>2.2.1.CR1</version.org.wildfly.core>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
Upgrade Keycloak to latest bug fix release.

Modifications
-------------
Update Keycloak version in build.

Result
------
Product now uses latest Keycloak.
