### PR TITLE
SWARM-1126: Split boms so that 'bom' is only productized

### DIFF
--- a/boms/pom.xml
+++ b/boms/pom.xml
@@ -48,16 +48,4 @@
     </plugins>
   </build>
 
-  <modules>
-    <module>bom-deprecated</module>
-    <module>bom-experimental</module>
-    <module>bom-unstable</module>
-    <module>bom-stable</module>
-    <module>bom-frozen</module>
-    <module>bom-locked</module>
-
-    <module>bom-all</module>
-    <module>bom</module>
-  </modules>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1175,6 +1175,7 @@
     <module>meta/fraction-metadata</module>
     <module>plugin</module>
     <module>boms</module>
+    <module>boms/bom</module>
 
     <module>arquillian</module>
 
@@ -1279,6 +1280,14 @@
         <module>jaxrs-client-api</module>
 
         <module>swarmtool</module>
+        <module>boms/bom-deprecated</module>
+        <module>boms/bom-experimental</module>
+        <module>boms/bom-unstable</module>
+        <module>boms/bom-stable</module>
+        <module>boms/bom-frozen</module>
+        <module>boms/bom-locked</module>
+
+        <module>boms/bom-all</module>
 
         <module>fractions/javaee/batch-jberet</module>
         <module>fractions/javaee/ejb-remote</module>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
For a product, not all the boms make sense.

Modifications
-------------
Remove bom modules from /boms and add those modules to specific profiles for community and supported.

Result
------
No impact to community build, only 'bom' built for product.
