### PR TITLE
SWARM-1131: Pass user defined settings.xml to arquillian tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,7 @@
             <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
             <swarm.bind.address>127.0.0.1</swarm.bind.address>
             <project.version>${project.version}</project.version>
+            <org.apache.maven.user-settings>${session.request.userSettingsFile.path}</org.apache.maven.user-settings>
           </systemPropertyVariables>
         </configuration>
       </plugin>
@@ -173,6 +174,7 @@
               <testSourceDirectory>src/it/java</testSourceDirectory>
               <systemPropertyVariables>
                 <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
+                <org.apache.maven.user-settings>${session.request.userSettingsFile.path}</org.apache.maven.user-settings>
               </systemPropertyVariables>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,13 @@
               </systemPropertyVariables>
             </configuration>
           </execution>
+          <execution>
+            <id>verify-integration-test</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>verify</goal>
+            </goals>
+          </execution>
         </executions>
       </plugin>
       <plugin>

--- a/standalone-servers/pom.xml
+++ b/standalone-servers/pom.xml
@@ -99,24 +99,8 @@
         </pluginManagement>
         <plugins>
           <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>integration-test</id>
-                <goals>
-                  <goal>integration-test</goal>
-                </goals>
-                <configuration>
-                  <testSourceDirectory>src/it/java</testSourceDirectory>
-                </configuration>
-              </execution>
-              <execution>
-                <id>verify</id>
-                <goals>
-                  <goal>verify</goal>
-                </goals>
-              </execution>
-            </executions>
           </plugin>
         </plugins>
       </build>

--- a/testsuite/testsuite-buildtool/multi-module/view/pom.xml
+++ b/testsuite/testsuite-buildtool/multi-module/view/pom.xml
@@ -40,14 +40,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
 
     </plugins>


### PR DESCRIPTION
Motivation
----------
When building wildfly-swarm with an alternate settings.xml via mvn -s ..., arquillian tests still use the default one.

Modifications
-------------
Pass built-in Maven property userSettingsFile to forked surefire test processes in form of a ShrinkWrap Resolvers built-in system property which is automatically picked up.
See also: https://developer.jboss.org/message/969270#969270

Result
------
Arquillian test execution is now consistent with Maven execution/session.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
