### PR TITLE
SWARM-1099: ApplicationEnvironment needs to null-check values from sw…

### DIFF
--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/DependencyTree.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/DependencyTree.java
@@ -23,14 +23,11 @@ public class DependencyTree<T> {
      * @param parent
      */
     public void add(T parent, T child) {
-        if (!depTree.keySet().contains(parent)) {
-            depTree.put(parent, new HashSet<>());
-        }
+        final Set<T> children = depTree.computeIfAbsent(parent, p -> new HashSet<>());
         if (!child.equals(parent)) {
-            depTree.get(parent).add(child);
+            children.add(child);
         }
     }
-
 
     /**
      * Direct dep without any transient dependencies
@@ -38,9 +35,7 @@ public class DependencyTree<T> {
      * @param parent
      */
     public void add(T parent) {
-        if (!depTree.keySet().contains(parent)) {
-            depTree.put(parent, new HashSet<>());
-        }
+        depTree.computeIfAbsent(parent, p -> new HashSet<>());
     }
 
     public Collection<T> getDirectDeps() {


### PR DESCRIPTION
…arm.cp.info yaml file

Motivation
----------
Under certain circumstances (see SWARM-1099), a value for a given key in the yaml file defined by swarm.cp.info might be null.
In this case, ApplicationEnvironment fails with a NPE because it assumes that non-existing values are represented as empty lists, not null.

Modifications
-------------
ApplicationEnvironment now additionally checks for null before iterating the (possibly null) collection.
Quality of the involved code has been improved by the way.

Result
------
ApplicationEnvironment no longer fails when "special" dependecies (like the one in SWARM-1099) are present.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
