### PR TITLE
SWARM-1133: fraction autodetection broken for messaging

### DIFF
--- a/fractions/javaee/messaging/src/main/java/org/wildfly/swarm/messaging/detect/MessagingPackageDetector.java
+++ b/fractions/javaee/messaging/src/main/java/org/wildfly/swarm/messaging/detect/MessagingPackageDetector.java
@@ -23,7 +23,7 @@ import org.wildfly.swarm.spi.meta.PackageFractionDetector;
 public class MessagingPackageDetector extends PackageFractionDetector {
 
     public MessagingPackageDetector() {
-        super();
+        anyPackageOf("javax.jms");
     }
 
     @Override

--- a/swarmtool/src/main/java/org/wildfly/swarm/swarmtool/Main.java
+++ b/swarmtool/src/main/java/org/wildfly/swarm/swarmtool/Main.java
@@ -258,7 +258,7 @@ public class Main {
 
         addSwarmFractions(tool, foundOptions.valuesOf(FRACTIONS_OPT));
 
-        System.err.println(String.format("Building %s/%s-%s.jar", outDir, jarName, suffix));
+        System.err.println(String.format("Building %s/%s%s.jar", outDir, jarName, suffix));
         return tool.build(jarName, Paths.get(outDir));
     }
 


### PR DESCRIPTION
Motivation
----------
Ever since the fix for SWARM-974, fraction autodetection
for messaging is broken. This is because
the `MessagingPackageDetector` forgets to declare
the correct package (`javax.jms`).

Modifications
-------------
Changed the `MessagingPackageDetector` to declare
the `javax.jms` package.

Also a tiny modification to Swarmtool to avoid
printing wrong file name.

Result
------
Autodetection of the messaging fraction works again.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
