### PR TITLE
SWARM-1135 - Unable to selectively enable loggers using -D

### DIFF
--- a/fractions/wildfly/logging/src/main/java/org/wildfly/swarm/logging/LoggingFraction.java
+++ b/fractions/wildfly/logging/src/main/java/org/wildfly/swarm/logging/LoggingFraction.java
@@ -70,10 +70,41 @@ public class LoggingFraction extends Logging<LoggingFraction> implements Fractio
 
     public LoggingFraction applyDefaults(Level level) {
         defaultColorFormatter()
-                .consoleHandler(level, COLOR_PATTERN)
+                .consoleHandler(Level.ALL, COLOR_PATTERN)
                 .rootLogger(level, CONSOLE);
 
+        Properties allProps = System.getProperties();
+        for (String name : allProps.stringPropertyNames()) {
+            if (isSimpleLoggerName(name)) {
+                System.err.println("name-->" + name);
+                String logger = name.substring((LoggingProperties.LOGGING + ".").length());
+                Level loggerLevel = Level.valueOf(allProps.getProperty(name).trim().toUpperCase());
+                logger(logger, (l) -> {
+                    l.level(loggerLevel);
+                    l.category(logger);
+                    l.handler(CONSOLE);
+                });
+            }
+        }
+
+
         return this;
+    }
+
+    protected boolean isSimpleLoggerName(String name) {
+        if (!name.startsWith(LoggingProperties.LOGGING)) {
+            return false;
+        }
+
+        if (name.endsWith("level")) {
+            return false;
+        }
+
+        if (name.matches("^.*\\.handlers.[0-9]+$")) {
+            return false;
+        }
+
+        return true;
     }
 
     /**
@@ -183,9 +214,9 @@ public class LoggingFraction extends Logging<LoggingFraction> implements Fractio
             formatterProperties.put(nextElement, properties.getProperty(nextElement));
         }
         customFormatter(new CustomFormatter(name)
-                                .module(module)
-                                .attributeClass(className)
-                                .properties(formatterProperties));
+                .module(module)
+                .attributeClass(className)
+                .properties(formatterProperties));
         return this;
     }
 
@@ -218,8 +249,8 @@ public class LoggingFraction extends Logging<LoggingFraction> implements Fractio
      */
     public LoggingFraction consoleHandler(Level level, String formatter) {
         consoleHandler(new ConsoleHandler(CONSOLE)
-                               .level(level)
-                               .namedFormatter(formatter));
+                .level(level)
+                .namedFormatter(formatter));
         return this;
     }
 
@@ -246,9 +277,9 @@ public class LoggingFraction extends Logging<LoggingFraction> implements Fractio
         fileProperties.put("path", path);
         fileProperties.put("relative-to", "jboss.server.log.dir");
         fileHandler(new FileHandler(name)
-                            .level(level)
-                            .formatter(formatter)
-                            .file(fileProperties));
+                .level(level)
+                .formatter(formatter)
+                .file(fileProperties));
         return this;
     }
 
@@ -280,10 +311,10 @@ public class LoggingFraction extends Logging<LoggingFraction> implements Fractio
         }
 
         customHandler(new CustomHandler(name)
-                              .module(module)
-                              .attributeClass(className)
-                              .formatter(formatter)
-                              .properties(handlerProperties));
+                .module(module)
+                .attributeClass(className)
+                .formatter(formatter)
+                .properties(handlerProperties));
         return this;
     }
 
@@ -327,7 +358,7 @@ public class LoggingFraction extends Logging<LoggingFraction> implements Fractio
      */
     public LoggingFraction rootLogger(Level level, String... handlers) {
         rootLogger(new RootLogger().level(level)
-                           .handlers(handlers));
+                .handlers(handlers));
         return this;
     }
 

--- a/fractions/wildfly/logging/src/main/java/org/wildfly/swarm/logging/runtime/EarlyLoggingCustomizer.java
+++ b/fractions/wildfly/logging/src/main/java/org/wildfly/swarm/logging/runtime/EarlyLoggingCustomizer.java
@@ -1,0 +1,33 @@
+package org.wildfly.swarm.logging.runtime;
+
+import java.util.logging.LogManager;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Any;
+import javax.inject.Inject;
+
+import org.wildfly.swarm.config.logging.Logger;
+import org.wildfly.swarm.logging.LoggingFraction;
+import org.wildfly.swarm.spi.api.Customizer;
+import org.wildfly.swarm.spi.runtime.annotations.Post;
+
+/**
+ * @author Bob McWhirter
+ */
+@Post
+@ApplicationScoped
+public class EarlyLoggingCustomizer implements Customizer {
+
+    @Inject
+    @Any
+    private LoggingFraction fraction;
+
+    @Override
+    public void customize() {
+        for (Logger logger : fraction.subresources().loggers()) {
+            java.util.logging.Logger l = LogManager.getLogManager().getLogger(logger.getKey());
+            l.setLevel(java.util.logging.Level.parse(logger.level().toString()));
+        }
+
+    }
+}


### PR DESCRIPTION
Motivation
----------

It is useful to enable some logging categories (org.wildfly.swarm.config
and org.wildfly.swarm.metrics) from the command-line during development.

Modifications
-------------

Promote the -Dswarm.logging.<category>=<level> properties to actually
adjust the related loggers early, and ensure that they are propagated
to the logging subsystem if applicable.

Result
------

-Dswarm.logging.org.wildfly.swarm.config=DEBUG works.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
