### PR TITLE
SWARM-1140: Detect Undertow fraction when Vaadin is present

### DIFF
--- a/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/detect/UndertowPackageDetector.java
+++ b/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/detect/UndertowPackageDetector.java
@@ -23,7 +23,7 @@ import org.wildfly.swarm.spi.meta.PackageFractionDetector;
 public class UndertowPackageDetector extends PackageFractionDetector {
 
     public UndertowPackageDetector() {
-        anyPackageOf("javax.servlet", "javax.websocket", "io.undertow");
+        anyPackageOf("javax.servlet", "javax.websocket", "io.undertow", "com.vaadin");
     }
 
     @Override


### PR DESCRIPTION
Motivation
----------
Undertow fraction is not auto-detected when Vaadin is present.

Modifications
-------------
Added "com.vaadin" to the packages Undertow fraction will be detected for.

Result
------
Undertow fraction is pulled in when Vaadin is present.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
