### PR TITLE
SWARM-1059 - better error messages when configurable enums are (mis-)…

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/ConfigurableManager.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/ConfigurableManager.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -133,7 +134,14 @@ public class ConfigurableManager implements AutoCloseable {
     }
 
     private <ENUMTYPE extends Enum<ENUMTYPE>> Converter<ENUMTYPE> converter(Class<ENUMTYPE> enumType) {
-        return (str) -> Enum.valueOf(enumType, str.toUpperCase().replace('-', '_'));
+        return (str) -> {
+            try {
+                return Enum.valueOf(enumType, str.toUpperCase().replace('-', '_'));
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("Invalid value '" + str + "'; should be one of: "
+                        + String.join(",", Arrays.stream(enumType.getEnumConstants()).map((constant) -> constant.toString()).collect(Collectors.toList())));
+            }
+        };
     }
 
     private Resolver<List> listResolver(Resolver<String> resolver, ConfigKey key) {


### PR DESCRIPTION
…used

Motivation
----------

Instead of just saying "no!" we should indicate what allowable
values are when a configurable item is expecting an enum.

Modifications
-------------

Improve the error message on the percolated exception.

Result
------

Better guidance if you do poorly.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
