### PR TITLE
SWARM-1148 - Adjust root logger with -Dswarm.logging=<level>

### DIFF
--- a/fractions/wildfly/logging/src/main/java/org/wildfly/swarm/logging/LoggingFraction.java
+++ b/fractions/wildfly/logging/src/main/java/org/wildfly/swarm/logging/LoggingFraction.java
@@ -91,7 +91,7 @@ public class LoggingFraction extends Logging<LoggingFraction> implements Fractio
     }
 
     protected boolean isSimpleLoggerName(String name) {
-        if (!name.startsWith(LoggingProperties.LOGGING)) {
+        if (!name.startsWith(LoggingProperties.LOGGING + ".")) {
             return false;
         }
 


### PR DESCRIPTION
Motivation
----------

Previous release introduced a bug.  Bugs are bad.

Modifications
-------------

Fix the logic to avoid a string IOOBE when looking for
-Dswarm.logging.<category>=<level> and someone attempts
to change the level of the root logger.

Result
------

-Dswarm.logging=DEBUG doesn't break.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
