### PR TITLE
SWARM-1040 - Don't reject SSL config without an alias.

### DIFF
--- a/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/descriptors/CertInfo.java
+++ b/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/descriptors/CertInfo.java
@@ -66,6 +66,6 @@ public class CertInfo {
 
 
     public boolean isValid() {
-        return ((keystorePath != null && keystorePassword != null && keystoreAlias != null) || generateSelfSignedCertificateHost != null);
+        return ((keystorePath != null && keystorePassword != null) || generateSelfSignedCertificateHost != null);
     }
 }


### PR DESCRIPTION
Motivation
----------

We were being overly cautious in determining if SSL configuration
was valid.

Modifications
-------------

Remove the alias check.

Result
------

One fewer safety net.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
