### PR TITLE
SWARM-900: Resource security protection outside main()

### DIFF
--- a/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/runtime/HttpSecurityPreparer.java
+++ b/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/runtime/HttpSecurityPreparer.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.undertow.runtime;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.Node;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.wildfly.swarm.spi.api.ArchivePreparer;
+import org.wildfly.swarm.spi.api.JARArchive;
+import org.wildfly.swarm.spi.api.annotations.Configurable;
+import org.wildfly.swarm.undertow.descriptors.JBossWebAsset;
+import org.wildfly.swarm.undertow.descriptors.SecurityConstraint;
+import org.wildfly.swarm.undertow.descriptors.WebXmlAsset;
+
+/**
+ * @author Heiko Braun
+ */
+@ApplicationScoped
+public class HttpSecurityPreparer implements ArchivePreparer {
+
+    private static final Logger LOG = Logger.getLogger(HttpSecurityPreparer.class);
+
+    private final String[] SUPPORTED_AUTH_METHODS = new String[] {"BASIC", "DIGEST", "FORM", "KEYCLOAK"};
+
+    @Override
+    public void prepareArchive(Archive<?> archive) {
+
+        if (httpConfig == null || httpConfig.isEmpty()) {
+            return;
+        }
+
+        if (!httpConfig.containsKey("login-config")) {
+            throw new RuntimeException("Syntax error: HTTP security constraints requires a login-config declaration");
+        }
+
+        // unsupported auth method
+        Map<String, Object> loginConfig = (Map<String, Object>)httpConfig.get("login-config");
+        String authMethod = (String)loginConfig.getOrDefault("auth-method", "NONE");
+        boolean isSupported = false;
+        for (String supported : SUPPORTED_AUTH_METHODS) {
+            if (authMethod.equals(supported)) {
+                isSupported = true;
+                break;
+            }
+        }
+
+        if (!isSupported) {
+            LOG.warn("Ignoring unsupported auth-method: " + authMethod);
+            return;
+        }
+
+        WebXmlAsset webXml = findWebXml(archive);
+        JBossWebAsset jbossWeb = findJBossWeb(archive);
+
+        // Setup web.xml
+        webXml.setContextParam("resteasy.scan", "true");
+        webXml.setLoginConfig(authMethod, "ignored");
+
+        // security domain
+        if (loginConfig.containsKey("security-domain")) {
+            jbossWeb.setSecurityDomain((String)loginConfig.get("security-domain"));
+        }
+
+        // form login
+        if (loginConfig.containsKey("form-login-config")) {
+            Map<String, Object> formLoginConfig = (Map<String, Object>) loginConfig.get("form-login-config");
+            webXml.setFormLoginConfig(
+                    "Security Realm",
+                    (String)formLoginConfig.get("form-login-page"),
+                    (String)formLoginConfig.get("form-error-page")
+                    );
+        }
+
+        // security constraints
+        List<Map<String, Object>> securityConstraints =
+                (List<Map<String, Object>>) httpConfig.getOrDefault("security-constraints", Collections.EMPTY_LIST);
+
+        for (Map<String, Object> sc : securityConstraints) {
+            SecurityConstraint securityConstraint = webXml
+                    .protect((String) sc.getOrDefault("url-pattern", ""));
+
+            ((List<String>) sc.getOrDefault("methods", Collections.emptyList()))
+                    .forEach(securityConstraint::withMethod);
+
+            ((List<String>) sc.getOrDefault("roles", Collections.emptyList()))
+                    .forEach(securityConstraint::withRole);
+        }
+    }
+
+    private WebXmlAsset findWebXml(Archive<?> archive) {
+        WebXmlAsset webXml;
+        Node node = archive.as(JARArchive.class).get("WEB-INF/web.xml");
+        if (node == null) {
+            webXml = new WebXmlAsset();
+            archive.as(JARArchive.class).add(webXml);
+        } else {
+            Asset asset = node.getAsset();
+            if (!(asset instanceof WebXmlAsset)) {
+                webXml = new WebXmlAsset(asset.openStream());
+                archive.as(JARArchive.class).add(webXml);
+            } else {
+                webXml = (WebXmlAsset) asset;
+            }
+        }
+        return webXml;
+    }
+
+    private JBossWebAsset findJBossWeb(Archive<?> archive) {
+        JBossWebAsset jbossWeb;
+        Node node = archive.as(JARArchive.class).get("WEB-INF/jboss-web.xml");
+        if (node == null) {
+            jbossWeb = new JBossWebAsset();
+            archive.as(JARArchive.class).add(jbossWeb, "WEB-INF/jboss-web.xml");
+        } else {
+            Asset asset = node.getAsset();
+            if (!(asset instanceof WebXmlAsset)) {
+                jbossWeb = new JBossWebAsset(asset.openStream());
+                archive.as(JARArchive.class).add(jbossWeb, "WEB-INF/jboss-web.xml");
+            } else {
+                jbossWeb = (JBossWebAsset) asset;
+            }
+        }
+        return jbossWeb;
+    }
+
+    @Configurable("swarm.http")
+    Map<String, Object> httpConfig;
+
+}

--- a/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/runtime/HttpSecurityPreparer.java
+++ b/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/runtime/HttpSecurityPreparer.java
@@ -108,7 +108,7 @@ public class HttpSecurityPreparer implements ArchivePreparer {
 
         for (Map<String, Object> sc : securityConstraints) {
             SecurityConstraint securityConstraint = webXml
-                    .protect((String) sc.getOrDefault("url-pattern", ""));
+                    .protect((String) sc.getOrDefault("url-pattern", "/*"));
 
             ((List<String>) sc.getOrDefault("methods", Collections.emptyList()))
                     .forEach(securityConstraint::withMethod);

--- a/fractions/javaee/undertow/src/test/resources/security.yml
+++ b/fractions/javaee/undertow/src/test/resources/security.yml
@@ -1,0 +1,8 @@
+swarm:
+  http:
+    login-config:
+      auth-method: BASIC
+    security-constraints:
+      - url-pattern: /protected
+        methods: [GET, POST]
+        roles: [admin]

--- a/fractions/javaee/undertow/src/test/resources/security.yml
+++ b/fractions/javaee/undertow/src/test/resources/security.yml
@@ -1,8 +1,10 @@
 swarm:
-  http:
-    login-config:
-      auth-method: BASIC
-    security-constraints:
-      - url-pattern: /protected
-        methods: [GET, POST]
-        roles: [admin]
+  deployment:
+    app.war:
+      web:
+        login-config:
+          auth-method: BASIC
+        security-constraints:
+          - url-pattern: /protected
+            methods: [GET, POST]
+            roles: [admin]

--- a/fractions/keycloak/src/main/java/org/wildfly/swarm/keycloak/runtime/SecuredArchivePreparer.java
+++ b/fractions/keycloak/src/main/java/org/wildfly/swarm/keycloak/runtime/SecuredArchivePreparer.java
@@ -21,9 +21,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 
 import javax.enterprise.context.ApplicationScoped;
 
@@ -35,11 +32,9 @@ import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
 import org.jboss.shrinkwrap.api.importer.ZipImporter;
 import org.wildfly.swarm.bootstrap.util.BootstrapProperties;
-import org.wildfly.swarm.keycloak.Secured;
 import org.wildfly.swarm.spi.api.ArchivePreparer;
 import org.wildfly.swarm.spi.api.JARArchive;
 import org.wildfly.swarm.spi.api.annotations.Configurable;
-import org.wildfly.swarm.undertow.descriptors.SecurityConstraint;
 
 @ApplicationScoped
 public class SecuredArchivePreparer implements ArchivePreparer {
@@ -62,21 +57,6 @@ public class SecuredArchivePreparer implements ArchivePreparer {
             // not adding it.
         }
 
-        if (securityConstraints == null || securityConstraints.isEmpty()) {
-            return;
-        }
-
-        Secured secured = archive.as(Secured.class);
-        securityConstraints.forEach(sc -> {
-            SecurityConstraint securityConstraint = secured
-                    .protect((String) sc.getOrDefault("url-pattern", "/*"));
-
-            ((List<String>) sc.getOrDefault("methods", Collections.emptyList()))
-                    .forEach(securityConstraint::withMethod);
-
-            ((List<String>) sc.getOrDefault("roles", Collections.emptyList()))
-                    .forEach(securityConstraint::withRole);
-        });
     }
 
     private InputStream getKeycloakJson(String path) {
@@ -137,8 +117,5 @@ public class SecuredArchivePreparer implements ArchivePreparer {
 
     @Configurable("swarm.keycloak.json.path")
     String keycloakJsonPath;
-
-    @Configurable("swarm.keycloak.security.constraints")
-    List<Map<String, Object>> securityConstraints;
 
 }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

---

Motivation
----------

Support HTTP security constraints to be configured outside main()

Modifications
-------------

Move parsing to undertow archive preparer and consolidate keycloak and standard auth method config layout

Result
------

Basic, Digest, Form and Keycloak constraints can be configured in project-defaults.yml
