### PR TITLE
SWARM-1051 - Ensure jboss-deployment-structure.xml is respected.

### DIFF
--- a/core/spi/src/main/java/org/wildfly/swarm/spi/api/JBossDeploymentStructureAsset.java
+++ b/core/spi/src/main/java/org/wildfly/swarm/spi/api/JBossDeploymentStructureAsset.java
@@ -43,14 +43,14 @@ public class JBossDeploymentStructureAsset implements Asset {
     public JBossDeploymentStructureAsset() {
         this.descriptor =
                 withTCCL(Descriptors.class.getClassLoader(),
-                         () -> Descriptors.create(JBossDeploymentStructureDescriptor.class));
+                        () -> Descriptors.create(JBossDeploymentStructureDescriptor.class));
     }
 
     public JBossDeploymentStructureAsset(InputStream fromStream) {
         this.descriptor =
                 withTCCL(Descriptors.class.getClassLoader(),
-                         () -> Descriptors.importAs(JBossDeploymentStructureDescriptor.class)
-                                 .fromStream(fromStream));
+                        () -> Descriptors.importAs(JBossDeploymentStructureDescriptor.class)
+                                .fromStream(fromStream));
 
         // Import dependencies and exclusions into internal structure
         DeploymentType<JBossDeploymentStructureDescriptor> deployment = this.descriptor.getAllDeployment().get(0);

--- a/core/spi/src/main/java/org/wildfly/swarm/spi/api/Module.java
+++ b/core/spi/src/main/java/org/wildfly/swarm/spi/api/Module.java
@@ -20,15 +20,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-/** JBoss Modules module descriptor.
+/**
+ * JBoss Modules module descriptor.
  *
  * <p>If a module is added to an archive, this descriptor is returned in order
  * to allow specific customization regarding exports, services, etc.</p>
  *
+ * @author Ken Finnigan
  * @see JBossDeploymentStructureContainer#addModule(String)
  * @see JBossDeploymentStructureContainer#addModule(String, String)
- *
- * @author Ken Finnigan
  */
 public class Module {
 
@@ -38,10 +38,14 @@ public class Module {
 
     Module(String name, String slot) {
         this.name = name;
+        if (slot == null) {
+            slot = "main";
+        }
         this.slot = slot;
     }
 
-    /** The name of the module.
+    /**
+     * The name of the module.
      *
      * @return The name of the module.
      */
@@ -54,7 +58,8 @@ public class Module {
         return this;
     }
 
-    /** The slot of the module.
+    /**
+     * The slot of the module.
      *
      * @return The slot of the module.
      */
@@ -67,7 +72,8 @@ public class Module {
         return this;
     }
 
-    /** Determine if this module should be exported.
+    /**
+     * Determine if this module should be exported.
      *
      * @return {@code null} if undefined, otherwise {@code true} if the module is to be exported, otherwise {@code false}.
      */
@@ -75,7 +81,8 @@ public class Module {
         return this.export;
     }
 
-    /** Set the flag to determine if this module should be exported.
+    /**
+     * Set the flag to determine if this module should be exported.
      *
      * @param export The flag.
      * @return this module descriptor.
@@ -85,7 +92,8 @@ public class Module {
         return this;
     }
 
-    /** Retrieve the services flag.
+    /**
+     * Retrieve the services flag.
      *
      * @return The services flag.
      */
@@ -93,7 +101,8 @@ public class Module {
         return this.services;
     }
 
-    /** Set the services flag.
+    /**
+     * Set the services flag.
      *
      * @param services The services flag.
      * @return this module descriptor.
@@ -103,7 +112,8 @@ public class Module {
         return this;
     }
 
-    /** Determine if this module is considered optional.
+    /**
+     * Determine if this module is considered optional.
      *
      * @return {@code null} if undefined, otherwise {@code true} if the module is optional, otherwise {@code false}.
      */
@@ -111,7 +121,8 @@ public class Module {
         return this.optional;
     }
 
-    /** Set the optional flag.
+    /**
+     * Set the optional flag.
      *
      * @param optional The optional flag.
      * @return this module.
@@ -121,7 +132,8 @@ public class Module {
         return this;
     }
 
-    /** Retrieve the meta-inf disposition.
+    /**
+     * Retrieve the meta-inf disposition.
      *
      * @return The meta-inf disposition.
      */
@@ -129,7 +141,8 @@ public class Module {
         return this.metaInf;
     }
 
-    /** Set the meta-inf disposition.
+    /**
+     * Set the meta-inf disposition.
      *
      * @param metaInf The meta-inf disposition.
      * @return this module.
@@ -139,7 +152,8 @@ public class Module {
         return this;
     }
 
-    /** Retrieve the list of paths imported from this module.
+    /**
+     * Retrieve the list of paths imported from this module.
      *
      * @return The list of paths imported from this module.
      */
@@ -147,7 +161,8 @@ public class Module {
         return this.imports.get(INCLUDE);
     }
 
-    /** Retreive the list of paths excluded from importation from this module.
+    /**
+     * Retreive the list of paths excluded from importation from this module.
      *
      * @return The list of paths excluded from importation from this module.
      */
@@ -155,7 +170,8 @@ public class Module {
         return this.imports.get(EXCLUDE);
     }
 
-    /** Add a path to import from this module.
+    /**
+     * Add a path to import from this module.
      *
      * @param path The path to add.
      * @return this module descriptor.
@@ -166,7 +182,8 @@ public class Module {
         return this;
     }
 
-    /** Add a path to exclude from importing from this module.
+    /**
+     * Add a path to exclude from importing from this module.
      *
      * @param path The excluded path to add.
      * @return this module descriptor.
@@ -177,7 +194,8 @@ public class Module {
         return this;
     }
 
-    /** Retrieve this list of paths exported from this module.
+    /**
+     * Retrieve this list of paths exported from this module.
      *
      * @return The list of paths exported from this module.
      */
@@ -185,7 +203,8 @@ public class Module {
         return this.exports.get(INCLUDE);
     }
 
-    /** Retrieve the list of paths excluded from exportation from this module.
+    /**
+     * Retrieve the list of paths excluded from exportation from this module.
      *
      * @return The list of paths excluded from exportation from this module.
      */
@@ -193,7 +212,8 @@ public class Module {
         return this.exports.get(EXCLUDE);
     }
 
-    /** Add a path to export from this module.
+    /**
+     * Add a path to export from this module.
      *
      * @param path The path to add.
      * @return this module descriptor.
@@ -204,7 +224,8 @@ public class Module {
         return this;
     }
 
-    /** Add a path to exclude from exporting from this module.
+    /**
+     * Add a path to exclude from exporting from this module.
      *
      * @param path The excluded path to add.
      * @return this module descriptor.

--- a/pom.xml
+++ b/pom.xml
@@ -1346,6 +1346,7 @@
         <module>testsuite/testsuite-camel-jpa</module>
         <module>testsuite/testsuite-camel-other</module>
         <module>testsuite/testsuite-cdi-jaxrsapi</module>
+        <module>testsuite/testsuite-classloader</module>
         <module>testsuite/testsuite-drools-server</module>
         <module>testsuite/testsuite-ejb-remote</module>
         <module>testsuite/testsuite-flyway</module>

--- a/testsuite/testsuite-classloader/pom.xml
+++ b/testsuite/testsuite-classloader/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>testsuite</artifactId>
+    <version>2017.4.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>testsuite-classloader</artifactId>
+
+  <name>Test Suite: ClassLoader-related</name>
+  <description>Test Suite: ClassLoader-related</description>
+
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>arquillian</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.junit</groupId>
+      <artifactId>arquillian-junit-container</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/testsuite/testsuite-classloader/src/main/java/org/wildfly/swarm/classloader/test/MyResource.java
+++ b/testsuite/testsuite-classloader/src/main/java/org/wildfly/swarm/classloader/test/MyResource.java
@@ -1,0 +1,16 @@
+package org.wildfly.swarm.classloader.test;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ * @author Bob McWhirter
+ */
+@Path("/")
+public class MyResource {
+
+    @GET
+    public String get() throws ClassNotFoundException {
+        return "success: " + Class.forName("com.fasterxml.jackson.datatype.jdk8.Jdk8BeanSerializerModifier").getName();
+    }
+}

--- a/testsuite/testsuite-classloader/src/main/resources/META-INF/jboss-deployment-structure.xml
+++ b/testsuite/testsuite-classloader/src/main/resources/META-INF/jboss-deployment-structure.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.2">
+  <deployment>
+    <dependencies>
+      <module name="com.fasterxml.jackson.datatype.jackson-datatype-jdk8"/>
+    </dependencies>
+  </deployment>
+</jboss-deployment-structure>

--- a/testsuite/testsuite-classloader/src/test/java/org/wildfly/swarm/classloader/test/ClassLoaderTest.java
+++ b/testsuite/testsuite-classloader/src/test/java/org/wildfly/swarm/classloader/test/ClassLoaderTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.classloader.test;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.arquillian.DefaultDeployment;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Bob McWhirter
+ */
+@RunWith(Arquillian.class)
+@DefaultDeployment
+public class ClassLoaderTest {
+
+    @Test
+    @RunAsClient
+    public void testNothing() throws Exception {
+        String content = getUrlContents("http://127.0.0.1:8080/");
+        assertThat( content ).contains("success: com.fasterxml.jackson.datatype.jdk8.Jdk8BeanSerializerModifier");
+    }
+
+    private static String getUrlContents(String theUrl) {
+        StringBuilder content = new StringBuilder();
+
+        try {
+            URL url = new URL(theUrl);
+            URLConnection urlConnection = url.openConnection();
+            BufferedReader bufferedReader = new BufferedReader(
+                    new InputStreamReader(urlConnection.getInputStream())
+            );
+
+            String line;
+
+            while ((line = bufferedReader.readLine()) != null) {
+                content.append(line + "\n");
+            }
+            bufferedReader.close();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        return content.toString();
+    }
+
+}

--- a/testsuite/testsuite-msc/src/main/resources/project-defaults.yml
+++ b/testsuite/testsuite-msc/src/main/resources/project-defaults.yml
@@ -2,4 +2,4 @@
 swarm:
   msc:
     service-activators:
-      org.wildfly.swarm.msc.test.MyServiceActivator
+      MyServiceActivator


### PR DESCRIPTION
Motivation
----------

Advanced users may wish to add dependencies to their applications
using traditional jboss-deployment-structure.xml. It should work.

Modifications
-------------

While in general jboss-deployment-structure.xml is respected, we did
have an issue where round-tripping a user-provided dependency with
the implicit slot of `main` was ignored and produced a broken
jboss-deployment-structure with a slot="" which resulted in a boot-time
issue.  This is *not* the issue reflected by the original bug report
(SWARM-1051).

Result
------

Better support for jboss-deployment-structure.xml.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
