### PR TITLE
SWARM-1153 - Be more careful about -Dswarm.logging.** property setting.

### DIFF
--- a/fractions/wildfly/logging/src/main/java/org/wildfly/swarm/logging/LoggingFraction.java
+++ b/fractions/wildfly/logging/src/main/java/org/wildfly/swarm/logging/LoggingFraction.java
@@ -77,12 +77,16 @@ public class LoggingFraction extends Logging<LoggingFraction> implements Fractio
         for (String name : allProps.stringPropertyNames()) {
             if (isSimpleLoggerName(name)) {
                 String logger = name.substring((LoggingProperties.LOGGING + ".").length());
-                Level loggerLevel = Level.valueOf(allProps.getProperty(name).trim().toUpperCase());
-                logger(logger, (l) -> {
-                    l.level(loggerLevel);
-                    l.category(logger);
-                    l.handler(CONSOLE);
-                });
+                try {
+                    Level loggerLevel = Level.valueOf(allProps.getProperty(name).trim().toUpperCase());
+                    logger(logger, (l) -> {
+                        l.level(loggerLevel);
+                        l.category(logger);
+                        l.handler(CONSOLE);
+                    });
+                } catch (IllegalArgumentException e) {
+                    // apparently wasn't a logging category+level, ignore.
+                }
             }
         }
 

--- a/testsuite/testsuite-logging/pom.xml
+++ b/testsuite/testsuite-logging/pom.xml
@@ -29,6 +29,10 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>undertow</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>arquillian</artifactId>
       <scope>test</scope>
     </dependency>

--- a/testsuite/testsuite-logging/src/main/java/org/wildfly/swarm/logging/test/MainWithProperties.java
+++ b/testsuite/testsuite-logging/src/main/java/org/wildfly/swarm/logging/test/MainWithProperties.java
@@ -1,0 +1,21 @@
+package org.wildfly.swarm.logging.test;
+
+import org.wildfly.swarm.Swarm;
+
+/**
+ * @author Bob McWhirter
+ */
+public class MainWithProperties {
+
+    private MainWithProperties() {
+    }
+
+    public static void main(String... args) throws Exception {
+        System.setProperty("swarm.logging", "TRACE");
+        System.setProperty("swarm.logging.custom.category", "DEBUG");
+        System.setProperty("swarm.logging.pattern-formatters.MY_COLOR_PATTERN.pattern", "%K{level}%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p (%t) [%c.%M()] %s%e%n");
+        Swarm swarm = new Swarm(args);
+        swarm.start().deploy();
+    }
+
+}

--- a/testsuite/testsuite-logging/src/test/java/org/wildfly/swarm/logging/test/ArqLoggingLevelsTest.java
+++ b/testsuite/testsuite-logging/src/test/java/org/wildfly/swarm/logging/test/ArqLoggingLevelsTest.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.logging.test;
+
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.logging.Logger;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.arquillian.DefaultDeployment;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Bob McWhirter
+ */
+@RunWith(Arquillian.class)
+@DefaultDeployment(main = MainWithProperties.class)
+public class ArqLoggingLevelsTest {
+
+    @Test
+    public void testCustomCategory() {
+        Logger logger = Logger.getLogger("custom.category");
+
+        logger.info("gouda info");
+        logger.debug("gouda debug");
+
+        assertFalse(logger.isTraceEnabled());
+        assertTrue(logger.isDebugEnabled());
+        assertTrue(logger.isInfoEnabled());
+    }
+
+    @Test
+    public void testRoot() {
+        Logger logger = Logger.getLogger("");
+
+        logger.info("gouda info");
+        logger.debug("gouda debug");
+
+        assertTrue(logger.isTraceEnabled());
+        assertTrue(logger.isDebugEnabled());
+        assertTrue(logger.isInfoEnabled());
+    }
+
+}


### PR DESCRIPTION
Motivation
----------

There's a lot of properties that are not setting category logging
levels, and we should be better about not breaking.

Modifications
-------------

Not only checking for simple logger name, but also seeing if the RHS of
the property represents a log-level.  If not, it's probably not a logger
category.

Plus, tests.

Result
------

Less breakage.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
