### PR TITLE
SWARM-1115 - @DefaultDeployment should ensure persistence.xml is loca…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1240,6 +1240,7 @@
     <module>testsuite/testsuite-container</module>
     <module>testsuite/testsuite-datasources</module>
     <module>testsuite/testsuite-datasources-config</module>
+    <module>testsuite/testsuite-default-deployment</module>
     <module>testsuite/testsuite-ee</module>
     <module>testsuite/testsuite-ejb</module>
     <module>testsuite/testsuite-hystrix</module>

--- a/testsuite/testsuite-default-deployment/pom.xml
+++ b/testsuite/testsuite-default-deployment/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>testsuite</artifactId>
+    <version>2017.4.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>testsuite-default-deployment</artifactId>
+
+  <name>Test Suite: @DefaultDeployment</name>
+  <description>Test Suite: @DefaultDeployment</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>undertow</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>arquillian</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.junit</groupId>
+      <artifactId>arquillian-junit-container</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/testsuite/testsuite-default-deployment/src/main/java/org/wildfly/swarm/defaultdeployment/Main.java
+++ b/testsuite/testsuite-default-deployment/src/main/java/org/wildfly/swarm/defaultdeployment/Main.java
@@ -1,0 +1,33 @@
+package org.wildfly.swarm.defaultdeployment;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.Node;
+import org.wildfly.swarm.Swarm;
+
+/**
+ * @author Bob McWhirter
+ */
+public class Main {
+
+    private Main() {
+
+    }
+
+    public static void main(String... args) throws Exception {
+        Swarm swarm = new Swarm(args);
+        swarm.start();
+        Archive<?> deployment = swarm.createDefaultDeployment();
+
+        Node persistenceXml = deployment.get("WEB-INF/classes/META-INF/persistence.xml");
+
+        if (persistenceXml == null) {
+            throw new Error("persistence.xml is not found");
+        }
+
+        if (persistenceXml.getAsset() == null) {
+            throw new Error("persistence.xml is not found");
+        }
+
+        swarm.deploy(deployment);
+    }
+}

--- a/testsuite/testsuite-default-deployment/src/main/resources/META-INF/persistence.xml
+++ b/testsuite/testsuite-default-deployment/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- JBoss, Home of Professional Open Source Copyright 2012, Red Hat, Inc.
+    and/or its affiliates, and individual contributors by the @authors tag. See
+    the copyright.txt in the distribution for a full listing of individual contributors.
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not
+    use this file except in compliance with the License. You may obtain a copy
+    of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required
+    by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied. See the License for the specific
+    language governing permissions and limitations under the License. -->
+<persistence version="2.1"
+   xmlns="http://xmlns.jcp.org/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="
+        http://xmlns.jcp.org/xml/ns/persistence
+        http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
+   <persistence-unit name="primary" transaction-type="JTA">
+      <!-- If you are running in a production environment, add a managed
+         data source, this example data source is just for development and testing! -->
+      <!-- The datasource is deployed as WEB-INF/ticket-monster-ds.xml, you
+         can find it in the source at src/main/webapp/WEB-INF/ticket-monster-ds.xml -->
+      <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+      <properties>
+         <!-- Properties for Hibernate -->
+         <property name="hibernate.hbm2ddl.auto" value="create-drop" />
+         <property name="hibernate.show_sql" value="false" />
+      </properties>
+   </persistence-unit>
+</persistence>

--- a/testsuite/testsuite-default-deployment/src/test/java/org/wildfly/swarm/defaultdeployment/WarDefaultDeploymentTest.java
+++ b/testsuite/testsuite-default-deployment/src/test/java/org/wildfly/swarm/defaultdeployment/WarDefaultDeploymentTest.java
@@ -1,0 +1,21 @@
+package org.wildfly.swarm.defaultdeployment;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.arquillian.DefaultDeployment;
+
+/**
+ * @author Bob McWhirter
+ */
+@RunWith(Arquillian.class)
+@DefaultDeployment(main = Main.class)
+public class WarDefaultDeploymentTest {
+
+    @Test
+    @RunAsClient
+    public void testNothing() {
+        // because the test is in the main();
+    }
+}


### PR DESCRIPTION
…ted right.

Motivation
----------

For .wars, src/main/resources/META-INF/persistence.xml is weird and should
end up in WEB-INF/classes/META-INF/persistence.xml.

Modifications
-------------

Change DefaultDeployment to handle the special-case of persistence.xml.

Result
------

@DefaultDeployment is slightly more useful.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
