### PR TITLE
SWARM-1152 - Support float/double values in the YAML.

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/config/MapConfigNodeFactory.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/MapConfigNodeFactory.java
@@ -84,6 +84,10 @@ public class MapConfigNodeFactory {
             child = new ConfigNode("" + value);
         } else if (value instanceof Boolean) {
             child = new ConfigNode("" + value);
+        } else if (value instanceof Float) {
+            child = new ConfigNode("" + value);
+        } else if (value instanceof Double) {
+            child = new ConfigNode("" + value);
         }
 
         return child;

--- a/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/ProjectStagesTest.java
+++ b/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/ProjectStagesTest.java
@@ -68,6 +68,7 @@ public class ProjectStagesTest {
         assertThat(view.resolve("myname").getValue()).isEqualTo("foo");
         swarm.withProfile("bar");
         assertThat(view.resolve("myname").getValue()).isEqualTo("foo");
+        assertThat(view.resolve("mydottednumber").as(Double.class).getValue()).isEqualTo(2.82);
     }
 
     @Test

--- a/testsuite/testsuite-project-stages/src/test/resources/project-bar.yml
+++ b/testsuite/testsuite-project-stages/src/test/resources/project-bar.yml
@@ -1,2 +1,3 @@
 
 myname: bar
+mydottednumber: 2.82


### PR DESCRIPTION
Motivation
----------

Some key=value pairs involve a floating-point shaped value.

Modifications
-------------

Support Double/Float values.

Result
------

key=value pairs with floating-point shaped values are not ignored.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
