### PR TITLE
SWARM-1155: Datasource test should not rely on JDK7

### DIFF
--- a/testsuite/testsuite-datasources/src/test/java/org/wildfly/swarm/datasources/test/ArquillianModulesTest.java
+++ b/testsuite/testsuite-datasources/src/test/java/org/wildfly/swarm/datasources/test/ArquillianModulesTest.java
@@ -50,7 +50,7 @@ public class ArquillianModulesTest {
     @Test
     public void testDatasource() {
         String response = getUrlContents("http://localhost:8080/");
-        assertThat(response).contains("Howdy using connection: org.jboss.jca.adapters.jdbc.jdk7.WrappedConnectionJDK7");
+        assertThat(response).matches("^(Howdy using connection: org.jboss.jca.adapters.jdbc.jdk)(7|8)(.WrappedConnectionJDK)(7|8)\\@[a-zA-Z\\d]+\n$");
     }
 
     private static String getUrlContents(String theUrl) {


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
When using EAP the JDK8 classes are used instead, causing this test to fail. Need to make the test pass with JDK7 or JDK8 classes.

Modifications
-------------
Modified the test to use a regex comparison that works with either JDK7 or JDK8.

Result
------
No impact to product, only a test.
