### PR TITLE
SWARM-1128 - support $swarm.whatever environment vars.

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/core/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -28,6 +28,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -175,14 +176,22 @@ public class Swarm {
      * @throws Exception If an error occurs performing classloading and initialization magic.
      */
     public Swarm(boolean debugBootstrap, String... args) throws Exception {
-        this(debugBootstrap, null, args);
+        this(debugBootstrap, null, null, args);
     }
 
     public Swarm(Properties properties, String... args) throws Exception {
-        this(false, properties, args);
+        this(false, properties, null, args);
     }
 
-    public Swarm(boolean debugBootstrap, Properties properties, String... args) throws Exception {
+    public Swarm(boolean debug, Properties properties, String... args) throws Exception {
+        this(debug, properties, null, args);
+    }
+
+    public Swarm(Properties properties, Map<String, String> environment, String... args) throws Exception {
+        this(false, properties, environment, args);
+    }
+
+    public Swarm(boolean debugBootstrap, Properties properties, Map<String, String> environment, String... args) throws Exception {
         if (System.getProperty(BOOT_MODULE_PROPERTY) == null) {
             System.setProperty(BOOT_MODULE_PROPERTY, BootModuleLoader.class.getName());
         }
@@ -217,7 +226,7 @@ public class Swarm {
         installModuleMBeanServer();
         createShrinkWrapDomain();
 
-        this.configView = ConfigViewFactory.defaultFactory(properties);
+        this.configView = ConfigViewFactory.defaultFactory(properties, environment);
         this.commandLine = CommandLine.parse(args);
         this.commandLine.apply(this);
 

--- a/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigResolutionStrategy.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigResolutionStrategy.java
@@ -2,6 +2,7 @@ package org.wildfly.swarm.container.config;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
@@ -52,6 +53,10 @@ class ConfigResolutionStrategy {
     void withProperties(Properties properties) {
         this.nodes.add(PropertiesConfigNodeFactory.load(properties));
         this.properties = PropertiesManipulator.forProperties(properties);
+    }
+
+    void withEnvironment(Map<String, String> environment) {
+        this.nodes.add(EnvironmentConfigNodeFactory.load(environment));
     }
 
     /**

--- a/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewFactory.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewFactory.java
@@ -41,24 +41,29 @@ public class ConfigViewFactory {
     private final ConfigViewImpl configView;
 
     public static ConfigViewFactory defaultFactory() throws ModuleLoadException {
-        return defaultFactory(null);
+        return defaultFactory(null, System.getenv());
     }
 
-    public static ConfigViewFactory defaultFactory(Properties properties) throws ModuleLoadException {
+    public static ConfigViewFactory defaultFactory(Properties properties, Map<String, String> environment) throws ModuleLoadException {
         return new ConfigViewFactory(
                 properties,
+                environment,
                 new FilesystemConfigLocator(),
                 ClassLoaderConfigLocator.system(),
                 ClassLoaderConfigLocator.forApplication()
         );
     }
 
-    private ConfigViewFactory(Properties properties) {
-        this.configView = new ConfigViewImpl().withProperties(properties);
+    public ConfigViewFactory(Properties properties) {
+        this.configView = new ConfigViewImpl().withProperties(properties).withEnvironment(System.getenv());
     }
 
-    public ConfigViewFactory(Properties properties, ConfigLocator... locators) {
-        this(properties);
+    public ConfigViewFactory(Properties properties, Map<String,String> environment) {
+        this.configView = new ConfigViewImpl().withProperties(properties).withEnvironment(environment);
+    }
+
+    public ConfigViewFactory(Properties properties, Map<String, String> environment, ConfigLocator... locators) {
+        this(properties, environment);
         for (ConfigLocator locator : locators) {
             addLocator(locator);
         }

--- a/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewImpl.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewImpl.java
@@ -48,6 +48,15 @@ public class ConfigViewImpl implements ConfigView {
             this.strategy.withProperties(properties);
         }
         return this;
+    }
+
+    public ConfigViewImpl withEnvironment(Map<String, String> environment) {
+        if (environment != null) {
+            this.strategy.withEnvironment(environment);
+        } else {
+            this.strategy.withEnvironment(System.getenv());
+        }
+        return this;
 
     }
 

--- a/core/container/src/main/java/org/wildfly/swarm/container/config/EnvironmentConfigNodeFactory.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/EnvironmentConfigNodeFactory.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.container.config;
+
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import javax.enterprise.inject.Vetoed;
+
+import org.wildfly.swarm.spi.api.config.ConfigKey;
+
+/**
+ * Factory capable ofr building a {@code ConfigNode} tree from a {@link Properties} object.
+ *
+ * @author Bob McWhirter
+ */
+@Vetoed
+public class EnvironmentConfigNodeFactory {
+
+    private EnvironmentConfigNodeFactory() {
+
+    }
+
+    /**
+     * Load a given {@link Properties} into a {@link ConfigNode}.
+     *
+     * @param input The properties to load.
+     * @return The loaded {@code ConfigNode}.
+     */
+    public static ConfigNode load(Map<String, String> input) {
+        ConfigNode config = new ConfigNode();
+
+        load(config, input);
+
+        return config;
+    }
+
+    protected static void load(ConfigNode config, Map<String, String> input) {
+        Set<String> names = input.keySet();
+
+        for (String name : names) {
+            String value = input.get(name);
+            ConfigKey key = ConfigKey.parse(name);
+            config.recursiveChild(key, value);
+        }
+    }
+
+}
+
+

--- a/core/container/src/test/java/org/wildfly/swarm/container/config/EnvironmentConfigNodeFactoryTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/container/config/EnvironmentConfigNodeFactoryTest.java
@@ -1,0 +1,42 @@
+package org.wildfly.swarm.container.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.wildfly.swarm.spi.api.config.ConfigKey;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Bob McWhirter
+ */
+public class EnvironmentConfigNodeFactoryTest {
+
+    @Test
+    public void testLoadSimple() {
+
+        Map<String, String> env = new HashMap<String, String>() {{
+            put("name", "bob");
+            put("cheese", "cheddar");
+        }};
+
+        ConfigNode node = EnvironmentConfigNodeFactory.load(env);
+
+        assertThat(node.valueOf(ConfigKey.parse("name"))).isEqualTo("bob");
+        assertThat(node.valueOf(ConfigKey.parse("cheese"))).isEqualTo("cheddar");
+    }
+
+    @Test
+    public void testLoadNested() {
+        Map<String, String> env = new HashMap<String, String>() {{
+            put("swarm.http.port", "8080");
+            put("swarm.data-sources.ExampleDS.url", "jdbc:db");
+        }};
+
+        ConfigNode node = EnvironmentConfigNodeFactory.load(env);
+
+        assertThat(node.valueOf(ConfigKey.of("swarm", "http", "port"))).isEqualTo("8080");
+        assertThat(node.valueOf(ConfigKey.of("swarm", "data-sources", "ExampleDS", "url"))).isEqualTo("jdbc:db");
+    }
+}

--- a/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/ProjectStagesTest.java
+++ b/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/ProjectStagesTest.java
@@ -1,6 +1,8 @@
 package org.wildfly.swarm;
 
 import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 import org.junit.Test;
@@ -76,6 +78,30 @@ public class ProjectStagesTest {
         Swarm swarm = new Swarm(new Properties(), "-Sfoo");
         ConfigView view = swarm.configView();
         assertThat(view.resolve("myname").getValue()).isEqualTo("foo");
+    }
+
+    @Test
+    public void testEnvironmentVars() throws Exception {
+        Map<String,String> environment = new HashMap<>();
+        environment.put("myname", "from_env");
+        Swarm swarm = new Swarm( new Properties(), environment );
+
+        ConfigView view = swarm.configView();
+        assertThat(view.resolve("myname").getValue()).isEqualTo("from_env");
+    }
+
+    @Test
+    public void testPropertiesPreferredToEnvironmentVars() throws Exception {
+        Map<String,String> environment = new HashMap<>();
+        Properties properties = new Properties();
+
+        environment.put("myname", "from_env");
+        properties.setProperty("myname", "from_props");
+
+        Swarm swarm = new Swarm( properties, environment );
+
+        ConfigView view = swarm.configView();
+        assertThat(view.resolve("myname").getValue()).isEqualTo("from_props");
     }
 
 }

--- a/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/StageConfigTest.java
+++ b/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/StageConfigTest.java
@@ -20,7 +20,7 @@ public class StageConfigTest {
         try {
             URL projectStages = getClass().getClassLoader().getResource("simple-project-stages.yml");
             System.setProperty(SwarmProperties.PROJECT_STAGE_FILE, projectStages.toExternalForm());
-            Swarm swarm = new Swarm(false, new Properties());
+            Swarm swarm = new Swarm(new Properties());
 
             ConfigView view = swarm.configView();
             assertThat(view.resolve("foo.bar.baz").getValue()).isEqualTo("cheddar");


### PR DESCRIPTION
Motivation
----------

Sometimes environment variables are easier than properties.

Modifications
-------------

If an environment variable is named exactly the same as a
configurable item, use it.  Properties still win.

Result
------

Easier to configure in Docker-like scenarios.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
