### PR TITLE
SWARM-1162 -S not correctly selecting active profiles.

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewFactory.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewFactory.java
@@ -58,7 +58,7 @@ public class ConfigViewFactory {
         this.configView = new ConfigViewImpl().withProperties(properties).withEnvironment(System.getenv());
     }
 
-    public ConfigViewFactory(Properties properties, Map<String,String> environment) {
+    public ConfigViewFactory(Properties properties, Map<String, String> environment) {
         this.configView = new ConfigViewImpl().withProperties(properties).withEnvironment(environment);
     }
 
@@ -125,6 +125,9 @@ public class ConfigViewFactory {
     }
 
     public ConfigViewImpl get(boolean activate) {
+        for (String profile : this.profiles) {
+            this.configView.withProfile(profile);
+        }
         this.configView.activate();
         return this.configView;
     }
@@ -168,7 +171,13 @@ public class ConfigViewFactory {
         this.configView.withProfile(name);
     }
 
+    public void withProfile(String name) {
+        this.configView.withProfile(name);
+    }
+
     private List<ConfigLocator> locators = new ArrayList<>();
+
+    private List<String> profiles = new ArrayList<>();
 
     private static final String PROJECT_PREFIX = "project";
 

--- a/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewImpl.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewImpl.java
@@ -107,15 +107,7 @@ public class ConfigViewImpl implements ConfigView {
         return this.strategy.valueOf(key);
     }
 
-    /**
-     * Activate this view with the given node names.
-     *
-     * <p>This method should be called only after defaults, properties
-     * and all relevant nodes have been registered.</p>
-     *
-     * @param names The names to activate.
-     */
-    public void withProfile(String... names) {
+    void withProfile(String... names) {
         for (String name : names) {
             List<ConfigNode> nodes = this.registry.get(name);
             if (nodes != null) {
@@ -127,7 +119,7 @@ public class ConfigViewImpl implements ConfigView {
 
     }
 
-    public void withProfile(List<String> names) {
+    void withProfile(List<String> names) {
         withProfile(names.toArray(new String[]{}));
     }
 

--- a/fractions/javaee/undertow/src/test/java/org/wildfly/swarm/undertow/runtime/ContextPathArchivePreparerTest.java
+++ b/fractions/javaee/undertow/src/test/java/org/wildfly/swarm/undertow/runtime/ContextPathArchivePreparerTest.java
@@ -15,8 +15,6 @@
  */
 package org.wildfly.swarm.undertow.runtime;
 
-import static org.fest.assertions.Assertions.assertThat;
-
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.URL;
@@ -30,6 +28,8 @@ import org.wildfly.swarm.container.config.ConfigViewImpl;
 import org.wildfly.swarm.undertow.WARArchive;
 import org.wildfly.swarm.undertow.internal.DefaultWarDeploymentFactory;
 import org.wildfly.swarm.undertow.internal.UndertowExternalMountsAsset;
+
+import static org.fest.assertions.Assertions.assertThat;
 
 /**
  * @author Ken Finnigan
@@ -77,34 +77,34 @@ public class ContextPathArchivePreparerTest {
         assertThat(archive.getContextRoot()).isNotNull();
         assertThat(archive.getContextRoot()).isEqualTo("/another-root");
     }
-    
+
     @Test
     public void testExternalMount() throws Exception {
         WARArchive archive = DefaultWarDeploymentFactory.archiveFromCurrentApp();
 
         assertThat(archive.getContextRoot()).isNull();
-        
+
         URL url = getClass().getClassLoader().getResource("mounts.yml");
         ConfigViewFactory factory = new ConfigViewFactory(new Properties());
         factory.load("test", url);
-        ConfigViewImpl view = factory.get();
-        view.withProfile("test");
+        factory.withProfile("test");
+        ConfigViewImpl view = factory.get(true);
 
         List<String> mounts = view.resolve("swarm.context.mounts").as(List.class).getValue();
 
-        ContextPathArchivePreparer preparer = new ContextPathArchivePreparer();     
+        ContextPathArchivePreparer preparer = new ContextPathArchivePreparer();
         preparer.mounts = mounts;
-        
+
         preparer.prepareArchive(archive);
 
         Node externalMount = archive.get(WARArchive.EXTERNAL_MOUNT_PATH);
         assertThat(externalMount).isNotNull();
         assertThat(externalMount.getAsset()).isInstanceOf(UndertowExternalMountsAsset.class);
         UndertowExternalMountsAsset externalMountAsset = (UndertowExternalMountsAsset) externalMount.getAsset();
-        try ( BufferedReader reader = new BufferedReader(new InputStreamReader(externalMountAsset.openStream())); ){
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(externalMountAsset.openStream()));) {
             assertThat(reader.readLine()).endsWith("external1");
             assertThat(reader.readLine()).endsWith("external2");
-        }        
-        
+        }
+
     }
 }

--- a/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/ProjectStagesTest.java
+++ b/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/ProjectStagesTest.java
@@ -63,8 +63,18 @@ public class ProjectStagesTest {
     }
 
     @Test
+    public void testCLIBasedSelectedStage() throws Exception {
+        Swarm swarm = new Swarm(new Properties(),
+                "-S", "production");
+
+        ConfigView view = swarm.configView();
+
+        assertThat(view.resolve("foo.bar.baz").getValue()).isEqualTo("brie");
+    }
+
+    @Test
     public void testSwarmAPIToLoadConfig() throws Exception {
-        Swarm swarm = new Swarm( new Properties());
+        Swarm swarm = new Swarm(new Properties());
         swarm.withProfile("foo");
         ConfigView view = swarm.configView();
         assertThat(view.resolve("myname").getValue()).isEqualTo("foo");
@@ -82,9 +92,9 @@ public class ProjectStagesTest {
 
     @Test
     public void testEnvironmentVars() throws Exception {
-        Map<String,String> environment = new HashMap<>();
+        Map<String, String> environment = new HashMap<>();
         environment.put("myname", "from_env");
-        Swarm swarm = new Swarm( new Properties(), environment );
+        Swarm swarm = new Swarm(new Properties(), environment);
 
         ConfigView view = swarm.configView();
         assertThat(view.resolve("myname").getValue()).isEqualTo("from_env");
@@ -92,13 +102,13 @@ public class ProjectStagesTest {
 
     @Test
     public void testPropertiesPreferredToEnvironmentVars() throws Exception {
-        Map<String,String> environment = new HashMap<>();
+        Map<String, String> environment = new HashMap<>();
         Properties properties = new Properties();
 
         environment.put("myname", "from_env");
         properties.setProperty("myname", "from_props");
 
-        Swarm swarm = new Swarm( properties, environment );
+        Swarm swarm = new Swarm(properties, environment);
 
         ConfigView view = swarm.configView();
         assertThat(view.resolve("myname").getValue()).isEqualTo("from_props");

--- a/testsuite/testsuite-project-stages/src/test/resources/project-stages.yml
+++ b/testsuite/testsuite-project-stages/src/test/resources/project-stages.yml
@@ -1,0 +1,9 @@
+foo:
+  bar:
+    baz: cheddar
+---
+project:
+  stage: production
+foo:
+  bar:
+   baz: brie


### PR DESCRIPTION
Motivation
----------

We document that -S should activate a profile either from
project-<profile>.yml or the pertinent profile in a project-stages.yml.
This was not the case in reality.

Modifications
-------------

Change the processing ordering to support both CLI-based selection,
and main() withProfile() selection.

Result
------

-S now works as documented.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
