### PR TITLE
SWARM-1163: Provide interface for version, etc

### DIFF
--- a/core/container/pom.xml
+++ b/core/container/pom.xml
@@ -37,6 +37,39 @@
         <filtering>true</filtering>
       </resource>
     </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>templating-maven-plugin</artifactId>
+        <version>1.0.0</version>
+        <executions>
+          <execution>
+            <id>filter-src</id>
+            <goals>
+              <goal>filter-sources</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-source</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${project.build.directory}/generated-sources/java-templates</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
 
   <dependencies>

--- a/core/container/src/main/java-templates/org/wildfly/swarm/SwarmInfo.java
+++ b/core/container/src/main/java-templates/org/wildfly/swarm/SwarmInfo.java
@@ -9,7 +9,7 @@ public interface SwarmInfo {
 
     final String GROUP_ID = "${project.groupId}";
 
-    default boolean isProduct() {
+    static boolean isProduct() {
         return VERSION.contains("-redhat-");
     }
 }

--- a/core/container/src/main/java-templates/org/wildfly/swarm/SwarmInfo.java
+++ b/core/container/src/main/java-templates/org/wildfly/swarm/SwarmInfo.java
@@ -1,0 +1,15 @@
+package org.wildfly.swarm;
+
+/**
+ * @author Ken Finnigan
+ */
+public interface SwarmInfo {
+
+    final String VERSION = "${project.version}";
+
+    final String GROUP_ID = "${project.groupId}";
+
+    default boolean isProduct() {
+        return VERSION.contains("-redhat-");
+    }
+}

--- a/core/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/core/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -82,7 +82,6 @@ import org.wildfly.swarm.spi.api.SocketBinding;
 import org.wildfly.swarm.spi.api.StageConfig;
 import org.wildfly.swarm.spi.api.SwarmProperties;
 import org.wildfly.swarm.spi.api.config.ConfigView;
-import org.wildfly.swarm.spi.api.internal.SwarmInternalProperties;
 
 /**
  * Default {@code main(...)} if an application does not provide one.
@@ -122,8 +121,6 @@ import org.wildfly.swarm.spi.api.internal.SwarmInternalProperties;
  */
 @Vetoed
 public class Swarm {
-
-    public static final String VERSION = Swarm.class.getPackage().getImplementationVersion();
 
     private static final String BOOT_MODULE_PROPERTY = "boot.module.loader";
 
@@ -198,8 +195,6 @@ public class Swarm {
         if (debugBootstrap) {
             Module.setModuleLogger(new StreamModuleLogger(System.err));
         }
-
-        System.setProperty(SwarmInternalProperties.VERSION, (VERSION == null ? "unknown" : VERSION));
 
         setArgs(args);
         this.debugBootstrap = debugBootstrap;

--- a/core/container/src/main/java/org/wildfly/swarm/cli/CommandLine.java
+++ b/core/container/src/main/java/org/wildfly/swarm/cli/CommandLine.java
@@ -37,6 +37,7 @@ import org.jboss.modules.ModuleClassLoader;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoadException;
 import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.SwarmInfo;
 import org.wildfly.swarm.spi.api.SwarmProperties;
 
 /**
@@ -281,7 +282,7 @@ public class CommandLine {
      * @param out The output stream to display help upon.
      */
     public void displayVersion(PrintStream out) {
-        out.println("WildFly Swarm version " + Swarm.VERSION);
+        out.println("WildFly Swarm version " + SwarmInfo.VERSION);
     }
 
     /**

--- a/core/container/src/main/resources/wildfly-swarm.properties
+++ b/core/container/src/main/resources/wildfly-swarm.properties
@@ -1,1 +1,0 @@
-version: ${project.version}

--- a/core/spi/src/main/java/org/wildfly/swarm/spi/api/internal/SwarmInternalProperties.java
+++ b/core/spi/src/main/java/org/wildfly/swarm/spi/api/internal/SwarmInternalProperties.java
@@ -22,8 +22,6 @@ package org.wildfly.swarm.spi.api.internal;
  */
 public interface SwarmInternalProperties {
 
-    String VERSION = "swarm.version";
-
     String BUILD_MODULES = "swarm.build.modules";
 
     String BUILD_REPOS = "swarm.build.repos";

--- a/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/InstallMonitorFilter.java
+++ b/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/InstallMonitorFilter.java
@@ -18,8 +18,8 @@ package org.wildfly.swarm.monitor.runtime;
 import javax.enterprise.context.ApplicationScoped;
 
 import org.jboss.shrinkwrap.api.Archive;
+import org.wildfly.swarm.SwarmInfo;
 import org.wildfly.swarm.spi.api.ArchivePreparer;
-import org.wildfly.swarm.spi.api.internal.SwarmInternalProperties;
 import org.wildfly.swarm.undertow.WARArchive;
 
 /**
@@ -32,7 +32,7 @@ public class InstallMonitorFilter implements ArchivePreparer {
     public void prepareArchive(Archive<?> archive) {
         try {
             WARArchive warArchive = archive.as(WARArchive.class);
-            warArchive.addDependency("org.wildfly.swarm:health-api:jar:" + System.getProperty(SwarmInternalProperties.VERSION));
+            warArchive.addDependency("org.wildfly.swarm:health-api:jar:" + SwarmInfo.VERSION);
             warArchive.findWebXmlAsset().setContextParam("resteasy.scan", "true");
         } catch (Exception e) {
             throw new RuntimeException("Failed to install health processor", e);

--- a/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/MonitorService.java
+++ b/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/MonitorService.java
@@ -38,8 +38,8 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
+import org.wildfly.swarm.SwarmInfo;
 import org.wildfly.swarm.monitor.HealthMetaData;
-import org.wildfly.swarm.spi.api.internal.SwarmInternalProperties;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADDRESS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
@@ -108,7 +108,7 @@ public class MonitorService implements Monitor, Service<MonitorService> {
         try {
             ModelNode response = controllerClient.execute(op);
             ModelNode unwrapped = unwrap(response);
-            unwrapped.get("swarm-version").set(System.getProperty(SwarmInternalProperties.VERSION));
+            unwrapped.get("swarm-version").set(SwarmInfo.VERSION);
             return unwrapped;
         } catch (IOException e) {
             return new ModelNode().get(FAILURE_DESCRIPTION).set(e.getMessage());


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
Currently the WF Swarm version is only available as a system property. We want to make it, and other details, available an interface.

Modifications
-------------
Created SwarmInfo that is filtered during build to add the version and groupId.

Result
------
No impact to product functionality, but version is available through SwarmInfo.
