### PR TITLE
SWARM-1164 - -D properties pass on CLI not actually passing.

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/core/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -290,6 +290,11 @@ public class Swarm {
         return this;
     }
 
+    public Swarm withProperty(String name, String value) {
+        this.configView.withProperty(name, value);
+        return this;
+    }
+
     /**
      * Add a fraction to the container.
      *

--- a/core/container/src/main/java/org/wildfly/swarm/cli/CommandLine.java
+++ b/core/container/src/main/java/org/wildfly/swarm/cli/CommandLine.java
@@ -292,7 +292,7 @@ public class CommandLine {
      *
      * @throws IOException If a URL is attempted to be read and fails.
      */
-    public void applyProperties() throws IOException {
+    public void applyProperties(Swarm swarm) throws IOException {
         URL propsUrl = get(PROPERTIES_URL);
 
         if (propsUrl != null) {
@@ -300,18 +300,18 @@ public class CommandLine {
             urlProps.load(propsUrl.openStream());
 
             for (String name : urlProps.stringPropertyNames()) {
-                System.setProperty(name, urlProps.getProperty(name));
+                swarm.withProperty(name, urlProps.getProperty(name));
             }
         }
 
         Properties props = get(PROPERTY);
 
         for (String name : props.stringPropertyNames()) {
-            System.setProperty(name, props.getProperty(name));
+            swarm.withProperty(name, props.getProperty(name));
         }
 
         if (get(BIND) != null) {
-            System.setProperty(SwarmProperties.BIND_ADDRESS, get(BIND));
+            swarm.withProperty(SwarmProperties.BIND_ADDRESS, get(BIND));
         }
     }
 
@@ -348,7 +348,7 @@ public class CommandLine {
      * @throws IOException If an error occurs resolving any URL.
      */
     public void apply(Swarm swarm) throws IOException, ModuleLoadException {
-        applyProperties();
+        applyProperties(swarm);
         applyConfigurations(swarm);
 
         if (get(HELP)) {

--- a/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigResolutionStrategy.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigResolutionStrategy.java
@@ -46,12 +46,14 @@ class ConfigResolutionStrategy {
     }
 
     private ConfigResolutionStrategy(PropertiesManipulator properties) {
-        this.nodes.add(PropertiesConfigNodeFactory.load(properties.getProperties()));
+        this.propertiesNode = PropertiesConfigNodeFactory.load(properties.getProperties());
+        this.nodes.add(this.propertiesNode);
         this.properties = properties;
     }
 
     void withProperties(Properties properties) {
-        this.nodes.add(PropertiesConfigNodeFactory.load(properties));
+        this.propertiesNode = PropertiesConfigNodeFactory.load(properties);
+        this.nodes.add(this.propertiesNode);
         this.properties = PropertiesManipulator.forProperties(properties);
     }
 
@@ -70,6 +72,10 @@ class ConfigResolutionStrategy {
 
     void defaults(ConfigNode defaults) {
         this.defaults = defaults;
+    }
+
+    void withProperty(String name, String value) {
+        this.propertiesNode.recursiveChild(name, value);
     }
 
     /**
@@ -153,5 +159,6 @@ class ConfigResolutionStrategy {
 
     private ConfigNode defaults;
 
+    private ConfigNode propertiesNode;
 
 }

--- a/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewFactory.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewFactory.java
@@ -175,6 +175,10 @@ public class ConfigViewFactory {
         this.configView.withProfile(name);
     }
 
+    public void withProperty(String name, String value) {
+        this.configView.withProperty(name, value);
+    }
+
     private List<ConfigLocator> locators = new ArrayList<>();
 
     private List<String> profiles = new ArrayList<>();
@@ -184,4 +188,5 @@ public class ConfigViewFactory {
     private static final String STAGE = "stage";
 
     private static final String DEFAULT = "default";
+
 }

--- a/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewImpl.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewImpl.java
@@ -50,6 +50,11 @@ public class ConfigViewImpl implements ConfigView {
         return this;
     }
 
+    public ConfigViewImpl withProperty(String name, String value) {
+        this.strategy.withProperty(name, value);
+        return this;
+    }
+
     public ConfigViewImpl withEnvironment(Map<String, String> environment) {
         if (environment != null) {
             this.strategy.withEnvironment(environment);

--- a/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/ProjectStagesTest.java
+++ b/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/ProjectStagesTest.java
@@ -114,4 +114,18 @@ public class ProjectStagesTest {
         assertThat(view.resolve("myname").getValue()).isEqualTo("from_props");
     }
 
+    @Test
+    public void testPropertiesOnCLIPreferredToEnvironmentVars() throws Exception {
+        Map<String, String> environment = new HashMap<>();
+        Properties properties = new Properties();
+
+        environment.put("myname", "from_env");
+        properties.setProperty("myname", "from_props");
+
+        Swarm swarm = new Swarm(properties, environment, "-Dmyname=tacos");
+
+        ConfigView view = swarm.configView();
+        assertThat(view.resolve("myname").getValue()).isEqualTo("tacos");
+    }
+
 }


### PR DESCRIPTION
Motivation
----------

While the JVM would typically take -Dfoo=bar before the -jar argument,
our own CommandLine should part out properties given as ARGV arguments.

This wasn't working.

Modifications
-------------

Instead of relying purely on System properties, and eagerly converting
them to configuration items before parsing the CLI ARGV, we now do two
things:

- The ARGV, as parsed, passes properties to (new) Swarm.withProperty()
  which progressively affects the properties bound to config-values.

- When the CommandLine applies properties, it no longer directly sets
  them via System.setProperty(), because this makes testing more tricky,
  and the ConfigView sets properties (on the System or isolated Properties
  instance) at a later resolved phase anyhow.

Result
------

`java -jar myapp-swarm.jar -Dfoo=bar` once again functions as documented.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
