### PR TITLE
SWARM-1166: JUnit Test categories

### DIFF
--- a/build-resources/pom.xml
+++ b/build-resources/pom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>build-resources</artifactId>
+  <version>2017.4.0-SNAPSHOT</version>
+
+  <name>WildFly Swarm Build Resources</name>
+  <description>Resources that are necessary for building WildFly Swarm</description>
+
+</project>

--- a/build-resources/src/main/java/category/CommunityOnly.java
+++ b/build-resources/src/main/java/category/CommunityOnly.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package category;
+
+/**
+ * This test is only applicable within a Community build.
+ *
+ * @author Ken Finnigan
+ */
+public interface CommunityOnly {
+}

--- a/build-resources/src/main/java/category/ProductOnly.java
+++ b/build-resources/src/main/java/category/ProductOnly.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package category;
+
+/**
+ * This test is only applicable within a Product build.
+ *
+ * @author Ken Finnigan
+ */
+public interface ProductOnly {
+}

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
     <!-- Surefire args -->
     <surefire.jpda.args />
     <surefire.system.args>-da ${surefire.jpda.args}</surefire.system.args>
+    <testCategory.excluded>category.CommunityOnly</testCategory.excluded>
 
     <!-- Checkstyle configuration -->
     <linkXRef>false</linkXRef>
@@ -135,6 +136,7 @@
           <reuseForks>false</reuseForks>
           <runOrder>alphabetical</runOrder>
           <failIfNoTests>false</failIfNoTests>
+          <excludedGroups>${testCategory.excluded}</excludedGroups>
           <systemPropertyVariables>
             <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
             <swarm.bind.address>127.0.0.1</swarm.bind.address>
@@ -142,6 +144,13 @@
             <org.apache.maven.user-settings>${session.request.userSettingsFile.path}</org.apache.maven.user-settings>
           </systemPropertyVariables>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>build-resources</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -282,6 +291,11 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>build-resources</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -454,6 +468,11 @@
       </dependency>
 
       <!-- Project Artifacts -->
+      <dependency>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>build-resources</artifactId>
+        <version>2017.4.0-SNAPSHOT</version>
+      </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>tools</artifactId>
@@ -1173,6 +1192,8 @@
   </pluginRepositories>
 
   <modules>
+    <module>build-resources</module>
+
     <module>tools</module>
 
     <!-- base -->
@@ -1290,6 +1311,9 @@
           <name>!swarm.product.build</name>
         </property>
       </activation>
+      <properties>
+        <testCategory.excluded>category.ProductOnly</testCategory.excluded>
+      </properties>
       <modules>
         <module>jaxrs-client-api</module>
 

--- a/testsuite/testsuite-undertow/src/test/java/org/wildfly/swarm/undertow/HTTPSCustomizerSelfSignedCertificateTest.java
+++ b/testsuite/testsuite-undertow/src/test/java/org/wildfly/swarm/undertow/HTTPSCustomizerSelfSignedCertificateTest.java
@@ -19,6 +19,7 @@ import java.net.URL;
 
 import javax.net.ssl.SSLHandshakeException;
 
+import category.CommunityOnly;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
@@ -26,6 +27,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.wildfly.swarm.Swarm;
 import org.wildfly.swarm.arquillian.CreateSwarm;
@@ -35,6 +37,7 @@ import org.wildfly.swarm.spi.api.SwarmProperties;
 /**
  * @author <a href="mailto:ggastald@redhat.com">George Gastaldi</a>
  */
+@Category(CommunityOnly.class)
 @RunWith(Arquillian.class)
 public class HTTPSCustomizerSelfSignedCertificateTest {
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
We need to be able to exclude tests from community or product builds due to differing functionality.

It's now possible to add `@Category(CommunityOnly.class)` or `@Category(ProductOnly.class)` onto a Test or Test method and have it excluded from the other build type.

Modifications
-------------
Added `build-resources` module to contain the interfaces defining the categories, modified the surefire-plugin configuration to set `excludedGroups` based on property that is set by community and product builds.

Result
------
No impact on product, purely for tests.
