### PR TITLE
SWARM-1036 - Management interface is terribly open by default.

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/marshal/SocketBindingGroupMarshaller.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/marshal/SocketBindingGroupMarshaller.java
@@ -33,6 +33,7 @@ import org.wildfly.swarm.spi.api.SocketBindingGroup;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEFAULT_INTERFACE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INTERFACE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MULTICAST_ADDRESS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MULTICAST_PORT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
@@ -98,6 +99,9 @@ public class SocketBindingGroupMarshaller implements ConfigurationMarshaller {
         node.get(OP_ADDR).set(address.append("socket-binding", binding.name()).toModelNode());
         node.get(OP).set(ADD);
         node.get(PORT).set(new ValueExpression(binding.portExpression()));
+        if (binding.iface() != null) {
+            node.get(INTERFACE).set(binding.iface());
+        }
         if (binding.multicastAddress() != null) {
             node.get(MULTICAST_ADDRESS).set(binding.multicastAddress());
         }

--- a/core/spi/src/main/java/org/wildfly/swarm/spi/api/SocketBinding.java
+++ b/core/spi/src/main/java/org/wildfly/swarm/spi/api/SocketBinding.java
@@ -30,6 +30,8 @@ public class SocketBinding {
 
     private String name;
 
+    private String iface;
+
     private String portExpression;
 
     private String multicastAddress;
@@ -50,6 +52,24 @@ public class SocketBinding {
      */
     public String name() {
         return this.name;
+    }
+
+    /** Set the interface for this binding.
+     *
+     * @param iface The name of the interface.
+     * @return This binding.
+     */
+    public SocketBinding iface(String iface) {
+        this.iface = iface;
+        return this;
+    }
+
+    /** Retrieve the interface for this binding.
+     *
+     * @return The name of the interface.
+     */
+    public String iface() {
+        return this.iface;
     }
 
     /** Set the port.

--- a/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/runtime/ManagementInterfaceProducer.java
+++ b/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/runtime/ManagementInterfaceProducer.java
@@ -13,11 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.swarm.management;
+package org.wildfly.swarm.management.runtime;
 
-public interface ManagementProperties {
-    int DEFAULT_HTTP_PORT = 9990;
-    int DEFAULT_HTTPS_PORT = 9993;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
 
-    String MANAGEMENT_BIND_ADDRESS = "swarm.management.bind.address";
+import org.wildfly.swarm.container.Interface;
+import org.wildfly.swarm.management.ManagementProperties;
+import org.wildfly.swarm.spi.api.SwarmProperties;
+
+/**
+ * @author Bob McWhirter
+ */
+@ApplicationScoped
+public class ManagementInterfaceProducer {
+
+    @Produces
+    public Interface publicInterace() {
+        return new Interface("management", SwarmProperties.propertyVar(ManagementProperties.MANAGEMENT_BIND_ADDRESS, "127.0.0.1"));
+    }
 }

--- a/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/runtime/ManagementSocketBindingsCustomizer.java
+++ b/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/runtime/ManagementSocketBindingsCustomizer.java
@@ -22,9 +22,13 @@ import javax.inject.Named;
 import org.wildfly.swarm.config.management.HTTPInterfaceManagementInterface;
 import org.wildfly.swarm.management.ManagementFraction;
 import org.wildfly.swarm.spi.api.Customizer;
+import org.wildfly.swarm.spi.api.Defaultable;
 import org.wildfly.swarm.spi.api.SocketBinding;
 import org.wildfly.swarm.spi.api.SocketBindingGroup;
+import org.wildfly.swarm.spi.api.annotations.Configurable;
 import org.wildfly.swarm.spi.runtime.annotations.Pre;
+
+import static org.wildfly.swarm.spi.api.Defaultable.string;
 
 /**
  * @author Bob McWhirter
@@ -41,13 +45,18 @@ public class ManagementSocketBindingsCustomizer implements Customizer {
     ManagementFraction fraction;
 
     public void customize() {
-        this.group.socketBinding(new SocketBinding("management-http")
-                .port(fraction.httpPort()));
+        this.group.socketBinding(
+                new SocketBinding("management-http")
+                        .iface(iface.get())
+                        .port(fraction.httpPort()));
         this.group.socketBinding(new SocketBinding("management-https")
                 .port(fraction.httpsPort()));
 
         if (fraction.isHttpDisable()) {
-            fraction.httpInterfaceManagementInterface((HTTPInterfaceManagementInterface<?>)null);
+            fraction.httpInterfaceManagementInterface((HTTPInterfaceManagementInterface<?>) null);
         }
     }
+
+    @Configurable("swarm.management.bind.interface")
+    private Defaultable<String> iface = string("management");
 }


### PR DESCRIPTION
Motivation
----------

Since the management fraction is required by the undertow fraction
if you're attempting to use HTTPS, it should *not* bind to the public
interface by default.

Modifications
-------------

When the management fraction is included, we now behave more like
WildFly proper by creating a `management` interface that, by default,
binds to 127.0.0.1 (instead of 0.0.0.0/all) and is used by the
management socket-bindings for HTTP and HTTPS interfaces (9990 etc).

This can be adjusted using swarm.management.bind.address, if the
desire is to use a different address.

Additionally, the management interface can be ignored, and reset
to use the public interface (possibly ill-adviced) by the configuration
item of swarm.management.bind.interface=public instead.

Result
------

Safer and sturdier.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
