### PR TITLE
SWARM-1087: Adjust to handle product config-api

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/internal/SwarmMessages.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/SwarmMessages.java
@@ -136,6 +136,13 @@ public interface SwarmMessages extends BasicLogger {
                     "OpenSSL usage with WildFly Swarm on HP-UX is NOT supported.")
     void http2NotSupported();
 
+    @Message(id = 40, value = "This version of WildFly Swarm does not support generating self signed certificates.")
+    RuntimeException generateSelfSignedCertificateNotSupported();
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 41, value = "Error invoking SslServerIdentity.generateSelfSignedCertificateHost(String) in HTTPSCustomizer.")
+    void failToInvokeGenerateSelfSignedCertificateHost(@Cause Throwable cause);
+
 
     // ------------------------------------------------------------------------
     // ------------------------------------------------------------------------

--- a/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/runtime/CertInfoProducer.java
+++ b/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/runtime/CertInfoProducer.java
@@ -17,7 +17,9 @@ import javax.inject.Singleton;
 
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleIdentifier;
+import org.wildfly.swarm.SwarmInfo;
 import org.wildfly.swarm.bootstrap.util.TempFileManager;
+import org.wildfly.swarm.internal.SwarmMessages;
 import org.wildfly.swarm.spi.api.Defaultable;
 import org.wildfly.swarm.spi.api.annotations.Configurable;
 import org.wildfly.swarm.undertow.UndertowFraction;
@@ -47,6 +49,9 @@ public class CertInfoProducer {
     @Singleton
     public CertInfo produceCertInfo() {
         if (generateSelfCertificate.get()) {
+            if (SwarmInfo.isProduct()) {
+                throw SwarmMessages.MESSAGES.generateSelfSignedCertificateNotSupported();
+            }
             checkDataDir();
             return new CertInfo(selfCertificateHost.get(), JBOSS_DATA_DIR);
         } else {

--- a/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/runtime/HTTPSCustomizer.java
+++ b/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/runtime/HTTPSCustomizer.java
@@ -15,12 +15,16 @@
  */
 package org.wildfly.swarm.undertow.runtime;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
 import org.wildfly.swarm.config.ManagementCoreService;
+import org.wildfly.swarm.config.management.security_realm.SslServerIdentity;
 import org.wildfly.swarm.config.undertow.Server;
 import org.wildfly.swarm.internal.SwarmMessages;
 import org.wildfly.swarm.spi.api.Customizer;
@@ -73,10 +77,23 @@ public class HTTPSCustomizer implements Customizer {
                                 .keystorePassword(certInfo.keystorePassword())
                                 .keyPassword(certInfo.keyPassword())
                                 .alias(certInfo.keystoreAlias())
-                                .generateSelfSignedCertificateHost(certInfo.generateSelfSignedCertificateHost());
+                                .alias(certInfo.keystoreAlias());
+
+                        handleSelfSignedCertificateHost(identity);
                     });
                 });
             }
+        }
+    }
+
+    private void handleSelfSignedCertificateHost(SslServerIdentity identity) {
+        try {
+            Method genMethod = identity.getClass().getMethod("generateSelfSignedCertificateHost", String.class);
+            genMethod.invoke(identity, certInfo.generateSelfSignedCertificateHost());
+        } catch (NoSuchMethodException e) {
+            // Do Nothing. Just means the method doesn't exist on the Config API.
+        } catch (InvocationTargetException | IllegalAccessException e) {
+            SwarmMessages.MESSAGES.failToInvokeGenerateSelfSignedCertificateHost(e);
         }
     }
 }

--- a/fractions/javaee/undertow/src/test/java/org/wildfly/swarm/undertow/runtime/CertInfoProducerTest.java
+++ b/fractions/javaee/undertow/src/test/java/org/wildfly/swarm/undertow/runtime/CertInfoProducerTest.java
@@ -1,6 +1,8 @@
 package org.wildfly.swarm.undertow.runtime;
 
+import category.CommunityOnly;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.wildfly.swarm.undertow.UndertowFraction;
 import org.wildfly.swarm.undertow.descriptors.CertInfo;
 
@@ -24,6 +26,7 @@ public class CertInfoProducerTest {
     }
 
     @Test
+    @Category(CommunityOnly.class)
     public void testGenerateWithDefaults() {
         CertInfoProducer producer = new CertInfoProducer();
         producer.undertow = new UndertowFraction();
@@ -37,6 +40,7 @@ public class CertInfoProducerTest {
     }
 
     @Test
+    @Category(CommunityOnly.class)
     public void testGenerateWithExplicitHost() {
         CertInfoProducer producer = new CertInfoProducer();
         producer.undertow = new UndertowFraction();


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
Our productized wildfly-config-api doesn't include a means to generate a self signed certificate so we need to handle cases where that method isn't present.

Modifications
-------------
Throw an error when generate self signed cert requested and it's not available. Switch to calling the method through reflection to handle when it isn't there.

Result
------
No direct impact.
