### PR TITLE
SWARM-790 - add missing module to prepare for weld split.

### DIFF
--- a/fractions/javaee/webservices/module.conf
+++ b/fractions/javaee/webservices/module.conf
@@ -2,3 +2,4 @@ org.jboss.ws.cxf.jbossws-cxf-server
 org.jboss.ws.cxf.jbossws-cxf-client
 org.jboss.ws.cxf.jbossws-cxf-transports-undertow
 org.jboss.ws.saaj-impl
+org.jboss.as.webservices.server.integration


### PR DESCRIPTION
Motivation
----------

Once weld is lighter, we'll be missing this.

Modifications
-------------

Add the webservices integration module to the webservices fraction.

Result
------

No-op currently.  Avoid breakage in the future.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
