### PR TITLE
SWARM-1114: JSF auto-detection when faces-config.xml is present

### DIFF
--- a/fractions/javaee/jsf/src/main/java/org/wildfly/swarm/jsf/detect/FacesXmlDetector.java
+++ b/fractions/javaee/jsf/src/main/java/org/wildfly/swarm/jsf/detect/FacesXmlDetector.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.swarm.jsf.detect;
+
+import org.wildfly.swarm.spi.meta.FileDetector;
+
+/**
+ * @author Heiko Braun
+ */
+public class FacesXmlDetector extends FileDetector {
+
+    @Override
+    public String extensionToDetect() {
+        return XML;
+    }
+
+    @Override
+    public boolean detectionComplete() {
+        return detectionComplete;
+    }
+
+    @Override
+    public boolean wasDetected() {
+        return detected;
+    }
+
+    @Override
+    public void detect(String fileName) {
+        if (!detectionComplete() && fileName.endsWith(FACES_CONFIG_XML)) {
+            detected = true;
+            detectionComplete = true;
+        }
+    }
+
+    @Override
+    public String artifactId() {
+        return JSF;
+    }
+
+    private static final String XML = "xml";
+
+    private static final String FACES_CONFIG_XML = "faces-config.xml";
+
+    private static final String JSF = "jsf";
+
+    private boolean detected = false;
+
+    private boolean detectionComplete = false;
+
+}
+

--- a/meta/fraction-metadata/src/main/java/org/wildfly/swarm/fractions/FractionUsageAnalyzer.java
+++ b/meta/fraction-metadata/src/main/java/org/wildfly/swarm/fractions/FractionUsageAnalyzer.java
@@ -32,6 +32,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 import org.wildfly.swarm.fractions.scanner.ClassAndPackageScanner;
+import org.wildfly.swarm.fractions.scanner.FilePresenceScanner;
 import org.wildfly.swarm.fractions.scanner.JarScanner;
 import org.wildfly.swarm.fractions.scanner.Scanner;
 import org.wildfly.swarm.fractions.scanner.WarScanner;
@@ -154,10 +155,10 @@ public class FractionUsageAnalyzer {
     }
 
     private void fireScanner(String suffix, Consumer<Scanner<?>> scannerConsumer) {
-        scanners.stream()
+        List<Scanner<?>> scanners = this.scanners.stream()
                 .filter(s -> s.extension().equals(suffix))
-                .findFirst()
-                .ifPresent(scannerConsumer);
+                .collect(Collectors.toList());
+        scanners.forEach(scannerConsumer);
     }
 
     private String suffix(String name) {
@@ -176,6 +177,7 @@ public class FractionUsageAnalyzer {
         scanners.add(new JarScanner());
         scanners.add(new ClassAndPackageScanner());
         scanners.add(new WebXmlDescriptorScanner());
+        scanners.add(new FilePresenceScanner());
 
         ClassAndPackageScanner.classesPackagesAlreadyDetected.clear();
 

--- a/meta/fraction-metadata/src/main/java/org/wildfly/swarm/fractions/scanner/FilePresenceScanner.java
+++ b/meta/fraction-metadata/src/main/java/org/wildfly/swarm/fractions/scanner/FilePresenceScanner.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.fractions.scanner;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.function.Consumer;
+
+import org.wildfly.swarm.spi.meta.FileDetector;
+import org.wildfly.swarm.spi.meta.FractionDetector;
+
+/**
+ * @author Heiko Braun
+ */
+public class FilePresenceScanner implements Scanner<String> {
+    @Override
+    public String extension() {
+        return XML;
+    }
+
+    /**
+     * scans all xml files
+     */
+    @Override
+    public void scan(String name, final InputStream input, Collection<FractionDetector<String>> detectors, Consumer<File> handleFileAsZip) throws IOException {
+        detectors.stream()
+                .filter(d -> FileDetector.class.isAssignableFrom(d.getClass()))
+                .forEach(d -> d.detect(name));
+    }
+
+    private static final String XML = "xml";
+}
+

--- a/meta/meta-spi/src/main/java/org/wildfly/swarm/spi/meta/FileDetector.java
+++ b/meta/meta-spi/src/main/java/org/wildfly/swarm/spi/meta/FileDetector.java
@@ -6,7 +6,5 @@ package org.wildfly.swarm.spi.meta;
  */
 public abstract class FileDetector implements FractionDetector<String> {
     @Override
-    public void detect(String fileName) {
-
-    }
+    public abstract void detect(String fileName);
 }

--- a/meta/meta-spi/src/main/java/org/wildfly/swarm/spi/meta/FileDetector.java
+++ b/meta/meta-spi/src/main/java/org/wildfly/swarm/spi/meta/FileDetector.java
@@ -1,0 +1,12 @@
+package org.wildfly.swarm.spi.meta;
+
+/**
+ * @author Heiko Braun
+ * @since 09/03/2017
+ */
+public abstract class FileDetector implements FractionDetector<String> {
+    @Override
+    public void detect(String fileName) {
+
+    }
+}


### PR DESCRIPTION
Motivation
----------

Auto-detection did not kick in when faces-config.xml was present

Modifications
-------------

Added new scanner and detector

Result
------

The JSF fraction and it's dependents (i.e. undertow) will be added to the uberJar build
