### PR TITLE
SWARM-1174 - -S should actually work, consistently.

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/core/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -578,14 +578,15 @@ public class Swarm {
                 this.configView.withProfile(syntheticName);
             }
 
-            // deprecated project-stages.yml
             this.configView.load("stages");
-            this.configView.load("defaults");
 
             for (String profile : this.profiles) {
                 this.configView.load(profile);
                 this.configView.withProfile(profile);
             }
+
+            this.configView.load("defaults");
+
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewFactory.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewFactory.java
@@ -74,6 +74,7 @@ public class ConfigViewFactory {
     }
 
     public ConfigViewFactory load(String profileName) {
+        this.profiles.add(profileName);
         this.locators
                 .stream()
                 .flatMap(locator -> {
@@ -128,6 +129,7 @@ public class ConfigViewFactory {
         for (String profile : this.profiles) {
             this.configView.withProfile(profile);
         }
+
         this.configView.activate();
         return this.configView;
     }

--- a/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/ProjectStagesTest.java
+++ b/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/ProjectStagesTest.java
@@ -68,7 +68,6 @@ public class ProjectStagesTest {
                 "-S", "production");
 
         ConfigView view = swarm.configView();
-
         assertThat(view.resolve("foo.bar.baz").getValue()).isEqualTo("brie");
     }
 


### PR DESCRIPTION
Motivation
----------

-S wasn't working consistently, always, only sometimes, inconsistently.

Modifications
-------------

Further adjust the order of loading .yml files and activation of
profiles so that -foo.yml will activate using -S even if a -defaults.yml
is present.

Result
------

-S supposedly, in theory, might actually work as documented.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
