### PR TITLE
SWARM-1139 / SWARM-1168 / SWARM-1156 - Logging/stderr/printStackTrace.

### DIFF
--- a/core/bootstrap/pom.xml
+++ b/core/bootstrap/pom.xml
@@ -78,6 +78,27 @@
       <artifactId>snakeyaml</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-annotations</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-processor</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.shrinkwrap</groupId>
       <artifactId>shrinkwrap-api</artifactId>
       <scope>test</scope>

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/MavenDependencyResolution.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/MavenDependencyResolution.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.jboss.modules.maven.ArtifactCoordinates;
+import org.wildfly.swarm.bootstrap.logging.BootstrapLogger;
 import org.wildfly.swarm.bootstrap.modules.MavenResolvers;
 
 /**
@@ -16,6 +17,7 @@ import org.wildfly.swarm.bootstrap.modules.MavenResolvers;
  * @since 18/07/16
  */
 public class MavenDependencyResolution implements DependencyResolution {
+    private static BootstrapLogger LOGGER = BootstrapLogger.logger("org.wildfly.swarm.bootstrap");
 
     @Override
     public Set<String> resolve(List<String> exclusions) throws IOException {
@@ -37,14 +39,13 @@ public class MavenDependencyResolution implements DependencyResolution {
                     try {
                         final File artifact = MavenResolvers.get().resolveJarArtifact(coords);
                         if (artifact == null) {
-                            System.err.println("Unable to resolve artifact: " + coords);
+                            LOGGER.error("Unable to resolve artifact: " + coords);
                         } else {
                             archivePaths.add(artifact.getAbsolutePath());
                         }
                     } catch (IOException e) {
-                        e.printStackTrace();
+                        LOGGER.error("Error resolving artifact " + coords, e);
                     }
-
                 });
 
         return archivePaths;

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/ApplicationModuleFinder.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/ApplicationModuleFinder.java
@@ -173,10 +173,8 @@ public class ApplicationModuleFinder extends AbstractSingleModuleFinder {
                                 )
                         );
                     } catch (IOException e) {
-                        e.printStackTrace();
+                        throw new RuntimeException(e);
                     }
-
-
                 });
     }
 

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/BootstrapClasspathModuleFinder.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/BootstrapClasspathModuleFinder.java
@@ -68,10 +68,8 @@ public class BootstrapClasspathModuleFinder implements ModuleFinder {
                         identifier);
 
             } catch (IOException e) {
-                e.printStackTrace();
                 throw new ModuleLoadException(e);
             } catch (Throwable t) {
-                t.printStackTrace();
                 throw t;
             } finally {
                 try {

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/BootstrapModuleFinder.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/BootstrapModuleFinder.java
@@ -87,9 +87,8 @@ public class BootstrapModuleFinder extends AbstractSingleModuleFinder {
                                     )
                             );
                         } catch (IOException e) {
-                            e.printStackTrace();
+                            throw new RuntimeException(e);
                         }
-
                     });
 
             builder.addDependency(DependencySpec.createLocalDependencySpec());

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/MavenResolvers.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/MavenResolvers.java
@@ -15,17 +15,20 @@
  */
 package org.wildfly.swarm.bootstrap.modules;
 
-import org.jboss.modules.maven.MavenResolver;
-import org.wildfly.swarm.bootstrap.util.BootstrapProperties;
-
 import java.io.File;
 import java.util.Arrays;
 import java.util.Optional;
+
+import org.jboss.modules.maven.MavenResolver;
+import org.wildfly.swarm.bootstrap.logging.BootstrapLogger;
+import org.wildfly.swarm.bootstrap.util.BootstrapProperties;
 
 /**
  * @author Bob McWhirter
  */
 public class MavenResolvers {
+
+    private static BootstrapLogger LOGGER = BootstrapLogger.logger("org.wildfly.swarm.bootstrap");
 
     public static synchronized MavenResolver get() {
         return INSTANCE;
@@ -42,10 +45,10 @@ public class MavenResolvers {
                     .findFirst();
             if (gradleClassPathFile.isPresent()) {
                 String gradleCachePath = gradleClassPathFile.get().substring(0, gradleClassPathFile.get().indexOf("files-2.1") + 9);
-                System.err.println("Dependencies not bundled, will resolve from gradle cache: " + gradleCachePath);
+                LOGGER.info("Dependencies not bundled; resolving from Gradle cache.");
                 INSTANCE.addResolver(new GradleResolver(gradleCachePath));
             } else {
-                System.err.println("Dependencies not bundled, will resolve from local M2REPO");
+                LOGGER.info("Dependencies not bundled; resolving from M2REPO.");
                 INSTANCE.addResolver(MavenResolver.createDefaultResolver());
             }
         }

--- a/core/container/src/main/java/org/wildfly/swarm/container/DeploymentException.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/DeploymentException.java
@@ -27,7 +27,7 @@ import org.jboss.shrinkwrap.api.Archive;
  * @author Bob McWhirter
  */
 @Vetoed
-public class DeploymentException extends Exception {
+public class DeploymentException extends RuntimeException {
 
     public DeploymentException(String message) {
         this.archive = null;

--- a/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewFactory.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewFactory.java
@@ -81,16 +81,15 @@ public class ConfigViewFactory {
                     try {
                         return locator.locate(profileName);
                     } catch (IOException e) {
-                        e.printStackTrace();
+                        throw new RuntimeException(e);
                     }
-                    return null;
                 })
                 .filter(Objects::nonNull)
                 .forEach(url -> {
                     try {
                         load(profileName, url);
                     } catch (IOException e) {
-                        e.printStackTrace();
+                        throw new RuntimeException(e);
                     }
                 });
         return this;

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/ConfigurableManager.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/ConfigurableManager.java
@@ -664,7 +664,7 @@ public class ConfigurableManager implements AutoCloseable {
                 }
 
             } catch (Exception e) {
-                e.printStackTrace();
+                SwarmConfigMessages.MESSAGES.errorResolvingConfigurableValue(each.key().name(), e);
             }
         }
         SwarmConfigMessages.MESSAGES.configuration(str.toString());

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/TempFileProviderProducer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/TempFileProviderProducer.java
@@ -28,6 +28,7 @@ import javax.inject.Singleton;
 
 import org.jboss.vfs.TempFileProvider;
 import org.wildfly.swarm.bootstrap.util.TempFileManager;
+import org.wildfly.swarm.internal.SwarmMessages;
 
 /**
  * @author Bob McWhirter
@@ -50,8 +51,7 @@ public class TempFileProviderProducer {
             this.tempFileProvider = TempFileProvider.create(TEMP_DIR_NAME, tempFileExecutor, true);
 
         } catch (IOException e) {
-            //TODO This should be properly logged
-            e.printStackTrace();
+            SwarmMessages.MESSAGES.errorSettingUpTempFileProvider(e);
         }
     }
 
@@ -67,7 +67,7 @@ public class TempFileProviderProducer {
             try {
                 this.tempFileProvider.close();
             } catch (IOException e) {
-                e.printStackTrace();
+                SwarmMessages.MESSAGES.errorCleaningUpTempFileProvider(e);
             }
         }
     }

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/StandaloneXMLConfigProducer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/StandaloneXMLConfigProducer.java
@@ -47,7 +47,7 @@ public class StandaloneXMLConfigProducer {
             }
             return result;
         } catch (ModuleLoadException e) {
-            e.printStackTrace();
+            SwarmConfigMessages.MESSAGES.errorLoadingModule(e);
         }
         return null;
     }

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/StandaloneXMLParser.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/StandaloneXMLParser.java
@@ -15,7 +15,6 @@
  */
 package org.wildfly.swarm.container.runtime.xmlconfig;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
@@ -93,26 +92,12 @@ public class StandaloneXMLParser {
     }
 
     public List<ModelNode> parse(URL xml) throws Exception {
-
         final List<ModelNode> operationList = new ArrayList<>();
 
-        InputStream input = null;
-        try {
-            input = xml.openStream();
-
+        try (InputStream input = xml.openStream()) {
             final XMLStreamReader reader = XMLInputFactory.newInstance().createXMLStreamReader(input);
             WrappedXMLStreamReader wrappedReader = new WrappedXMLStreamReader(reader, this.recognizedNames, xmlMapper);
             xmlMapper.parseDocument(operationList, wrappedReader);
-        } catch (XMLStreamException t) {
-            t.printStackTrace();
-        } finally {
-            try {
-                if (input != null) {
-                    input.close();
-                }
-            } catch (IOException e) {
-                // ignore
-            }
         }
 
         return operationList;

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/StandaloneXMLParserProducer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/StandaloneXMLParserProducer.java
@@ -37,9 +37,9 @@ import org.jboss.as.controller.parsing.ProfileParsingCompletionHandler;
 import org.jboss.dmr.ModelNode;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleIdentifier;
-import org.jboss.modules.ModuleLoadException;
 import org.jboss.staxmapper.XMLElementReader;
 import org.wildfly.swarm.bootstrap.performance.Performance;
+import org.wildfly.swarm.internal.SwarmConfigMessages;
 import org.wildfly.swarm.internal.SwarmMessages;
 import org.wildfly.swarm.spi.api.Fraction;
 import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
@@ -58,8 +58,10 @@ public class StandaloneXMLParserProducer {
     private StandaloneXMLParser parser = new StandaloneXMLParser();
 
     @PostConstruct
-    public void setupFactories() {
-        this.fractions.forEach(this::setupFactory);
+    public void setupFactories() throws Exception {
+        for (Fraction fraction : this.fractions) {
+            setupFactory(fraction);
+        }
     }
 
     @Produces
@@ -68,7 +70,7 @@ public class StandaloneXMLParserProducer {
         return this.parser;
     }
 
-    private void setupFactory(Fraction fraction) {
+    private void setupFactory(Fraction fraction) throws Exception {
         try (AutoCloseable handle = Performance.time("Setting up XML parser: " + fraction.getClass().getSimpleName())) {
             WildFlyExtension anno = fraction.getClass().getAnnotation(WildFlyExtension.class);
 
@@ -84,43 +86,37 @@ public class StandaloneXMLParserProducer {
                 extensionClassName = null;
             }
 
-            try {
-                Module extensionModule = Module.getBootModuleLoader().loadModule(ModuleIdentifier.create(extensionModuleName));
+            Module extensionModule = Module.getBootModuleLoader().loadModule(ModuleIdentifier.create(extensionModuleName));
 
-                if (noClass) {
-                    // ignore it all
-                } else if (extensionClassName != null) {
-                    Class<?> extCls = extensionModule.getClassLoader().loadClass(extensionClassName);
-                    try {
-                        Extension ext = (Extension) extCls.newInstance();
-                        add(ext);
-                    } catch (InstantiationException | IllegalAccessException e) {
-                        e.printStackTrace();
-                    }
-                } else {
-                    ServiceLoader<Extension> extensionLoader = extensionModule.loadService(Extension.class);
-
-                    Iterator<Extension> extensionIter = extensionLoader.iterator();
-                    List<Extension> extensions = new ArrayList<>();
-
-                    if (extensionIter.hasNext()) {
-                        Extension ext = extensionIter.next();
-                        extensions.add(ext);
-                    }
-
-                    if (extensions.size() > 1) {
-                        throw SwarmMessages.MESSAGES.fractionHasMultipleExtensions(fraction.getClass().getName(), extensions.stream().map(Objects::toString).collect(Collectors.toList()));
-                    }
-
-                    if (!extensions.isEmpty()) {
-                        add(extensions.get(0));
-                    }
+            if (noClass) {
+                // ignore it all
+            } else if (extensionClassName != null) {
+                Class<?> extCls = extensionModule.getClassLoader().loadClass(extensionClassName);
+                try {
+                    Extension ext = (Extension) extCls.newInstance();
+                    add(ext);
+                } catch (InstantiationException | IllegalAccessException e) {
+                    SwarmConfigMessages.MESSAGES.errorCreatingExtension(extensionClassName, extensionModuleName, e);
                 }
-            } catch (ModuleLoadException | ClassNotFoundException e) {
-                throw new RuntimeException(e);
+            } else {
+                ServiceLoader<Extension> extensionLoader = extensionModule.loadService(Extension.class);
+
+                Iterator<Extension> extensionIter = extensionLoader.iterator();
+                List<Extension> extensions = new ArrayList<>();
+
+                if (extensionIter.hasNext()) {
+                    Extension ext = extensionIter.next();
+                    extensions.add(ext);
+                }
+
+                if (extensions.size() > 1) {
+                    throw SwarmMessages.MESSAGES.fractionHasMultipleExtensions(fraction.getClass().getName(), extensions.stream().map(Objects::toString).collect(Collectors.toList()));
+                }
+
+                if (!extensions.isEmpty()) {
+                    add(extensions.get(0));
+                }
             }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
         }
     }
 

--- a/core/container/src/main/java/org/wildfly/swarm/internal/DeployerMessages.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/DeployerMessages.java
@@ -24,17 +24,35 @@ import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
+import org.wildfly.swarm.container.DeploymentException;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@MessageLogger(projectCode = "WFSMETRICS", length = 4)
-public interface SwarmMetricsMessages extends BasicLogger {
+@MessageLogger(projectCode = "WFSDEPLOY", length = 4)
+public interface DeployerMessages extends BasicLogger {
 
-    SwarmMetricsMessages MESSAGES = Logger.getMessageLogger(SwarmMetricsMessages.class, "org.wildfly.swarm.metrics");
+    DeployerMessages MESSAGES = Logger.getMessageLogger(DeployerMessages.class, "org.wildfly.swarm.deployer");
 
-    @LogMessage(level = Logger.Level.TRACE)
-    @Message(id = 1, value = "Boot performance:\n%s")
-    void bootPerformance(String metrics);
+    @Message(id = 1, value = "Unable to create default deployment.")
+    DeploymentException unableToCreateDefaultDeployment();
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 2, value = "No deployments specified")
+    void noDeploymentsSpecified();
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 3, value = "Deploying %s")
+    void deploying(String deploymentName);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 4, value = "Deployment content: %s")
+    void deploymentContent(String path);
+
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 5, value = "Exporting deployment to %s")
+    void exportingDeployment(String exportLocation);
+
+
 
 }

--- a/core/container/src/main/java/org/wildfly/swarm/internal/SwarmConfigMessages.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/SwarmConfigMessages.java
@@ -19,8 +19,6 @@
 
 package org.wildfly.swarm.internal;
 
-import java.net.URL;
-
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Cause;
@@ -31,53 +29,37 @@ import org.jboss.logging.annotations.MessageLogger;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@MessageLogger(projectCode = "WFSWARM", length = 4)
+@MessageLogger(projectCode = "WFSCONFIG", length = 4)
 public interface SwarmConfigMessages extends BasicLogger {
 
     SwarmConfigMessages MESSAGES = Logger.getMessageLogger(SwarmConfigMessages.class, "org.wildfly.swarm.config");
 
-    @Message(id = 1, value = "Stage config is not present.")
-    RuntimeException missingStageConfig();
-
-    @Message(id = 3, value = "Project stage '%s' cannot be found.")
-    RuntimeException stageNotFound(String stageName);
-
-    @Message(id = 10, value = "Failed to load stage configuration from URL : %s")
-    RuntimeException failedLoadingStageConfig(@Cause Throwable cause, URL url);
-
-    @Message(id = 11, value = "Missing stage 'default' in project-stages.yml")
-    RuntimeException missingDefaultStage();
-
-    @LogMessage(level = Logger.Level.INFO)
-    @Message(id = 20, value = "Stage Config found in %s at location: %s")
-    void stageConfigLocation(String configType, String configLocation);
-
-    @LogMessage(level = Logger.Level.WARN)
-    @Message(id = 21, value = "Failed to parse project stage URL reference, ignoring: %s")
-    void malformedStageConfigUrl(String error);
-
-    @LogMessage(level = Logger.Level.WARN)
-    @Message(id = 22, value = "Project stage superseded by external configuration %s")
-    void stageConfigSuperseded(String location);
-
-    @LogMessage(level = Logger.Level.INFO)
-    @Message(id = 24, value = "Using project stage: %s")
-    void usingProjectStage(String stageName);
-
     @LogMessage(level = Logger.Level.DEBUG)
-    @Message(id = 30, value = "Marshalling Project Stage property %s")
+    @Message(id = 1, value = "Marshalling Project Stage property %s")
     void marshalProjectStageProperty(String key);
 
     @LogMessage(level = Logger.Level.DEBUG)
-    @Message(id = 31, value = "Marshalling XML from %s as: \n %s")
+    @Message(id = 2, value = "Marshalling XML from %s as: \n %s")
     void marshalXml(String location, String xml);
 
     @LogMessage(level = Logger.Level.DEBUG)
-    @Message(id = 32, value = "Load standalone.xml via %s from %s")
+    @Message(id = 3, value = "Load standalone.xml via %s from %s")
     void loadingStandaloneXml(String loader, String location);
 
     @LogMessage(level = Logger.Level.DEBUG)
-    @Message(id = 37, value = "Configuration:\n%s")
+    @Message(id = 4, value = "Configuration:\n%s")
     void configuration(String configuration);
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 5, value = "Error resolving configurable value for %s.")
+    void errorResolvingConfigurableValue(String key, @Cause Throwable cause);
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 6, value = "Error loading module.")
+    void errorLoadingModule(@Cause Throwable cause);
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 7, value = "Error create extension %s from module %s.")
+    void errorCreatingExtension(String extensionClassName, String extensionModuleName, @Cause Throwable cause);
 
 }

--- a/core/container/src/main/java/org/wildfly/swarm/internal/SwarmMessages.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/SwarmMessages.java
@@ -42,93 +42,87 @@ public interface SwarmMessages extends BasicLogger {
 
     SwarmMessages MESSAGES = Logger.getMessageLogger(SwarmMessages.class, "org.wildfly.swarm");
 
-    @Message(id = 2, value = "Cannot invoke %s on a container that has not been started.")
+    @Message(id = 1, value = "Cannot invoke %s on a container that has not been started.")
     IllegalStateException containerNotStarted(String method);
 
-    @Message(id = 4, value = "%s requires an argument.")
+    @Message(id = 2, value = "%s requires an argument.")
     RuntimeException argumentRequired(String arg);
 
-    @Message(id = 5, value = "Unable to create default deployment")
-    DeploymentException cannotCreateDefaultDeployment();
-
-    @Message(id = 6, value = "Failed to mount deployment.")
+    @Message(id = 3, value = "Failed to mount deployment.")
     DeploymentException failToMountDeployment(@Cause Throwable cause, @Param Archive<?> archive);
 
-    @Message(id = 7, value = "Deployment failed: %s")
+    @Message(id = 4, value = "Deployment failed: %s")
     String deploymentFailed(String failureMessage);
 
-    @Message(id = 8, value = "Failure during deployment")
+    @Message(id = 5, value = "Failure during deployment")
     DeploymentException deploymentFailed(@Cause Throwable cause, @Param Archive<?> archive);
 
-    @Message(id = 9, value = "JavaArchive spec does not support Libraries")
+    @Message(id = 6, value = "JavaArchive spec does not support Libraries")
     UnsupportedOperationException librariesNotSupported();
 
-    @Message(id = 12, value = "Fraction \"%s\" was configured using @WildFlyExtension with a module='',"
+    @Message(id = 7, value = "Fraction \"%s\" was configured using @WildFlyExtension with a module='',"
             + " but has multiple extension classes.  Please use classname='' to specify exactly one, or noClass=true to ignore all. %s")
     RuntimeException fractionHasMultipleExtensions(String className, Collection<String> extensions);
 
-    @Message(id = 13, value = "Artifact '%s' not found.")
+    @Message(id = 8, value = "Artifact '%s' not found.")
     RuntimeException artifactNotFound(String gav);
 
-    @Message(id = 14, value = "Unable to determine version number from GAV: %s")
+    @Message(id = 9, value = "Unable to determine version number from GAV: %s")
     RuntimeException unableToDetermineVersion(String gav);
 
-    @Message(id = 15, value = "GAV must includes at least 2 segments")
+    @Message(id = 10, value = "GAV must includes at least 2 segments")
     RuntimeException gavMinimumSegments();
 
-    @Message(id = 16, value = "System property '%s' not provided.")
+    @Message(id = 11, value = "System property '%s' not provided.")
     IllegalStateException systemPropertyNotFound(String key);
 
-    @Message(id = 17, value = "Cannot identify FileSystemLayout for given path: %s")
+    @Message(id = 12, value = "Cannot identify FileSystemLayout for given path: %s")
     IllegalArgumentException cannotIdentifyFileSystemLayout(String path);
 
-    @Message(id = 18, value = "Installed fraction: %24s - %-15s %s:%s:%s")
+    @Message(id = 13, value = "Installed fraction: %24s - %-15s %s:%s:%s")
     String availableFraction(String name, String stabilityLevel, String groupId, String artifactId, String version);
 
-    @Message(id = 19, value = "No deployments specified on the command-line")
-    String noDeploymentsSpecified();
-
     @LogMessage(level = Logger.Level.ERROR)
-    @Message(id = 23, value = "Unable to setup Shrinkwrap Domain")
+    @Message(id = 14, value = "Unable to setup Shrinkwrap Domain")
     void shrinkwrapDomainSetupFailed(@Cause Throwable cause);
 
     @LogMessage(level = Logger.Level.DEBUG)
-    @Message(id = 25, value = "Add deployment module: %s")
+    @Message(id = 15, value = "Add deployment module: %s")
     void deploymentModuleAdded(DeploymentModule module);
 
     @LogMessage(level = Logger.Level.DEBUG)
-    @Message(id = 26, value = "Calling Pre Customizer: %s")
+    @Message(id = 16, value = "Calling Pre Customizer: %s")
     void callingPreCustomizer(Customizer customizer);
 
     @LogMessage(level = Logger.Level.DEBUG)
-    @Message(id = 27, value = "Calling Post Customizer: %s")
+    @Message(id = 17, value = "Calling Post Customizer: %s")
     void callingPostCustomizer(Customizer customizer);
 
     @LogMessage(level = Logger.Level.DEBUG)
-    @Message(id = 28, value = "WildFly Bootstrap operations: \n %s")
+    @Message(id = 18, value = "WildFly Bootstrap operations: \n %s")
     void wildflyBootstrap(String operations);
 
     @LogMessage(level = Logger.Level.INFO)
-    @Message(id = 29, value = "Install MSC service for command line args: %s")
+    @Message(id = 19, value = "Install MSC service for command line args: %s")
     void argsInstalled(List<String> args);
 
-    @Message(id = 33, value = "HTTP/S is configured correctly, but org.wildfly.swarm:management is not available")
+    @Message(id = 20, value = "HTTP/S is configured correctly, but org.wildfly.swarm:management is not available")
     RuntimeException httpsRequiresManagementFraction();
 
     @LogMessage(level = Logger.Level.WARN)
-    @Message(id = 34, value = "Ignoring subsystem %s:%s")
+    @Message(id = 21, value = "Ignoring subsystem %s:%s")
     void ignoringSubsystem(String nsURI, String name);
 
     @LogMessage(level = Logger.Level.WARN)
-    @Message(id = 35, value = "Failed to register modules mbeans")
+    @Message(id = 22, value = "Failed to register modules mbeans")
     void moduleMBeanServerNotInstalled(@Cause Throwable cause);
 
     @LogMessage(level = Logger.Level.ERROR)
-    @Message(id = 36, value = "Error installing user-space CDI extension: %s")
+    @Message(id = 23, value = "Error installing user-space CDI extension: %s")
     void errorInstallingUserSpaceExtension(String factoryClassName);
 
     @LogMessage(level = Logger.Level.WARN)
-    @Message(id = 38, value =
+    @Message(id = 24, value =
             "In order to use HTTP/2 in WildFly Swarm, you must have the OpenSSL provider with ALPN capability from " +
                     "JBoss Core Services installed and configured. This is due to the fact that HTTP/2 requires " +
                     "a TLS stack that supports ALPN, which is not provided by the default installation of Java 8. " +
@@ -136,12 +130,29 @@ public interface SwarmMessages extends BasicLogger {
                     "OpenSSL usage with WildFly Swarm on HP-UX is NOT supported.")
     void http2NotSupported();
 
-    @Message(id = 40, value = "This version of WildFly Swarm does not support generating self signed certificates.")
+    @Message(id = 25, value = "This version of WildFly Swarm does not support generating self signed certificates.")
     RuntimeException generateSelfSignedCertificateNotSupported();
 
     @LogMessage(level = Logger.Level.ERROR)
-    @Message(id = 41, value = "Error invoking SslServerIdentity.generateSelfSignedCertificateHost(String) in HTTPSCustomizer.")
+    @Message(id = 26, value = "Error invoking SslServerIdentity.generateSelfSignedCertificateHost(String) in HTTPSCustomizer.")
     void failToInvokeGenerateSelfSignedCertificateHost(@Cause Throwable cause);
+
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 27, value = "Shutdown requested")
+    void shutdownRequested();
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 28, value = "Error invoking SslServerIdentity.generateSelfSignedCertificateHost(String) in HTTPSCustomizer.")
+    void errorWaitingForContainerShutdown(@Cause Throwable cause);
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 29, value = "Error setting up temporary file provider.")
+    void errorSettingUpTempFileProvider(@Cause Throwable cause);
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 30, value = "Error cleaning up temporary file provider.")
+    void errorCleaningUpTempFileProvider(@Cause Throwable cause);
+
 
 
     // ------------------------------------------------------------------------
@@ -150,6 +161,5 @@ public interface SwarmMessages extends BasicLogger {
     @LogMessage(level = Logger.Level.INFO)
     @Message(id = 99999, value = "WildFly Swarm is Ready")
     void wildflySwarmIsReady();
-
 
 }

--- a/core/spi/src/main/java/org/wildfly/swarm/spi/api/ArchiveMetadataProcessor.java
+++ b/core/spi/src/main/java/org/wildfly/swarm/spi/api/ArchiveMetadataProcessor.java
@@ -28,5 +28,5 @@ import org.jboss.shrinkwrap.api.Archive;
  * @author Ken Finnigan
  */
 public interface ArchiveMetadataProcessor {
-    void processArchive(Archive<?> archive, Index index);
+    void processArchive(Archive<?> archive, Index index) throws Exception;
 }

--- a/core/spi/src/main/java/org/wildfly/swarm/spi/api/ArchivePreparer.java
+++ b/core/spi/src/main/java/org/wildfly/swarm/spi/api/ArchivePreparer.java
@@ -17,16 +17,16 @@ package org.wildfly.swarm.spi.api;
 
 import org.jboss.shrinkwrap.api.Archive;
 
-/** General deployment processor.
+/**
+ * General deployment processor.
  *
  * <p>Typically used internally by fractions, a {@code ArchivePreparer} may
  * inspect and modify the deployment. Each preparer is given an opportunity
  * to prepare every deployment.</p>
  *
- * @apiNote Used by {@code Fraction} authors.
- *
  * @author Bob McWhirter
+ * @apiNote Used by {@code Fraction} authors.
  */
 public interface ArchivePreparer {
-    void prepareArchive(Archive<?> archive);
+    void prepareArchive(Archive<?> archive) throws Exception;
 }

--- a/core/spi/src/main/java/org/wildfly/swarm/spi/api/ArtifactLookup.java
+++ b/core/spi/src/main/java/org/wildfly/swarm/spi/api/ArtifactLookup.java
@@ -38,12 +38,8 @@ public interface ArtifactLookup {
 
             try {
                 return (ArtifactLookup) Class.forName("org.wildfly.swarm.internal.ArtifactManager").newInstance();
-            } catch (InstantiationException e1) {
-                e1.printStackTrace();
-            } catch (IllegalAccessException e1) {
-                e1.printStackTrace();
-            } catch (ClassNotFoundException e1) {
-                e1.printStackTrace();
+            } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e1) {
+                // TODO handle error
             }
             return null;
         });

--- a/core/spi/src/main/java/org/wildfly/swarm/spi/api/Customizer.java
+++ b/core/spi/src/main/java/org/wildfly/swarm/spi/api/Customizer.java
@@ -37,5 +37,5 @@ public interface Customizer {
 
     /** Perform customization.
      */
-    void customize();
+    void customize() throws Exception;
 }

--- a/fractions/drools-server/pom.xml
+++ b/fractions/drools-server/pom.xml
@@ -100,6 +100,24 @@
       <groupId>org.kie.server</groupId>
       <artifactId>kie-server-rest-drools</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-annotations</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-processor</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/fractions/drools-server/src/main/java/org/wildfly/swarm/drools/server/runtime/DroolsDeploymentProducer.java
+++ b/fractions/drools-server/src/main/java/org/wildfly/swarm/drools/server/runtime/DroolsDeploymentProducer.java
@@ -1,7 +1,6 @@
 package org.wildfly.swarm.drools.server.runtime;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 
@@ -24,22 +23,19 @@ public class DroolsDeploymentProducer {
     @Produces
     public Archive droolsWar() throws Exception {
         if (System.getProperty("org.drools.server.swarm.web.conf") == null) {
-            try {
-                //Path dir = Files.createTempDirectory("swarm-keycloak-config");
-                File dir = TempFileManager.INSTANCE.newTempDirectory("swarm-drools-web-config", ".d");
-                System.setProperty("org.drools.server.swarm.conf", dir.getAbsolutePath());
-                Files.copy(getClass().getClassLoader().getResourceAsStream("config/web/web.xml"),
-                        dir.toPath().resolve("web.xml"),
-                        StandardCopyOption.REPLACE_EXISTING);
-                Files.copy(getClass().getClassLoader().getResourceAsStream("config/web/jboss-web.xml"),
-                        dir.toPath().resolve("jboss-web.xml"),
-                        StandardCopyOption.REPLACE_EXISTING);
-                configFolder = dir.toPath().toString();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
+            //Path dir = Files.createTempDirectory("swarm-keycloak-config");
+            File dir = TempFileManager.INSTANCE.newTempDirectory("swarm-drools-web-config", ".d");
+            System.setProperty("org.drools.server.swarm.conf", dir.getAbsolutePath());
+            Files.copy(getClass().getClassLoader().getResourceAsStream("config/web/web.xml"),
+                    dir.toPath().resolve("web.xml"),
+                    StandardCopyOption.REPLACE_EXISTING);
+            Files.copy(getClass().getClassLoader().getResourceAsStream("config/web/jboss-web.xml"),
+                    dir.toPath().resolve("jboss-web.xml"),
+                    StandardCopyOption.REPLACE_EXISTING);
+            configFolder = dir.toPath().toString();
         }
-        System.out.println("\tConfiguration folder is " + configFolder);
+
+        DroolsMessages.MESSAGES.configurationDirectory(configFolder);
 
         JAXRSArchive deployment = ShrinkWrap.create(JAXRSArchive.class, "drools-server.war");
         deployment.addAllDependencies();

--- a/fractions/drools-server/src/main/java/org/wildfly/swarm/drools/server/runtime/DroolsMessages.java
+++ b/fractions/drools-server/src/main/java/org/wildfly/swarm/drools/server/runtime/DroolsMessages.java
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-package org.wildfly.swarm.internal;
+package org.wildfly.swarm.drools.server.runtime;
 
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
@@ -28,13 +28,13 @@ import org.jboss.logging.annotations.MessageLogger;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@MessageLogger(projectCode = "WFSMETRICS", length = 4)
-public interface SwarmMetricsMessages extends BasicLogger {
+@MessageLogger(projectCode = "WFSDROOLS", length = 4)
+public interface DroolsMessages extends BasicLogger {
 
-    SwarmMetricsMessages MESSAGES = Logger.getMessageLogger(SwarmMetricsMessages.class, "org.wildfly.swarm.metrics");
+    DroolsMessages MESSAGES = Logger.getMessageLogger(DroolsMessages.class, "org.wildfly.swarm.drools");
 
-    @LogMessage(level = Logger.Level.TRACE)
-    @Message(id = 1, value = "Boot performance:\n%s")
-    void bootPerformance(String metrics);
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 1, value = "Configuration directory: %s")
+    void configurationDirectory(String dir);
 
 }

--- a/fractions/drools-server/src/main/java/org/wildfly/swarm/drools/server/runtime/DroolsSetup.java
+++ b/fractions/drools-server/src/main/java/org/wildfly/swarm/drools/server/runtime/DroolsSetup.java
@@ -1,7 +1,6 @@
 package org.wildfly.swarm.drools.server.runtime;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 
@@ -33,22 +32,18 @@ public class DroolsSetup implements Customizer {
     Instance<SecurityFraction> security;
 
     @Override
-    public void customize() {
+    public void customize() throws Exception {
         if (System.getProperty("org.drools.server.swarm.security.conf") == null) {
-            try {
-                //Path dir = Files.createTempDirectory("swarm-keycloak-config");
-                File dir = TempFileManager.INSTANCE.newTempDirectory("swarm-drools-security-config", ".d");
-                System.setProperty("org.drools.server.swarm.conf", dir.getAbsolutePath());
-                Files.copy(getClass().getClassLoader().getResourceAsStream("config/security/application-users.properties"),
-                        dir.toPath().resolve("application-users.properties"),
-                        StandardCopyOption.REPLACE_EXISTING);
-                Files.copy(getClass().getClassLoader().getResourceAsStream("config/security/application-roles.properties"),
-                        dir.toPath().resolve("application-roles.properties"),
-                        StandardCopyOption.REPLACE_EXISTING);
-                configFolder = dir.toPath().toString();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
+            //Path dir = Files.createTempDirectory("swarm-keycloak-config");
+            File dir = TempFileManager.INSTANCE.newTempDirectory("swarm-drools-security-config", ".d");
+            System.setProperty("org.drools.server.swarm.conf", dir.getAbsolutePath());
+            Files.copy(getClass().getClassLoader().getResourceAsStream("config/security/application-users.properties"),
+                    dir.toPath().resolve("application-users.properties"),
+                    StandardCopyOption.REPLACE_EXISTING);
+            Files.copy(getClass().getClassLoader().getResourceAsStream("config/security/application-roles.properties"),
+                    dir.toPath().resolve("application-roles.properties"),
+                    StandardCopyOption.REPLACE_EXISTING);
+            configFolder = dir.toPath().toString();
         }
 
 

--- a/fractions/fluentd/src/main/java/org/wildfly/swarm/fluentd/runtime/FluentdCustomizer.java
+++ b/fractions/fluentd/src/main/java/org/wildfly/swarm/fluentd/runtime/FluentdCustomizer.java
@@ -56,33 +56,29 @@ public class FluentdCustomizer implements Customizer {
 
     @Override
     public void customize() {
-        try {
-            String hostname = this.hostname.orElse(this.fluentdFraction.hostname());
-            int port = this.port.orElse(this.fluentdFraction.port());
+        String hostname = this.hostname.orElse(this.fluentdFraction.hostname());
+        int port = this.port.orElse(this.fluentdFraction.port());
 
-            if (hostname != null) {
-                Properties handlerProps = new Properties();
+        if (hostname != null) {
+            Properties handlerProps = new Properties();
 
-                handlerProps.put("hostname", hostname);
-                handlerProps.put("port", "" + port);
-                handlerProps.put("tag", this.fluentdFraction.getTag());
+            handlerProps.put("hostname", hostname);
+            handlerProps.put("port", "" + port);
+            handlerProps.put("tag", this.fluentdFraction.getTag());
 
-                final CustomHandler<?> fluentd = new CustomHandler<>("fluentd-handler")
-                        .module("org.wildfly.swarm.fluentd:runtime")
-                        .attributeClass(FluentdHandler.class.getName())
-                        .properties(handlerProps);
+            final CustomHandler<?> fluentd = new CustomHandler<>("fluentd-handler")
+                    .module("org.wildfly.swarm.fluentd:runtime")
+                    .attributeClass(FluentdHandler.class.getName())
+                    .properties(handlerProps);
 
-                final Level level = this.fluentdFraction.level();
+            final Level level = this.fluentdFraction.level();
 
-                this.loggingFraction
-                        //.consoleHandler(level, LoggingFraction.COLOR_PATTERN)
-                        .customHandler(fluentd)
-                        .rootLogger(level, LoggingFraction.CONSOLE, fluentd.getKey());
-            } else {
-                throw new IllegalArgumentException("Not enabling fluentd, no host set");
-            }
-        } catch (Throwable t) {
-            t.printStackTrace();
+            this.loggingFraction
+                    //.consoleHandler(level, LoggingFraction.COLOR_PATTERN)
+                    .customHandler(fluentd)
+                    .rootLogger(level, LoggingFraction.CONSOLE, fluentd.getKey());
+        } else {
+            throw new IllegalArgumentException("Not enabling fluentd, no host set");
         }
     }
 }

--- a/fractions/javaee/jaxrs/src/main/java/org/wildfly/swarm/jaxrs/internal/JAXRSArchiveImpl.java
+++ b/fractions/javaee/jaxrs/src/main/java/org/wildfly/swarm/jaxrs/internal/JAXRSArchiveImpl.java
@@ -49,7 +49,7 @@ public class JAXRSArchiveImpl extends WebContainerBase<JAXRSArchive> implements 
      *
      * @param delegate The storage backing.
      */
-    public JAXRSArchiveImpl(Archive<?> delegate) {
+    public JAXRSArchiveImpl(Archive<?> delegate) throws IOException {
         super(JAXRSArchive.class, delegate);
 
         addGeneratedApplication();
@@ -99,19 +99,15 @@ public class JAXRSArchiveImpl extends WebContainerBase<JAXRSArchive> implements 
         return false;
     }
 
-    protected void addGeneratedApplication() {
+    protected void addGeneratedApplication() throws IOException {
         if (!hasApplicationPathAnnotation(getArchive())) {
             String name = "org.wildfly.swarm.generated.WildFlySwarmDefaultJAXRSApplication";
             String path = "WEB-INF/classes/" + name.replace('.', '/') + ".class";
 
             byte[] generatedApp;
-            try {
-                generatedApp = ApplicationFactory2.create(name, "/");
-                add(new ByteArrayAsset(generatedApp), path);
-                addHandlers(new ApplicationHandler(this, path));
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
+            generatedApp = ApplicationFactory2.create(name, "/");
+            add(new ByteArrayAsset(generatedApp), path);
+            addHandlers(new ApplicationHandler(this, path));
         }
     }
 

--- a/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/descriptors/WebXmlContainer.java
+++ b/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/descriptors/WebXmlContainer.java
@@ -27,15 +27,17 @@ import org.jboss.shrinkwrap.api.container.ServiceProviderContainer;
 import org.wildfly.swarm.spi.api.JBossDeploymentStructureContainer;
 import org.wildfly.swarm.undertow.internal.FaviconServletExtension;
 
-/** Archive mix-in supporting manipulation of {@code web.xml}.
+/**
+ * Archive mix-in supporting manipulation of {@code web.xml}.
  *
  * @author Ken Finnigan
  */
 public interface WebXmlContainer<T extends Archive<T>> extends Archive<T>, ServiceProviderContainer<T>, JBossDeploymentStructureContainer<T> {
 
-    /** Add a context parameter.
+    /**
+     * Add a context parameter.
      *
-     * @param name The name of the context parameter.
+     * @param name   The name of the context parameter.
      * @param values The values for the context parameter.
      * @return This archive.
      */
@@ -46,7 +48,8 @@ public interface WebXmlContainer<T extends Archive<T>> extends Archive<T>, Servi
         return (T) this;
     }
 
-    /** Retrieve the context parameter value.
+    /**
+     * Retrieve the context parameter value.
      *
      * @param name The name of the context parameter.
      * @return Thie value of the context parameter.
@@ -55,31 +58,24 @@ public interface WebXmlContainer<T extends Archive<T>> extends Archive<T>, Servi
         return findWebXmlAsset().getContextParam(name);
     }
 
-    /** Add the default WildFly Swarm {@code favicon.ico} handler.
+    /**
+     * Add the default WildFly Swarm {@code favicon.ico} handler.
      *
      * @return This archive.
      */
     @SuppressWarnings("unchecked")
-    default T addFaviconExceptionHandler() {
+    default T addFaviconExceptionHandler() throws IOException {
         // Add FaviconServletExtension
         String path = "WEB-INF/classes/" + FaviconServletExtension.EXTENSION_NAME.replace('.', '/') + ".class";
         byte[] generatedExtension;
-        try {
-            generatedExtension = FaviconFactory.createFaviconServletExtension(FaviconServletExtension.EXTENSION_NAME);
-            add(new ByteArrayAsset(generatedExtension), path);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+        generatedExtension = FaviconFactory.createFaviconServletExtension(FaviconServletExtension.EXTENSION_NAME);
+        add(new ByteArrayAsset(generatedExtension), path);
 
         // Add FaviconErrorHandler
         path = "WEB-INF/classes/" + FaviconServletExtension.HANDLER_NAME.replace('.', '/') + ".class";
         byte[] generatedHandler;
-        try {
-            generatedHandler = FaviconFactory.createFaviconErrorHandler(FaviconServletExtension.HANDLER_NAME);
-            add(new ByteArrayAsset(generatedHandler), path);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+        generatedHandler = FaviconFactory.createFaviconErrorHandler(FaviconServletExtension.HANDLER_NAME);
+        add(new ByteArrayAsset(generatedHandler), path);
 
         // Add services entry for FaviconServletExtension
         this.addAsServiceProvider(ServletExtension.class.getName(), FaviconServletExtension.EXTENSION_NAME);
@@ -90,9 +86,10 @@ public interface WebXmlContainer<T extends Archive<T>> extends Archive<T>, Servi
         return (T) this;
     }
 
-    /** Add a servlet.
+    /**
+     * Add a servlet.
      *
-     * @param servletName The name of the servlet.
+     * @param servletName  The name of the servlet.
      * @param servletClass The class of the servlet.
      * @return This archive.
      */
@@ -100,7 +97,8 @@ public interface WebXmlContainer<T extends Archive<T>> extends Archive<T>, Servi
         return findWebXmlAsset().addServlet(servletName, servletClass);
     }
 
-    /** Retrieve a servlet by class.
+    /**
+     * Retrieve a servlet by class.
      *
      * @param servletClass The servlet class.
      * @return The servlet descriptor.
@@ -109,7 +107,8 @@ public interface WebXmlContainer<T extends Archive<T>> extends Archive<T>, Servi
         return findWebXmlAsset().getServlet(servletClass);
     }
 
-    /** Locate or create a {@code web.xml} asset.
+    /**
+     * Locate or create a {@code web.xml} asset.
      *
      * @return The existing or new {@code web.xml}.
      */

--- a/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/internal/FaviconServletExtension.java
+++ b/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/internal/FaviconServletExtension.java
@@ -15,7 +15,8 @@
  */
 package org.wildfly.swarm.undertow.internal;
 
-import javax.enterprise.inject.Vetoed;
+import java.lang.reflect.InvocationTargetException;
+
 import javax.servlet.ServletContext;
 
 import io.undertow.Handlers;
@@ -26,7 +27,6 @@ import io.undertow.servlet.api.DeploymentInfo;
 /**
  * @author Ken Finnigan
  */
-@Vetoed
 public class FaviconServletExtension implements ServletExtension {
     public static final String HANDLER_NAME = "org.wildfly.swarm.generated.FaviconErrorHandler";
 
@@ -37,10 +37,10 @@ public class FaviconServletExtension implements ServletExtension {
         deploymentInfo.addInnerHandlerChainWrapper(handler -> {
             try {
                 return Handlers.path((HttpHandler) Class.forName(HANDLER_NAME).getConstructor(HttpHandler.class).newInstance(handler));
-            } catch (Exception e) {
-                e.printStackTrace();
-                return handler;
+            } catch (ClassNotFoundException | NoSuchMethodException | InstantiationException | InvocationTargetException | IllegalAccessException e) {
+                servletContext.log("Error loading favicon handler", e);
             }
+            return handler;
         });
     }
 }

--- a/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/internal/WARArchiveImpl.java
+++ b/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/internal/WARArchiveImpl.java
@@ -15,6 +15,7 @@
  */
 package org.wildfly.swarm.undertow.internal;
 
+import java.io.IOException;
 import java.util.logging.Logger;
 
 import org.jboss.shrinkwrap.api.Archive;
@@ -40,7 +41,7 @@ public class WARArchiveImpl extends WebContainerBase<WARArchive> implements WARA
      *
      * @param delegate The storage backing.
      */
-    public WARArchiveImpl(Archive<?> delegate) {
+    public WARArchiveImpl(Archive<?> delegate) throws IOException {
         super(WARArchive.class, delegate);
         addFaviconExceptionHandler();
     }

--- a/fractions/keycloak-server/pom.xml
+++ b/fractions/keycloak-server/pom.xml
@@ -146,6 +146,22 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-annotations</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-processor</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
 </project>

--- a/fractions/keycloak-server/src/main/java/org/wildfly/swarm/keycloak/server/KeycloakServerFraction.java
+++ b/fractions/keycloak-server/src/main/java/org/wildfly/swarm/keycloak/server/KeycloakServerFraction.java
@@ -44,7 +44,6 @@ public class KeycloakServerFraction extends KeycloakServer<KeycloakServerFractio
 
     @Override
     public Fraction applyDefaults() {
-        System.err.println("Applying defaults");
         webContext(DEFAULT_WEB_CONTEXT);
         masterRealmName(DEFAULT_REALM_NAME);
         scheduledTaskInterval(900L);

--- a/fractions/keycloak-server/src/main/java/org/wildfly/swarm/keycloak/server/runtime/KeycloakServerMessages.java
+++ b/fractions/keycloak-server/src/main/java/org/wildfly/swarm/keycloak/server/runtime/KeycloakServerMessages.java
@@ -17,24 +17,18 @@
  * limitations under the License.
  */
 
-package org.wildfly.swarm.internal;
+package org.wildfly.swarm.keycloak.server.runtime;
 
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
-import org.jboss.logging.annotations.LogMessage;
-import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@MessageLogger(projectCode = "WFSMETRICS", length = 4)
-public interface SwarmMetricsMessages extends BasicLogger {
+@MessageLogger(projectCode = "WFSKCSRV", length = 4)
+public interface KeycloakServerMessages extends BasicLogger {
 
-    SwarmMetricsMessages MESSAGES = Logger.getMessageLogger(SwarmMetricsMessages.class, "org.wildfly.swarm.metrics");
-
-    @LogMessage(level = Logger.Level.TRACE)
-    @Message(id = 1, value = "Boot performance:\n%s")
-    void bootPerformance(String metrics);
+    KeycloakServerMessages MESSAGES = Logger.getMessageLogger(KeycloakServerMessages.class, "org.wildfly.swarm.keycloak.server");
 
 }

--- a/fractions/keycloak/src/main/java/org/wildfly/swarm/keycloak/runtime/SecuredArchivePreparer.java
+++ b/fractions/keycloak/src/main/java/org/wildfly/swarm/keycloak/runtime/SecuredArchivePreparer.java
@@ -42,7 +42,7 @@ public class SecuredArchivePreparer implements ArchivePreparer {
     private static final Logger LOG = Logger.getLogger(SecuredArchivePreparer.class);
 
     @Override
-    public void prepareArchive(Archive<?> archive) {
+    public void prepareArchive(Archive<?> archive) throws IOException {
         InputStream keycloakJson = null;
         if (keycloakJsonPath != null) {
             keycloakJson = getKeycloakJson(keycloakJsonPath);
@@ -92,14 +92,13 @@ public class SecuredArchivePreparer implements ArchivePreparer {
                     }
                 } catch (IOException e) {
                     // ignore
-                    // e.printStackTrace();
                 }
             }
         }
         return keycloakJson;
     }
 
-    private Asset createAsset(InputStream in) {
+    private Asset createAsset(InputStream in) throws IOException {
         StringBuilder str = new StringBuilder();
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
 
@@ -108,9 +107,6 @@ public class SecuredArchivePreparer implements ArchivePreparer {
             while ((line = reader.readLine()) != null) {
                 str.append(line).append("\n");
             }
-
-        } catch (IOException e) {
-            e.printStackTrace();
         }
         return new ByteArrayAsset(str.toString().getBytes());
     }

--- a/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/HealthAnnotationProcessor.java
+++ b/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/HealthAnnotationProcessor.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Optional;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.naming.NamingException;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
@@ -44,7 +45,7 @@ public class HealthAnnotationProcessor implements ArchiveMetadataProcessor {
     public static final DotName APP_PATH = DotName.createSimple("javax.ws.rs.ApplicationPath");
 
     @Override
-    public void processArchive(Archive<?> archive, Index index) {
+    public void processArchive(Archive<?> archive, Index index) throws NamingException {
 
         // first pass: jboss-web context root
         Optional<String> jbossWebContext = Optional.empty();
@@ -109,12 +110,8 @@ public class HealthAnnotationProcessor implements ArchiveMetadataProcessor {
                             throw new RuntimeException("@Health requires an explicit @Path annotation");
                         }
 
-                        try {
-                            HealthMetaData metaData = new HealthMetaData(sb.toString(), isSecure);
-                            Monitor.lookup().registerHealth(metaData);
-                        } catch (Exception e) {
-                            e.printStackTrace();
-                        }
+                        HealthMetaData metaData = new HealthMetaData(sb.toString(), isSecure);
+                        Monitor.lookup().registerHealth(metaData);
                     }
                 }
 

--- a/fractions/netflix/archaius/src/main/java/org/wildfly/swarm/netflix/archaius/runtime/ArchaiusCustomizer.java
+++ b/fractions/netflix/archaius/src/main/java/org/wildfly/swarm/netflix/archaius/runtime/ArchaiusCustomizer.java
@@ -56,7 +56,7 @@ public class ArchaiusCustomizer implements Customizer {
                         }
                         seen.add(e.key());
                     } catch (Exception ex) {
-                        ex.printStackTrace();
+                        throw new RuntimeException(ex);
                     }
                 });
 

--- a/fractions/netflix/ribbon/src/main/java/org/wildfly/swarm/netflix/ribbon/internal/RibbonArchiveImpl.java
+++ b/fractions/netflix/ribbon/src/main/java/org/wildfly/swarm/netflix/ribbon/internal/RibbonArchiveImpl.java
@@ -15,6 +15,8 @@
  */
 package org.wildfly.swarm.netflix.ribbon.internal;
 
+import java.io.IOException;
+
 import org.jboss.shrinkwrap.impl.base.ArchiveBase;
 import org.wildfly.swarm.netflix.ribbon.RibbonArchive;
 import org.wildfly.swarm.topology.internal.TopologyArchiveImpl;
@@ -29,7 +31,7 @@ public class RibbonArchiveImpl extends TopologyArchiveImpl implements RibbonArch
      *
      * @param archive
      */
-    public RibbonArchiveImpl(ArchiveBase<?> archive) {
+    public RibbonArchiveImpl(ArchiveBase<?> archive) throws IOException {
         super(archive);
     }
 

--- a/fractions/swagger-webapp/pom.xml
+++ b/fractions/swagger-webapp/pom.xml
@@ -87,6 +87,23 @@
       <groupId>org.webjars</groupId>
       <artifactId>swagger-ui</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-annotations</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-processor</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
 </project>

--- a/fractions/swagger-webapp/src/main/java/org/wildfly/swarm/swagger/webapp/SwaggerWebAppFraction.java
+++ b/fractions/swagger-webapp/src/main/java/org/wildfly/swarm/swagger/webapp/SwaggerWebAppFraction.java
@@ -75,13 +75,13 @@ public class SwaggerWebAppFraction implements Fraction<SwaggerWebAppFraction> {
             try {
                 this.webContent = ArtifactLookup.get().artifact(content);
             } catch (Exception e) {
-                //e.printStackTrace();
+                SwaggerWebAppMessages.MESSAGES.unableToLocateWebContent(content);
             }
         } else if (maybeFile.isDirectory()) {
             try {
                 this.webContent = loadFromDirectory(maybeFile);
             } catch (IOException e) {
-                e.printStackTrace();
+                SwaggerWebAppMessages.MESSAGES.unableToLocateWebContent(maybeFile.toString());
             }
         } else {
             this.webContent = ShrinkWrap.createFromZipFile(JARArchive.class, maybeFile);

--- a/fractions/swagger-webapp/src/main/java/org/wildfly/swarm/swagger/webapp/SwaggerWebAppMessages.java
+++ b/fractions/swagger-webapp/src/main/java/org/wildfly/swarm/swagger/webapp/SwaggerWebAppMessages.java
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-package org.wildfly.swarm.internal;
+package org.wildfly.swarm.swagger.webapp;
 
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
@@ -28,13 +28,13 @@ import org.jboss.logging.annotations.MessageLogger;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@MessageLogger(projectCode = "WFSMETRICS", length = 4)
-public interface SwarmMetricsMessages extends BasicLogger {
+@MessageLogger(projectCode = "WFSSWGRUI", length = 4)
+public interface SwaggerWebAppMessages extends BasicLogger {
 
-    SwarmMetricsMessages MESSAGES = Logger.getMessageLogger(SwarmMetricsMessages.class, "org.wildfly.swarm.metrics");
+    SwaggerWebAppMessages MESSAGES = Logger.getMessageLogger(SwaggerWebAppMessages.class, "org.wildfly.swarm.swagger.webapp");
 
-    @LogMessage(level = Logger.Level.TRACE)
-    @Message(id = 1, value = "Boot performance:\n%s")
-    void bootPerformance(String metrics);
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 1, value = "Unable to load Swagger UI web content from %s.")
+    void unableToLocateWebContent(String descriptor);
 
 }

--- a/fractions/swagger/pom.xml
+++ b/fractions/swagger/pom.xml
@@ -100,6 +100,23 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>meta-spi</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-annotations</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-processor</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
 </project>

--- a/fractions/swagger/src/main/java/org/wildfly/swarm/swagger/SwaggerConfig.java
+++ b/fractions/swagger/src/main/java/org/wildfly/swarm/swagger/SwaggerConfig.java
@@ -28,11 +28,10 @@ import java.util.Set;
  */
 public class SwaggerConfig {
 
-    public SwaggerConfig(InputStream input) {
-        BufferedReader in = new BufferedReader(new InputStreamReader(input));
+    public SwaggerConfig(InputStream input) throws IOException {
         String line;
 
-        try {
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(input))) {
             while ((line = in.readLine()) != null) {
                 int separatorIndex = line.indexOf(":");
                 Key key = Key.valueOf(line.substring(0, separatorIndex).toUpperCase());
@@ -47,15 +46,6 @@ public class SwaggerConfig {
             }
         } catch (IllegalArgumentException ia) {
             throw new RuntimeException("Invalid key: " + ia.getMessage());
-        } catch (IOException e) {
-            System.err.println("ERROR reading SwaggerConfigurationAsset" + e);
-            e.printStackTrace();
-        } finally {
-            try {
-                in.close();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
         }
     }
 

--- a/fractions/swagger/src/main/java/org/wildfly/swarm/swagger/SwaggerMessages.java
+++ b/fractions/swagger/src/main/java/org/wildfly/swarm/swagger/SwaggerMessages.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.swarm.swagger;
+
+import java.util.List;
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@MessageLogger(projectCode = "WFSSWGR", length = 4)
+public interface SwaggerMessages extends BasicLogger {
+
+    SwaggerMessages MESSAGES = Logger.getMessageLogger(SwaggerMessages.class, "org.wildfly.swarm.swagger");
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 1, value = "No swagger configuration found; Swagger not activated.")
+    void noConfigurationFound();
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 2, value = "Ignoring package: %s")
+    void ignoringPackage(String pkg);
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 3, value = "No eligible packages in deployment: %s")
+    void noEligiblePackages(String deployment);
+
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 4, value = "Configure Swagger for deployment %s with package %s")
+    void configureSwaggerForPackage(String deployment, String pkg);
+
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 5, value = "Configure Swagger for deployment %s with packages %s")
+    void configureSwaggerForSeveralPackages(String deployment, List<String> packages);
+
+
+}

--- a/fractions/swagger/src/main/java/org/wildfly/swarm/swagger/deployment/SwaggerServiceActivator.java
+++ b/fractions/swagger/src/main/java/org/wildfly/swarm/swagger/deployment/SwaggerServiceActivator.java
@@ -15,6 +15,7 @@
  */
 package org.wildfly.swarm.swagger.deployment;
 
+import java.io.IOException;
 import java.io.InputStream;
 
 import io.swagger.jaxrs.config.BeanConfig;
@@ -23,6 +24,7 @@ import org.jboss.msc.service.ServiceActivatorContext;
 import org.jboss.msc.service.ServiceRegistryException;
 import org.wildfly.swarm.swagger.SwaggerArchive;
 import org.wildfly.swarm.swagger.SwaggerConfig;
+import org.wildfly.swarm.swagger.SwaggerMessages;
 
 /**
  * @author Lance Ball
@@ -36,41 +38,44 @@ public class SwaggerServiceActivator implements ServiceActivator {
 
 
         if (in == null) {
-
             // No config available. Print a warning and return
-            System.err.println("WARN: No swagger configuration found. Swagger not activated.");
+            SwaggerMessages.MESSAGES.noConfigurationFound();
             return;
         }
 
-        SwaggerConfig config = new SwaggerConfig(in);
+        try {
+            SwaggerConfig config = new SwaggerConfig(in);
 
-        BeanConfig beanConfig = new BeanConfig();
-        beanConfig.setHost((String) config.get(SwaggerConfig.Key.HOST));
-        beanConfig.setLicense((String) config.get(SwaggerConfig.Key.LICENSE));
-        beanConfig.setLicenseUrl((String) config.get(SwaggerConfig.Key.LICENSE_URL));
-        beanConfig.setTermsOfServiceUrl((String) config.get(SwaggerConfig.Key.TERMS_OF_SERVICE_URL));
+            BeanConfig beanConfig = new BeanConfig();
+            beanConfig.setHost((String) config.get(SwaggerConfig.Key.HOST));
+            beanConfig.setLicense((String) config.get(SwaggerConfig.Key.LICENSE));
+            beanConfig.setLicenseUrl((String) config.get(SwaggerConfig.Key.LICENSE_URL));
+            beanConfig.setTermsOfServiceUrl((String) config.get(SwaggerConfig.Key.TERMS_OF_SERVICE_URL));
 
-        // some type inconsistencies in the API (String vs String[])
-        String[] packages = (String[]) config.get(SwaggerConfig.Key.PACKAGES);
+            // some type inconsistencies in the API (String vs String[])
+            String[] packages = (String[]) config.get(SwaggerConfig.Key.PACKAGES);
 
-        if (packages != null) {
-            StringBuffer sb = new StringBuffer();
-            for (String s : packages) {
-                sb.append(s).append(',');
+            if (packages != null) {
+                StringBuffer sb = new StringBuffer();
+                for (String s : packages) {
+                    sb.append(s).append(',');
+                }
+
+                beanConfig.setResourcePackage(sb.toString());
             }
 
-            beanConfig.setResourcePackage(sb.toString());
+            beanConfig.setVersion((String) config.get(SwaggerConfig.Key.VERSION));
+            beanConfig.setBasePath((String) config.get(SwaggerConfig.Key.ROOT));
+            beanConfig.setContact((String) config.get(SwaggerConfig.Key.CONTACT));
+            beanConfig.setDescription((String) config.get(SwaggerConfig.Key.DESCRIPTION));
+            beanConfig.setTitle((String) config.get(SwaggerConfig.Key.TITLE));
+            beanConfig.setPrettyPrint((String) config.get(SwaggerConfig.Key.PRETTY_PRINT));
+            beanConfig.setSchemes((String[]) config.get(SwaggerConfig.Key.SCHEMES));
+
+            beanConfig.setScan(true);
+        } catch (IOException e) {
+            throw new ServiceRegistryException(e);
         }
-
-        beanConfig.setVersion((String) config.get(SwaggerConfig.Key.VERSION));
-        beanConfig.setBasePath((String) config.get(SwaggerConfig.Key.ROOT));
-        beanConfig.setContact((String) config.get(SwaggerConfig.Key.CONTACT));
-        beanConfig.setDescription((String) config.get(SwaggerConfig.Key.DESCRIPTION));
-        beanConfig.setTitle((String) config.get(SwaggerConfig.Key.TITLE));
-        beanConfig.setPrettyPrint((String) config.get(SwaggerConfig.Key.PRETTY_PRINT));
-        beanConfig.setSchemes((String[]) config.get(SwaggerConfig.Key.SCHEMES));
-
-        beanConfig.setScan(true);
 
     }
 }

--- a/fractions/swagger/src/main/java/org/wildfly/swarm/swagger/internal/SwaggerArchiveImpl.java
+++ b/fractions/swagger/src/main/java/org/wildfly/swarm/swagger/internal/SwaggerArchiveImpl.java
@@ -15,6 +15,8 @@
  */
 package org.wildfly.swarm.swagger.internal;
 
+import java.io.IOException;
+
 import org.jboss.shrinkwrap.api.Node;
 import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.impl.base.ArchiveBase;
@@ -30,7 +32,7 @@ public class SwaggerArchiveImpl extends AssignableBase<ArchiveBase<?>> implement
 
     public static final String SERVICE_ACTIVATOR_CLASS_NAME = "org.wildfly.swarm.swagger.deployment.SwaggerServiceActivator";
 
-    public SwaggerArchiveImpl(ArchiveBase<?> archive) {
+    public SwaggerArchiveImpl(ArchiveBase<?> archive) throws IOException {
         super(archive);
 
         if (!as(ServiceActivatorArchive.class).containsServiceActivator(SERVICE_ACTIVATOR_CLASS_NAME)) {
@@ -132,7 +134,7 @@ public class SwaggerArchiveImpl extends AssignableBase<ArchiveBase<?>> implement
         return getConfigurationAsset().getResourcePackages();
     }
 
-    private void loadOrCreateConfigurationAsset() {
+    private void loadOrCreateConfigurationAsset() throws IOException {
         Node node = getArchive().get(SWAGGER_CONFIGURATION_PATH);
         if (node != null) {
             Asset asset = node.getAsset();

--- a/fractions/swagger/src/main/java/org/wildfly/swarm/swagger/internal/SwaggerConfigurationAsset.java
+++ b/fractions/swagger/src/main/java/org/wildfly/swarm/swagger/internal/SwaggerConfigurationAsset.java
@@ -16,6 +16,7 @@
 package org.wildfly.swarm.swagger.internal;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.Set;
@@ -32,7 +33,7 @@ public class SwaggerConfigurationAsset implements Asset {
         configuration = new SwaggerConfig();
     }
 
-    public SwaggerConfigurationAsset(InputStream is) {
+    public SwaggerConfigurationAsset(InputStream is) throws IOException {
         configuration = new SwaggerConfig(is);
     }
 

--- a/fractions/swagger/src/test/java/org/wildfly/swarm/swagger/SwaggerArchiveTest.java
+++ b/fractions/swagger/src/test/java/org/wildfly/swarm/swagger/SwaggerArchiveTest.java
@@ -15,6 +15,7 @@
  */
 package org.wildfly.swarm.swagger;
 
+import java.io.IOException;
 import java.util.Arrays;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -48,7 +49,7 @@ public class SwaggerArchiveTest {
     }
 
     @Test
-    public void testSwaggerConfiguration() {
+    public void testSwaggerConfiguration() throws IOException {
         JARArchive archive = ShrinkWrap.create(JARArchive.class, "myapp.jar");
 
         archive.as(SwaggerArchive.class)

--- a/fractions/topology-consul/pom.xml
+++ b/fractions/topology-consul/pom.xml
@@ -122,6 +122,22 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-annotations</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-processor</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
 </project>

--- a/fractions/topology-consul/src/main/java/org/wildfly/swarm/topology/consul/ConsulTopologyMessages.java
+++ b/fractions/topology-consul/src/main/java/org/wildfly/swarm/topology/consul/ConsulTopologyMessages.java
@@ -17,10 +17,11 @@
  * limitations under the License.
  */
 
-package org.wildfly.swarm.internal;
+package org.wildfly.swarm.topology.consul;
 
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
@@ -28,13 +29,17 @@ import org.jboss.logging.annotations.MessageLogger;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@MessageLogger(projectCode = "WFSMETRICS", length = 4)
-public interface SwarmMetricsMessages extends BasicLogger {
+@MessageLogger(projectCode = "WFSCNSL", length = 4)
+public interface ConsulTopologyMessages extends BasicLogger {
 
-    SwarmMetricsMessages MESSAGES = Logger.getMessageLogger(SwarmMetricsMessages.class, "org.wildfly.swarm.metrics");
+    ConsulTopologyMessages MESSAGES = Logger.getMessageLogger(ConsulTopologyMessages.class, "org.wildfly.swarm.topology.consul");
 
-    @LogMessage(level = Logger.Level.TRACE)
-    @Message(id = 1, value = "Boot performance:\n%s")
-    void bootPerformance(String metrics);
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 1, value = "Error stopping catalog watcher for: %s.")
+    void errorStoppingCatalogWatcher(String key, @Cause Throwable t);
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 2, value = "Error stopping catalog watcher for: %s.")
+    void errorSettingUpCatalogWatcher(String key, @Cause Throwable t);
 
 }

--- a/fractions/topology-consul/src/main/java/org/wildfly/swarm/topology/consul/runtime/Advertiser.java
+++ b/fractions/topology-consul/src/main/java/org/wildfly/swarm/topology/consul/runtime/Advertiser.java
@@ -30,6 +30,7 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
+import org.wildfly.swarm.topology.TopologyMessages;
 import org.wildfly.swarm.topology.runtime.Registration;
 
 /**
@@ -112,9 +113,8 @@ public class Advertiser implements Service<Advertiser>, Runnable {
                     .forEach(e -> {
                         try {
                             client.pass(serviceId(e));
-                        } catch (NotRegisteredException e1) {
-                            // ignore?
-                            e1.printStackTrace();
+                        } catch (NotRegisteredException ex) {
+                            TopologyMessages.MESSAGES.notRegistered(e.toString(), ex);
                         }
                     });
             try {

--- a/fractions/topology-consul/src/main/java/org/wildfly/swarm/topology/consul/runtime/CatalogWatcher.java
+++ b/fractions/topology-consul/src/main/java/org/wildfly/swarm/topology/consul/runtime/CatalogWatcher.java
@@ -36,6 +36,7 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
+import org.wildfly.swarm.topology.consul.ConsulTopologyMessages;
 import org.wildfly.swarm.topology.runtime.TopologyManager;
 
 /**
@@ -77,11 +78,11 @@ public class CatalogWatcher implements Service<CatalogWatcher>, Runnable {
     public void stop(StopContext stopContext) {
         this.thread.interrupt();
 
-        this.watchers.values().forEach(e -> {
+        this.watchers.entrySet().forEach(e -> {
             try {
-                e.stop();
-            } catch (Exception e1) {
-                e1.printStackTrace();
+                e.getValue().stop();
+            } catch (Exception ex) {
+                ConsulTopologyMessages.MESSAGES.errorStoppingCatalogWatcher(e.getKey(), ex);
             }
         });
     }
@@ -149,7 +150,7 @@ public class CatalogWatcher implements Service<CatalogWatcher>, Runnable {
             healthCache.awaitInitialized(1, TimeUnit.SECONDS);
             this.watchers.put(serviceName, healthCache);
         } catch (Exception e) {
-            e.printStackTrace();
+            ConsulTopologyMessages.MESSAGES.errorSettingUpCatalogWatcher(serviceName, e);
         }
     }
 

--- a/fractions/topology-consul/src/main/java/org/wildfly/swarm/topology/consul/runtime/ConsulURLCustomizer.java
+++ b/fractions/topology-consul/src/main/java/org/wildfly/swarm/topology/consul/runtime/ConsulURLCustomizer.java
@@ -31,7 +31,7 @@ import org.wildfly.swarm.topology.consul.ConsulTopologyFraction;
  */
 @Pre
 @ApplicationScoped
-public class ConsultURLCustomizer implements Customizer {
+public class ConsulURLCustomizer implements Customizer {
 
     @Inject
     @Any
@@ -43,14 +43,10 @@ public class ConsultURLCustomizer implements Customizer {
 
 
     @Override
-    public void customize() {
+    public void customize() throws MalformedURLException {
 
         if (this.consulUrl != null) {
-            try {
-                this.fraction.url(this.consulUrl);
-            } catch (MalformedURLException e) {
-                e.printStackTrace();
-            }
+            this.fraction.url(this.consulUrl);
         }
 
     }

--- a/fractions/topology-jgroups/pom.xml
+++ b/fractions/topology-jgroups/pom.xml
@@ -113,6 +113,23 @@
       </exclusions>
     </dependency>
 
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-annotations</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-processor</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/fractions/topology-webapp/src/main/java/org/wildfly/swarm/topology/webapp/runtime/TopologySSEServlet.java
+++ b/fractions/topology-webapp/src/main/java/org/wildfly/swarm/topology/webapp/runtime/TopologySSEServlet.java
@@ -60,8 +60,7 @@ public class TopologySSEServlet extends HttpServlet {
         try {
             this.topology = Topology.lookup();
         } catch (NamingException e) {
-            e.printStackTrace();
-            throw new ServletException();
+            throw new ServletException(e);
         }
 
         this.keepAliveExecutor = Executors.newScheduledThreadPool(2);

--- a/fractions/topology/pom.xml
+++ b/fractions/topology/pom.xml
@@ -61,6 +61,24 @@
       <artifactId>wildfly-naming</artifactId>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-annotations</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-processor</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/fractions/topology/src/main/java/org/wildfly/swarm/topology/TopologyConnector.java
+++ b/fractions/topology/src/main/java/org/wildfly/swarm/topology/TopologyConnector.java
@@ -22,7 +22,7 @@ import org.jboss.as.network.SocketBinding;
  */
 public interface TopologyConnector {
 
-    void advertise(String name, SocketBinding binding, String... tags);
+    void advertise(String name, SocketBinding binding, String... tags) throws Exception;
 
-    void unadvertise(String name, SocketBinding binding);
+    void unadvertise(String name, SocketBinding binding) throws Exception;
 }

--- a/fractions/topology/src/main/java/org/wildfly/swarm/topology/TopologyMessages.java
+++ b/fractions/topology/src/main/java/org/wildfly/swarm/topology/TopologyMessages.java
@@ -17,10 +17,11 @@
  * limitations under the License.
  */
 
-package org.wildfly.swarm.internal;
+package org.wildfly.swarm.topology;
 
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
@@ -28,13 +29,25 @@ import org.jboss.logging.annotations.MessageLogger;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@MessageLogger(projectCode = "WFSMETRICS", length = 4)
-public interface SwarmMetricsMessages extends BasicLogger {
+@MessageLogger(projectCode = "WFSTOPO", length = 4)
+public interface TopologyMessages extends BasicLogger {
 
-    SwarmMetricsMessages MESSAGES = Logger.getMessageLogger(SwarmMetricsMessages.class, "org.wildfly.swarm.metrics");
+    TopologyMessages MESSAGES = Logger.getMessageLogger(TopologyMessages.class, "org.wildfly.swarm.topology");
 
-    @LogMessage(level = Logger.Level.TRACE)
-    @Message(id = 1, value = "Boot performance:\n%s")
-    void bootPerformance(String metrics);
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 1, value = "Error firing topology event on %s.")
+    void errorFiringEvent(String listenerClass, @Cause Throwable t);
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 2, value = "Client not registered: %s.")
+    void notRegistered(String clientId, @Cause Throwable t);
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 3, value = "Error starting advertisement.")
+    void errorStartingAdvertisement(@Cause Throwable cause);
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 4, value = "Error stopping advertisement.")
+    void errorStoppingAdvertisement(@Cause Throwable cause);
 
 }

--- a/fractions/topology/src/main/java/org/wildfly/swarm/topology/deployment/RegistrationAdvertiser.java
+++ b/fractions/topology/src/main/java/org/wildfly/swarm/topology/deployment/RegistrationAdvertiser.java
@@ -28,6 +28,7 @@ import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.wildfly.swarm.topology.TopologyConnector;
+import org.wildfly.swarm.topology.TopologyMessages;
 
 /**
  * @author Bob McWhirter
@@ -63,12 +64,20 @@ public class RegistrationAdvertiser implements Service<Void> {
 
     @Override
     public void start(StartContext startContext) throws StartException {
-        this.topologyConnectorInjector.getValue().advertise(this.name, this.socketBindingInjector.getValue(), this.tags);
+        try {
+            this.topologyConnectorInjector.getValue().advertise(this.name, this.socketBindingInjector.getValue(), this.tags);
+        } catch (Exception e) {
+            throw new StartException(e);
+        }
     }
 
     @Override
     public void stop(StopContext stopContext) {
-        this.topologyConnectorInjector.getValue().unadvertise(this.name, this.socketBindingInjector.getValue());
+        try {
+            this.topologyConnectorInjector.getValue().unadvertise(this.name, this.socketBindingInjector.getValue());
+        } catch (Exception e) {
+            TopologyMessages.MESSAGES.errorStoppingAdvertisement(e);
+        }
     }
 
     @Override

--- a/fractions/topology/src/main/java/org/wildfly/swarm/topology/internal/TopologyArchiveImpl.java
+++ b/fractions/topology/src/main/java/org/wildfly/swarm/topology/internal/TopologyArchiveImpl.java
@@ -44,7 +44,7 @@ public class TopologyArchiveImpl extends AssignableBase<ArchiveBase<?>> implemen
      *
      * @param archive
      */
-    public TopologyArchiveImpl(ArchiveBase<?> archive) {
+    public TopologyArchiveImpl(ArchiveBase<?> archive) throws IOException {
         super(archive);
 
         Node regConf = as(JARArchive.class).get(REGISTRATION_CONF);
@@ -54,8 +54,6 @@ public class TopologyArchiveImpl extends AssignableBase<ArchiveBase<?>> implemen
                         .forEach(line -> {
                             this.serviceNames.add(line);
                         });
-            } catch (IOException e) {
-                e.printStackTrace();
             }
         }
     }

--- a/fractions/topology/src/main/java/org/wildfly/swarm/topology/runtime/TopologyManager.java
+++ b/fractions/topology/src/main/java/org/wildfly/swarm/topology/runtime/TopologyManager.java
@@ -30,6 +30,7 @@ import org.jboss.msc.service.ServiceTarget;
 import org.wildfly.swarm.topology.AdvertisementHandle;
 import org.wildfly.swarm.topology.Topology;
 import org.wildfly.swarm.topology.TopologyListener;
+import org.wildfly.swarm.topology.TopologyMessages;
 import org.wildfly.swarm.topology.deployment.RegistrationAdvertiser;
 
 /**
@@ -139,7 +140,7 @@ public class TopologyManager implements Topology {
                 try {
                     e.onChange(this);
                 } catch (Throwable t) {
-                    t.printStackTrace();
+                    TopologyMessages.MESSAGES.errorFiringEvent(e.getClass().getName(), t);
                     removeListener(e);
                 }
             });

--- a/fractions/wildfly/management/pom.xml
+++ b/fractions/wildfly/management/pom.xml
@@ -76,6 +76,24 @@
         </exclusion>
       </exclusions>
     </dependency>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-annotations</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-processor</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/InMemoryAuthentication.java
+++ b/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/InMemoryAuthentication.java
@@ -59,7 +59,7 @@ public class InMemoryAuthentication {
                 byte[] hash = digest.digest(str.getBytes());
                 add(userName, hash);
             } catch (NoSuchAlgorithmException e) {
-                e.printStackTrace();
+                ManagementMessages.MESSAGES.unknownAlgorithm("MD5", e);
             }
         } else {
             this.plugin.property(userName + ".hash", (prop) -> {

--- a/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/ManagementMessages.java
+++ b/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/ManagementMessages.java
@@ -17,10 +17,11 @@
  * limitations under the License.
  */
 
-package org.wildfly.swarm.internal;
+package org.wildfly.swarm.management;
 
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
@@ -28,13 +29,13 @@ import org.jboss.logging.annotations.MessageLogger;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@MessageLogger(projectCode = "WFSMETRICS", length = 4)
-public interface SwarmMetricsMessages extends BasicLogger {
+@MessageLogger(projectCode = "WFSMGMT", length = 4)
+public interface ManagementMessages extends BasicLogger {
 
-    SwarmMetricsMessages MESSAGES = Logger.getMessageLogger(SwarmMetricsMessages.class, "org.wildfly.swarm.metrics");
+    ManagementMessages MESSAGES = Logger.getMessageLogger(ManagementMessages.class, "org.wildfly.swarm.management");
 
-    @LogMessage(level = Logger.Level.TRACE)
-    @Message(id = 1, value = "Boot performance:\n%s")
-    void bootPerformance(String metrics);
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 1, value = "Unknown algorithm: %s.")
+    void unknownAlgorithm(String name, @Cause Throwable t);
 
 }

--- a/fractions/wildfly/msc/pom.xml
+++ b/fractions/wildfly/msc/pom.xml
@@ -41,12 +41,35 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>container</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
 
     <!-- Provided APIs -->
     <dependency>
       <groupId>org.jboss.msc</groupId>
       <artifactId>jboss-msc</artifactId>
     </dependency>
+
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-annotations</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-processor</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
+
 
 </project>

--- a/fractions/wildfly/msc/src/main/java/org/wildfly/swarm/msc/MSCMessages.java
+++ b/fractions/wildfly/msc/src/main/java/org/wildfly/swarm/msc/MSCMessages.java
@@ -1,0 +1,20 @@
+package org.wildfly.swarm.msc;
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
+
+/**
+ * @author Bob McWhirter
+ */
+@MessageLogger(projectCode = "WFSMSC", length = 4)
+public interface MSCMessages extends BasicLogger {
+    MSCMessages MESSAGES = Logger.getMessageLogger(MSCMessages.class, "org.wildfly.swarm.msc");
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 1, value = "Error reading ServiceActivator asset")
+    void errorReadingServiceActivatorAsset(@Cause Throwable cause);
+}

--- a/fractions/wildfly/msc/src/main/java/org/wildfly/swarm/msc/internal/ServiceActivatorAsset.java
+++ b/fractions/wildfly/msc/src/main/java/org/wildfly/swarm/msc/internal/ServiceActivatorAsset.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import org.jboss.msc.service.ServiceActivator;
 import org.jboss.shrinkwrap.api.asset.Asset;
+import org.wildfly.swarm.msc.MSCMessages;
 
 /**
  * @author Bob McWhirter
@@ -36,24 +37,14 @@ public class ServiceActivatorAsset implements Asset {
     }
 
     public ServiceActivatorAsset(InputStream inputStream) {
-        BufferedReader in = new BufferedReader(new InputStreamReader(inputStream));
-        String line;
-
-        try {
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(inputStream))) {
+            String line = null;
             while ((line = in.readLine()) != null) {
                 addServiceActivator(line);
             }
         } catch (IOException e) {
-            System.err.println("ERROR reading ServiceActivatorAsset" + e);
-            e.printStackTrace();
-        } finally {
-            try {
-                in.close();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
+            MSCMessages.MESSAGES.errorReadingServiceActivatorAsset(e);
         }
-
     }
 
     public void addServiceActivator(String className) {


### PR DESCRIPTION
Motivation
----------

Our logging is sub-par, many times just println()'ing.  We also are not
handling exceptions in a decent manner, just printing stack traces.

Modifications
-------------

Split WFSWARM into more logging prefixes and categories.  Renumber
(BREAKING CHANGE if you grep logs), avoid simple printStackTrace().

Modify a few SPI interfaces to allow "throws Exception" so that we
can actually percolate errors up instead of blindly trundling forward
when a customizer has an issue.

Result
------

Cleaning logs, better logging, better error-handling.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
