### PR TITLE
SWARM-1168 - Ensure logging fraction is always included.

### DIFF
--- a/fractions/cdi-extensions/cdi-config/pom.xml
+++ b/fractions/cdi-extensions/cdi-config/pom.xml
@@ -35,6 +35,10 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>container</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
 
     <!-- Provided APIs -->
     <dependency>

--- a/fractions/cdi-extensions/cdi-jaxrsapi/pom.xml
+++ b/fractions/cdi-extensions/cdi-jaxrsapi/pom.xml
@@ -40,6 +40,10 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>jaxrs</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
 
     <!-- Provided APIs -->
     <dependency>

--- a/fractions/javaee/batch-jberet/pom.xml
+++ b/fractions/javaee/batch-jberet/pom.xml
@@ -57,6 +57,10 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>cdi</artifactId>
     </dependency>
     <dependency>

--- a/fractions/javaee/bean-validation/pom.xml
+++ b/fractions/javaee/bean-validation/pom.xml
@@ -42,6 +42,10 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>container</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
 
     <!-- Provided APIs -->
     <dependency>

--- a/fractions/javaee/cdi/pom.xml
+++ b/fractions/javaee/cdi/pom.xml
@@ -44,6 +44,10 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>cdi-config</artifactId>
     </dependency>
     <dependency>

--- a/fractions/javaee/connector/pom.xml
+++ b/fractions/javaee/connector/pom.xml
@@ -41,6 +41,10 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>container</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
 
     <!-- Provided APIs -->
     <dependency>

--- a/fractions/javaee/ee/pom.xml
+++ b/fractions/javaee/ee/pom.xml
@@ -43,6 +43,10 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>naming</artifactId>
     </dependency>
 

--- a/fractions/javaee/ejb-remote/pom.xml
+++ b/fractions/javaee/ejb-remote/pom.xml
@@ -38,6 +38,10 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>ejb</artifactId>
     </dependency>
     <dependency>

--- a/fractions/javaee/ejb/pom.xml
+++ b/fractions/javaee/ejb/pom.xml
@@ -43,6 +43,10 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>ee</artifactId>
     </dependency>
     <dependency>

--- a/fractions/javaee/jaxrs-cdi/pom.xml
+++ b/fractions/javaee/jaxrs-cdi/pom.xml
@@ -43,6 +43,10 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>container</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.wildfly.core</groupId>

--- a/fractions/javaee/jaxrs-jaxb/pom.xml
+++ b/fractions/javaee/jaxrs-jaxb/pom.xml
@@ -38,6 +38,10 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>jaxrs</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
 
     <!-- Meta SPI -->
     <dependency>

--- a/fractions/javaee/jaxrs-jsonp/pom.xml
+++ b/fractions/javaee/jaxrs-jsonp/pom.xml
@@ -38,6 +38,10 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>jaxrs</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
 
     <!-- Provided APIs -->
     <dependency>

--- a/fractions/javaee/jaxrs-multipart/pom.xml
+++ b/fractions/javaee/jaxrs-multipart/pom.xml
@@ -43,6 +43,10 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>jaxrs</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
 
     <!-- Provided APIs -->
     <dependency>

--- a/fractions/javaee/jaxrs-validator/pom.xml
+++ b/fractions/javaee/jaxrs-validator/pom.xml
@@ -40,6 +40,10 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>hibernate-validator</artifactId>
     </dependency>
 

--- a/fractions/javaee/jaxrs/pom.xml
+++ b/fractions/javaee/jaxrs/pom.xml
@@ -43,6 +43,10 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>undertow</artifactId>
     </dependency>
     <dependency>

--- a/fractions/javaee/jca/pom.xml
+++ b/fractions/javaee/jca/pom.xml
@@ -43,6 +43,10 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>transactions</artifactId>
     </dependency>
 

--- a/fractions/javaee/jpa-eclipselink/pom.xml
+++ b/fractions/javaee/jpa-eclipselink/pom.xml
@@ -1,55 +1,56 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.wildfly.swarm</groupId>
-        <artifactId>wildfly-swarm</artifactId>
-        <version>2017.4.0-SNAPSHOT</version>
-        <relativePath>../../../</relativePath>
-    </parent>
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>wildfly-swarm</artifactId>
+    <version>2017.4.0-SNAPSHOT</version>
+    <relativePath>../../../</relativePath>
+  </parent>
 
-    <artifactId>jpa-eclipselink</artifactId>
+  <artifactId>jpa-eclipselink</artifactId>
 
-    <name>JPA EclipseLink</name>
-    <description>Java Persistence API with EclipseLink</description>
+  <name>JPA EclipseLink</name>
+  <description>Java Persistence API with EclipseLink</description>
 
-    <properties>
-        <swarm.fraction.stability>stable</swarm.fraction.stability>
-        <swarm.fraction.tags>JavaEE,Data,EclipseLink</swarm.fraction.tags>
-    </properties>
+  <properties>
+    <swarm.fraction.stability>stable</swarm.fraction.stability>
+    <swarm.fraction.tags>JavaEE,Data,EclipseLink</swarm.fraction.tags>
+  </properties>
 
-    <build>
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-                <filtering>true</filtering>
-            </resource>
-        </resources>
-    </build>
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+  </build>
 
-    <dependencies>
+  <dependencies>
         <!-- Fraction Dependencies -->
-        <dependency>
-            <groupId>org.wildfly.swarm</groupId>
-            <artifactId>jpa</artifactId>
-        </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
 
-        <dependency>
-            <groupId>org.wildfly</groupId>
-            <artifactId>jipijapa-eclipselink</artifactId>
-        </dependency>
+    <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>jipijapa-eclipselink</artifactId>
+    </dependency>
 
-        <!-- Provided Dependencies -->
-        <dependency>
-            <groupId>org.eclipse.persistence</groupId>
-            <artifactId>eclipselink</artifactId>
-            <version>${version.eclipse.link}</version>
-            <scope>provided</scope>
-        </dependency>
-
-    </dependencies>
-
-
+    <!-- Provided Dependencies -->
+    <dependency>
+      <groupId>org.eclipse.persistence</groupId>
+      <artifactId>eclipselink</artifactId>
+      <version>${version.eclipse.link}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
 
 </project>

--- a/fractions/javaee/jpa-spatial/pom.xml
+++ b/fractions/javaee/jpa-spatial/pom.xml
@@ -40,6 +40,10 @@
       <artifactId>jpa</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.vividsolutions</groupId>
       <artifactId>jts</artifactId>
       <version>1.13</version>

--- a/fractions/javaee/jpa/pom.xml
+++ b/fractions/javaee/jpa/pom.xml
@@ -41,6 +41,10 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>datasources</artifactId>
     </dependency>
     <dependency>

--- a/fractions/javaee/jsf/pom.xml
+++ b/fractions/javaee/jsf/pom.xml
@@ -41,6 +41,10 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>container</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
 
     <!-- Fraction Dependencies -->
     <dependency>

--- a/fractions/javaee/naming/pom.xml
+++ b/fractions/javaee/naming/pom.xml
@@ -45,6 +45,10 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>container</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.wildfly.core</groupId>

--- a/fractions/javaee/transactions/pom.xml
+++ b/fractions/javaee/transactions/pom.xml
@@ -44,6 +44,11 @@
 
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>naming</artifactId>
     </dependency>
 

--- a/fractions/javaee/webservices/pom.xml
+++ b/fractions/javaee/webservices/pom.xml
@@ -44,6 +44,10 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>security</artifactId>
     </dependency>
     <dependency>

--- a/fractions/javafx/pom.xml
+++ b/fractions/javafx/pom.xml
@@ -35,6 +35,10 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>spi</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/fractions/netflix/archaius/pom.xml
+++ b/fractions/netflix/archaius/pom.xml
@@ -40,6 +40,10 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>container</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.wildfly.swarm</groupId>

--- a/fractions/netflix/guava/pom.xml
+++ b/fractions/netflix/guava/pom.xml
@@ -40,6 +40,10 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>container</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
 
     <!-- Provided APIs -->
     <dependency>

--- a/fractions/netflix/hystrix/pom.xml
+++ b/fractions/netflix/hystrix/pom.xml
@@ -43,6 +43,10 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>spi</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/fractions/netflix/ribbon-secured-client/pom.xml
+++ b/fractions/netflix/ribbon-secured-client/pom.xml
@@ -35,6 +35,10 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>keycloak</artifactId>
     </dependency>
 

--- a/fractions/netflix/ribbon-secured/pom.xml
+++ b/fractions/netflix/ribbon-secured/pom.xml
@@ -42,6 +42,10 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>spi</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/fractions/netflix/ribbon/pom.xml
+++ b/fractions/netflix/ribbon/pom.xml
@@ -43,6 +43,10 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>spi</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/fractions/netflix/rxjava/pom.xml
+++ b/fractions/netflix/rxjava/pom.xml
@@ -40,6 +40,10 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>container</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
 
     <!-- Provided APIs -->
     <dependency>

--- a/fractions/netflix/rxnetty/pom.xml
+++ b/fractions/netflix/rxnetty/pom.xml
@@ -42,6 +42,10 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>netflix-rxjava</artifactId>
     </dependency>
     <dependency>

--- a/fractions/netflix/servo/pom.xml
+++ b/fractions/netflix/servo/pom.xml
@@ -42,6 +42,10 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>netflix-guava</artifactId>
     </dependency>
 

--- a/fractions/wildfly/hibernate-search/pom.xml
+++ b/fractions/wildfly/hibernate-search/pom.xml
@@ -46,6 +46,10 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>transactions</artifactId>
     </dependency>
 

--- a/fractions/wildfly/hibernate-validator/pom.xml
+++ b/fractions/wildfly/hibernate-validator/pom.xml
@@ -42,6 +42,10 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>bean-validation</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
 
     <!-- Provided APIs -->
     <dependency>

--- a/fractions/wildfly/io/pom.xml
+++ b/fractions/wildfly/io/pom.xml
@@ -41,6 +41,10 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>container</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/fractions/wildfly/jdr/pom.xml
+++ b/fractions/wildfly/jdr/pom.xml
@@ -44,6 +44,10 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>management</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.wildfly.swarm</groupId>

--- a/fractions/wildfly/jgroups/pom.xml
+++ b/fractions/wildfly/jgroups/pom.xml
@@ -41,6 +41,10 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>container</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>javax.inject</groupId>

--- a/fractions/wildfly/management-console/pom.xml
+++ b/fractions/wildfly/management-console/pom.xml
@@ -56,6 +56,10 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>undertow</artifactId>
     </dependency>
     <dependency>

--- a/fractions/wildfly/mod_cluster/pom.xml
+++ b/fractions/wildfly/mod_cluster/pom.xml
@@ -40,6 +40,10 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>undertow</artifactId>
     </dependency>
     <dependency>

--- a/fractions/wildfly/request-controller/pom.xml
+++ b/fractions/wildfly/request-controller/pom.xml
@@ -41,6 +41,10 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>container</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.wildfly.core</groupId>

--- a/fractions/wildfly/security/pom.xml
+++ b/fractions/wildfly/security/pom.xml
@@ -41,6 +41,10 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>ee</artifactId>
     </dependency>
     <dependency>

--- a/meta/fraction-metadata/src/test/java/org/wildfly/swarm/fractions/FractionListTest.java
+++ b/meta/fraction-metadata/src/test/java/org/wildfly/swarm/fractions/FractionListTest.java
@@ -32,6 +32,31 @@ import static org.fest.assertions.Assertions.assertThat;
 public class FractionListTest {
 
     @Test
+    public void testAllHaveLogging() {
+        FractionList list = FractionList.get();
+        Collection<FractionDescriptor> descriptors = list.getFractionDescriptors();
+
+        for (FractionDescriptor each : descriptors) {
+            if ( each.getArtifactId().equals( "container" ) ) {
+                // because container cannot have a dependency on logging.
+                continue;
+            }
+            assertThat(hasLogging(each))
+                    .as(each.gav() + " has logging")
+                    .isTrue();
+        }
+    }
+
+    private boolean hasLogging(FractionDescriptor desc) {
+        if ( desc.getGroupId().equals( "org.wildfly.swarm" ) && desc.getArtifactId().equals( "logging" ) ) {
+            return true;
+        }
+
+        return desc.getDependencies().stream()
+                .anyMatch(this::hasLogging);
+    }
+
+    @Test
     public void testList() throws IOException {
         FractionList list = FractionList.get();
 
@@ -43,7 +68,7 @@ public class FractionListTest {
 
         Assertions.assertThat(ee.getGroupId()).isEqualTo("org.wildfly.swarm");
         Assertions.assertThat(ee.getArtifactId()).isEqualTo("ee");
-        Assertions.assertThat(ee.getDependencies()).hasSize(2);
+        Assertions.assertThat(ee.getDependencies()).hasSize(3);
 
         Assertions.assertThat(ee.getDependencies().stream().filter(e -> e.getArtifactId().equals("container")).collect(Collectors.toList())).isNotEmpty();
         Assertions.assertThat(ee.getDependencies().stream().filter(e -> e.getArtifactId().equals("naming")).collect(Collectors.toList())).isNotEmpty();


### PR DESCRIPTION
Motivation
----------

Logging is good. Ensure it's always nearby.

Modifications
-------------

Even though many fractions get it transitively, let's be
explicit about it in the dependency list.  Belt and suspenders.

Test to verify such.

Result
------

Logging is available always.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
