### PR TITLE
SWARM-1209 - Ignore most ENV vars

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/config/EnvironmentConfigNodeFactory.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/EnvironmentConfigNodeFactory.java
@@ -53,9 +53,11 @@ public class EnvironmentConfigNodeFactory {
         Set<String> names = input.keySet();
 
         for (String name : names) {
-            String value = input.get(name);
-            ConfigKey key = ConfigKey.parse(name);
-            config.recursiveChild(key, value);
+            if (name.startsWith("swarm.")) {
+                String value = input.get(name);
+                ConfigKey key = ConfigKey.parse(name);
+                config.recursiveChild(key, value);
+            }
         }
     }
 

--- a/core/container/src/test/java/org/wildfly/swarm/container/config/EnvironmentConfigNodeFactoryTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/container/config/EnvironmentConfigNodeFactoryTest.java
@@ -17,14 +17,16 @@ public class EnvironmentConfigNodeFactoryTest {
     public void testLoadSimple() {
 
         Map<String, String> env = new HashMap<String, String>() {{
-            put("name", "bob");
-            put("cheese", "cheddar");
+            put("swarm.name", "bob");
+            put("swarm.cheese", "cheddar");
+            put("not.swarm.taco", "crunchy");
         }};
 
         ConfigNode node = EnvironmentConfigNodeFactory.load(env);
 
-        assertThat(node.valueOf(ConfigKey.parse("name"))).isEqualTo("bob");
-        assertThat(node.valueOf(ConfigKey.parse("cheese"))).isEqualTo("cheddar");
+        assertThat(node.valueOf(ConfigKey.parse("swarm.name"))).isEqualTo("bob");
+        assertThat(node.valueOf(ConfigKey.parse("swarm.cheese"))).isEqualTo("cheddar");
+        assertThat(node.valueOf(ConfigKey.parse("not.swarm.taco"))).isNull();
     }
 
     @Test

--- a/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/ProjectStagesTest.java
+++ b/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/ProjectStagesTest.java
@@ -76,27 +76,27 @@ public class ProjectStagesTest {
         Swarm swarm = new Swarm(new Properties());
         swarm.withProfile("foo");
         ConfigView view = swarm.configView();
-        assertThat(view.resolve("myname").getValue()).isEqualTo("foo");
+        assertThat(view.resolve("swarm.myname").getValue()).isEqualTo("foo");
         swarm.withProfile("bar");
-        assertThat(view.resolve("myname").getValue()).isEqualTo("foo");
-        assertThat(view.resolve("mydottednumber").as(Double.class).getValue()).isEqualTo(2.82);
+        assertThat(view.resolve("swarm.myname").getValue()).isEqualTo("foo");
+        assertThat(view.resolve("swarm.mydottednumber").as(Double.class).getValue()).isEqualTo(2.82);
     }
 
     @Test
     public void testCLIToLoadConfig() throws Exception {
         Swarm swarm = new Swarm(new Properties(), "-Sfoo");
         ConfigView view = swarm.configView();
-        assertThat(view.resolve("myname").getValue()).isEqualTo("foo");
+        assertThat(view.resolve("swarm.myname").getValue()).isEqualTo("foo");
     }
 
     @Test
     public void testEnvironmentVars() throws Exception {
         Map<String, String> environment = new HashMap<>();
-        environment.put("myname", "from_env");
+        environment.put("swarm.myname", "from_env");
         Swarm swarm = new Swarm(new Properties(), environment);
 
         ConfigView view = swarm.configView();
-        assertThat(view.resolve("myname").getValue()).isEqualTo("from_env");
+        assertThat(view.resolve("swarm.myname").getValue()).isEqualTo("from_env");
     }
 
     @Test
@@ -104,13 +104,13 @@ public class ProjectStagesTest {
         Map<String, String> environment = new HashMap<>();
         Properties properties = new Properties();
 
-        environment.put("myname", "from_env");
-        properties.setProperty("myname", "from_props");
+        environment.put("swarm.myname", "from_env");
+        properties.setProperty("swarm.myname", "from_props");
 
         Swarm swarm = new Swarm(properties, environment);
 
         ConfigView view = swarm.configView();
-        assertThat(view.resolve("myname").getValue()).isEqualTo("from_props");
+        assertThat(view.resolve("swarm.myname").getValue()).isEqualTo("from_props");
     }
 
     @Test
@@ -118,13 +118,13 @@ public class ProjectStagesTest {
         Map<String, String> environment = new HashMap<>();
         Properties properties = new Properties();
 
-        environment.put("myname", "from_env");
-        properties.setProperty("myname", "from_props");
+        environment.put("swarm.myname", "from_env");
+        properties.setProperty("swarm.myname", "from_props");
 
-        Swarm swarm = new Swarm(properties, environment, "-Dmyname=tacos");
+        Swarm swarm = new Swarm(properties, environment, "-Dswarm.myname=tacos");
 
         ConfigView view = swarm.configView();
-        assertThat(view.resolve("myname").getValue()).isEqualTo("tacos");
+        assertThat(view.resolve("swarm.myname").getValue()).isEqualTo("tacos");
     }
 
 }

--- a/testsuite/testsuite-project-stages/src/test/resources/project-bar.yml
+++ b/testsuite/testsuite-project-stages/src/test/resources/project-bar.yml
@@ -1,3 +1,4 @@
 
-myname: bar
-mydottednumber: 2.82
+swarm:
+  myname: bar
+  mydottednumber: 2.82

--- a/testsuite/testsuite-project-stages/src/test/resources/project-foo.yml
+++ b/testsuite/testsuite-project-stages/src/test/resources/project-foo.yml
@@ -1,2 +1,3 @@
 
-myname: foo
+swarm:
+  myname: foo


### PR DESCRIPTION
Motivation
----------

Pushing all environment vars to properties (and then to DMR)
is a bad idea.

Modifications
-------------

Only push env-vars that have a "swarm." prefix around.  Ignore all
others.  Adjust tests to accomodate the new assumptions.

Result
------

Fewer breakages with weirdo ENV vars.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
