### PR TITLE
SWARM-1211 - Clean up warnings and deprecations.

### DIFF
--- a/arquillian/resolver/src/main/java/org/wildfly/swarm/arquillian/resolver/ShrinkwrapArtifactResolvingHelper.java
+++ b/arquillian/resolver/src/main/java/org/wildfly/swarm/arquillian/resolver/ShrinkwrapArtifactResolvingHelper.java
@@ -143,7 +143,7 @@ public class ShrinkwrapArtifactResolvingHelper implements ArtifactResolvingHelpe
     @Override
     public Set<ArtifactSpec> resolveAll(final Collection<ArtifactSpec> specs, boolean transitive, boolean defaultExcludes) {
         if (specs.isEmpty()) {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
 
         MavenResolutionStrategy transitivityStrategy = (transitive ? TransitiveStrategy.INSTANCE : NonTransitiveStrategy.INSTANCE);

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/FractionManifest.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/FractionManifest.java
@@ -53,6 +53,7 @@ public class FractionManifest {
         }
     }
 
+    @SuppressWarnings("unchecked")
     protected void read(InputStream in) throws IOException {
         Yaml yaml = new Yaml();
         Map data = (Map) yaml.load(in);

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/SystemDependencyResolution.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/SystemDependencyResolution.java
@@ -14,10 +14,10 @@ import java.util.stream.Collectors;
  * @author Heiko Braun
  * @since 18/07/16
  */
-public class SystemDependencyResolution implements DependencyResolution {
+class SystemDependencyResolution implements DependencyResolution {
 
 
-    public SystemDependencyResolution() {
+    SystemDependencyResolution() {
         final String classpathProp = System.getProperty("java.class.path");
         final String javaHomProp = System.getProperty("java.home");
         final String userDirProp = System.getProperty("user.dir");
@@ -27,7 +27,7 @@ public class SystemDependencyResolution implements DependencyResolution {
         this.useGradleRepo = classpathProp.contains(File.separator + ".gradle");
 
         this.classpath = Arrays.asList(classpathProp.split(File.pathSeparator));
-        this.testClasspath = testClasspatProp != null ? Arrays.asList(testClasspatProp.split(File.pathSeparator)) : Collections.EMPTY_LIST;
+        this.testClasspath = testClasspatProp != null ? Arrays.asList(testClasspatProp.split(File.pathSeparator)) : Collections.emptyList();
 
         this.pwd = userDirProp;
         this.javaHome = javaHomProp.endsWith(JRE) ? javaHomProp.substring(0, javaHomProp.lastIndexOf(JRE)) : javaHomProp;
@@ -44,7 +44,7 @@ public class SystemDependencyResolution implements DependencyResolution {
             ApplicationEnvironment env = ApplicationEnvironment.get();
             Set<String> classpathElements = new HashSet<>();
             Set<String> providedGAVs = new HashSet<>();
-            List<String> testClasspathElements = testClasspath != null ? testClasspath : Collections.EMPTY_LIST;
+            List<String> testClasspathElements = testClasspath != null ? testClasspath : Collections.emptyList();
 
             for (final String element : classpath) {
                 if (!element.startsWith(javaHome) && !element.startsWith(pwd + File.separatorChar) && !element.endsWith(".pom")) {
@@ -80,17 +80,15 @@ public class SystemDependencyResolution implements DependencyResolution {
         return archivesPaths;
     }
 
-    private static final String JAR = ".jar";
-
     private static final String JRE = "jre";
 
-    final List<String> classpath;
+    private final List<String> classpath;
 
-    final String javaHome;
+    private final String javaHome;
 
-    final String pwd;
+    private final String pwd;
 
-    final List<String> testClasspath;
+    private final List<String> testClasspath;
 
     private final boolean useGradleRepo;
 

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/WildFlySwarmManifest.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/WildFlySwarmManifest.java
@@ -60,6 +60,7 @@ public class WildFlySwarmManifest {
         }
     }
 
+    @SuppressWarnings("unchecked")
     public void read(InputStream in) throws IOException {
         Yaml yaml = new Yaml();
         Map data = (Map) yaml.load(in);
@@ -98,7 +99,7 @@ public class WildFlySwarmManifest {
 
     @Override
     public String toString() {
-        Map data = new LinkedHashMap() {{
+        Map<String,Object> data = new LinkedHashMap<String,Object>() {{
             if (asset != null) {
                 put(ASSET, asset);
             }
@@ -119,7 +120,7 @@ public class WildFlySwarmManifest {
         return yaml.dump(data);
     }
 
-    protected void setupProperties() {
+    private void setupProperties() {
         // enumerate all properties, not just those with string
         // values, because Gradle (and others) can set non-string
         // values for things like swarm.http.port (integer)
@@ -185,6 +186,7 @@ public class WildFlySwarmManifest {
         this.bundleDependencies = bundleDependencies;
     }
 
+    @SuppressWarnings("unused")
     public boolean isBundleDependencies() {
         if (this.bundleDependencies == null) {
             return true;

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/GradleResolver.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/GradleResolver.java
@@ -43,7 +43,7 @@ import java.util.stream.Collectors;
  */
 public class GradleResolver implements MavenResolver {
     private final String gradleCachePath;
-    private final List<String> remoteRepositories = new LinkedList();
+    private final List<String> remoteRepositories = new LinkedList<>();
 
     public GradleResolver(String gradleCachePath) {
         this.gradleCachePath = gradleCachePath;

--- a/core/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/core/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -694,6 +694,7 @@ public class Swarm {
      * @return The {@code ConfigView} through a deprecated interface.
      * @see #configView()
      */
+    @SuppressWarnings("deprecation")
     @Deprecated
     public StageConfig stageConfig() {
         return this.configView.get();

--- a/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigNode.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigNode.java
@@ -229,7 +229,7 @@ public class ConfigNode implements ConfigTree {
     }
 
     public Map asMap() {
-        Map map = new HashMap();
+        Map<String,Object> map = new HashMap<>();
 
         this.children.entrySet()
                 .forEach(entry -> {

--- a/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewFactory.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewFactory.java
@@ -137,6 +137,7 @@ public class ConfigViewFactory {
         loadProjectStages(url.openStream());
     }
 
+    @SuppressWarnings("unchecked")
     private void loadProjectStages(InputStream inputStream) {
         Yaml yaml = new Yaml();
         Iterable<Object> docs = yaml.loadAll(inputStream);
@@ -163,6 +164,7 @@ public class ConfigViewFactory {
         loadYamlProjectConfig(name, url.openStream());
     }
 
+    @SuppressWarnings("unchecked")
     private void loadYamlProjectConfig(String name, InputStream inputStream) {
         Yaml yaml = new Yaml();
         Map<String, ?> doc = (Map<String, ?>) yaml.load(inputStream);

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/ConfigurableManager.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/ConfigurableManager.java
@@ -93,6 +93,7 @@ public class ConfigurableManager implements AutoCloseable {
         return this.configurables;
     }
 
+    @SuppressWarnings("unchecked")
     protected <T> void configure(ConfigurableHandle configurable) throws Exception {
         try (AutoCloseable handle = Performance.accumulate("ConfigurableManager#configure")) {
             Resolver<?> resolver = this.configView.resolve(configurable.key());
@@ -164,7 +165,7 @@ public class ConfigurableManager implements AutoCloseable {
 
     private Converter<Map> mapConverter(ConfigKey key) {
         return (ignored) -> {
-            Map map = new HashMap();
+            Map<String,Object> map = new HashMap<>();
             Set<SimpleKey> subKeys = this.configView.simpleSubkeys(key);
 
             for (SimpleKey subKey : subKeys) {

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/ObjectBackedConfigurableHandle.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/ObjectBackedConfigurableHandle.java
@@ -37,20 +37,22 @@ public class ObjectBackedConfigurableHandle implements ConfigurableHandle {
         return this.field.getType();
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public <T> void set(T value) throws IllegalAccessException {
         if (isDefaultable()) {
-            ((Defaultable) this.field.get(this.instance)).set(value);
+            ((Defaultable<T>) this.field.get(this.instance)).set(value);
         } else {
             this.field.set(this.instance, value);
         }
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public <T> T currentValue() throws IllegalAccessException {
         Object value = this.field.get(this.instance);
         if (value instanceof Defaultable) {
-            return (T) ((Defaultable) value).get();
+            return ((Defaultable<T>) value).get();
         }
         return (T) value;
     }

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeDeployer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeDeployer.java
@@ -170,7 +170,7 @@ public class RuntimeDeployer implements Deployer {
             // check for "org.wildfly.swarm.allDependencies" flag
             // see DependenciesContainer#addAllDependencies()
             if (deployment instanceof DependenciesContainer) {
-                DependenciesContainer depContainer = (DependenciesContainer) deployment;
+                DependenciesContainer<?> depContainer = (DependenciesContainer) deployment;
                 if (depContainer.hasMarker(DependenciesContainer.ALL_DEPENDENCIES_MARKER)) {
                     if (!depContainer.hasMarker(ALL_DEPENDENCIES_ADDED_MARKER)) {
                         ApplicationEnvironment appEnv = ApplicationEnvironment.get();
@@ -181,7 +181,7 @@ public class RuntimeDeployer implements Deployer {
                                 depContainer.addAsLibrary(artifactLookup.artifact(gav));
                             }
                         } else {
-                            Set<String> paths = appEnv.resolveDependencies(Collections.EMPTY_LIST);
+                            Set<String> paths = appEnv.resolveDependencies(Collections.emptyList());
                             for (String path : paths) {
                                 final File pathFile = new File(path);
                                 if (path.endsWith(".jar")) {
@@ -294,12 +294,13 @@ public class RuntimeDeployer implements Deployer {
         }
     }
 
+    @SuppressWarnings("unused")
     @PreDestroy
     void stop() {
         for (Closeable each : this.mountPoints) {
             try {
                 each.close();
-            } catch (IOException e) {
+            } catch (IOException ignored) {
             }
         }
 
@@ -309,25 +310,32 @@ public class RuntimeDeployer implements Deployer {
 
     private String defaultDeploymentType;
 
+    @SuppressWarnings("unused")
     @Inject
     private ModelControllerClient client;
 
+    @SuppressWarnings("unused")
     @Inject
     private SimpleContentProvider contentProvider;
 
+    @SuppressWarnings("unused")
     @Inject
     private TempFileProvider tempFileProvider;
 
+    @SuppressWarnings("unused")
     @Inject
     private DefaultDeploymentCreator defaultDeploymentCreator;
 
     private final List<Closeable> mountPoints = new ArrayList<>();
 
+    @SuppressWarnings("unused")
     private boolean debug = false;
 
+    @SuppressWarnings("unused")
     @Inject
     private Instance<ArchivePreparer> archivePreparers;
 
+    @SuppressWarnings("unused")
     @Inject
     private Instance<ArchiveMetadataProcessor> archiveMetadataProcessors;
 }

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/ConfigViewProducingExtension.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/ConfigViewProducingExtension.java
@@ -40,9 +40,10 @@ public class ConfigViewProducingExtension implements Extension {
         this.configView = configView;
     }
 
+    @SuppressWarnings("unused")
     void afterBeanDiscovery(@Observes AfterBeanDiscovery abd, BeanManager beanManager) throws Exception {
         try (AutoCloseable handle = Performance.time("ConfigViewProducingExtension.afterBeanDiscovery")) {
-            CommonBean<ConfigView> configViewBean = CommonBeanBuilder.newBuilder()
+            CommonBean<ConfigView> configViewBean = CommonBeanBuilder.newBuilder(ConfigView.class)
                     .beanClass(ConfigViewProducingExtension.class)
                     .scope(Singleton.class)
                     .addQualifier(DefaultLiteral.INSTANCE)

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/ConfigurationValueProducer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/ConfigurationValueProducer.java
@@ -89,6 +89,7 @@ public class ConfigurationValueProducer {
         return resolve(injectionPoint, Double.class);
     }
 
+    @SuppressWarnings("unchecked")
     @ConfigurationValue("")
     @Dependent
     @Produces
@@ -106,6 +107,7 @@ public class ConfigurationValueProducer {
         return Optional.ofNullable(resolve(injectionPoint, valueType));
     }
 
+    @SuppressWarnings("unchecked")
     private <T> Class<T> unwrapType(Type type) {
         if (type instanceof ParameterizedType) {
             type = ((ParameterizedType) type).getRawType();

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/SocketBindingExtension.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/SocketBindingExtension.java
@@ -48,32 +48,26 @@ public class SocketBindingExtension implements Extension {
         this.bindings = bindings;
     }
 
+    @SuppressWarnings("unused")
     void afterBeanDiscovery(@Observes AfterBeanDiscovery abd, BeanManager beanManager) throws Exception {
         try (AutoCloseable handle = Performance.time("SocketBindingExtension.afterBeanDiscovery")) {
 
             for (SocketBindingRequest each : this.bindings) {
 
-                Supplier<Customizer> supplier = () -> {
-                    return new Customizer() {
-                        @Override
-                        public void customize() {
-                            Set<Bean<?>> groups = beanManager.getBeans(SocketBindingGroup.class, AnyLiteral.INSTANCE);
+                Supplier<Customizer> supplier = () -> (Customizer) () -> {
+                    Set<Bean<?>> groups = beanManager.getBeans(SocketBindingGroup.class, AnyLiteral.INSTANCE);
 
-                            groups.stream()
-                                    .map((Bean e) -> {
-                                        CreationalContext<SocketBindingGroup> ctx = beanManager.createCreationalContext(e);
-                                        return (SocketBindingGroup) beanManager.getReference(e, SocketBindingGroup.class, ctx);
-                                    })
-                                    .filter(group -> group.name().equals(each.socketBindingGroup()))
-                                    .findFirst()
-                                    .ifPresent((group) -> {
-                                        group.socketBinding(each.socketBinding());
-                                    });
-                        }
-                    };
+                    groups.stream()
+                            .map((Bean<?> e) -> {
+                                CreationalContext<?> ctx = beanManager.createCreationalContext(e);
+                                return (SocketBindingGroup) beanManager.getReference(e, SocketBindingGroup.class, ctx);
+                            })
+                            .filter(group -> group.name().equals(each.socketBindingGroup()))
+                            .findFirst()
+                            .ifPresent((group) -> group.socketBinding(each.socketBinding()));
                 };
 
-                CommonBean<Customizer> customizerBean = CommonBeanBuilder.newBuilder()
+                CommonBean<Customizer> customizerBean = CommonBeanBuilder.newBuilder(Customizer.class)
                         .beanClass(SocketBindingExtension.class)
                         .scope(Singleton.class)
                         .addQualifier(new AnnotationLiteral<Pre>() {

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/XMLConfigProducingExtension.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/XMLConfigProducingExtension.java
@@ -44,7 +44,7 @@ public class XMLConfigProducingExtension implements Extension {
 
     void afterBeanDiscovery(@Observes AfterBeanDiscovery abd, BeanManager beanManager) throws Exception {
         try (AutoCloseable handle = Performance.time("XMLConfigProducingExtension.afterBeanDiscovery")) {
-            CommonBean<URL> urlBean = CommonBeanBuilder.newBuilder()
+            CommonBean<URL> urlBean = CommonBeanBuilder.newBuilder(URL.class)
                     .beanClass(XMLConfigProducingExtension.class)
                     .scope(Dependent.class)
                     .addQualifier(XMLConfig.Literal.INSTANCE)
@@ -55,7 +55,7 @@ public class XMLConfigProducingExtension implements Extension {
         }
     }
 
-    protected URL getXMLConfig() {
+    private URL getXMLConfig() {
         if (this.xmlConfig.isPresent()) {
             return this.xmlConfig.get();
         }

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/cli/CommandLineArgsExtension.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/cli/CommandLineArgsExtension.java
@@ -44,7 +44,7 @@ public class CommandLineArgsExtension implements Extension {
     }
 
     void afterBeanDiscovery(@Observes AfterBeanDiscovery abd) {
-        CommonBean<String[]> stringBean = CommonBeanBuilder.newBuilder()
+        CommonBean<String[]> stringBean = CommonBeanBuilder.newBuilder(String[].class)
                 .beanClass(CommandLineArgsExtension.class)
                 .scope(Dependent.class)
                 .createSupplier(() -> args)
@@ -52,7 +52,7 @@ public class CommandLineArgsExtension implements Extension {
                 .addType(String[].class)
                 .addType(Object.class).build();
         abd.addBean(stringBean);
-        CommonBean<List<String>> listBean = CommonBeanBuilder.newBuilder()
+        CommonBean<List> listBean = CommonBeanBuilder.newBuilder(List.class)
                 .beanClass(CommandLineArgsExtension.class)
                 .scope(Dependent.class)
                 .createSupplier(() -> argsList)

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/BootstrapPersister.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/BootstrapPersister.java
@@ -13,6 +13,7 @@ import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.RunningModeControl;
 import org.jboss.as.controller.extension.ExtensionRegistry;
+import org.jboss.as.controller.extension.RuntimeHostControllerInfoAccessor;
 import org.jboss.as.controller.parsing.Namespace;
 import org.jboss.as.controller.persistence.ConfigurationPersistenceException;
 import org.jboss.as.controller.persistence.ConfigurationPersister;
@@ -98,7 +99,13 @@ public class BootstrapPersister implements ExtensibleConfigurationPersister {
     private XmlConfigurationPersister createDelegate(File configFile) {
 
         QName rootElement = new QName(Namespace.CURRENT.getUriString(), "server");
-        ExtensionRegistry extensionRegistry = new ExtensionRegistry(ProcessType.SELF_CONTAINED, new RunningModeControl(RunningMode.NORMAL));
+        ExtensionRegistry extensionRegistry = new ExtensionRegistry(
+                ProcessType.SELF_CONTAINED,
+                new RunningModeControl(RunningMode.NORMAL),
+                null,
+                null,
+                RuntimeHostControllerInfoAccessor.SERVER
+        );
         StandaloneXml parser = new StandaloneXml(Module.getBootModuleLoader(), Executors.newSingleThreadExecutor(), extensionRegistry);
 
         XmlConfigurationPersister persister = new XmlConfigurationPersister(

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/StandaloneXMLParser.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/xmlconfig/StandaloneXMLParser.java
@@ -62,7 +62,7 @@ public class StandaloneXMLParser {
 
             @Override
             public Set<ProfileParsingCompletionHandler> getProfileParsingCompletionHandlers() {
-                return Collections.EMPTY_SET;
+                return Collections.emptySet();
             }
 
             @Override

--- a/core/container/src/test/java/org/wildfly/swarm/cli/CommandLineTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/cli/CommandLineTest.java
@@ -96,7 +96,7 @@ public class CommandLineTest {
     @Test
     public void testLongArgWithEqual() throws Exception {
         String fileName = "my.properties";
-        String expectedPath = new File(System.getProperty("user.dir"), fileName).toURL().toString();
+        String expectedPath = new File(System.getProperty("user.dir"), fileName).toURI().toURL().toString();
 
         CommandLine cmd = CommandLine.parse("--properties=" + fileName);
 
@@ -106,7 +106,7 @@ public class CommandLineTest {
     @Test
     public void testLongArgWithoutEqual() throws Exception {
         String fileName = "my.properties";
-        String expectedPath = new File(System.getProperty("user.dir"), fileName).toURL().toString();
+        String expectedPath = new File(System.getProperty("user.dir"), fileName).toURI().toURL().toString();
 
         CommandLine cmd = CommandLine.parse("--properties", fileName);
 

--- a/core/container/src/test/java/org/wildfly/swarm/container/config/ConfigViewYamlTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/container/config/ConfigViewYamlTest.java
@@ -14,6 +14,7 @@ import static org.fest.assertions.Assertions.assertThat;
  */
 public class ConfigViewYamlTest {
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testYamlWithLiteralLists() throws Exception {
         URL url = getClass().getClassLoader().getResource("project-lists.yml");

--- a/core/container/src/test/java/org/wildfly/swarm/container/config/MapConfigNodeFactoryTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/container/config/MapConfigNodeFactoryTest.java
@@ -17,14 +17,14 @@ public class MapConfigNodeFactoryTest {
     @Test
     public void testLoad() {
 
-        Map input = new HashMap() {{
-            put("swarm", new HashMap() {{
+        Map<String,Object> input = new HashMap<String,Object>() {{
+            put("swarm", new HashMap<String,Object>() {{
                 put("port", 8080);
                 put("enabled", true);
-                put("things", new ArrayList() {{
+                put("things", new ArrayList<Object>() {{
                     add("one");
                     add("two");
-                    add(new HashMap() {{
+                    add(new HashMap<String,Object>() {{
                         put("name", "three");
                         put("cheese", "cheddar");
                         put("item", 3);

--- a/core/spi/src/main/java/org/wildfly/swarm/spi/api/Fraction.java
+++ b/core/spi/src/main/java/org/wildfly/swarm/spi/api/Fraction.java
@@ -41,6 +41,7 @@ public interface Fraction<T extends Fraction> {
      *
      * @return this fraction.
      */
+    @SuppressWarnings("unchecked")
     default T applyDefaults() {
         return (T) this;
     }

--- a/core/spi/src/main/java/org/wildfly/swarm/spi/api/cdi/CommonBeanBuilder.java
+++ b/core/spi/src/main/java/org/wildfly/swarm/spi/api/cdi/CommonBeanBuilder.java
@@ -37,31 +37,31 @@ public class CommonBeanBuilder<T> {
         this.types = new HashSet<>();
     }
 
-    public static CommonBeanBuilder newBuilder() {
-        return new CommonBeanBuilder();
+    public static <B> CommonBeanBuilder<B> newBuilder(Class<B> beanClass) {
+        return new CommonBeanBuilder<B>();
     }
 
-    public CommonBeanBuilder beanClass(Class<?> beanClass) {
+    public CommonBeanBuilder<T> beanClass(Class<?> beanClass) {
         this.beanClass = beanClass;
         return this;
     }
 
-    public CommonBeanBuilder scope(Class<? extends Annotation> scope) {
+    public CommonBeanBuilder<T> scope(Class<? extends Annotation> scope) {
         this.scope = scope;
         return this;
     }
 
-    public CommonBeanBuilder addQualifier(Annotation qualifier) {
+    public CommonBeanBuilder<T> addQualifier(Annotation qualifier) {
         qualifiers.add(qualifier);
         return this;
     }
 
-    public CommonBeanBuilder createSupplier(Supplier<T> createSupplier) {
+    public CommonBeanBuilder<T> createSupplier(Supplier<T> createSupplier) {
         this.createSupplier = createSupplier;
         return this;
     }
 
-    public CommonBeanBuilder addType(Type type) {
+    public CommonBeanBuilder<T> addType(Type type) {
         types.add(type);
         return this;
     }

--- a/core/spi/src/main/java/org/wildfly/swarm/spi/api/config/Builder.java
+++ b/core/spi/src/main/java/org/wildfly/swarm/spi/api/config/Builder.java
@@ -14,11 +14,13 @@ public class Builder<T> implements Resolver<T> {
         this.key = key;
     }
 
+    @SuppressWarnings("unchecked")
     public <N> Resolver<N> as(Class<N> clazz) {
         targetType = clazz;
         return (Resolver<N>) this;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public <N> Resolver<N> as(Class<N> clazz, Converter<N> converter) {
         targetType = clazz;
@@ -31,6 +33,7 @@ public class Builder<T> implements Resolver<T> {
         return key;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public T getValue() {
 
@@ -71,6 +74,7 @@ public class Builder<T> implements Resolver<T> {
         return this;
     }
 
+    @SuppressWarnings("unchecked")
     private T convert(String value) throws MalformedURLException {
 
         if (value == null) {

--- a/core/spi/src/main/java/org/wildfly/swarm/spi/api/config/ConfigView.java
+++ b/core/spi/src/main/java/org/wildfly/swarm/spi/api/config/ConfigView.java
@@ -9,6 +9,7 @@ import org.wildfly.swarm.spi.api.StageConfig;
 /**
  * @author Bob McWhirter
  */
+@SuppressWarnings("deprecation")
 public interface ConfigView extends StageConfig {
 
     Object valueOf(ConfigKey key);

--- a/fractions/cdi-extensions/cdi-config/src/main/java/org/wildfly/swarm/cdi/config/deployment/ConfigViewBean.java
+++ b/fractions/cdi-extensions/cdi-config/src/main/java/org/wildfly/swarm/cdi/config/deployment/ConfigViewBean.java
@@ -50,7 +50,7 @@ public class ConfigViewBean implements Bean<ConfigView> {
 
     @Override
     public Set<InjectionPoint> getInjectionPoints() {
-        return Collections.EMPTY_SET;
+        return Collections.emptySet();
     }
 
     @Override
@@ -84,7 +84,7 @@ public class ConfigViewBean implements Bean<ConfigView> {
 
     @Override
     public Set<Class<? extends Annotation>> getStereotypes() {
-        return Collections.EMPTY_SET;
+        return Collections.emptySet();
     }
 
     @Override

--- a/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/DriverInfo.java
+++ b/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/DriverInfo.java
@@ -223,6 +223,7 @@ public abstract class DriverInfo {
         return "[DriverInfo: detectable=" + this.detectableClassName + "]";
     }
 
+    @SuppressWarnings("unchecked")
     public void installDatasource(DatasourcesFraction fraction, String dsName, DataSourceConsumer config) {
         fraction.dataSource(dsName, (ds) -> {
             ds.driverName(this.name);

--- a/fractions/javaee/ee/src/main/java/org/wildfly/swarm/ee/EEFraction.java
+++ b/fractions/javaee/ee/src/main/java/org/wildfly/swarm/ee/EEFraction.java
@@ -61,6 +61,7 @@ public class EEFraction extends EE<EEFraction> implements Fraction<EEFraction> {
         return applyDefaults(null);
     }
 
+    @SuppressWarnings("unchecked")
     public EEFraction applyDefaults(DefaultBindingsServiceConsumer config) {
         specDescriptorPropertyReplacement(false)
                 .contextService(new ContextService(DEFAULT_KEY)

--- a/fractions/javaee/messaging/src/main/java/org/wildfly/swarm/messaging/EnhancedServer.java
+++ b/fractions/javaee/messaging/src/main/java/org/wildfly/swarm/messaging/EnhancedServer.java
@@ -154,7 +154,7 @@ public class EnhancedServer extends org.wildfly.swarm.config.messaging.activemq.
     public EnhancedServer enableRemote() {
         enableHTTPConnections();
 
-        connectionFactory(new ConnectionFactory("RemoteConnectionFactory")
+        connectionFactory(new ConnectionFactory<>("RemoteConnectionFactory")
                                   .connectors(Collections.singletonList("http-connector"))
                                   .entries("java:/RemoteConnectionFactory", "java:jboss/exported/jms/RemoteConnectionFactory"));
         return this;

--- a/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/runtime/HttpSecurityPreparer.java
+++ b/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/runtime/HttpSecurityPreparer.java
@@ -41,6 +41,7 @@ public class HttpSecurityPreparer implements ArchivePreparer {
 
     private final String[] SUPPORTED_AUTH_METHODS = new String[] {"BASIC", "DIGEST", "FORM", "KEYCLOAK"};
 
+    @SuppressWarnings("unchecked")
     @Override
     public void prepareArchive(Archive<?> archive) {
 

--- a/fractions/javaee/undertow/src/test/java/org/wildfly/swarm/undertow/runtime/ContextPathArchivePreparerTest.java
+++ b/fractions/javaee/undertow/src/test/java/org/wildfly/swarm/undertow/runtime/ContextPathArchivePreparerTest.java
@@ -78,6 +78,7 @@ public class ContextPathArchivePreparerTest {
         assertThat(archive.getContextRoot()).isEqualTo("/another-root");
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testExternalMount() throws Exception {
         WARArchive archive = DefaultWarDeploymentFactory.archiveFromCurrentApp();

--- a/fractions/javaee/undertow/src/test/java/org/wildfly/swarm/undertow/runtime/HttpSecurityPreparerTest.java
+++ b/fractions/javaee/undertow/src/test/java/org/wildfly/swarm/undertow/runtime/HttpSecurityPreparerTest.java
@@ -47,6 +47,7 @@ public class HttpSecurityPreparerTest {
         assertThat(archive.get(WebXmlAsset.NAME)).isNull();
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void yaml_parsing() throws Exception {
 
@@ -114,6 +115,7 @@ public class HttpSecurityPreparerTest {
         }
     }
 
+    @SuppressWarnings("unchecked")
     private Map<String, Object> findWebConfig(Map<String, Object> deploymentConfig) {
         String[] path = new String[] {archive.getName(), "web"};
         Map<String, Object> curr = deploymentConfig;

--- a/fractions/javaee/undertow/src/test/java/org/wildfly/swarm/undertow/runtime/MockInstance.java
+++ b/fractions/javaee/undertow/src/test/java/org/wildfly/swarm/undertow/runtime/MockInstance.java
@@ -1,8 +1,10 @@
 package org.wildfly.swarm.undertow.runtime;
 
 import java.lang.annotation.Annotation;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 
 import javax.enterprise.inject.Instance;
 import javax.enterprise.util.TypeLiteral;
@@ -55,7 +57,7 @@ public class MockInstance<T> implements Instance<T> {
             return Collections.singleton(this.instance).iterator();
         }
 
-        return (Iterator<T>) Collections.emptyList().iterator();
+        return new ArrayList<T>().iterator();
     }
 
     @Override

--- a/fractions/jolokia/src/main/java/org/wildfly/swarm/jolokia/access/ConfigurationValueAccessPreparer.java
+++ b/fractions/jolokia/src/main/java/org/wildfly/swarm/jolokia/access/ConfigurationValueAccessPreparer.java
@@ -30,7 +30,7 @@ public class ConfigurationValueAccessPreparer extends AbstractJolokiaAccessPrepa
             } catch (MalformedURLException e) {
                 File file = new File(this.jolokiaAccessXml);
                 if (file.exists()) {
-                    url = file.toURL();
+                    url = file.toURI().toURL();
                 }
             }
 

--- a/fractions/keycloak/src/main/java/org/wildfly/swarm/keycloak/deployment/KeycloakThreadSetupHandler.java
+++ b/fractions/keycloak/src/main/java/org/wildfly/swarm/keycloak/deployment/KeycloakThreadSetupHandler.java
@@ -1,0 +1,33 @@
+package org.wildfly.swarm.keycloak.deployment;
+
+import io.undertow.server.HttpServerExchange;
+import io.undertow.servlet.api.ThreadSetupHandler;
+import org.keycloak.KeycloakSecurityContext;
+import org.keycloak.adapters.undertow.OIDCUndertowHttpFacade;
+
+/**
+ * @author Bob McWhirter
+ */
+class KeycloakThreadSetupHandler implements ThreadSetupHandler {
+    @Override
+    public <T, C> Action<T, C> create(final Action<T, C> action) {
+
+        return new Action<T, C>() {
+
+            @Override
+            public T call(HttpServerExchange exchange, C context) throws Exception {
+                if (exchange == null) {
+                    return null;
+                }
+                KeycloakSecurityContext c = exchange.getAttachment(OIDCUndertowHttpFacade.KEYCLOAK_SECURITY_CONTEXT_KEY);
+                KeycloakSecurityContextAssociation.associate(c);
+                try {
+                    return action.call(exchange, context);
+                } finally {
+                    KeycloakSecurityContextAssociation.disassociate();
+                }
+            }
+        };
+    }
+
+}

--- a/fractions/keycloak/src/main/java/org/wildfly/swarm/keycloak/deployment/SecurityContextServletExtension.java
+++ b/fractions/keycloak/src/main/java/org/wildfly/swarm/keycloak/deployment/SecurityContextServletExtension.java
@@ -17,57 +17,31 @@ package org.wildfly.swarm.keycloak.deployment;
 
 import javax.servlet.ServletContext;
 
-import io.undertow.server.HandlerWrapper;
-import io.undertow.server.HttpHandler;
-import io.undertow.server.HttpServerExchange;
 import io.undertow.servlet.ServletExtension;
 import io.undertow.servlet.api.DeploymentInfo;
-import io.undertow.servlet.api.ThreadSetupAction;
 import org.keycloak.KeycloakSecurityContext;
 import org.keycloak.adapters.undertow.OIDCUndertowHttpFacade;
 
 /**
  * @author Bob McWhirter
  */
+@SuppressWarnings("unused")
 public class SecurityContextServletExtension implements ServletExtension {
     @Override
     public void handleDeployment(DeploymentInfo info, ServletContext context) {
-        info.addThreadSetupAction(new ThreadSetupAction() {
-            @Override
-            public Handle setup(HttpServerExchange exchange) {
-                if (exchange == null) {
-                    return null;
-                }
-                KeycloakSecurityContext c = exchange.getAttachment(OIDCUndertowHttpFacade.KEYCLOAK_SECURITY_CONTEXT_KEY);
+        info.addThreadSetupAction(new KeycloakThreadSetupHandler());
+
+        info.addInnerHandlerChainWrapper(next -> exchange -> {
+            KeycloakSecurityContext c = exchange.getAttachment(OIDCUndertowHttpFacade.KEYCLOAK_SECURITY_CONTEXT_KEY);
+            if (c != null) {
                 KeycloakSecurityContextAssociation.associate(c);
-                return new Handle() {
-                    @Override
-                    public void tearDown() {
-                        KeycloakSecurityContextAssociation.disassociate();
-                    }
-                };
             }
-        });
-
-        info.addInnerHandlerChainWrapper(new HandlerWrapper() {
-            @Override
-            public HttpHandler wrap(HttpHandler next) {
-                return new HttpHandler() {
-                    @Override
-                    public void handleRequest(HttpServerExchange exchange) throws Exception {
-                        KeycloakSecurityContext c = exchange.getAttachment(OIDCUndertowHttpFacade.KEYCLOAK_SECURITY_CONTEXT_KEY);
-                        if (c != null) {
-                            KeycloakSecurityContextAssociation.associate(c);
-                        }
-
-                        try {
-                            next.handleRequest(exchange);
-                        } finally {
-                            KeycloakSecurityContextAssociation.disassociate();
-                        }
-                    }
-                };
+            try {
+                next.handleRequest(exchange);
+            } finally {
+                KeycloakSecurityContextAssociation.disassociate();
             }
         });
     }
+
 }

--- a/fractions/topology-webapp/src/main/java/org/wildfly/swarm/topology/webapp/runtime/TopologyProxiedServiceCustomizer.java
+++ b/fractions/topology-webapp/src/main/java/org/wildfly/swarm/topology/webapp/runtime/TopologyProxiedServiceCustomizer.java
@@ -41,9 +41,11 @@ import static org.wildfly.swarm.topology.webapp.TopologyWebAppFraction.proxyHand
 @ApplicationScoped
 public class TopologyProxiedServiceCustomizer implements Customizer {
 
+    @SuppressWarnings("unused")
     @Inject @Any
     private UndertowFraction undertow;
 
+    @SuppressWarnings("unused")
     @Inject @Any
     private TopologyWebAppFraction fraction;
 
@@ -52,7 +54,7 @@ public class TopologyProxiedServiceCustomizer implements Customizer {
         if (!mappings.isEmpty()) {
             HandlerConfiguration handlerConfig = undertow.subresources().handlerConfiguration();
             for (String serviceName : mappings.keySet()) {
-                ReverseProxy proxy = new ReverseProxy(proxyHandlerName(serviceName)).hosts(Collections.emptyList());
+                ReverseProxy<?> proxy = new ReverseProxy<>(proxyHandlerName(serviceName)).hosts(Collections.emptyList());
                 handlerConfig.reverseProxy(proxy);
 
                 String contextPath = mappings.get(serviceName);

--- a/fractions/topology/src/test/java/org/wildfly/swarm/topology/runtime/AdvertisingMetadataProcessorTest.java
+++ b/fractions/topology/src/test/java/org/wildfly/swarm/topology/runtime/AdvertisingMetadataProcessorTest.java
@@ -66,7 +66,7 @@ public class AdvertisingMetadataProcessorTest {
         assertThat(advertisements).contains("gouda");
     }
 
-    Index createIndex(Archive archive) throws IOException {
+    Index createIndex(Archive<?> archive) throws IOException {
         Indexer indexer = new Indexer();
 
         Map<ArchivePath, Node> c = archive.getContent();

--- a/fractions/vertx/src/main/java/org/wildfly/swarm/vertx/runtime/VertxAdapterCustomizer.java
+++ b/fractions/vertx/src/main/java/org/wildfly/swarm/vertx/runtime/VertxAdapterCustomizer.java
@@ -40,6 +40,7 @@ public class VertxAdapterCustomizer implements Customizer {
     @Inject
     Instance<VertxFraction> vertxFractionInstance;
 
+    @SuppressWarnings("unchecked")
     @Override
     public void customize() {
         if (!resourceAdapterFractionInstance.isUnsatisfied() && !vertxFractionInstance.isUnsatisfied()) {

--- a/meta/fraction-metadata/src/main/java/org/wildfly/swarm/fractions/FractionUsageAnalyzer.java
+++ b/meta/fraction-metadata/src/main/java/org/wildfly/swarm/fractions/FractionUsageAnalyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -150,6 +150,7 @@ public class FractionUsageAnalyzer {
         return detectors;
     }
 
+    @SuppressWarnings("unchecked")
     private <T> FractionDetector<T> convert(FractionDetector<?> detector) {
         return (FractionDetector<T>) detector;
     }

--- a/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/GradleArtifactResolvingHelper.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/GradleArtifactResolvingHelper.java
@@ -74,7 +74,7 @@ public class GradleArtifactResolvingHelper implements ArtifactResolvingHelper {
     @Override
     public Set<ArtifactSpec> resolveAll(final Collection<ArtifactSpec> specs, boolean transitive, boolean defaultExcludes) throws Exception {
         if (specs.isEmpty()) {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
 
         return doResolve(specs, transitive)

--- a/plugin/src/main/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelper.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelper.java
@@ -109,9 +109,9 @@ public class MavenArtifactResolvingHelper implements ArtifactResolvingHelper {
     @Override
     public Set<ArtifactSpec> resolveAll(Collection<ArtifactSpec> specs, boolean transitive, boolean defaultExcludes) throws Exception {
         if (specs.isEmpty()) {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
-        List<DependencyNode> nodes = null;
+        List<DependencyNode> nodes;
         if (transitive) {
 
             final CollectRequest request = new CollectRequest();
@@ -203,7 +203,7 @@ public class MavenArtifactResolvingHelper implements ArtifactResolvingHelper {
         }
     }
 
-    protected RemoteRepository buildRemoteRepository(final String id, final String url, final Authentication auth) {
+    private RemoteRepository buildRemoteRepository(final String id, final String url, final Authentication auth) {
         RemoteRepository.Builder builder = new RemoteRepository.Builder(id, "default", url);
         if (auth != null
                 && auth.getUsername() != null

--- a/testsuite/testsuite-infinispan/src/main/java/org/wildfly/swarm/infinispan/test/MyResource.java
+++ b/testsuite/testsuite-infinispan/src/main/java/org/wildfly/swarm/infinispan/test/MyResource.java
@@ -23,7 +23,7 @@ public class MyResource {
     public String get() throws Exception {
         EmbeddedCacheManager cacheContainer
                 = (EmbeddedCacheManager) new InitialContext().lookup("java:jboss/infinispan/container/server");
-        Cache cache = cacheContainer.getCache("server");
+        Cache<String,String> cache = cacheContainer.getCache("server");
         if (cache.keySet().contains(key)) {
             return (String) cache.get(key);
         }

--- a/testsuite/testsuite-infinispan/src/test/java/org/wildfly/swarm/infinispan/test/InfinispanRemoteTest.java
+++ b/testsuite/testsuite-infinispan/src/test/java/org/wildfly/swarm/infinispan/test/InfinispanRemoteTest.java
@@ -39,7 +39,7 @@ public class InfinispanRemoteTest {
     public void testBasic() throws Exception {
         CacheContainer cacheContainer =
                 (CacheContainer) new InitialContext().lookup("java:jboss/infinispan/container/server");
-        Cache cache = cacheContainer.getCache("default");
+        Cache<String,String> cache = cacheContainer.getCache("default");
         cache.put("ham", "biscuit");
         assertEquals("biscuit", cache.get("ham"));
     }

--- a/testsuite/testsuite-jaxrs/src/main/java/org/wildfly/swarm/jaxrs/CustomJsonProvider.java
+++ b/testsuite/testsuite-jaxrs/src/main/java/org/wildfly/swarm/jaxrs/CustomJsonProvider.java
@@ -42,7 +42,7 @@ public class CustomJsonProvider extends JacksonJaxbJsonProvider {
     private ObjectMapper getObjectMapper() {
         ObjectMapper mapper = new ObjectMapper();
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        mapper.setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES);
+        mapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
         return mapper;
     }
 

--- a/testsuite/testsuite-jaxrs/src/main/java/org/wildfly/swarm/jaxrs/JsonParsingExceptionResource.java
+++ b/testsuite/testsuite-jaxrs/src/main/java/org/wildfly/swarm/jaxrs/JsonParsingExceptionResource.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.core.JsonParseException;
 @Path("/json")
 public class JsonParsingExceptionResource {
 
+    @SuppressWarnings("deprecation")
     @GET
     @Path("/throw")
     public Response get() throws JsonParseException {

--- a/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/StageConfigTest.java
+++ b/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/StageConfigTest.java
@@ -13,6 +13,7 @@ import static org.fest.assertions.Assertions.assertThat;
 /**
  * @author Bob McWhirter
  */
+@SuppressWarnings("deprecation")
 public class StageConfigTest {
 
     @Test

--- a/testsuite/testsuite-transactions/src/test/java/org/wildfly/swarm/transactions/test/TransactionsArquillianTest.java
+++ b/testsuite/testsuite-transactions/src/test/java/org/wildfly/swarm/transactions/test/TransactionsArquillianTest.java
@@ -39,6 +39,7 @@ public class TransactionsArquillianTest {
     @ArquillianResource
     ServiceRegistry registry;
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testPorts() throws Exception {
         ServiceController<SocketBinding> statusManagerService = (ServiceController<SocketBinding>) registry.getService(ServiceName.parse("org.wildfly.network.socket-binding.txn-status-manager"));

--- a/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
@@ -224,8 +224,8 @@ public class BuildTool {
         addJarManifest();
         addWildFlySwarmApplicationManifest();
         addAdditionalModules();
-        addProjectAsset((ResolvedDependencies) this.dependencyManager);
-        populateUberJarMavenRepository((ResolvedDependencies) this.dependencyManager);
+        addProjectAsset(this.dependencyManager);
+        populateUberJarMavenRepository(this.dependencyManager);
 
         return this.archive;
     }
@@ -245,6 +245,7 @@ public class BuildTool {
         return jbossModulesFound;
     }
 
+    @SuppressWarnings("unchecked")
     private void expandArtifact(File artifactFile) throws IOException {
         try {
             ZipFile zipFile = new ZipFile(artifactFile);
@@ -270,6 +271,7 @@ public class BuildTool {
         this.dependencyManager.analyzeDependencies(autodetect, declaredDependencies);
     }
 
+    @SuppressWarnings("UnusedParameters")
     private void addProjectAsset(ResolvedDependencies resolvedDependencies) {
         if (this.hollow) {
             return;
@@ -304,7 +306,7 @@ public class BuildTool {
                 .forEach(this::fraction);
     }
 
-    static String strippedSwarmGav(MavenArtifactDescriptor desc) {
+    private static String strippedSwarmGav(MavenArtifactDescriptor desc) {
         if (desc.groupId().equals(DependencyManager.WILDFLY_SWARM_GROUP_ID)) {
             return String.format("%s:%s", desc.artifactId(), desc.version());
         }
@@ -334,7 +336,7 @@ public class BuildTool {
 
     private void addWildflySwarmBootstrapJar() throws Exception {
 
-        ResolvedDependencies resolvedDependencies = (ResolvedDependencies) this.dependencyManager;
+        ResolvedDependencies resolvedDependencies = this.dependencyManager;
 
         ArtifactSpec artifact = resolvedDependencies.findWildFlySwarmBootstrapJar();
 
@@ -478,7 +480,7 @@ public class BuildTool {
 
             if (unresolved || !exploded) {
                 toBeResolved.add(dependency);
-            } else if (!unresolved) {
+            } else {
                 alreadyResolved.add(dependency);
             }
         }
@@ -510,12 +512,12 @@ public class BuildTool {
 
         toBeResolved.addAll(
                 resolvedDependencies.getDependencies().stream()
-                        .filter(a -> a.isResolved() == false)
+                        .filter(a -> !a.isResolved())
                         .collect(Collectors.toList())
         );
         toBeResolved.addAll(
                 resolvedDependencies.getModuleDependencies().stream()
-                        .filter(a -> a.isResolved() == false)
+                        .filter(a -> !a.isResolved())
                         .collect(Collectors.toList())
         );
 
@@ -571,7 +573,7 @@ public class BuildTool {
 
     private final DefaultArtifactResolver resolver;
 
-    public static final SimpleLogger STD_LOGGER = new SimpleLogger() {
+    private static final SimpleLogger STD_LOGGER = new SimpleLogger() {
         @Override
         public void info(String msg) {
             System.out.println(msg);

--- a/tools/src/main/java/org/wildfly/swarm/tools/DependencyManager.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/DependencyManager.java
@@ -180,7 +180,7 @@ public class DependencyManager implements ResolvedDependencies {
                     .filter(dep -> dep.type().equals(JAR))
                     .collect(Collectors.toList());
 
-            Collection<ArtifactSpec> resolvedTransientDependencies = Collections.EMPTY_SET;
+            Collection<ArtifactSpec> resolvedTransientDependencies = Collections.emptySet();
             if (filtered.size() > 0) {
 
                 resolvedTransientDependencies = resolver.resolveAllArtifactsNonTransitively(filtered);


### PR DESCRIPTION
Motivation
----------

Warnings and deprecations can hide important things if
we're used to seeing them so much that we begin to ignore
them.

Modifications
-------------

Some places the warnings were un-fixable beyond a @SuppressWarnings,
but other places we were definitely being too loosey-goosey with things
that could be fixed up.

Result
------

Cleaner build.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
