### PR TITLE
SWARM-1085 - support vanilla json-p.

### DIFF
--- a/fractions/javaee/jsonp/module.conf
+++ b/fractions/javaee/jsonp/module.conf
@@ -1,0 +1,1 @@
+javax.json.api

--- a/fractions/javaee/jsonp/pom.xml
+++ b/fractions/javaee/jsonp/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>wildfly-swarm</artifactId>
+    <version>2017.4.0-SNAPSHOT</version>
+    <relativePath>../../../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>jsonp</artifactId>
+
+  <name>JSON-P</name>
+  <description>JSON-P</description>
+
+  <packaging>jar</packaging>
+
+  <properties>
+    <swarm.fraction.bootstrap>true</swarm.fraction.bootstrap>
+    <swarm.fraction.stability>stable</swarm.fraction.stability>
+    <swarm.fraction.tags>JavaEE,JSON</swarm.fraction.tags>
+  </properties>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+  </build>
+
+  <dependencies>
+    <!-- Fraction Dependencies -->
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+
+    <!-- Provided APIs -->
+    <dependency>
+      <groupId>org.glassfish</groupId>
+      <artifactId>javax.json</artifactId>
+    </dependency>
+
+    <!-- Meta SPI -->
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>meta-spi</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.wildfly.core</groupId>
+      <artifactId>wildfly-core-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-servlet-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/fractions/javaee/jsonp/src/main/java/org/wildfly/swarm/jsonp/detect/JsonPPackageDetector.java
+++ b/fractions/javaee/jsonp/src/main/java/org/wildfly/swarm/jsonp/detect/JsonPPackageDetector.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.jsonp.detect;
+
+import org.wildfly.swarm.spi.meta.PackageFractionDetector;
+
+/**
+ * @author Ken Finnigan
+ */
+public class JsonPPackageDetector extends PackageFractionDetector {
+
+    public JsonPPackageDetector() {
+        allPackages("javax.json");
+    }
+
+    @Override
+    public String artifactId() {
+        return "jsonp";
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -793,6 +793,12 @@
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
+        <artifactId>jsonp</artifactId>
+        <version>2017.4.0-SNAPSHOT</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.wildfly.swarm</groupId>
         <artifactId>keycloak</artifactId>
         <version>2017.4.0-SNAPSHOT</version>
       </dependency>
@@ -1288,6 +1294,7 @@
     <module>fractions/javaee/jmx</module>
     <module>fractions/javaee/jpa</module>
     <module>fractions/javaee/jsf</module>
+    <module>fractions/javaee/jsonp</module>
     <module>fractions/javaee/naming</module>
     <module>fractions/javaee/remoting</module>
     <module>fractions/javaee/transactions</module>


### PR DESCRIPTION
Motivation
----------

JSON is usable without JAX-RS.

Modifications
-------------

New, :jsonp fraction, with autodetection.

Result
------

Lthon's example works.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
