### PR TITLE
SWARM-1207 - Should auto-detect CDI by beans.xml

### DIFF
--- a/fractions/javaee/cdi/src/main/java/org/wildfly/swarm/cdi/detect/BeansXmlDetector.java
+++ b/fractions/javaee/cdi/src/main/java/org/wildfly/swarm/cdi/detect/BeansXmlDetector.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.swarm.cdi.detect;
+
+import org.wildfly.swarm.spi.meta.FileDetector;
+
+/**
+ * @author Heiko Braun
+ */
+public class BeansXmlDetector extends FileDetector {
+
+    @Override
+    public String extensionToDetect() {
+        return XML;
+    }
+
+    @Override
+    public boolean detectionComplete() {
+        return detectionComplete;
+    }
+
+    @Override
+    public boolean wasDetected() {
+        return detected;
+    }
+
+    @Override
+    public void detect(String fileName) {
+        if (!detectionComplete() && fileName.endsWith(BEANS_XML)) {
+            detected = true;
+            detectionComplete = true;
+        }
+    }
+
+    @Override
+    public String artifactId() {
+        return CDI;
+    }
+
+    private static final String XML = "xml";
+
+    private static final String BEANS_XML = "beans.xml";
+
+    private static final String CDI = "cdi";
+
+    private boolean detected = false;
+
+    private boolean detectionComplete = false;
+
+}
+


### PR DESCRIPTION
Motivation
----------

Sometimes beans.xml is all you need for CDI.

Modifications
-------------

Add detector for beans.xml.

Result
------

Detect CDI based on beans.xml.  beans.xml.  beans.xml.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
