### PR TITLE
SWARM-1212: Introduce flag to skip execution of PackageMojo.

### DIFF
--- a/plugin/src/main/java/org/wildfly/swarm/plugin/maven/PackageMojo.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/maven/PackageMojo.java
@@ -69,6 +69,12 @@ public class PackageMojo extends AbstractSwarmMojo {
     @Parameter(alias = "hollow", defaultValue = "false", property = "swarm.hollow")
     protected boolean hollow;
 
+    /**
+     * Flag to skip packaging entirely.
+     */
+    @Parameter(alias = "skip", defaultValue = "false", property = "swarm.package.skip")
+    protected boolean skip;
+
     protected File divineFile() {
         if (this.project.getArtifact().getFile() != null) {
             return this.project.getArtifact().getFile();
@@ -87,6 +93,10 @@ public class PackageMojo extends AbstractSwarmMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (this.skip) {
+            getLog().info("Skipping packaging");
+            return;
+        }
         if (this.project.getPackaging().equals("pom")) {
             getLog().info("Not processing project with pom packaging");
             return;


### PR DESCRIPTION
Motivation
----------
Packaging is useless and just wastes time when using wildfly-swarm:run (useUberJar=false).

Modifications
-------------
Add "skip" parameter to PackageMojo. Many Maven plugins have this parameter.

Result
------
Packaging can be skipped when you don't need it.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
