### PR TITLE
SWARM-1218: Add RunNoForkMojo.

### DIFF
--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/RunNoForkMojo.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/RunNoForkMojo.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.plugin.maven;
+
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+/**
+ * Non-forking version of {@link RunMojo}.
+ */
+@Mojo(name = "run-no-fork",
+        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME,
+        requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME)
+public class RunNoForkMojo extends StartMojo {
+    public RunNoForkMojo() {
+        waitForProcess = true;
+    }
+}


### PR DESCRIPTION
Motivation
----------
RunMojo always forks the maven lifecycle which is annoying/wasting time in some cases.

Modifications
-------------
As there is no way to toggle lifecycle forking, introduce new RunNoForkMojo.
maven-source-plugin, maven-javadoc-plugin and others have done the same in the past.

Result
------
Swarm application can be started faster.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
