### PR TITLE
SWARM-1170 - If it's a war, we should auto-detect undertow.

### DIFF
--- a/meta/fraction-metadata/src/test/java/org/wildfly/swarm/fractions/FractionUsageAnalyzerTest.java
+++ b/meta/fraction-metadata/src/test/java/org/wildfly/swarm/fractions/FractionUsageAnalyzerTest.java
@@ -19,7 +19,9 @@ import java.io.File;
 import java.nio.file.Files;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.wildfly.swarm.jaxrs.JAXRSArchive;
 
@@ -41,6 +43,23 @@ public class FractionUsageAnalyzerTest {
                            .stream()
                            .filter(fd -> fd.getArtifactId().equals("jaxrs"))
                            .count())
+                .isEqualTo(1);
+    }
+
+    @Test
+    public void testDetectEmptyWarAsUndertow() throws Exception {
+        JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "test.war");
+        archive.add(EmptyAsset.INSTANCE, "nothing");
+        FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer();
+
+        final File out = Files.createTempFile(archive.getName(), ".war").toFile();
+        archive.as(ZipExporter.class).exportTo(out, true);
+
+        analyzer.source(out);
+        assertThat(analyzer.detectNeededFractions()
+                .stream()
+                .filter(fd -> fd.getArtifactId().equals("undertow"))
+                .count())
                 .isEqualTo(1);
     }
 }


### PR DESCRIPTION
Motivation
----------

Sometimes (I guess?) it's possible to have a .war that contains
nothing undertow/servlet/jaxrs-like within it, yet still function.

Modifications
-------------

Since FractionDetectors work on the *content* of the files, add
a special-case (for now) for .war == undertow.

Result
------

A .war without anything webby is known to be a war and detects
and requests undertow.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
