### PR TITLE
SWARM-648 - Provide a handy-dandy cli.jar

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>wildfly-swarm</artifactId>
+    <version>2017.4.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm.cli</groupId>
+  <artifactId>cli</artifactId>
+
+  <name>JBoss CLI</name>
+  <description>JBoss CLI</description>
+
+  <packaging>jar</packaging>
+
+  <properties>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>wildfly-swarm-plugin</artifactId>
+        <version>${project.version}</version>
+        <configuration>
+          <mainClass>org.wildfly.swarm.cli.Main</mainClass>
+        </configuration>
+        <executions>
+          <execution>
+            <id>package</id>
+            <goals>
+              <goal>package</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>cli</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.modules</groupId>
+      <artifactId>jboss-modules</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+
+</project>

--- a/cli/src/main/java/org/wildfly/swarm/cli/Main.java
+++ b/cli/src/main/java/org/wildfly/swarm/cli/Main.java
@@ -1,0 +1,35 @@
+package org.wildfly.swarm.cli;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+import org.jboss.modules.Module;
+import org.jboss.modules.ModuleIdentifier;
+
+/**
+ * @author Bob McWhirter
+ */
+public class Main {
+    private Main() {
+    }
+
+    public static void main(String... args) throws Exception {
+        Path tmpFile = null;
+        if (System.getProperty("jboss.cli.config") == null) {
+            tmpFile = Files.createTempFile("jboss-cli", ".xml");
+            Files.copy(Main.class.getResourceAsStream("/jboss-cli.xml"),
+                    tmpFile,
+                    StandardCopyOption.REPLACE_EXISTING);
+            System.setProperty("jboss.cli.config", tmpFile.toAbsolutePath().toString());
+        }
+        Module cli = Module.getBootModuleLoader().loadModule(ModuleIdentifier.create("org.jboss.as.cli"));
+        try {
+            cli.run(args);
+        } finally {
+            if (tmpFile != null) {
+                Files.delete(tmpFile);
+            }
+        }
+    }
+}

--- a/cli/src/main/resources/jboss-cli.xml
+++ b/cli/src/main/resources/jboss-cli.xml
@@ -1,0 +1,47 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<!--
+   WildFly Command-line Interface configuration.
+-->
+<jboss-cli xmlns="urn:jboss:cli:2.0">
+
+    <default-protocol use-legacy-override="true">http-remoting</default-protocol>
+
+    <!-- The default controller to connect to when 'connect' command is executed w/o arguments -->
+    <default-controller>
+        <protocol>http-remoting</protocol>
+        <host>localhost</host>
+        <port>9990</port>
+    </default-controller>
+
+    <!-- Example controller alias named 'Test'
+    <controllers>
+        <controller name="Test">
+            <protocol>http-remoting</protocol>
+            <host>localhost</host>
+            <port>9990</port>
+        </controller>
+    </controllers>
+    -->
+
+    <validate-operation-requests>true</validate-operation-requests>
+
+    <!-- Command and operation history log configuration -->
+    <history>
+        <enabled>true</enabled>
+        <file-name>.jboss-cli-history</file-name>
+        <file-dir>${user.home}</file-dir>
+        <max-size>500</max-size>
+    </history>
+
+    <!-- whether to resolve system properties specified as command argument or operation parameter values
+                  in the CLI VM before sending the operation requests to the controller -->
+    <resolve-parameter-values>false</resolve-parameter-values>
+
+
+    <!-- Whether to write info and error messages to the terminal output -->
+    <silent>false</silent>
+
+    <!-- Whether to filter out commands and attributes based on user's permissions -->
+    <access-control>false</access-control>
+</jboss-cli>

--- a/fractions/wildfly/cli/module.conf
+++ b/fractions/wildfly/cli/module.conf
@@ -1,0 +1,1 @@
+org.jboss.as.cli

--- a/fractions/wildfly/cli/pom.xml
+++ b/fractions/wildfly/cli/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>wildfly-swarm</artifactId>
+    <version>2017.4.0-SNAPSHOT</version>
+    <relativePath>../../../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>cli</artifactId>
+
+  <name>JBoss CLI</name>
+  <description>JBoss CLI</description>
+
+  <packaging>jar</packaging>
+
+  <properties>
+    <swarm.fraction.cdi>false</swarm.fraction.cdi>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>bootstrap</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>container</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.core</groupId>
+      <artifactId>wildfly-core-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-servlet-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -481,6 +481,11 @@
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
+        <artifactId>cli</artifactId>
+        <version>2017.4.0-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly.swarm</groupId>
         <artifactId>tools</artifactId>
         <version>2017.4.0-SNAPSHOT</version>
       </dependency>
@@ -1392,6 +1397,8 @@
         <module>client-apis/jaxrs-client-api</module>
 
         <module>swarmtool</module>
+        <module>cli</module>
+
         <module>plugins/gradle</module>
 
         <module>boms/bom-deprecated</module>
@@ -1431,6 +1438,7 @@
         <module>fractions/vertx</module>
         <module>fractions/zipkin-jaxrs</module>
 
+        <module>fractions/wildfly/cli</module>
         <module>fractions/wildfly/jdr</module>
         <module>fractions/wildfly/management-console</module>
         <module>fractions/wildfly/mod_cluster</module>


### PR DESCRIPTION
Motivation
----------

Since we support the management fraction, which can allow CLI'ing,
we should provide a way to CLI.

Modifications
-------------

Create a pseudo fraction (because JBoss-Modules and uberjar) for CLI.
Create a pseudo "standalone server" to produce a cli-swarm.jar.

Result
------

cli-swarm.jar.

    eduardo:cli bob$ java -jar ./target/cli-2017.4.0-SNAPSHOT-swarm.jar
    You are disconnected at the moment. Type 'connect' to connect to the server or 'help' for the list of supported commands.
    [disconnected /]

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
