### PR TITLE
SWARM-1043 - Be sure to log @Configurables from ArchivePreparers.

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/internal/SwarmMessages.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/SwarmMessages.java
@@ -153,6 +153,9 @@ public interface SwarmMessages extends BasicLogger {
     @Message(id = 30, value = "Error cleaning up temporary file provider.")
     void errorCleaningUpTempFileProvider(@Cause Throwable cause);
 
+    @LogMessage(level = Logger.Level.TRACE)
+    @Message(id = 31, value = "Registered archive-preparer: %s")
+    void registeredArchivePreparer(String preparer);
 
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
Motivation
----------

Due to their late initialization, the org.wildfly.swarm.config
logging category did not display the effective @Configurables
for ArchivePreparers.

Modifications
-------------

Loop the ArchivePreparers before logging the @Configurable
state.

Result
------

Now..

If:

    -Dswarm.logging.org.wildfly.swarm.config=DBEUG

Then:

    swarm.context.mounts     = (unset)
    swarm.context.path       = /

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
