### PR TITLE
SWARM-1219 - Failed deployment should stop the process.

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/core/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -607,7 +607,12 @@ public class Swarm {
         }
 
         Swarm swarm = new Swarm(args);
-        swarm.start().deploy();
+        try {
+            swarm.start().deploy();
+        } catch (Throwable t) {
+            swarm.stop();
+            throw t;
+        }
     }
 
     private static ArtifactLookup artifactLookup() {


### PR DESCRIPTION
Motivation
----------

If the default Swarm::main() should fail, we shouldn't leave the process
hanging around.

Modifications
-------------

If the swarm.start().deploy() throws, catch, call stop(), and
rethrow the exception on out.

Result
------

Hopefully a bad process will go away.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
