### PR TITLE
SWARM-1231 - When management and webservices is used, Ambgiuous CDI.

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/Interface.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/Interface.java
@@ -15,8 +15,6 @@
  */
 package org.wildfly.swarm.container;
 
-import javax.enterprise.inject.Vetoed;
-
 /** A network-level interface configured for the container.
  *
  * <p>An interface dictates which IP address other sockets are bound to,
@@ -27,8 +25,13 @@ import javax.enterprise.inject.Vetoed;
  * @see org.wildfly.swarm.spi.api.OutboundSocketBinding
  * @author Bob McWhirter
  */
-@Vetoed
 public class Interface {
+
+    /** Constant for use with {@link javax.inject.Named} */
+    public static final String PUBLIC = "public-interface";
+
+    /** Constant for use with {@link javax.inject.Named} */
+    public static final String MANAGEMENT = "management-interface";
 
     public Interface(String name, String expression) {
         this.name = name;

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/config/PublicInterfaceProducer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/config/PublicInterfaceProducer.java
@@ -17,6 +17,7 @@ package org.wildfly.swarm.container.runtime.config;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
+import javax.inject.Named;
 
 import org.wildfly.swarm.container.Interface;
 import org.wildfly.swarm.spi.api.SwarmProperties;
@@ -25,9 +26,10 @@ import org.wildfly.swarm.spi.api.SwarmProperties;
  * @author Bob McWhirter
  */
 @ApplicationScoped
-public class DefaultInterfaceProducer {
+public class PublicInterfaceProducer {
 
     @Produces
+    @Named(Interface.PUBLIC)
     public Interface publicInterace() {
         return new Interface("public", SwarmProperties.propertyVar(SwarmProperties.BIND_ADDRESS, "0.0.0.0"));
     }

--- a/fractions/javaee/webservices/src/main/java/org/wildfly/swarm/webservices/runtime/WSDLHostCustomizer.java
+++ b/fractions/javaee/webservices/src/main/java/org/wildfly/swarm/webservices/runtime/WSDLHostCustomizer.java
@@ -2,6 +2,7 @@ package org.wildfly.swarm.webservices.runtime;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import org.wildfly.swarm.container.Interface;
 import org.wildfly.swarm.spi.api.Customizer;
@@ -16,6 +17,7 @@ import org.wildfly.swarm.webservices.WebServicesFraction;
 public class WSDLHostCustomizer implements Customizer {
 
     @Inject
+    @Named(Interface.PUBLIC)
     Interface iface;
 
     @Inject

--- a/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/runtime/ManagementInterfaceProducer.java
+++ b/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/runtime/ManagementInterfaceProducer.java
@@ -17,6 +17,7 @@ package org.wildfly.swarm.management.runtime;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
+import javax.inject.Named;
 
 import org.wildfly.swarm.container.Interface;
 import org.wildfly.swarm.management.ManagementProperties;
@@ -29,6 +30,7 @@ import org.wildfly.swarm.spi.api.SwarmProperties;
 public class ManagementInterfaceProducer {
 
     @Produces
+    @Named(Interface.MANAGEMENT)
     public Interface publicInterace() {
         return new Interface("management", SwarmProperties.propertyVar(ManagementProperties.MANAGEMENT_BIND_ADDRESS, "127.0.0.1"));
     }


### PR DESCRIPTION
Motivation
----------

When :management fraction is included, we setup multiple interfaces.
When WebServices is used, it injects an interface, which is now ambiguous.

Modifications
-------------

Mix in some @Named annotations for both the creation and injection
of interfaces to avoid ambiguity.

Result
------

Should be able to inject Interface.PUBLIC or Interface.MANAGEMENT (if
present) as needed, unambiguously.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
