### PR TITLE
SWARM-831 - easy-to-enable audit-logging.

### DIFF
--- a/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/ManagementFraction.java
+++ b/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/ManagementFraction.java
@@ -49,8 +49,31 @@ public class ManagementFraction extends ManagementCoreService<ManagementFraction
         applyDefaults();
     }
 
+    public static final String JSON_FORMATTER = "json-formatter";
+
+    public static final String AUDIT_LOG_FILE = "audit-log.log";
+
+    public static final String FILE_HANDLER = "file";
+
     public ManagementFraction applyDefaults() {
         httpInterfaceManagementInterface();
+
+        auditAccess((access) -> {
+            access.jsonFormatter(JSON_FORMATTER, (formatter) -> {
+            });
+            access.fileHandler(FILE_HANDLER, (handler) -> {
+                handler.formatter(JSON_FORMATTER);
+                handler.path(AUDIT_LOG_FILE);
+                handler.relativeTo("user.dir");
+            });
+            access.auditLogLogger((logger) -> {
+                logger.logBoot(true);
+                logger.logReadOnly(true);
+                logger.enabled(false);
+                logger.handler(FILE_HANDLER);
+            });
+        });
+
         return this;
     }
 
@@ -104,6 +127,11 @@ public class ManagementFraction extends ManagementCoreService<ManagementFraction
 
     public boolean isHttpDisable() {
         return this.httpDisable.get();
+    }
+
+    public ManagementFraction enableDefaultAuditAccess() {
+        subresources().auditAccess().subresources().auditLogLogger().enabled(true);
+        return this;
     }
 
     @Configurable("swarm.management.http.port")

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <version.org.snakeyaml>1.17</version.org.snakeyaml>
 
     <version.maven.aether>3.2.5</version.maven.aether>
-    <version.wildfly.config-api>1.0.2.Final</version.wildfly.config-api>
+    <version.wildfly.config-api>1.0.3.Final</version.wildfly.config-api>
 
     <version.keycloak.config-api>1.0.2.Final</version.keycloak.config-api>
     <version.teiid.config-api>1.0.2</version.teiid.config-api>

--- a/testsuite/testsuite-management/src/main/resources/project-defaults.yml
+++ b/testsuite/testsuite-management/src/main/resources/project-defaults.yml
@@ -1,6 +1,9 @@
 
 swarm:
   management:
+    audit-access:
+      audit-log-logger:
+        enabled: true
     http-interface-management-interface:
       security-realm: ManagementRealm
     security-realms:

--- a/testsuite/testsuite-management/src/test/java/org/wildfly/swarm/management/test/ArqAuditLogTest.java
+++ b/testsuite/testsuite-management/src/test/java/org/wildfly/swarm/management/test/ArqAuditLogTest.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.management.test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.arquillian.DefaultDeployment;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Bob McWhirter
+ */
+@RunWith(Arquillian.class)
+@DefaultDeployment(type = DefaultDeployment.Type.JAR)
+public class ArqAuditLogTest {
+
+    @Test
+    public void testClient() throws Exception {
+        Path auditLog = Paths.get( "audit-log.log");
+        assertTrue(Files.exists(auditLog));
+    }
+
+}

--- a/testsuite/testsuite-management/src/test/java/org/wildfly/swarm/management/test/ArqSecuredManagementInterfaceTest.java
+++ b/testsuite/testsuite-management/src/test/java/org/wildfly/swarm/management/test/ArqSecuredManagementInterfaceTest.java
@@ -39,33 +39,6 @@ import static org.fest.assertions.Assertions.assertThat;
 @DefaultDeployment
 public class ArqSecuredManagementInterfaceTest {
 
-    /*
-    @Deployment(testable = false)
-    public static Archive createDeployment() {
-        JARArchive deployment = ShrinkWrap.create(JARArchive.class, "myapp.jar");
-        deployment.add(EmptyAsset.INSTANCE, "nothing");
-        return deployment;
-    }
-
-    public static Swarm newContainer() throws Exception {
-        return new Swarm()
-                .fraction(
-                        ManagementFraction.createDefaultFraction()
-                                .httpInterfaceManagementInterface((iface) -> {
-                                    iface.securityRealm("ManagementRealm");
-                                })
-                                .securityRealm("ManagementRealm", (realm) -> {
-                                    realm.inMemoryAuthentication((authn) -> {
-                                        authn.add("bob", "tacos!", true);
-                                    });
-                                    realm.inMemoryAuthorization((authz) -> {
-                                        authz.add("bob", "admin");
-                                    });
-                                })
-                );
-    }
-    */
-
     @Test
     @RunAsClient
     public void testClient() throws Exception {


### PR DESCRIPTION
Motivation
----------

Audit logging should be supported.  And easy.

Modifications
-------------

Apply default (but enabled=false) audit-logging for the
Management fraction.  Allow easy enablement with
`enableDefaultAuditAccess()` or:

    swarm:
      management:
        audit-access:
          audit-log-logger:
            enabled: true

Required an update to config-api to sort handler/formatter
DMR correctly.

Result
------

Either way, you get a JSON audit-log.log in $PWD.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
