### PR TITLE
SWARM-792 - augement the outer -swarm.jar uberjar.

### DIFF
--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/PackageMojo.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/PackageMojo.java
@@ -75,6 +75,9 @@ public class PackageMojo extends AbstractSwarmMojo {
     @Parameter(alias = "skip", defaultValue = "false", property = "swarm.package.skip")
     protected boolean skip;
 
+    @Parameter(alias = "uberjarResources")
+    protected String uberjarResources;
+
     protected File divineFile() {
         if (this.project.getArtifact().getFile() != null) {
             return this.project.getArtifact().getFile();
@@ -180,6 +183,13 @@ public class PackageMojo extends AbstractSwarmMojo {
         this.project.getResources()
                 .forEach(r -> tool.resourceDirectory(r.getDirectory()));
 
+        Path uberjarResourcesDir = null;
+        if (this.uberjarResources == null) {
+            uberjarResourcesDir = Paths.get(this.project.getBasedir().toString()).resolve("src").resolve("main").resolve("uberjar");
+        } else {
+            uberjarResourcesDir = Paths.get(this.uberjarResources);
+        }
+        tool.uberjarResourcesDirectory(uberjarResourcesDir);
 
         this.additionalModules.stream()
                 .map(m -> new File(this.project.getBuild().getOutputDirectory(), m))


### PR DESCRIPTION
Motivation
----------

Apparently Amazon Elastic Beanstalk respects something
in the root of an executable jar.  Support that.

Modifications
-------------

If it exists, src/main/uberjar/** will be added to the root
of the -swarm.jar.

Result
------

Better happiness and shinier hair.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
