### PR TITLE
SWARM-1165: Update to WildFly Core to 2.2.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <version.keycloak>2.5.4.Final</version.keycloak>
 
     <version.wildfly>10.1.0.Final</version.wildfly>
-    <version.org.wildfly.core>2.2.1.CR1</version.org.wildfly.core>
+    <version.org.wildfly.core>2.2.1.Final</version.org.wildfly.core>
     <version.org.jboss.msc.jboss-msc>1.2.6.Final</version.org.jboss.msc.jboss-msc>
     <version.jboss-logmanager-ext>1.0.0.Alpha3</version.jboss-logmanager-ext>
 


### PR DESCRIPTION
Motivation
----------
2.2.1.Final updates vital components like Undertow which was updated from 1.4.0 to 1.4.11 (which resolved at least two CVEs!).
And: Finals are better than CRs (Swarm currently uses 2.2.1.CR1).

Modifications
-------------
Bump version in root pom.xml.

Result
------
Some updated components, less bugs (hopefully).

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
