### PR TITLE
[SWARM-1236] multistart goal: make the startup timeout configurable

### DIFF
--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/MultiStartMojo.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/MultiStartMojo.java
@@ -162,10 +162,16 @@ public class MultiStartMojo extends AbstractSwarmMojo {
         for (PlexusConfiguration each : env.getChildren()) {
             executor.withEnvironment(each.getName(), each.getValue());
         }
+        int startTimeoutSeconds;
+        try {
+            startTimeoutSeconds = Integer.valueOf(props.getChild("start.timeout.seconds").getValue("30"));
+        } catch (NumberFormatException nfe) {
+            throw new IllegalArgumentException("Wrong format of the start timeout for " + artifact + "!. Integer expected.", nfe);
+        }
 
         try {
             SwarmProcess launched = executor.execute();
-            launched.awaitReadiness(30, TimeUnit.SECONDS);
+            launched.awaitReadiness(startTimeoutSeconds, TimeUnit.SECONDS);
             procs.add(launched);
         } catch (IOException | InterruptedException e) {
             throw new MojoFailureException("Unable to execute: " + artifact, e);

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/StartMojo.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/StartMojo.java
@@ -132,8 +132,14 @@ public class StartMojo extends AbstractSwarmMojo {
                 } catch (InterruptedException e) {
                 }
             }));
+            int startTimeoutSeconds;
+            try {
+                startTimeoutSeconds = Integer.valueOf(this.properties.getProperty("start.timeout.seconds", "120"));
+            } catch (NumberFormatException nfe) {
+                throw new IllegalArgumentException("Wrong format of the start timeout!. Integer expected.", nfe);
+            }
 
-            process.awaitReadiness(2, TimeUnit.MINUTES);
+            process.awaitReadiness(startTimeoutSeconds, TimeUnit.SECONDS);
 
             if (!process.isAlive()) {
                 throw new MojoFailureException("Process failed to start");


### PR DESCRIPTION
Motivation
----------
30s as a startup timeout is not always enough. Big applications may
take longer to deploy.

Modifications
-------------
The <process> configuration now accepts <start.timeout.seconds>
parameter. The default value is still 30s.

Result
------
Startup timeout for individual processes is configurable.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
