### PR TITLE
Keycloak Server wrong event store provider config

### DIFF
--- a/fractions/keycloak-server/src/main/java/org/wildfly/swarm/keycloak/server/KeycloakServerFraction.java
+++ b/fractions/keycloak-server/src/main/java/org/wildfly/swarm/keycloak/server/KeycloakServerFraction.java
@@ -48,7 +48,7 @@ public class KeycloakServerFraction extends KeycloakServer<KeycloakServerFractio
         masterRealmName(DEFAULT_REALM_NAME);
         scheduledTaskInterval(900L);
 
-        spi("eventStore", (eventStore) -> {
+        spi("eventsStore", (eventStore) -> {
             eventStore.defaultProvider("jpa");
             eventStore.provider("jpa", (provider) -> {
                 provider.enabled(true);


### PR DESCRIPTION
Rename eventStore to eventsStore.
https://issues.jboss.org/browse/SWARM-1240