### PR TITLE
SWARM-1249: MavenPluginTest should pass through custom settings.xml setting

### DIFF
--- a/testsuite/testsuite-maven-plugin/src/test/java/org/wildfly/swarm/maven/plugin/MavenPluginTest.java
+++ b/testsuite/testsuite-maven-plugin/src/test/java/org/wildfly/swarm/maven/plugin/MavenPluginTest.java
@@ -198,6 +198,12 @@ public class MavenPluginTest {
         verifier = new Verifier(projectDir.getAbsolutePath(), true);
         verifier.setForkJvm(true);
 
+        String settingsXml = System.getProperty("org.apache.maven.user-settings");
+        if (settingsXml != null && new File(settingsXml).isFile()) {
+            verifier.addCliOption("-s");
+            verifier.addCliOption(settingsXml);
+        }
+
         logPath = Paths.get(verifier.getBasedir()).resolve(verifier.getLogFileName());
     }
 


### PR DESCRIPTION
Motivation
----------
When the `MavenPluginTest` invokes Maven (via the `Verifier`), it should
pass through the location of `settings.xml`, if there's one configured.

This is because the testing Maven project can depend on artifacts that
are only available in a custom Maven repository, which is configured
in the `settings.xml` (e.g. a productized Swarm build).

Modifications
-------------
Detect if `settings.xml` location is configured (by checking a system
property that Maven sets) and if so, pass that to the `Verifier`
for use when invoking Maven.

Result
------
It is now possible for the testing project to require artifacts
from a custom repository configured in custom `settings.xml`,

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
