### PR TITLE
SWARM-1252 - Don't treat on/off/yes/no as Yaml booleans.

### DIFF
--- a/core/bootstrap/src/main/resources/modules/org/yaml/snakeyaml/main/module.xml
+++ b/core/bootstrap/src/main/resources/modules/org/yaml/snakeyaml/main/module.xml
@@ -10,6 +10,9 @@
     <system export="true">
       <paths>
         <path name="org/yaml/snakeyaml"/>
+        <path name="org/yaml/snakeyaml/constructor"/>
+        <path name="org/yaml/snakeyaml/representer"/>
+        <path name="org/yaml/snakeyaml/resolver"/>
       </paths>
     </system>
   </dependencies>

--- a/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewFactory.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewFactory.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,7 +27,13 @@ import java.util.Properties;
 import javax.enterprise.inject.Vetoed;
 
 import org.jboss.modules.ModuleLoadException;
+import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.nodes.NodeId;
+import org.yaml.snakeyaml.nodes.Tag;
+import org.yaml.snakeyaml.representer.Representer;
+import org.yaml.snakeyaml.resolver.Resolver;
 
 /**
  * @author Heiko Braun
@@ -139,7 +145,7 @@ public class ConfigViewFactory {
 
     @SuppressWarnings("unchecked")
     private void loadProjectStages(InputStream inputStream) {
-        Yaml yaml = new Yaml();
+        Yaml yaml = newYaml();
         Iterable<Object> docs = yaml.loadAll(inputStream);
 
         for (Object item : docs) {
@@ -166,13 +172,38 @@ public class ConfigViewFactory {
 
     @SuppressWarnings("unchecked")
     private void loadYamlProjectConfig(String name, InputStream inputStream) {
-        Yaml yaml = new Yaml();
-        Map<String, ?> doc = (Map<String, ?>) yaml.load(inputStream);
+        Map<String, ?> doc = loadYaml(inputStream);
 
         ConfigNode node = MapConfigNodeFactory.load(doc);
         this.configView.register(name, node);
         this.configView.withProfile(name);
     }
+
+    static Map<String, ?> loadYaml(InputStream input) {
+        Yaml yaml = newYaml();
+        return (Map<String, ?>) yaml.load(input);
+    }
+
+    private static Yaml newYaml() {
+        return new Yaml(new Constructor(),
+                        new Representer(),
+                        new DumperOptions(),
+                        new Resolver() {
+                            @Override
+                            public Tag resolve(NodeId kind, String value, boolean implicit) {
+                                if (value != null) {
+                                    if (value.equalsIgnoreCase("on") ||
+                                            value.equalsIgnoreCase("off") ||
+                                            value.equalsIgnoreCase("yes") ||
+                                            value.equalsIgnoreCase("no")) {
+                                        return Tag.STR;
+                                    }
+                                }
+                                return super.resolve(kind, value, implicit);
+                            }
+                        });
+    }
+
 
     public void withProfile(String name) {
         this.configView.withProfile(name);

--- a/core/container/src/test/java/org/wildfly/swarm/container/config/ConfigViewFactoryTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/container/config/ConfigViewFactoryTest.java
@@ -1,0 +1,24 @@
+package org.wildfly.swarm.container.config;
+
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.util.Map;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+
+/**
+ * Created by bob on 4/3/17.
+ */
+public class ConfigViewFactoryTest {
+
+    @Test
+    public void testJohnsYaml() {
+        InputStream in = getClass().getResourceAsStream("/john.yml");
+        Map<String, ?> doc = ConfigViewFactory.loadYaml(in);
+        Map<String, ?> foo = (Map<String, ?>) doc.get("foo");
+        Map<String, ?> on = (Map<String, ?>) foo.get("on");
+        assertThat((Boolean) on.get("startup")).isTrue();
+    }
+}

--- a/core/container/src/test/resources/john.yml
+++ b/core/container/src/test/resources/john.yml
@@ -1,0 +1,3 @@
+foo:
+  on:
+    startup: true


### PR DESCRIPTION
Motivation
----------
We like our booleans to be true or false, not on or off.

Modifications
-------------
Override the Yaml parser to not treat on/off/yes/no as
magical boolean-like creatures.

Result
------
John Ament is happier.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
