### PR TITLE
SWARM-1253: NPE when login-config not present

### DIFF
--- a/fractions/javaee/undertow/src/test/java/org/wildfly/swarm/undertow/runtime/HttpSecurityPreparerTest.java
+++ b/fractions/javaee/undertow/src/test/java/org/wildfly/swarm/undertow/runtime/HttpSecurityPreparerTest.java
@@ -1,36 +1,28 @@
 package org.wildfly.swarm.undertow.runtime;
 
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathExpression;
-import javax.xml.xpath.XPathFactory;
 
-import com.sun.org.apache.xpath.internal.XPathAPI;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.webapp31.WebAppDescriptor;
 import org.junit.Before;
 import org.junit.Test;
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-import org.w3c.dom.traversal.NodeIterator;
 import org.wildfly.swarm.undertow.WARArchive;
 import org.wildfly.swarm.undertow.descriptors.WebXmlAsset;
 import org.yaml.snakeyaml.Yaml;
 
 import static org.fest.assertions.Assertions.assertThat;
 
-
 public class HttpSecurityPreparerTest {
 
     private HttpSecurityPreparer preparer;
+
     private WARArchive archive;
 
     private DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
@@ -52,25 +44,35 @@ public class HttpSecurityPreparerTest {
     public void yaml_parsing() throws Exception {
 
         InputStream in = getClass().getClassLoader().getResourceAsStream("security.yml");
-        assertThat(in).isNotNull().as("security.yml not null");
+        assertThat(in).isNotNull().as("security.yml is null");
         Yaml yaml = new Yaml();
         Map<String, Object> httpConfig = (Map<String, Object>) yaml.load(in);
 
-        preparer.deploymentConfigs = (Map)((Map)httpConfig.get("swarm")).get("deployment");
+        preparer.deploymentConfigs = (Map) ((Map) httpConfig.get("swarm")).get("deployment");
         preparer.prepareArchive(archive);
 
-        try (InputStream assetStream = archive.get(WebXmlAsset.NAME).getAsset().openStream()) {
-            Document document = factory.newDocumentBuilder().parse(assetStream);
-            XPath xpath = XPathFactory.newInstance().newXPath();
+        WebAppDescriptor webXml = Descriptors.importAs(WebAppDescriptor.class).fromStream(archive.get(WebXmlAsset.NAME).getAsset().openStream());
 
-            XPathExpression xpr = xpath.compile("count(//security-constraint)");
-            int securityConstraintsNum = ((Number) xpr.evaluate(document, XPathConstants.NUMBER)).intValue();
-            assertThat(securityConstraintsNum).isEqualTo(1);
+        assertThat(webXml.getAllSecurityConstraint().size()).isEqualTo(1);
+        assertThat(webXml.getAllSecurityConstraint().get(0).getAllWebResourceCollection().get(0).getAllUrlPattern().get(0)).isEqualTo("/protected");
+    }
 
-            xpr = xpath.compile("//url-pattern/text()");
-            String urlPattern = (String) xpr.evaluate(document, XPathConstants.STRING);
-            assertThat(urlPattern).isEqualTo("/protected");
-        }
+    @SuppressWarnings("unchecked")
+    @Test
+    public void yaml_parsing_again() throws Exception {
+
+        InputStream in = getClass().getClassLoader().getResourceAsStream("security2.yml");
+        assertThat(in).isNotNull().as("security2.yml is null");
+        Yaml yaml = new Yaml();
+        Map<String, Object> httpConfig = (Map<String, Object>) yaml.load(in);
+
+        preparer.deploymentConfigs = (Map) ((Map) httpConfig.get("swarm")).get("deployment");
+        preparer.prepareArchive(archive);
+
+        WebAppDescriptor webXml = Descriptors.importAs(WebAppDescriptor.class).fromStream(archive.get(WebXmlAsset.NAME).getAsset().openStream());
+
+        assertThat(webXml.getAllSecurityConstraint().size()).isEqualTo(1);
+        assertThat(webXml.getAllSecurityConstraint().get(0).getAllWebResourceCollection().get(0).getAllUrlPattern().get(0)).isEqualTo("/protected");
     }
 
     @Test
@@ -85,7 +87,8 @@ public class HttpSecurityPreparerTest {
         preparer.deploymentConfigs = deploymentConfig;
         preparer.prepareArchive(archive);
 
-        assertThat(archive.get(WebXmlAsset.NAME)).isNull();
+        WebAppDescriptor webXml = Descriptors.importAs(WebAppDescriptor.class).fromStream(archive.get(WebXmlAsset.NAME).getAsset().openStream());
+        assertThat(webXml.getAllLoginConfig()).isEmpty();
     }
 
     @Test
@@ -101,27 +104,19 @@ public class HttpSecurityPreparerTest {
         preparer.deploymentConfigs = deploymentConfig;
         preparer.prepareArchive(archive);
 
-        try (InputStream assetStream = archive.get(WebXmlAsset.NAME).getAsset().openStream()) {
-            Document document = factory.newDocumentBuilder().parse(assetStream);
-            XPath xpath = XPathFactory.newInstance().newXPath();
+        WebAppDescriptor webXml = Descriptors.importAs(WebAppDescriptor.class).fromStream(archive.get(WebXmlAsset.NAME).getAsset().openStream());
 
-            XPathExpression xpr = xpath.compile("count(//security-constraint)");
-            int securityConstraintsNum = ((Number) xpr.evaluate(document, XPathConstants.NUMBER)).intValue();
-            assertThat(securityConstraintsNum).isEqualTo(1);
-
-            xpr = xpath.compile("//url-pattern/text()");
-            String urlPattern = (String) xpr.evaluate(document, XPathConstants.STRING);
-            assertThat(urlPattern).isEqualTo("/aaa");
-        }
+        assertThat(webXml.getAllSecurityConstraint().size()).isEqualTo(1);
+        assertThat(webXml.getAllSecurityConstraint().get(0).getAllWebResourceCollection().get(0).getAllUrlPattern().get(0)).isEqualTo("/aaa");
     }
 
     @SuppressWarnings("unchecked")
     private Map<String, Object> findWebConfig(Map<String, Object> deploymentConfig) {
-        String[] path = new String[] {archive.getName(), "web"};
+        String[] path = new String[]{archive.getName(), "web"};
         Map<String, Object> curr = deploymentConfig;
 
-        for (int i=0; i<path.length; i++) {
-            curr = (Map<String, Object>)curr.get(path[i]);
+        for (int i = 0; i < path.length; i++) {
+            curr = (Map<String, Object>) curr.get(path[i]);
         }
 
         return curr;
@@ -158,14 +153,11 @@ public class HttpSecurityPreparerTest {
         preparer.deploymentConfigs = deploymentConfig;
         preparer.prepareArchive(archive);
 
-        try (InputStream assetStream = archive.get(WebXmlAsset.NAME).getAsset().openStream()) {
-            Document document = factory.newDocumentBuilder().parse(assetStream);
-            XPath xpath = XPathFactory.newInstance().newXPath();
+        WebAppDescriptor webXml = Descriptors.importAs(WebAppDescriptor.class).fromStream(archive.get(WebXmlAsset.NAME).getAsset().openStream());
 
-            XPathExpression xpr = xpath.compile("count(//security-constraint)");
-            Number count = (Number) xpr.evaluate(document, XPathConstants.NUMBER);
-            assertThat(count.intValue()).isEqualTo(2);
-        }
+        assertThat(webXml.getAllSecurityConstraint().size()).isEqualTo(2);
+        assertThat(webXml.getAllSecurityConstraint().get(0).getAllWebResourceCollection().get(0).getAllUrlPattern().get(0)).isEqualTo("/aaa");
+        assertThat(webXml.getAllSecurityConstraint().get(1).getAllWebResourceCollection().get(0).getAllUrlPattern().get(0)).isEqualTo("/bbb");
     }
 
     @Test
@@ -181,18 +173,10 @@ public class HttpSecurityPreparerTest {
         preparer.deploymentConfigs = deploymentConfig;
         preparer.prepareArchive(archive);
 
-        try (InputStream assetStream = archive.get(WebXmlAsset.NAME).getAsset().openStream()) {
-            Document document = factory.newDocumentBuilder().parse(assetStream);
-            XPath xpath = XPathFactory.newInstance().newXPath();
+        WebAppDescriptor webXml = Descriptors.importAs(WebAppDescriptor.class).fromStream(archive.get(WebXmlAsset.NAME).getAsset().openStream());
 
-            XPathExpression xpr  = xpath.compile("count(//http-method)");
-            int methodsNum = ((Number) xpr.evaluate(document, XPathConstants.NUMBER)).intValue();
-            assertThat(methodsNum).isEqualTo(1);
-
-            xpr = xpath.compile("//http-method/text()");
-            String urlPattern = (String) xpr.evaluate(document, XPathConstants.STRING);
-            assertThat(urlPattern).isEqualTo("GET");
-        }
+        assertThat(webXml.getAllSecurityConstraint().size()).isEqualTo(1);
+        assertThat(webXml.getAllSecurityConstraint().get(0).getAllWebResourceCollection().get(0).getAllHttpMethod().get(0)).isEqualTo("GET");
     }
 
     @Test
@@ -209,22 +193,11 @@ public class HttpSecurityPreparerTest {
         preparer.deploymentConfigs = deploymentConfig;
         preparer.prepareArchive(archive);
 
-        try (InputStream assetStream = archive.get(WebXmlAsset.NAME).getAsset().openStream()) {
-            Document document = factory.newDocumentBuilder().parse(assetStream);
-            XPath xpath = XPathFactory.newInstance().newXPath();
+        WebAppDescriptor webXml = Descriptors.importAs(WebAppDescriptor.class).fromStream(archive.get(WebXmlAsset.NAME).getAsset().openStream());
 
-            XPathExpression xpr  = xpath.compile("count(//http-method)");
-            int methodsNum = ((Number) xpr.evaluate(document, XPathConstants.NUMBER)).intValue();
-            assertThat(methodsNum).isEqualTo(2);
-
-            List<String> methods = new ArrayList<>();
-            NodeIterator it = XPathAPI.selectNodeIterator(document, "//http-method/text()");
-            Node node;
-            while ((node = it.nextNode()) != null) {
-                methods.add(node.getNodeValue());
-            }
-            assertThat(methods).contains("GET", "POST");
-        }
+        assertThat(webXml.getAllSecurityConstraint().size()).isEqualTo(1);
+        assertThat(webXml.getAllSecurityConstraint().get(0).getAllWebResourceCollection().get(0).getAllHttpMethod().get(0)).isEqualTo("GET");
+        assertThat(webXml.getAllSecurityConstraint().get(0).getAllWebResourceCollection().get(0).getAllHttpMethod().get(1)).isEqualTo("POST");
     }
 
 }

--- a/fractions/javaee/undertow/src/test/resources/security2.yml
+++ b/fractions/javaee/undertow/src/test/resources/security2.yml
@@ -1,0 +1,7 @@
+swarm:
+  deployment:
+    app.war:
+      web:
+        security-constraints:
+          - url-pattern: /protected
+            roles: [admin]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
`login-config` is not a required part of web.xml but it's non presence causes an NPE.

Modifications
-------------
Prevent NPE when `login-config` is not present in project-defaults.yml and add a test for it.

Result
------
NPE no longer occurs when `login-config` not present.
