### PR TITLE
SWARM-1256: JNDI error using topology web-app.

### DIFF
--- a/fractions/topology-webapp/src/main/java/org/wildfly/swarm/topology/webapp/runtime/TopologyWebAppActivator.java
+++ b/fractions/topology-webapp/src/main/java/org/wildfly/swarm/topology/webapp/runtime/TopologyWebAppActivator.java
@@ -25,6 +25,7 @@ import javax.inject.Inject;
 
 import io.undertow.server.HttpHandler;
 import org.jboss.as.naming.service.DefaultNamespaceContextSelectorService;
+import org.jboss.as.naming.service.NamingService;
 import org.jboss.msc.service.ServiceActivator;
 import org.jboss.msc.service.ServiceActivatorContext;
 import org.jboss.msc.service.ServiceBuilder;
@@ -52,10 +53,12 @@ public class TopologyWebAppActivator implements ServiceActivator {
         ServiceBuilder<TopologyProxyService> serviceBuilder = target
                 .addService(TopologyProxyService.SERVICE_NAME, proxyService)
                 .addDependency(DefaultNamespaceContextSelectorService.SERVICE_NAME)
-                .addDependency(TopologyManagerActivator.CONNECTOR_SERVICE_NAME);
+                .addDependency(TopologyManagerActivator.CONNECTOR_SERVICE_NAME)
+                .addDependency(NamingService.SERVICE_NAME);
+
         for (String serviceName : serviceNames) {
             serviceBuilder.addDependency(proxyService.mscServiceNameForServiceProxy(serviceName),
-                    HttpHandler.class, proxyService.getHandlerInjectorFor(serviceName));
+                                         HttpHandler.class, proxyService.getHandlerInjectorFor(serviceName));
         }
         serviceBuilder.install();
     }


### PR DESCRIPTION
Motivation
----------
There's a bug in using JNDI before JNDI is ready.

Modifications
-------------
Add an MSC dependency on the naming service.

Result
------
Less bugs, happier George.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
