### PR TITLE
SWARM-1261: Ensure we can disable the topology web-app endpoint.

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
@@ -231,7 +231,9 @@ public class RuntimeServer implements Server {
 
             try (AutoCloseable deployments = Performance.time("Implicit Deployments")) {
                 for (Archive each : this.implicitDeployments) {
-                    deployer.deploy(each);
+                    if (each != null) {
+                        deployer.deploy(each);
+                    }
                 }
             }
 

--- a/fractions/topology-webapp/src/main/java/org/wildfly/swarm/topology/webapp/TopologyWebAppFraction.java
+++ b/fractions/topology-webapp/src/main/java/org/wildfly/swarm/topology/webapp/TopologyWebAppFraction.java
@@ -18,8 +18,11 @@ package org.wildfly.swarm.topology.webapp;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.wildfly.swarm.spi.api.Defaultable;
 import org.wildfly.swarm.spi.api.Fraction;
 import org.wildfly.swarm.spi.api.annotations.Configurable;
+
+import static org.wildfly.swarm.spi.api.Defaultable.*;
 
 /**
  * @author Lance Ball
@@ -75,15 +78,15 @@ public class TopologyWebAppFraction implements Fraction<TopologyWebAppFraction> 
      * @param exposeTopologyEndpoint whether to expose the endpoint or not
      */
     public void exposeTopologyEndpoint(boolean exposeTopologyEndpoint) {
-        this.exposeTopologyEndpoint = exposeTopologyEndpoint;
+        this.exposeTopologyEndpoint.set(exposeTopologyEndpoint);
     }
 
     public boolean exposeTopologyEndpoint() {
-        return exposeTopologyEndpoint;
+        return exposeTopologyEndpoint.get();
     }
 
     private Map<String, String> proxiedServiceMappings = new HashMap<>();
 
-    private boolean exposeTopologyEndpoint = true;
+    private Defaultable<Boolean> exposeTopologyEndpoint = bool(true);
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1483,6 +1483,7 @@
         <module>testsuite/testsuite-topology-consul</module>
         <module>testsuite/testsuite-topology-jgroups</module>
         <module>testsuite/testsuite-topology-webapp</module>
+        <module>testsuite/testsuite-topology-webapp-no-endpoint</module>
         <module>testsuite/testsuite-vertx</module>
         <module>testsuite/testsuite-webservices</module>
         <module>testsuite/testsuite-zipkin-jaxrs</module>

--- a/testsuite/testsuite-topology-webapp-no-endpoint/pom.xml
+++ b/testsuite/testsuite-topology-webapp-no-endpoint/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>testsuite</artifactId>
+    <version>2017.4.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>testsuite-topology-webapp-no-endpoint</artifactId>
+
+  <name>Test Suite: Topology Web App w/o Endpoint</name>
+  <description>Test Suite: Topology Web App w/o Endpoint</description>
+
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>topology-webapp</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>topology-jgroups</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>arquillian</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.junit</groupId>
+      <artifactId>arquillian-junit-container</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/testsuite/testsuite-topology-webapp-no-endpoint/src/main/java/org/wildfly/swarm/topology/webapp/test/Dummy.java
+++ b/testsuite/testsuite-topology-webapp-no-endpoint/src/main/java/org/wildfly/swarm/topology/webapp/test/Dummy.java
@@ -1,0 +1,7 @@
+package org.wildfly.swarm.topology.webapp.test;
+
+/**
+ * Created by bob on 4/5/17.
+ */
+public class Dummy {
+}

--- a/testsuite/testsuite-topology-webapp-no-endpoint/src/main/resources/project-defaults.yml
+++ b/testsuite/testsuite-topology-webapp-no-endpoint/src/main/resources/project-defaults.yml
@@ -1,0 +1,6 @@
+swarm:
+  topology:
+    web-app:
+      expose-topology-endpoint: false
+      proxied-service-mappings:
+        myService: /my-proxy

--- a/testsuite/testsuite-topology-webapp-no-endpoint/src/test/java/org/wildfly/swarm/topology/webapp/test/TopologyWebAppArquillianTest.java
+++ b/testsuite/testsuite-topology-webapp-no-endpoint/src/test/java/org/wildfly/swarm/topology/webapp/test/TopologyWebAppArquillianTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.topology.webapp.test;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistry;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.arquillian.CreateSwarm;
+import org.wildfly.swarm.arquillian.DefaultDeployment;
+import org.wildfly.swarm.spi.api.JARArchive;
+import org.wildfly.swarm.topology.jgroups.JGroupsTopologyFraction;
+import org.wildfly.swarm.topology.webapp.TopologyWebAppFraction;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Lance Ball
+ * @author Ken Finnigan
+ */
+@RunWith(Arquillian.class)
+@DefaultDeployment(type = DefaultDeployment.Type.WAR)
+public class TopologyWebAppArquillianTest {
+
+    /*
+    @CreateSwarm
+    public static Swarm newContainer() throws Exception {
+        TopologyWebAppFraction topology = new TopologyWebAppFraction();
+        topology.proxyService("myService", "/my-proxy");
+
+        return new Swarm()
+                .fraction(topology)
+                .fraction(new JGroupsTopologyFraction());
+    }
+    */
+
+    @ArquillianResource
+    private ServiceRegistry registry;
+
+    @Test
+    public void testTopologyProxyHandlerPresence() throws Exception {
+        ServiceController<?> proxyService = registry.getService(ServiceName.parse("swarm.topology.proxy"));
+        assertNotNull("TopologyProxyService is not available in service registry", proxyService);
+
+        ServiceController<?> proxyHandler = registry
+                .getService(ServiceName.parse("jboss.undertow.handler.myService-proxy-handler"));
+        assertNotNull("`myService` Undertow handler is not available in service registry", proxyHandler);
+    }
+}


### PR DESCRIPTION
Motivation
----------
George wanted to disable the topology end-point while keeping the
proxies going.

Modifications
-------------
Ensure that a null returned from an Archive producer.

Result
------
Able to disable the endpoint.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
