### PR TITLE
SWARM-1222: Autodetect based on web.xml contents and java pkgs.

### DIFF
--- a/fractions/wildfly/security/pom.xml
+++ b/fractions/wildfly/security/pom.xml
@@ -47,6 +47,11 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>ee</artifactId>
     </dependency>
+    <!-- Meta SPI -->
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>meta-spi</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.wildfly.core</groupId>
       <artifactId>wildfly-core-feature-pack</artifactId>

--- a/fractions/wildfly/security/src/main/java/org/wildfly/swarm/security/detect/SecurityPackageDetector.java
+++ b/fractions/wildfly/security/src/main/java/org/wildfly/swarm/security/detect/SecurityPackageDetector.java
@@ -1,0 +1,18 @@
+package org.wildfly.swarm.security.detect;
+
+import org.wildfly.swarm.spi.meta.PackageFractionDetector;
+
+/**
+ * Created by bob on 4/12/17.
+ */
+public class SecurityPackageDetector extends PackageFractionDetector {
+
+    public SecurityPackageDetector() {
+        anyPackageOf("javax.annotation.security", "javax.security");
+    }
+
+    @Override
+    public String artifactId() {
+        return "security";
+    }
+}

--- a/fractions/wildfly/security/src/main/java/org/wildfly/swarm/security/detect/SecurityWebXmlDetector.java
+++ b/fractions/wildfly/security/src/main/java/org/wildfly/swarm/security/detect/SecurityWebXmlDetector.java
@@ -1,0 +1,21 @@
+package org.wildfly.swarm.security.detect;
+
+import org.wildfly.swarm.spi.meta.WebXmlDescriptorFractionDetector;
+
+/**
+ * Created by bob on 4/12/17.
+ */
+public class SecurityWebXmlDetector extends WebXmlDescriptorFractionDetector {
+
+    @Override
+    public String artifactId() {
+        return "security";
+    }
+
+    @Override
+    protected boolean doDetect() {
+        return this.webXMl.getAllSecurityConstraint().size() > 0 ||
+                this.webXMl.getAllSecurityRole().size() > 0 ||
+                this.webXMl.getAllLoginConfig().size() > 0;
+    }
+}

--- a/meta/meta-spi/src/main/java/org/wildfly/swarm/spi/meta/WebXmlDescriptorFractionDetector.java
+++ b/meta/meta-spi/src/main/java/org/wildfly/swarm/spi/meta/WebXmlDescriptorFractionDetector.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.spi.meta;
+
+import java.io.InputStream;
+
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.webapp31.WebAppDescriptor;
+
+/**
+ * @author Ken Finnigan
+ */
+public abstract class WebXmlDescriptorFractionDetector implements FractionDetector<InputStream> {
+
+    @Override
+    public String extensionToDetect() {
+        return "xml";
+    }
+
+    @Override
+    public boolean detectionComplete() {
+        return detectionComplete;
+    }
+
+    @Override
+    public boolean wasDetected() {
+        return detected;
+    }
+
+    @Override
+    public void detect(InputStream element) {
+        if (!detectionComplete() && element != null) {
+            this.webXMl = Descriptors.importAs(WebAppDescriptor.class)
+                    .fromStream(element);
+            if (this.webXMl != null) {
+                if (doDetect()) {
+                    detected = true;
+                    detectionComplete = true;
+                }
+            }
+        }
+    }
+
+    protected abstract boolean doDetect();
+
+
+    private boolean detected = false;
+
+    private boolean detectionComplete = false;
+
+    protected WebAppDescriptor webXMl;
+}


### PR DESCRIPTION
Motivation
----------
We should be able to autodetect security-related things based
upon:

* Various bits within web.xml
* Usage of javax.security.** and javax.annotation.security.**

Modifications
-------------
Two new concrete detectors for security. Also an abstract
WebXml descriptor detector to make it easy to scrub around
for arbitrary web.xml contents beyond just servlets.

Result
------
Autodetectable security fraction.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
