### PR TITLE
SWARM-1223: Auto-detect JPA based on persistence.xml.

### DIFF
--- a/fractions/javaee/jpa/src/main/java/org/wildfly/swarm/jpa/detect/PersistenceXmlDetector.java
+++ b/fractions/javaee/jpa/src/main/java/org/wildfly/swarm/jpa/detect/PersistenceXmlDetector.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.swarm.jpa.detect;
+
+import org.wildfly.swarm.spi.meta.FileDetector;
+
+/**
+ * @author Heiko Braun
+ */
+public class PersistenceXmlDetector extends FileDetector {
+
+    @Override
+    public String extensionToDetect() {
+        return XML;
+    }
+
+    @Override
+    public boolean detectionComplete() {
+        return detectionComplete;
+    }
+
+    @Override
+    public boolean wasDetected() {
+        return detected;
+    }
+
+    @Override
+    public void detect(String fileName) {
+        if (!detectionComplete() && fileName.endsWith(PERSISTENCE_XML)) {
+            detected = true;
+            detectionComplete = true;
+        }
+    }
+
+    @Override
+    public String artifactId() {
+        return JPA;
+    }
+
+    private static final String XML = "xml";
+
+    private static final String PERSISTENCE_XML = "persistence.xml";
+
+    private static final String JPA = "jpa";
+
+    private boolean detected = false;
+
+    private boolean detectionComplete = false;
+
+}
+


### PR DESCRIPTION
Motivation
----------
Sometimes persistence.xml is all you have.  Detect it.

Modifications
-------------
Scrub around for persistence.xml.

Result
------
JPA detected by the mere existance of a persistence.xml.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
