### PR TITLE
SWARM-1001: Add dependencies to WAR default deployments.

### DIFF
--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/DefaultDeploymentScenarioGenerator.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/DefaultDeploymentScenarioGenerator.java
@@ -31,7 +31,9 @@ import org.jboss.shrinkwrap.impl.base.URLPackageScanner;
 import org.jboss.shrinkwrap.impl.base.asset.AssetUtil;
 import org.jboss.shrinkwrap.impl.base.path.BasicPath;
 import org.wildfly.swarm.arquillian.DefaultDeployment;
+import org.wildfly.swarm.spi.api.DependenciesContainer;
 import org.wildfly.swarm.spi.api.JARArchive;
+import org.wildfly.swarm.spi.api.MarkerContainer;
 import org.wildfly.swarm.spi.api.annotations.DeploymentModule;
 import org.wildfly.swarm.spi.api.annotations.DeploymentModules;
 
@@ -55,11 +57,15 @@ public class DefaultDeploymentScenarioGenerator extends AnnotationDeploymentScen
                         : "WEB-INF/classes"
         );
 
-        Archive archive = (
-                anno.type() == DefaultDeployment.Type.JAR
-                        ? ShrinkWrap.create(JavaArchive.class, testClass.getJavaClass().getSimpleName() + ".jar")
-                        : ShrinkWrap.create(WebArchive.class, testClass.getJavaClass().getSimpleName() + ".war")
-        );
+        Archive<?> archive;
+        if (DefaultDeployment.Type.WAR.equals(anno.type())) {
+            WebArchive webArchive = ShrinkWrap.create(WebArchive.class, testClass.getJavaClass().getSimpleName() + ".war");
+            // Add the marker to also include the project dependencies
+            MarkerContainer.addMarker(webArchive, DependenciesContainer.ALL_DEPENDENCIES_MARKER);
+            archive = webArchive;
+        } else {
+            archive = ShrinkWrap.create(JavaArchive.class, testClass.getJavaClass().getSimpleName() + ".jar");
+        }
 
         ClassLoader cl = testClass.getJavaClass().getClassLoader();
 

--- a/core/spi/src/main/java/org/wildfly/swarm/spi/api/MarkerContainer.java
+++ b/core/spi/src/main/java/org/wildfly/swarm/spi/api/MarkerContainer.java
@@ -32,12 +32,19 @@ public interface MarkerContainer<T extends Archive<T>> extends ManifestContainer
 
     @SuppressWarnings("unchecked")
     default T addMarker(String markerName) {
-        addAsManifestResource(new StringAsset("marker"), ArchivePaths.create(PATH_MARKERS, markerName));
-
+        addMarker(this, markerName);
         return (T) this;
     }
 
     default boolean hasMarker(String markerName) {
-        return contains(ArchivePaths.create("META-INF/markers", markerName));
+        return hasMarker(this, markerName);
+    }
+
+    static void addMarker(ManifestContainer<?> manifestContainer, String markerName) {
+        manifestContainer.addAsManifestResource(new StringAsset("marker"), ArchivePaths.create(PATH_MARKERS, markerName));
+    }
+
+    static boolean hasMarker(Archive<?> archive, String markerName) {
+        return archive.contains(ArchivePaths.create("META-INF/markers", markerName));
     }
 }

--- a/testsuite/testsuite-cdi/pom.xml
+++ b/testsuite/testsuite-cdi/pom.xml
@@ -29,9 +29,27 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>undertow</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>arquillian</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <!-- Used to test that the default deployment of type WAR includes non-fraction project dependencies -->
+    <dependency>
+       <groupId>org.jboss.cdi.tck</groupId>
+       <artifactId>cdi-tck-ext-lib</artifactId>
+       <version>1.2.10.Final</version>
+       <exclusions>
+          <exclusion>
+             <groupId>javax.enterprise</groupId>
+             <artifactId>cdi-api</artifactId>
+          </exclusion>
+       </exclusions>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/testsuite/testsuite-cdi/src/main/java/org/wildfly/swarm/cdi/test/basic/Cheddar.java
+++ b/testsuite/testsuite-cdi/src/main/java/org/wildfly/swarm/cdi/test/basic/Cheddar.java
@@ -1,4 +1,4 @@
-package org.wildfly.swarm.cdi.test;
+package org.wildfly.swarm.cdi.test.basic;
 
 import javax.inject.Singleton;
 

--- a/testsuite/testsuite-cdi/src/main/java/org/wildfly/swarm/cdi/test/basic/ConfigAwareBean.java
+++ b/testsuite/testsuite-cdi/src/main/java/org/wildfly/swarm/cdi/test/basic/ConfigAwareBean.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.swarm.cdi.test;
+package org.wildfly.swarm.cdi.test.basic;
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;

--- a/testsuite/testsuite-cdi/src/main/java/org/wildfly/swarm/cdi/test/defaultdeployment/Foo.java
+++ b/testsuite/testsuite-cdi/src/main/java/org/wildfly/swarm/cdi/test/defaultdeployment/Foo.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.cdi.test.defaultdeployment;
+
+import javax.inject.Inject;
+
+import org.jboss.cdi.tck.extlib.Strict;
+import org.jboss.cdi.tck.extlib.Translator;
+
+public class Foo {
+
+    // Translator comes from the org.jboss.cdi.tck:cdi-tck-ext-lib dependency
+    @Inject
+    @Strict
+    Translator translator;
+
+    String echo(String text) {
+        return translator.echo(text);
+    }
+
+}

--- a/testsuite/testsuite-cdi/src/test/java/org/wildfly/swarm/cdi/test/basic/CDIArquillianTest.java
+++ b/testsuite/testsuite-cdi/src/test/java/org/wildfly/swarm/cdi/test/basic/CDIArquillianTest.java
@@ -13,34 +13,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.swarm.cdi.test;
+package org.wildfly.swarm.cdi.test.basic;
 
-import java.util.Optional;
-
+import javax.enterprise.inject.spi.CDI;
 import javax.inject.Inject;
 
 import org.jboss.arquillian.junit.Arquillian;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.swarm.arquillian.DefaultDeployment;
-import org.wildfly.swarm.spi.runtime.annotations.ConfigurationValue;
+import org.wildfly.swarm.cdi.test.basic.Cheddar;
+
+import static org.junit.Assert.assertNotNull;
 
 /**
- * @author George Gastaldi
+ * @author Bob McWhirter
  */
 @RunWith(Arquillian.class)
 @DefaultDeployment(type = DefaultDeployment.Type.JAR)
-public class ConfigurationValueProducerTest {
+public class CDIArquillianTest {
 
     @Inject
-    @ConfigurationValue("logger.level")
-    private Optional<String> loggerLevel;
+    private Cheddar cheddar;
 
     @Test
-    public void testServerAddressExists() {
-        Assert.assertNotNull(loggerLevel);
-        Assert.assertEquals("DEBUG", loggerLevel.get());
+    public void testInjection() {
+        assertNotNull(cheddar);
     }
 
+    @Test
+    public void testCDIContainerPresence() throws Exception {
+        assertNotNull(CDI.current());
+    }
 }

--- a/testsuite/testsuite-cdi/src/test/java/org/wildfly/swarm/cdi/test/basic/ConfigValueProducerTest.java
+++ b/testsuite/testsuite-cdi/src/test/java/org/wildfly/swarm/cdi/test/basic/ConfigValueProducerTest.java
@@ -13,35 +13,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.swarm.cdi.test;
-
-import javax.enterprise.inject.spi.CDI;
-import javax.inject.Inject;
+package org.wildfly.swarm.cdi.test.basic;
 
 import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.swarm.arquillian.DefaultDeployment;
+import org.wildfly.swarm.cdi.test.basic.ConfigAwareBean;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 /**
- * @author Bob McWhirter
+ * @author Martin Kouba
  */
 @RunWith(Arquillian.class)
+@Ignore
 @DefaultDeployment(type = DefaultDeployment.Type.JAR)
-public class CDIArquillianTest {
-
-    @Inject
-    private Cheddar cheddar;
+public class ConfigValueProducerTest {
 
     @Test
-    public void testInjection() {
-        assertNotNull(cheddar);
+    public void testInjection(ConfigAwareBean configAwareBean) {
+        assertNotNull(configAwareBean);
+
+        assertEquals(Integer.valueOf(10), configAwareBean.getPortOffset());
+        assertEquals("DEBUG", configAwareBean.getLogLevel());
+        assertEquals(Integer.valueOf(10), configAwareBean
+                .getPortOffsetResolver().as(Integer.class).getValue());
     }
 
-    @Test
-    public void testCDIContainerPresence() throws Exception {
-        assertNotNull(CDI.current());
-    }
 }

--- a/testsuite/testsuite-cdi/src/test/java/org/wildfly/swarm/cdi/test/basic/ConfigurationValueProducerTest.java
+++ b/testsuite/testsuite-cdi/src/test/java/org/wildfly/swarm/cdi/test/basic/ConfigurationValueProducerTest.java
@@ -13,33 +13,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.swarm.cdi.test;
+package org.wildfly.swarm.cdi.test.basic;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
 
 import org.jboss.arquillian.junit.Arquillian;
-import org.junit.Ignore;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.swarm.arquillian.DefaultDeployment;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.wildfly.swarm.spi.runtime.annotations.ConfigurationValue;
 
 /**
- * @author Martin Kouba
+ * @author George Gastaldi
  */
 @RunWith(Arquillian.class)
-@Ignore
 @DefaultDeployment(type = DefaultDeployment.Type.JAR)
-public class ConfigValueProducerTest {
+public class ConfigurationValueProducerTest {
+
+    @Inject
+    @ConfigurationValue("logger.level")
+    private Optional<String> loggerLevel;
 
     @Test
-    public void testInjection(ConfigAwareBean configAwareBean) {
-        assertNotNull(configAwareBean);
-
-        assertEquals(Integer.valueOf(10), configAwareBean.getPortOffset());
-        assertEquals("DEBUG", configAwareBean.getLogLevel());
-        assertEquals(Integer.valueOf(10), configAwareBean
-                .getPortOffsetResolver().as(Integer.class).getValue());
+    public void testServerAddressExists() {
+        Assert.assertNotNull(loggerLevel);
+        Assert.assertEquals("DEBUG", loggerLevel.get());
     }
 
 }

--- a/testsuite/testsuite-cdi/src/test/java/org/wildfly/swarm/cdi/test/defaultdeployment/DefaultDeploymentProjectDependencyTest.java
+++ b/testsuite/testsuite-cdi/src/test/java/org/wildfly/swarm/cdi/test/defaultdeployment/DefaultDeploymentProjectDependencyTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.cdi.test.defaultdeployment;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import javax.inject.Inject;
+
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.arquillian.DefaultDeployment;
+
+/**
+ *
+ * @author Martin Kouba
+ */
+@RunWith(Arquillian.class)
+@DefaultDeployment(type = DefaultDeployment.Type.WAR)
+public class DefaultDeploymentProjectDependencyTest {
+
+    @Inject
+    Foo foo;
+
+    @Test
+    public void testDependencyPresent() throws Exception {
+        assertNotNull(foo);
+        assertEquals("ping", foo.echo("ping"));
+    }
+}


### PR DESCRIPTION
Motivation
----------
A default deployment of type WAR should also include the non-fraction project dependencies which
would be normally added to WEB-INF/lib.

Modifications
-------------
For a default deployment of type WAR add the DependenciesContainer.ALL_DEPENDENCIES_MARKER.
This marker is later detected in UberjarSimpleContainer.
Explicit non-fraction dependencies are added as a libraries to a ShrinkWrap test archive.

Result
------
WAR default deployments also contain non-fraction project dependencies in WEB-INF/lib.

- [ ] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
