### PR TITLE
SWARM-1217: Do not add generated Application if servlet mapping exists.

### DIFF
--- a/fractions/javaee/jaxrs/pom.xml
+++ b/fractions/javaee/jaxrs/pom.xml
@@ -110,6 +110,23 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-annotations</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-processor</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
       <groupId>org.wildfly.core</groupId>
       <artifactId>wildfly-core-feature-pack</artifactId>
       <type>zip</type>

--- a/fractions/javaee/jaxrs/src/main/java/org/wildfly/swarm/jaxrs/JAXRSMessages.java
+++ b/fractions/javaee/jaxrs/src/main/java/org/wildfly/swarm/jaxrs/JAXRSMessages.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.swarm.jaxrs;
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
+
+/**
+ * @author Martin Kouba
+ */
+@MessageLogger(projectCode = " WFSJAXRS", length = 4)
+public interface JAXRSMessages extends BasicLogger {
+
+    JAXRSMessages MESSAGES = Logger.getMessageLogger(JAXRSMessages.class, "org.wildfly.swarm.jaxrs");
+
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 1, value = "Unable to parse web.xml while searching for javax.ws.rs.core.Application servlet mapping:\n  %s")
+    void unableToParseWebXml(Object info);
+
+}

--- a/fractions/javaee/jaxrs/src/test/java/org/wildfly/swarm/jaxrs/JAXRSArchiveTest.java
+++ b/fractions/javaee/jaxrs/src/test/java/org/wildfly/swarm/jaxrs/JAXRSArchiveTest.java
@@ -18,6 +18,7 @@ package org.wildfly.swarm.jaxrs;
 import org.jboss.shrinkwrap.api.Node;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.wildfly.swarm.undertow.WARArchive;
@@ -84,6 +85,34 @@ public class JAXRSArchiveTest {
         WARArchive archive = ShrinkWrap.create( WARArchive.class );
         archive.addClass( MyOtherResource.class );
         assertThat( JAXRSArchive.isJAXRS( archive )).isTrue();
+    }
+
+    @Test
+    public void testWebXmlApplicationServletMappingPresent() {
+        JAXRSArchive archive = ShrinkWrap.create(JAXRSArchive.class);
+        archive.addClass(MyResource.class);
+        archive.setWebXML(new StringAsset(
+                "<web-app><servlet-mapping><servlet-name>Faces Servlet</servlet-name><url-pattern>*.jsf</url-pattern></servlet-mapping><servlet-mapping><servlet-name>javax.ws.rs.core.Application</servlet-name><url-pattern>/foo/*</url-pattern></servlet-mapping></web-app>"));
+        Node generated = archive.get(PATH);
+        assertThat(generated).isNull();
+    }
+
+    @Test
+    public void testWebXmlApplicationServletMappingAbsent() {
+        JAXRSArchive archive = ShrinkWrap.create(JAXRSArchive.class);
+        archive.addClass(MyResource.class);
+        archive.setWebXML(new StringAsset("<web-app><display-name>Foo</display-name></web-app>"));
+        Node generated = archive.get(PATH);
+        assertThat(generated).isNotNull();
+    }
+
+    @Test
+    public void testMalformedWebXmlApplicationServletMappingAbsent() {
+        JAXRSArchive archive = ShrinkWrap.create(JAXRSArchive.class);
+        archive.addClass(MyResource.class);
+        archive.setWebXML(new StringAsset("blablabla"));
+        Node generated = archive.get(PATH);
+        assertThat(generated).isNotNull();
     }
 
 }

--- a/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/descriptors/WebXmlAsset.java
+++ b/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/descriptors/WebXmlAsset.java
@@ -18,6 +18,7 @@ package org.wildfly.swarm.undertow.descriptors;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -130,6 +131,16 @@ public class WebXmlAsset implements NamedAsset {
         SecurityConstraint constraint = new SecurityConstraint(urlPattern);
         this.constraints.add(constraint);
         return constraint;
+    }
+
+    /**
+     *
+     * @param servletName
+     * @return the list of <code>url-pattern</code> elements or an empty list if no mapping is present
+     */
+    public List<String> getServletMapping(String servletName) {
+        return this.descriptor.getAllServletMapping().stream().filter((mapping) -> mapping.getServletName().equals(servletName)).findFirst()
+                .map(m -> m.getAllUrlPattern()).orElse(Collections.emptyList());
     }
 
     @Override


### PR DESCRIPTION
Motivation
----------
According to the JAX-RS spec if no Application subclass is present and there is web.xml that specifies a
servlet mapping for a servlet with name javax.ws.rs.core.Application, the servlet is added automatically.
In this case, Swarm must not add a generated Application class.

Modifications
-------------
JAXRSArchiveImpl now attempts to parse the existing web.xml and does not add/removes the generated Application class.

Result
------
jboss-eap-quickstarts/helloworld-html5 should pass.

- [ ] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
