### PR TITLE
SWARM-1272: Auto-detect jaxrs-multipart based on resteasy-multipart-provider packages

### DIFF
--- a/fractions/javaee/jaxrs-multipart/src/main/java/org/wildfly/swarm/jaxrs/multipart/detect/JAXRSMultipartPackageDetector.java
+++ b/fractions/javaee/jaxrs-multipart/src/main/java/org/wildfly/swarm/jaxrs/multipart/detect/JAXRSMultipartPackageDetector.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.jaxrs.multipart.detect;
+
+import org.wildfly.swarm.spi.meta.PackageFractionDetector;
+
+/**
+ * @author George Gastaldi
+ */
+public class JAXRSMultipartPackageDetector extends PackageFractionDetector {
+
+    public JAXRSMultipartPackageDetector() {
+        anyPackageOf("org.jboss.resteasy.plugins.providers.multipart", "org.jboss.resteasy.annotations.providers.multipart");
+    }
+
+    @Override
+    public String artifactId() {
+        return "jaxrs-multipart";
+    }
+}


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
When the multipart provider is used, the jaxrs-multipart fraction must be used.

Modifications
-------------
Created a JAXRSMultipartDetector to check if org.jboss.resteasy.plugins.providers.multipart or org.jboss.resteasy.annotations.providers.multipart
packages are used

Result
------
The jaxrs-multipart fraction is successfully detected