### PR TITLE
SWARM-1051: Fix Undertow custom jboss-deployment-structure.xml

### DIFF
--- a/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/UndertowFraction.java
+++ b/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/UndertowFraction.java
@@ -28,6 +28,7 @@ import org.wildfly.swarm.spi.api.Defaultable;
 import org.wildfly.swarm.spi.api.Fraction;
 import org.wildfly.swarm.spi.api.annotations.Configurable;
 import org.wildfly.swarm.spi.api.annotations.ConfigurableAlias;
+import org.wildfly.swarm.spi.api.annotations.DeploymentModule;
 import org.wildfly.swarm.spi.api.annotations.MarshalDMR;
 import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
 
@@ -46,6 +47,7 @@ import static org.wildfly.swarm.undertow.UndertowProperties.DEFAULT_SERVER;
  */
 @MarshalDMR
 @WildFlyExtension(module = "org.wildfly.extension.undertow")
+@DeploymentModule(name = "org.jboss.modules")
 public class UndertowFraction extends Undertow<UndertowFraction> implements Fraction {
 
     /**

--- a/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/descriptors/WebXmlContainer.java
+++ b/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/descriptors/WebXmlContainer.java
@@ -80,9 +80,6 @@ public interface WebXmlContainer<T extends Archive<T>> extends Archive<T>, Servi
         // Add services entry for FaviconServletExtension
         this.addAsServiceProvider(ServletExtension.class.getName(), FaviconServletExtension.EXTENSION_NAME);
 
-        // Add JBoss Modules to deployment
-        this.addModule("org.jboss.modules");
-
         return (T) this;
     }
 


### PR DESCRIPTION
Motivation
----------
Currently, a custom jboss-deployment-structure.xml in webapp/WEB-INF is simply ignored.

Modifications
-------------
Instead of adding the "org.jboss.modules" module in WebXmlContainer, use the default approach via @DeploymentModule.
See also:
https://issues.jboss.org/browse/SWARM-1051?focusedCommentId=13392917&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13392917

Result
------
A custom jboss-deployment-structure.xml is now picked up correctly and is properly extended with various entries from the installed Swarm fractions.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
