### PR TITLE
SWARM-1271 SWARM-1273: Activate project-whatever.yml better (and .yaml)

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/cli/CommandLine.java
+++ b/core/container/src/main/java/org/wildfly/swarm/cli/CommandLine.java
@@ -344,6 +344,7 @@ public class CommandLine {
         if (get(BIND) != null) {
             swarm.withProperty(SwarmProperties.BIND_ADDRESS, get(BIND));
         }
+
     }
 
     /**

--- a/core/container/src/main/java/org/wildfly/swarm/container/config/ClassLoaderConfigLocator.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/ClassLoaderConfigLocator.java
@@ -41,6 +41,13 @@ public class ClassLoaderConfigLocator extends ConfigLocator {
             located.add(each);
         }
 
+        resources = this.classLoader.getResources(PROJECT_PREFIX + profileName + ".yaml");
+
+        while (resources.hasMoreElements()) {
+            URL each = resources.nextElement();
+            located.add(each);
+        }
+
         resources = this.classLoader.getResources(PROJECT_PREFIX + profileName + ".properties");
 
         while (resources.hasMoreElements()) {

--- a/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewFactory.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewFactory.java
@@ -104,7 +104,7 @@ public class ConfigViewFactory {
     public void load(String profileName, URL url) throws IOException {
         if (url.getPath().endsWith(".properties")) {
             loadProperties(profileName, url);
-        } else if (url.getPath().endsWith(".yml")) {
+        } else if (url.getPath().endsWith(".yml") || url.getPath().endsWith(".yaml")) {
             loadYaml(profileName, url);
         }
     }
@@ -118,7 +118,7 @@ public class ConfigViewFactory {
     }
 
     protected void loadYaml(String profileName, URL url) throws IOException {
-        if (profileName.equals(STAGES) || url.getPath().endsWith("-stages.yml")) {
+        if (profileName.equals(STAGES) || url.getPath().endsWith("-stages.yml") || url.getPath().endsWith("-stages.yaml")) {
             loadProjectStages(url);
             return;
         }

--- a/core/container/src/main/java/org/wildfly/swarm/container/config/FilesystemConfigLocator.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/FilesystemConfigLocator.java
@@ -32,6 +32,12 @@ public class FilesystemConfigLocator extends ConfigLocator {
             located.add(path.toUri().toURL());
         }
 
+        path = this.root.resolve(PROJECT_PREFIX + profileName + ".yaml");
+
+        if (Files.exists(path)) {
+            located.add(path.toUri().toURL());
+        }
+
         path = this.root.resolve(PROJECT_PREFIX + profileName + ".properties");
         if (Files.exists(path)) {
             located.add(path.toUri().toURL());

--- a/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/ProjectStagesTest.java
+++ b/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/ProjectStagesTest.java
@@ -127,4 +127,25 @@ public class ProjectStagesTest {
         assertThat(view.resolve("swarm.myname").getValue()).isEqualTo("tacos");
     }
 
+    @Test
+    public void testPseudoPropertiesToSelectProjectStage() throws Exception {
+        Swarm swarm = new Swarm(new Properties(),
+                                "-Dswarm.project.stage=production");
+
+        ConfigView view = swarm.configView();
+        assertThat(view.resolve("foo.bar.baz").getValue()).isEqualTo("brie");
+    }
+
+    @Test
+    public void testIsolatedPropertiesToSelectProjectStage() throws Exception {
+        Properties props = new Properties();
+        props.setProperty("swarm.project.stage", "production");
+        Swarm swarm = new Swarm(props,
+                                "-Dswarm.project.stage=production");
+
+        ConfigView view = swarm.configView();
+        assertThat(view.resolve("foo.bar.baz").getValue()).isEqualTo("brie");
+        assertThat(view.resolve("foo.bar.taco").getValue()).isEqualTo("crunchy");
+    }
+
 }

--- a/testsuite/testsuite-project-stages/src/test/resources/project-defaults.yml
+++ b/testsuite/testsuite-project-stages/src/test/resources/project-defaults.yml
@@ -1,0 +1,4 @@
+foo:
+  bar:
+   baz: cheddar
+   taco: crunchy

--- a/testsuite/testsuite-project-stages/src/test/resources/project-production.yml
+++ b/testsuite/testsuite-project-stages/src/test/resources/project-production.yml
@@ -1,0 +1,3 @@
+foo:
+  bar:
+   baz: brie


### PR DESCRIPTION
Motivation
----------
People like to be able to activate a project-*.yml based upon the
swarm.project.stage property, passed either directly to the JVM
or through the swarm -D-alike processing.  That didn't work.

Also, people, such as myself, can never remember .yml or .yaml as
the preferred extension, so hey presto, let's support both.

Modifications
-------------
Better scrubbing around and loading of stages mentioned in the
swarm.project.stage property, no matter where it appears.  Also,
scrub around from .yaml in addition to .yml.

Result
------
Ken's happier because his project-openshift.yaml is found.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
