### PR TITLE
SWARM-1250: Allow fraction-usage analyzer to work with directories.

### DIFF
--- a/meta/fraction-metadata/src/main/java/org/wildfly/swarm/fractions/scanner/Scanner.java
+++ b/meta/fraction-metadata/src/main/java/org/wildfly/swarm/fractions/scanner/Scanner.java
@@ -19,6 +19,11 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.function.BiConsumer;
@@ -33,6 +38,20 @@ import org.wildfly.swarm.spi.meta.FractionDetector;
  */
 public interface Scanner<T> {
     String extension();
+
+    default void scan(Path source, Consumer<Path> childHandler) throws IOException {
+        if (Files.isDirectory(source)) {
+            Files.walkFileTree(source, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    childHandler.accept(file);
+                    return super.visitFile(file, attrs);
+                }
+            });
+        } else {
+            childHandler.accept(source);
+        }
+    }
 
     default void scan(ZipFile source, BiConsumer<ZipEntry, ZipFile> childHandler) throws IOException {
         final Enumeration<? extends ZipEntry> entries = source.entries();


### PR DESCRIPTION
Motivation
----------
George wants to scan target/classes and handle auto-detection,
for some reason.

Modifications
-------------
Improve the scanner bits to support non-zipfile input sources.

Result
------
Can scan an exploded .jar or .war (or target/classes) for auto-detection.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
