### PR TITLE
SWARM-1255: HealthCheck returns 500 - Internal Server Error due to a NPE

### DIFF
--- a/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/HttpContexts.java
+++ b/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/HttpContexts.java
@@ -16,6 +16,7 @@
 package org.wildfly.swarm.monitor.runtime;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -202,7 +203,10 @@ class HttpContexts implements HttpHandler {
 
             String delegateContext = healthCheck.getWebContext();
 
-            final InVMConnection connection = new InVMConnection(worker);
+            final InVMConnection connection = new InVMConnection(
+                    worker,
+                    exchange.getConnection().getLocalAddress(InetSocketAddress.class).getPort()
+            );
             final HttpServerExchange mockExchange = new HttpServerExchange(connection);
             mockExchange.setRequestScheme("http");
             mockExchange.setRequestMethod(new HttpString("GET"));

--- a/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/HttpContexts.java
+++ b/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/HttpContexts.java
@@ -150,14 +150,13 @@ class HttpContexts implements HttpHandler {
 
                     int i = 0;
                     for (InVMResponse resp : responses) {
-                        if (200 == resp.getStatus()) {
-                            sb.append(resp.getPayload());
-                        } else if (503 == resp.getStatus()) {
-                            sb.append(resp.getPayload());
-                            failed = true;
-                        } else {
-                            throw new RuntimeException("Unexpected status code: " + resp.getStatus());
+
+                        sb.append(resp.getPayload());
+
+                        if (!failed) {
+                            failed = resp.getStatus() != 200;
                         }
+
                         if (i < responses.size() - 1) {
                             sb.append(",\n");
                         }

--- a/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/InVMConnection.java
+++ b/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/InVMConnection.java
@@ -1,6 +1,7 @@
 package org.wildfly.swarm.monitor.runtime;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.util.LinkedList;
@@ -54,9 +55,10 @@ final class InVMConnection extends ServerConnection {
 
     protected final List<CloseListener> closeListeners = new LinkedList<>();
 
-    InVMConnection(XnioWorker worker) {
+    InVMConnection(XnioWorker worker, int port) {
         this.bufferPool = new DefaultByteBufferPool(false, 1024, 0, 0);
         this.worker = worker;
+        this.address = new InetSocketAddress(port); // port carried forward from the initial
     }
 
     public void flushTo(StringBuffer sb) {
@@ -144,12 +146,12 @@ final class InVMConnection extends ServerConnection {
 
     @Override
     public SocketAddress getLocalAddress() {
-        return null;
+        return address;
     }
 
     @Override
     public <A extends SocketAddress> A getLocalAddress(Class<A> type) {
-        return null;
+        return (A) address;
     }
 
     @Override
@@ -250,4 +252,6 @@ final class InVMConnection extends ServerConnection {
     }
 
     private boolean closed;
+
+    private final InetSocketAddress address;
 }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
Health endpoints yield an NPE when used with keycloak security

Modifications
-------------
Handle exception on InVm invocations gracefully and provide an InetSocketAddress to the internal invocations so that security contexts can be properly resolved
 
Result
------
The given reproducer works and so to the other health and security tests