### PR TITLE
SWARM-1096: Duplicate dependencies in the manifest YAML.

### DIFF
--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/ApplicationEnvironment.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/ApplicationEnvironment.java
@@ -262,11 +262,11 @@ public class ApplicationEnvironment {
      *
      * @return The list of Maven GAVs for application dependencies.
      */
-    public List<String> getDependencies() {
+    public Set<String> getDependencies() {
         if (this.mode == Mode.UBERJAR) {
             return this.applicationManifest.getDependencies();
         }
-        return Collections.emptyList();
+        return Collections.emptySet();
     }
 
     /**

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/WildFlySwarmManifest.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/WildFlySwarmManifest.java
@@ -10,10 +10,12 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import org.wildfly.swarm.bootstrap.util.BootstrapProperties;
 import org.yaml.snakeyaml.DumperOptions;
@@ -160,7 +162,7 @@ public class WildFlySwarmManifest {
         this.dependencies.add(gav);
     }
 
-    public List<String> getDependencies() {
+    public Set<String> getDependencies() {
         return this.dependencies;
     }
 
@@ -223,7 +225,7 @@ public class WildFlySwarmManifest {
 
     private List<String> bootstrapArtifacts = new ArrayList<>();
 
-    private List<String> dependencies = new ArrayList<>();
+    private Set<String> dependencies = new HashSet<>();
 
     private Properties properties = new Properties();
 

--- a/core/bootstrap/src/test/java/org/wildfly/swarm/bootstrap/modules/ApplicationModuleFinderTest.java
+++ b/core/bootstrap/src/test/java/org/wildfly/swarm/bootstrap/modules/ApplicationModuleFinderTest.java
@@ -23,7 +23,7 @@ public class ApplicationModuleFinderTest {
     public void testDependency() {
         // Mocks
         ApplicationEnvironment env = mock(ApplicationEnvironment.class);
-        when(env.getDependencies()).thenReturn(Collections.singletonList("org.jboss.forge.addon:ui-spi:jar:3.4.0.Final"));
+        when(env.getDependencies()).thenReturn(Collections.singleton("org.jboss.forge.addon:ui-spi:jar:3.4.0.Final"));
 
         ModuleSpec.Builder builder = mock(ModuleSpec.Builder.class);
 
@@ -37,7 +37,7 @@ public class ApplicationModuleFinderTest {
     public void testDependencyHasClassifier() {
         // Mocks
         ApplicationEnvironment env = mock(ApplicationEnvironment.class);
-        when(env.getDependencies()).thenReturn(Collections.singletonList("org.jboss.forge.addon:ui-spi:jar:forge-addon:3.4.0.Final"));
+        when(env.getDependencies()).thenReturn(Collections.singleton("org.jboss.forge.addon:ui-spi:jar:forge-addon:3.4.0.Final"));
 
         ModuleSpec.Builder builder = mock(ModuleSpec.Builder.class);
 


### PR DESCRIPTION
Motivation
----------
Duplicity is bad.  Causes extra work.  Why?

Modifications
-------------
Replace List<> with Set<> to ensure non-duplicates.

Result
------
Fewer duplicate bytes bloating the wildfly-swarm-manifest.yaml.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
