### PR TITLE
SWARM-1285: SwarmExecutor.execute() wrongly references weld-se-shaded artifact.

### DIFF
--- a/tools/src/main/java/org/wildfly/swarm/tools/exec/SwarmExecutor.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/exec/SwarmExecutor.java
@@ -230,14 +230,6 @@ public class SwarmExecutor {
             cli.add("-classpath");
             cli.add(String.join(File.pathSeparator,
                                 this.classpath.stream()
-                                        .sorted((o1, o2) -> {
-                                            if (o1.toString().contains("weld-se-shaded")) {
-                                                return -1;
-                                            } else if (o2.toString().contains("weld-se-shaded")) {
-                                                return 1;
-                                            }
-                                            return o1.compareTo(o2);
-                                        })
                                         .map(e -> e.toString())
                                         .collect(Collectors.toList())));
         }


### PR DESCRIPTION
Motivation
----------
org.wildfly.swarm.tools.exec.SwarmExecutor.execute() logic attempts to
place the weld-se-shaded jar as the first entry on the classpath.
However, this artifactId is only used in Weld 3 (it's weld-se in Weld
2). Also Swarm is not using the shaded artifact anymore.

Modifications
-------------
Do not sort the classpath entries.

Result
------
Everything should work the same as before.

- [ ] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
