### PR TITLE
SWARM-1295: improve logging test

### DIFF
--- a/testsuite/testsuite-logging/src/test/java/org/wildfly/swarm/logging/test/ArqLoggingLevelsTest.java
+++ b/testsuite/testsuite-logging/src/test/java/org/wildfly/swarm/logging/test/ArqLoggingLevelsTest.java
@@ -37,6 +37,20 @@ public class ArqLoggingLevelsTest {
 
         logger.info("gouda info");
         logger.debug("gouda debug");
+        logger.trace("gouda trace");
+
+        assertFalse(logger.isTraceEnabled());
+        assertTrue(logger.isDebugEnabled());
+        assertTrue(logger.isInfoEnabled());
+    }
+
+    @Test
+    public void testCustomCategoryChildren() {
+        Logger logger = Logger.getLogger("custom.category.children.Something");
+
+        logger.info("gouda info");
+        logger.debug("gouda debug");
+        logger.trace("gouda trace");
 
         assertFalse(logger.isTraceEnabled());
         assertTrue(logger.isDebugEnabled());
@@ -49,6 +63,7 @@ public class ArqLoggingLevelsTest {
 
         logger.info("gouda info");
         logger.debug("gouda debug");
+        logger.trace("gouda trace");
 
         assertTrue(logger.isTraceEnabled());
         assertTrue(logger.isDebugEnabled());


### PR DESCRIPTION
Motivation
----------
The `ArqLoggingLevelsTest` test checks that it's possible
to change logging levels via system properties. It should
check that setting a system property for custom.category
also affects children of that category.

Modifications
-------------
Improved the `ArqLoggingLevelsTest` to also check children
of the custom.category.

Result
------
No change, just more test coverage.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
