### PR TITLE
SWARM-1298: avoid double logging when using swarm.logging.category system properties

### DIFF
--- a/fractions/wildfly/logging/src/main/java/org/wildfly/swarm/logging/LoggingFraction.java
+++ b/fractions/wildfly/logging/src/main/java/org/wildfly/swarm/logging/LoggingFraction.java
@@ -82,7 +82,6 @@ public class LoggingFraction extends Logging<LoggingFraction> implements Fractio
                     logger(logger, (l) -> {
                         l.level(loggerLevel);
                         l.category(logger);
-                        l.handler(CONSOLE);
                     });
                 } catch (IllegalArgumentException e) {
                     // apparently wasn't a logging category+level, ignore.


### PR DESCRIPTION
Motivation
----------
If I use `-Dswarm.logging.category.name=DEBUG` to enable
debug logging, I get each of the debug log messages twice.
This appears e.g. in the `ArqLoggingLevelsTest` test.

The ultimate reason is that `LoggingFraction.applyDefaults(Level)`,
which adds the logger to the WildFly `logging` subsystem,
configures a handler for the logger. The thing is that by default,
log messages are already sent to the parent's logger handlers,
so in combination, the log message gets sent to 2 handlers.

Modifications
-------------
The newly created logger no longer has a handler set up.
This is how loggers are typically added with WildFly.

Another possibility would be to set the `use-parent-handlers`
management attribute to `false`.

Result
------
No more double logging.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
