### PR TITLE
SWARM-1282: Support a bom-certified.

### DIFF
--- a/boms/bom-certified/certified.conf
+++ b/boms/bom-certified/certified.conf
@@ -1,0 +1,6 @@
+arquillian
+hibernate-search
+ribbon
+hystrix
+archaius
+infinispan

--- a/boms/bom-certified/pom.xml
+++ b/boms/bom-certified/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>boms</artifactId>
+    <version>2017.5.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>bom-certified</artifactId>
+
+  <name>BOM: Certified Community</name>
+  <description>BOM: Certified Community</description>
+
+  <packaging>jar</packaging>
+
+   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>wildfly-swarm-fraction-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>fraction-metadata</artifactId>
+            <version>${version.certified-community}</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>generate-bom</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>generate-certified-bom</goal>
+            </goals>
+            <configuration>
+              <template>${project.parent.build.directory}/bom-template.xml</template>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+
+    <extensions>
+      <extension>
+        <groupId>org.apache.maven.wagon</groupId>
+        <artifactId>wagon-webdav-jackrabbit</artifactId>
+        <version>2.10</version>
+      </extension>
+    </extensions>
+  </build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,9 @@
   </scm>
 
   <properties>
-    <version.wildfly.swarm.fraction.plugin>53</version.wildfly.swarm.fraction.plugin>
+    <version.certified-community>2017.5.0-SNAPSHOT</version.certified-community>
+
+    <version.wildfly.swarm.fraction.plugin>54</version.wildfly.swarm.fraction.plugin>
     <version.wildfly.swarm.checkstyle>3</version.wildfly.swarm.checkstyle>
 
     <version.org.snakeyaml>1.17</version.org.snakeyaml>
@@ -1384,6 +1386,18 @@
   </modules>
 
   <profiles>
+
+    <profile>
+      <id>product-only</id>
+      <activation>
+        <property>
+          <name>swarm.product.build</name>
+        </property>
+      </activation>
+      <modules>
+        <module>boms/bom-certified</module>
+      </modules>
+    </profile>
     <profile>
       <id>unsupported</id>
       <activation>


### PR DESCRIPTION
Motivation
----------
We want, in the product build, another artifact :bom-certified
pointing to certified community bits that play friendly with
the productized bits, assuming there is a product.

Modifications
-------------
New project, boms/bom-certified, only enabled if -Dswarm.product.build.
Produces :bom-certified referencing bits from `certified.conf` near that
pom.xml using the fraction-list configured as a plugin dependency.

The dependency ultimately uses ${version.certified-community} defined
near the top of the root pom.xml, and in the community release is irrelevant
but currently matches itself.

Additionally, the plugin also avoids adding :arquillian from the productized
build (assuming there is a product) if -Dswarm.product.build, since :arquillian
would be purely and only a certified community fraction, if there is a product.

Result
------
When -Dswarm.product.build, a :bom-certified.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
