### PR TITLE
SWARM-1133: Add test for SWARM-1133.

### DIFF
--- a/fractions/javaee/messaging/pom.xml
+++ b/fractions/javaee/messaging/pom.xml
@@ -98,6 +98,18 @@
     </dependency>
 
     <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>fraction-metadata</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>ejb</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.wildfly.core</groupId>
       <artifactId>wildfly-core-feature-pack</artifactId>
       <type>zip</type>

--- a/fractions/javaee/messaging/src/test/java/org/wildfly/swarm/messaging/detector/MessageDetectorTest.java
+++ b/fractions/javaee/messaging/src/test/java/org/wildfly/swarm/messaging/detector/MessageDetectorTest.java
@@ -1,0 +1,32 @@
+package org.wildfly.swarm.messaging.detector;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.file.Files;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.junit.Test;
+import org.wildfly.swarm.fractions.FractionUsageAnalyzer;
+import org.wildfly.swarm.spi.api.JARArchive;
+
+public class MessageDetectorTest {
+
+	@Test
+	public void testFractionMatching() throws Exception {
+	    JARArchive archive = ShrinkWrap.create(JARArchive.class);
+	    archive.addClass(MyTopicMDB.class);
+	    FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer();
+	
+	    final File out = Files.createTempFile(archive.getName(), ".war").toFile();
+	    archive.as(ZipExporter.class).exportTo(out, true);
+	
+	    analyzer.source(out);
+	    assertThat(analyzer.detectNeededFractions()
+	                       .stream()
+	                       .filter(fd -> fd.getArtifactId().equals("messaging"))
+	                       .count())
+	            .isEqualTo(1);
+    }
+}

--- a/fractions/javaee/messaging/src/test/java/org/wildfly/swarm/messaging/detector/MyTopicMDB.java
+++ b/fractions/javaee/messaging/src/test/java/org/wildfly/swarm/messaging/detector/MyTopicMDB.java
@@ -1,0 +1,28 @@
+package org.wildfly.swarm.messaging.detector;
+
+import javax.ejb.ActivationConfigProperty;
+import javax.ejb.MessageDriven;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+import javax.jms.TextMessage;
+
+/**
+ * @author Yoshimasa Tanabe
+ */
+@MessageDriven(name = "MyTopicMDB", activationConfig = {
+        @ActivationConfigProperty(propertyName = "destinationLookup", propertyValue = "myTopic"),
+        @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Topic"),
+})
+public class MyTopicMDB implements MessageListener {
+
+    @Override
+    public void onMessage(Message message) {
+        try {
+            System.out.println("received: " + ((TextMessage) message).getText());
+        } catch (JMSException e) {
+            e.printStackTrace();
+        }
+    }
+
+}


### PR DESCRIPTION
Motivation
----------
Add tests to verify SWARM-1133 fix is working in future.

Modifications
-------------
Following a similar approach as in fraction-metadata, FractionUsageAnalyzerTest class, added a simple JUnit test with an MDB to check if right messaging fraction was actually added

Result
------
After these tests, they would only fail if SWARM-1133 is removed some day in future, keeping that feature safe.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
