### PR TITLE
SWARM-1235: Better document logging category name delineation.

### DIFF
--- a/fractions/wildfly/logging/README.adoc
+++ b/fractions/wildfly/logging/README.adoc
@@ -1,0 +1,8 @@
+# Logging
+
+The logging fraction helps configure logging categories,
+levels and handlers.
+
+When specifying log-levels through properties, since
+they include dots, they should be placed between
+square brackets, such as `swarm.logging.loggers.[com.mycorp.logger].level`.


### PR DESCRIPTION
Motivation
----------
Docs were unclear on using [ ] around logging category names.

Modifications
-------------
Added some docs.

Result
------
Stuff is documented.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
