### PR TITLE
SWARM-1259: Report all fractions during bootstrap

### DIFF
--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/BootstrapModuleFinder.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/BootstrapModuleFinder.java
@@ -33,7 +33,6 @@ import org.jboss.modules.ResourceLoaderSpec;
 import org.jboss.modules.ResourceLoaders;
 import org.jboss.modules.filter.PathFilter;
 import org.jboss.modules.filter.PathFilters;
-import org.jboss.modules.maven.ArtifactCoordinates;
 import org.wildfly.swarm.bootstrap.env.ApplicationEnvironment;
 import org.wildfly.swarm.bootstrap.logging.BootstrapLogger;
 import org.wildfly.swarm.bootstrap.performance.Performance;
@@ -62,16 +61,8 @@ public class BootstrapModuleFinder extends AbstractSingleModuleFinder {
 
             ApplicationEnvironment env = ApplicationEnvironment.get();
 
-            env.bootstrapArtifacts()
-                    .forEach((dep) -> {
-                        String[] parts = dep.split(":");
-                        ArtifactCoordinates coords = null;
-
-                        if (parts.length == 4) {
-                            coords = new ArtifactCoordinates(parts[0], parts[1], parts[3]);
-                        } else if (parts.length == 5) {
-                            coords = new ArtifactCoordinates(parts[0], parts[1], parts[3], parts[4]);
-                        }
+            env.bootstrapArtifactsAsCoordinates()
+                    .forEach((coords) -> {
                         try {
                             File artifact = MavenResolvers.get().resolveJarArtifact(coords);
                             if (artifact == null) {


### PR DESCRIPTION
Motivation
----------
Currently, fractions which are not recognized as bootstrap modules are
not reported to be "installed" during bootstrap. An example is
org.wildfly.swarm:jaxrs-jsonp which does not contain any config logic
but only brings some dependencies in. I think that from user POV it
makes sense to report such fractions. Also note that these fractions are
reported when using wildfly-swarm-plugin to run the application.

Modifications
-------------
ApplicationEnvironment - include also fraction manifests from bootstrap
artifacts.

Result
------
Fractions which do not contain any config java code are also reported as
"installed", e.g. Installed fraction: JAX-RS with JSON-P - STABLE.

- [ ] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
