### PR TITLE
SWARM-1322: Swarm's Arquillian container doesn't enable the @EJB enricher

### DIFF
--- a/arquillian/arquillian/src/main/resources/modules/org/jboss/arquillian/main/module.xml
+++ b/arquillian/arquillian/src/main/resources/modules/org/jboss/arquillian/main/module.xml
@@ -17,6 +17,7 @@
 
   <dependencies>
     <module name="javax.annotation.api" export="true"/>
+    <module name="javax.ejb.api" export="true"/>
     <module name="javax.enterprise.api" export="true"/>
     <module name="org.jboss.shrinkwrap" export="true"/>
     <module name="javax.api"/>


### PR DESCRIPTION
Motivation
----------
Arquillian ships with a bunch of test instance "enrichers"
for injecting objects to annotated fields. Among them are
enrichers for Java EE annotations `@Inject`, `@Resource`
and `@EJB`. These enrichers are enabled only if the respective
annotation (or some other identifying class) is "present
on the classpath". Which, for in-container tests, means
_visible from the classloader that loaded Arquillian_.
In Swarm's case, that's the module classloader for module
`org.jboss.arquillian`. This module is defined by Swarm itself.

This module currently exports `javax.annotation.api`, which
contains `@Resource`, and `javax.enterprise.api`, which
contains `@Inject` (and the `BeanManager`). For the `@EJB`
enricher to work, an export of `javax.ejb.api` is needed.

Modifications
-------------
Added an exported dependency on the `javax.ejb.api` module
to the `org.jboss.arquillian` module.

Result
------
`@EJB` enricher can actually work with Swarm Arquillian.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
