### PR TITLE
SWARM-836: Default favicon is broken.

### DIFF
--- a/fractions/javaee/undertow/pom.xml
+++ b/fractions/javaee/undertow/pom.xml
@@ -32,6 +32,16 @@
       <resource>
         <directory>src/main/resources</directory>
         <filtering>true</filtering>
+        <excludes>
+          <exclude>*.ico</exclude>
+        </excludes>
+      </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>false</filtering>
+        <includes>
+          <include>*.ico</include>
+        </includes>
       </resource>
     </resources>
   </build>


### PR DESCRIPTION
Motivation
----------
Display the default favicon correctly.

Modifications
-------------
Binary files must not be filtered. See also
https://issues.apache.org/jira/browse/MRESOURCES-127.

Result
------
The default wildfly-swarm favicon is not broken anymore!
