### PR TITLE
SWARM-1223: Add test for jpa detection.

### DIFF
--- a/testsuite/testsuite-jpa/src/test/java/org/wildfly/swarm/jpa/JPATest.java
+++ b/testsuite/testsuite-jpa/src/test/java/org/wildfly/swarm/jpa/JPATest.java
@@ -1,0 +1,31 @@
+package org.wildfly.swarm.jpa;
+
+import java.io.File;
+import java.nio.file.Files;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.junit.Test;
+import org.wildfly.swarm.fractions.FractionUsageAnalyzer;
+import org.wildfly.swarm.spi.api.JARArchive;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class JPATest {
+
+    @Test
+    public void testFractionMatching() throws Exception {
+        JARArchive archive = ShrinkWrap.create(JARArchive.class);
+        archive.addAsResource("persistence.xml");
+        FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer();
+
+        final File out = Files.createTempFile(archive.getName(), ".war").toFile();
+        archive.as(ZipExporter.class).exportTo(out, true);
+
+        analyzer.source(out);
+        assertThat(analyzer.detectNeededFractions()
+                       .stream()
+                       .filter(fd -> fd.getArtifactId().equals("jpa"))
+                       .count()).isEqualTo(1);
+    }
+}

--- a/testsuite/testsuite-jpa/src/test/resources/persistence.xml
+++ b/testsuite/testsuite-jpa/src/test/resources/persistence.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- JBoss, Home of Professional Open Source Copyright 2012, Red Hat, Inc.
+    and/or its affiliates, and individual contributors by the @authors tag. See
+    the copyright.txt in the distribution for a full listing of individual contributors.
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not
+    use this file except in compliance with the License. You may obtain a copy
+    of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required
+    by applicable law or agreed to in writing, software distributed under the
+    License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied. See the License for the specific
+    language governing permissions and limitations under the License. -->
+<persistence version="2.1"
+   xmlns="http://xmlns.jcp.org/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="
+        http://xmlns.jcp.org/xml/ns/persistence
+        http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
+   <persistence-unit name="primary" transaction-type="JTA">
+      <!-- If you are running in a production environment, add a managed
+         data source, this example data source is just for development and testing! -->
+      <!-- The datasource is deployed as WEB-INF/ticket-monster-ds.xml, you
+         can find it in the source at src/main/webapp/WEB-INF/ticket-monster-ds.xml -->
+      <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+      <properties>
+         <!-- Properties for Hibernate -->
+         <property name="hibernate.hbm2ddl.auto" value="create-drop" />
+         <property name="hibernate.show_sql" value="false" />
+      </properties>
+   </persistence-unit>
+</persistence>


### PR DESCRIPTION
Motivation
----------
It's advisable having a test for new features to ensure this is not regressed in future.

Modifications
-------------
New JUnit test had been added, checking with FractionUsageAnalyzer (same class used for fractions in the end) that jpa fraction exists when adding a persistence.xml file

Result
------
After the test, jpda fraction detection should be ok and test should pass.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----

I need this pull to be merged in order to make another one for https://issues.jboss.org/browse/SWARM-1330 that will affect this test.

Thanks very much!