### PR TITLE
SWARM-1333: Openshift service address not provided

### DIFF
--- a/fractions/topology-openshift/src/main/java/org/wildfly/swarm/topology/openshift/runtime/ServiceWatcher.java
+++ b/fractions/topology-openshift/src/main/java/org/wildfly/swarm/topology/openshift/runtime/ServiceWatcher.java
@@ -156,7 +156,7 @@ public class ServiceWatcher implements Service<ServiceWatcher>, IOpenShiftWatchL
                 .forEach(servicePort -> {
                     Registration registration = new Registration(TOPOLOGY_SOURCE_KEY,
                                                                  service.getName(),
-                                                                 service.getName(),
+                                                                 service.getClusterIP(),
                                                                  servicePort.getPort());
                     if (servicePort.getPort() == DEFAULT_HTTPS_PORT) {
                         registration.addTags(Collections.singletonList("https"));

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
 
     <version.com.orbitz.consul>0.9.16</version.com.orbitz.consul>
 
-    <version.openshift.client>5.5.0.Final</version.openshift.client>
+    <version.openshift.client>5.6.0.Final</version.openshift.client>
     <version.com.squareup.okhttp>3.4.2</version.com.squareup.okhttp>
     <version.com.squareup.okio>1.9.0</version.com.squareup.okio>
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
 
     <version.com.orbitz.consul>0.9.16</version.com.orbitz.consul>
 
-    <version.openshift.client>5.2.0.Final</version.openshift.client>
+    <version.openshift.client>5.5.0.Final</version.openshift.client>
     <version.com.squareup.okhttp>3.4.2</version.com.squareup.okhttp>
     <version.com.squareup.okio>1.9.0</version.com.squareup.okio>
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation:

The IP address of services is not available through the topology-openshift.

Changes:

Update the openshift-rest-client library to 5.5.0 and exposes the service ClusterIP 

Results:

Clients can retrieve full qualified service addresses through the topology openshift