### PR TITLE
ENTSWM-29: honour -Dmaven.repo.local setting

### DIFF
--- a/tools/src/main/java/org/wildfly/swarm/tools/ModuleAnalyzer.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/ModuleAnalyzer.java
@@ -38,6 +38,8 @@ import org.jboss.shrinkwrap.descriptor.spi.node.dom.XmlDomNodeImporterImpl;
  */
 public class ModuleAnalyzer {
 
+    private static final String DEFAULT_LOCAL_REPO = System.getProperty("user.home") + File.separator + ".m2" + File.separator + "repository";
+
     public ModuleAnalyzer(File f) throws IOException {
         this(new FileInputStream(f));
     }
@@ -81,7 +83,7 @@ public class ModuleAnalyzer {
 
         List<ArtifactSpec> dependencies = new ArrayList<>();
 
-        String localRepo = System.getProperty("user.home") + File.separator + ".m2" + File.separator + "repository";
+        String localRepo = System.getProperty("maven.repo.local", DEFAULT_LOCAL_REPO);
 
         for (ArtifactType<ResourcesType<ModuleDescriptor>> artifact : artifacts) {
             ArtifactSpec dep = ArtifactSpec.fromMscGav(artifact.getName());


### PR DESCRIPTION
Motivation
----------
Disable using artifacts from `$HOME/.m2/repository` when `maven.repo.local` is specified.
This is especially useful for wildfly-swarm-repository project, which relies on this setting working properly.

Modifications
-------------
ModuleAnalyzer will be using the aforementioned setting and fall back to user's .m2 repository when it is not specified.

Result
------
When `-Dmaven.repository.local` is set, artifacts from user's `.m2` repository won't be used

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
