### PR TITLE
SWARM-1341: Prevent overriding FilterConfiguration

### DIFF
--- a/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/UndertowFilterCustomizer.java
+++ b/fractions/monitor/src/main/java/org/wildfly/swarm/monitor/runtime/UndertowFilterCustomizer.java
@@ -37,7 +37,9 @@ public class UndertowFilterCustomizer implements Customizer {
         if (!undertowFractionInstance.isUnsatisfied()) {
             UndertowFraction undertow = undertowFractionInstance.get();
 
-            undertow.filterConfiguration();
+            if (undertow.subresources().filterConfiguration() == null) {
+              undertow.filterConfiguration();
+            }
             undertow.subresources().filterConfiguration()
                     .customFilter("wfs-monitor", customFilter -> {
                         customFilter.module("org.wildfly.swarm.monitor:runtime");


### PR DESCRIPTION
Motivation
----------
When using the monitoring fraction, it overrides filter configurations
from other (custom) fractions.

Modifications
-------------
Create new fraction configuration only in case none is already present.

Result
------
A new filter configuration is created only in case none is already
present. Monitoring fraction will use existing filter configuration, if
present.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
