### PR TITLE
ENTSWM-31: added switches to download sources and poms

### DIFF
--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/ExtraArtifactsHandler.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/ExtraArtifactsHandler.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.plugin.maven;
+
+import org.codehaus.plexus.util.StringUtils;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.DefaultDependencyNode;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyNode;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ *         <br>
+ *         Date: 5/12/17
+ */
+public class ExtraArtifactsHandler {
+
+    /**
+     * Takes a list of dependencies and creates a list of extras (poms, javadocs and/or sources) for those dependencies.
+     * <p/>
+     * Set one or more of the following system properties to make the method return artifacts of a specified type:
+     * <ul>
+     * <li><code>swarm.download.sources</code> for sources</li>
+     * <li><code>swarm.download.poms</code> for pom files</li>
+     * <li><code>swarm.download.javadocs</code> for javadocs</li>
+     * </ul>
+     * <p/>
+     *
+     * @param nodes list of dependencies
+     * @return list of extra artifacts
+     */
+    public static List<DependencyNode> getExtraDependencies(List<DependencyNode> nodes) {
+
+        ExtraArtifactsHandler fetcher = new ExtraArtifactsHandler(nodes);
+        if (isSet("swarm.download.sources")) {
+            System.out.println("will download sources");
+            fetcher.addWithClassifier("sources");
+        }
+
+        if (isSet("swarm.download.poms")) {
+            System.out.println("will download poms");
+            fetcher.addWithExtension("pom");
+        }
+
+        if (isSet("swarm.download.javadocs")) {
+            System.out.println("will download javadocs");
+            fetcher.addWithClassifier("javadoc");
+        }
+        return fetcher.output;
+    }
+
+    private static boolean isSet(String key) {
+        String value = System.getProperty(key);
+        return value != null && !"false".equals(value);
+    }
+
+    public void addWithExtension(String extension) {
+        addDependencies(
+                a -> a.getExtension().equals(extension) && StringUtils.isEmpty(a.getClassifier()),
+                Optional.of(extension), Optional.empty()
+        );
+    }
+
+    public void addWithClassifier(String classifier) {
+        addDependencies(
+                a -> a.getClassifier().equals(classifier) && "jar".equals(a.getExtension()),
+                Optional.empty(), Optional.of(classifier)
+        );
+    }
+
+    private void addDependencies(Function<Artifact, Boolean> duplicateFilter, Optional<String> extension, Optional<String> classifier) {
+        List<Dependency> dependencies = input.stream()
+                .map(DependencyNode::getDependency)
+                .collect(Collectors.toList());
+
+        Set<String> existingGavs = dependencies.stream()
+                .map(Dependency::getArtifact)
+                .filter(duplicateFilter::apply)
+                .map(this::toGav)
+                .collect(Collectors.toSet());
+
+        List<DependencyNode> newNodes = input.stream()
+                .filter(n -> !existingGavs.contains(toGav(n.getDependency().getArtifact())))
+                .map(n -> createNode(n, extension, classifier))
+                .collect(Collectors.toList());
+        output.addAll(newNodes);
+    }
+
+    private DependencyNode createNode(DependencyNode n, Optional<String> extension, Optional<String> classifier) {
+        Artifact original = n.getArtifact();
+        Artifact withExtension =
+                new DefaultArtifact(original.getGroupId(),
+                        original.getArtifactId(),
+                        classifier.orElse(original.getClassifier()),
+                        extension.orElse(original.getExtension()),
+                        original.getVersion(),
+                        original.getProperties(),
+                        (File) null);
+
+        DefaultDependencyNode nodeWithClassifier = new DefaultDependencyNode(new Dependency(withExtension, "system"));
+
+        return nodeWithClassifier;
+    }
+
+    private String toGav(Artifact artifact) {
+        return String.format("%s:%s:%s",
+                artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion());
+    }
+
+    public ExtraArtifactsHandler(List<DependencyNode> nodes) {
+        this.input = nodes;
+    }
+
+    private final List<DependencyNode> input;
+    private final List<DependencyNode> output = new ArrayList<>();
+}

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelper.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelper.java
@@ -15,14 +15,6 @@
  */
 package org.wildfly.swarm.plugin.maven;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
 import org.apache.maven.artifact.repository.Authentication;
@@ -53,6 +45,14 @@ import org.eclipse.aether.util.graph.visitor.PreorderNodeListGenerator;
 import org.eclipse.aether.util.repository.AuthenticationBuilder;
 import org.wildfly.swarm.tools.ArtifactResolvingHelper;
 import org.wildfly.swarm.tools.ArtifactSpec;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author Bob McWhirter
@@ -178,6 +178,10 @@ public class MavenArtifactResolvingHelper implements ArtifactResolvingHelper {
                 nodes.add(node);
             }
         }
+
+        List<DependencyNode> extraDependencies = ExtraArtifactsHandler.getExtraDependencies(nodes);
+
+        nodes.addAll(extraDependencies);
 
         resolveDependenciesInParallel(nodes);
 

--- a/plugins/maven/src/test/java/org/wildfly/swarm/plugin/maven/ExtraArtifactsHandlerTest.java
+++ b/plugins/maven/src/test/java/org/wildfly/swarm/plugin/maven/ExtraArtifactsHandlerTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.plugin.maven;
+
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.DefaultDependencyNode;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyNode;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ *         <br>
+ *         Date: 5/15/17
+ */
+public class ExtraArtifactsHandlerTest {
+
+    public static final String GROUP_ID = "org.wildfly.swarm";
+    public static final String ARTIFACT_ID = "wildfly-swarm";
+    public static final String JAR = "jar";
+    public static final String VERSION = "2017.5.0";
+
+    @Before
+    public void setUp() {
+        System.clearProperty("swarm.download.poms");
+        System.clearProperty("swarm.download.sources");
+        System.clearProperty("swarm.download.javadocs");
+    }
+
+    @Test
+    public void shouldGetOnlyPomWhenPomsSpecified() throws Exception {
+        System.setProperty("swarm.download.poms", "");
+
+        shouldGetWithClassifierAndExtension("", "pom");
+    }
+
+    @Test
+    public void shouldGetOnlySourcesWhenSourcesSpecified() throws Exception {
+        System.setProperty("swarm.download.sources", "");
+        shouldGetWithClassifierAndExtension("sources", "jar");
+    }
+
+    @Test
+    public void shouldGetOnlyJavadocWhenJavadocSpecified() throws Exception {
+        System.setProperty("swarm.download.javadocs", "");
+        shouldGetWithClassifierAndExtension("javadoc", "jar");
+    }
+
+    private void shouldGetWithClassifierAndExtension(String classifier, String extension) {
+        DependencyNode dependency = dependencyNode();
+        List<DependencyNode> extraDependencies =
+                ExtraArtifactsHandler.getExtraDependencies(Collections.singletonList(dependency));
+
+        assertThat(extraDependencies).hasSize(1);
+
+        DependencyNode extraDependency = extraDependencies.get(0);
+        Artifact artifact = extraDependency.getDependency().getArtifact();
+        assertThat(artifact.getGroupId()).isEqualTo(GROUP_ID);
+        assertThat(artifact.getArtifactId()).isEqualTo(ARTIFACT_ID);
+        assertThat(artifact.getVersion()).isEqualTo(VERSION);
+
+        assertThat(artifact.getClassifier()).isEqualTo(classifier);
+        assertThat(artifact.getExtension()).isEqualTo(extension);
+    }
+
+
+    private DependencyNode dependencyNode() {        
+        DefaultArtifact artifact = new DefaultArtifact(GROUP_ID, ARTIFACT_ID, JAR, VERSION);
+        return new DefaultDependencyNode(
+                new Dependency(artifact, "system")
+        );
+    }
+
+}


### PR DESCRIPTION
Motivation
----------
Prod needs to build a repository that contains sources and poms for the artifacts used by a user app.

Modifications
-------------
`ExtraArtifactsHandler` has been added and invoked in `MavenArtifactResolvingHelper#resolveAll`.
Based on system properties, pom, javadoc or source artifacts are added to the list of `DependencyNode`s to resolve.

Result
------
When `-Dswarm.download.poms`, `-Dswarm.download.javadocs` or `-Dswarm.download.sources`, is set during a build of a user app, the pom files, javadocs or sources (appropriately) are downloaded for every artifact downloaded by the swarm plugin.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
