### PR TITLE
SWARM-1293: {wildfly, keycloak}-config-api versions bumped to 1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,9 +37,9 @@
     <version.org.snakeyaml>1.17</version.org.snakeyaml>
 
     <version.maven.aether>3.2.5</version.maven.aether>
-    <version.wildfly.config-api>1.0.3.Final</version.wildfly.config-api>
+    <version.wildfly.config-api>1.1.0.Final</version.wildfly.config-api>
 
-    <version.keycloak.config-api>1.0.2.Final</version.keycloak.config-api>
+    <version.keycloak.config-api>1.1.0.Final</version.keycloak.config-api>
     <version.teiid.config-api>1.0.2</version.teiid.config-api>
     <version.keycloak>2.5.4.Final</version.keycloak>
 


### PR DESCRIPTION
**NOTE** requires release of wildfly-config-api and keylocak-config-api 1.1.0.Final

Motivation
----------
We should use a major.minor.0 version for the config APIs (see ENTSWM-6)

Modifications
-------------
wildfly-config-api and keycloak-config-api versions changed to 1.1.0.Final

Result
------
Newer version of config-apis will be used

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
