### PR TITLE
SWARM-1353 - Support @Configurable on EnhancedWhatnot.

### DIFF
--- a/core/spi/src/main/java/org/wildfly/swarm/spi/api/annotations/Configurable.java
+++ b/core/spi/src/main/java/org/wildfly/swarm/spi/api/annotations/Configurable.java
@@ -34,7 +34,7 @@ import javax.inject.Qualifier;
  */
 @Qualifier
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.FIELD, ElementType.TYPE})
+@Target({ElementType.FIELD, ElementType.TYPE, ElementType.METHOD})
 @Repeatable(Configurables.class)
 public @interface Configurable {
     @Nonbinding String value() default "";

--- a/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/EnhancedSecurityRealm.java
+++ b/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/EnhancedSecurityRealm.java
@@ -16,6 +16,7 @@
 package org.wildfly.swarm.management;
 
 import org.wildfly.swarm.config.management.SecurityRealm;
+import org.wildfly.swarm.spi.api.annotations.Configurable;
 
 /**
  * @author Bob McWhirter
@@ -29,6 +30,7 @@ public class EnhancedSecurityRealm extends SecurityRealm<EnhancedSecurityRealm> 
         plugIn("org.wildfly.swarm.management:runtime");
     }
 
+    @Configurable("in-memory-authentication")
     public EnhancedSecurityRealm inMemoryAuthentication(InMemoryAuthenticationConsumer consumer) {
         return plugInAuthentication((plugin) -> {
             plugin.name(IN_MEMORY_PLUGIN_NAME);
@@ -42,6 +44,7 @@ public class EnhancedSecurityRealm extends SecurityRealm<EnhancedSecurityRealm> 
         });
     }
 
+    @Configurable("in-memory-authorization")
     public EnhancedSecurityRealm inMemoryAuthorization(InMemoryAuthorizationConsumer consumer) {
         return plugInAuthorization((plugin) -> {
             plugin.name(IN_MEMORY_PLUGIN_NAME);

--- a/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/InMemoryAuthentication.java
+++ b/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/InMemoryAuthentication.java
@@ -19,12 +19,15 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Enumeration;
 import java.util.Properties;
+import java.util.function.Consumer;
 
 import org.wildfly.swarm.config.management.security_realm.PlugInAuthentication;
+import org.wildfly.swarm.spi.api.annotations.Configurable;
 
 /**
  * @author Bob McWhirter
  */
+@Configurable
 public class InMemoryAuthentication {
 
     public InMemoryAuthentication(String realm, PlugInAuthentication plugin) {
@@ -45,6 +48,18 @@ public class InMemoryAuthentication {
 
             add(userName, value, plainText);
         }
+    }
+
+    @Configurable
+    public InMemoryAuthentication user(String userName, Consumer<InMemoryUserAuthentication> consumer) {
+        InMemoryUserAuthentication config = new InMemoryUserAuthentication();
+        consumer.accept(config);
+        if (config.password() != null) {
+            add(userName, config.password(), true);
+        } else {
+            add(userName, config.hash(), false);
+        }
+        return this;
     }
 
     public void add(String userName, String password) {

--- a/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/InMemoryAuthorization.java
+++ b/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/InMemoryAuthorization.java
@@ -15,11 +15,16 @@
  */
 package org.wildfly.swarm.management;
 
+import java.util.List;
+import java.util.function.Consumer;
+
 import org.wildfly.swarm.config.management.security_realm.PlugInAuthorization;
+import org.wildfly.swarm.spi.api.annotations.Configurable;
 
 /**
  * @author Bob McWhirter
  */
+@Configurable
 public class InMemoryAuthorization {
 
     public InMemoryAuthorization(PlugInAuthorization plugin) {
@@ -31,7 +36,21 @@ public class InMemoryAuthorization {
             String value = String.join(",", roles);
             prop.value(value);
         });
+    }
 
+    public void add(String userName, List<String> roles) {
+        this.plugin.property(userName + ".roles", (prop) -> {
+            String value = String.join(",", roles);
+            prop.value(value);
+        });
+    }
+
+    @Configurable
+    public InMemoryAuthorization user(String userName, Consumer<InMemoryUserAuthorization> config) {
+        InMemoryUserAuthorization authz = new InMemoryUserAuthorization();
+        config.accept(authz);
+        add(userName, authz.roles());
+        return this;
     }
 
     private final PlugInAuthorization plugin;

--- a/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/InMemoryUserAuthentication.java
+++ b/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/InMemoryUserAuthentication.java
@@ -1,0 +1,34 @@
+package org.wildfly.swarm.management;
+
+import org.wildfly.swarm.spi.api.annotations.Configurable;
+
+/**
+ * Created by bob on 5/22/17.
+ */
+@Configurable
+public class InMemoryUserAuthentication {
+    public InMemoryUserAuthentication() {
+    }
+
+    public InMemoryUserAuthentication password(String password) {
+        this.password = password;
+        return this;
+    }
+
+    public String password() {
+        return this.password;
+    }
+
+    public InMemoryUserAuthentication hash(String hash) {
+        this.hash = hash;
+        return this;
+    }
+
+    public String hash() {
+        return this.hash;
+    }
+
+    private String password;
+
+    private String hash;
+}

--- a/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/InMemoryUserAuthorization.java
+++ b/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/InMemoryUserAuthorization.java
@@ -1,0 +1,26 @@
+package org.wildfly.swarm.management;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.wildfly.swarm.spi.api.annotations.Configurable;
+
+/**
+ * Created by bob on 5/22/17.
+ */
+@Configurable
+public class InMemoryUserAuthorization {
+    public InMemoryUserAuthorization() {
+    }
+
+    public InMemoryUserAuthorization roles(List<String> roles) {
+        this.roles.addAll(roles);
+        return this;
+    }
+
+    public List<String> roles() {
+        return this.roles;
+    }
+
+    private List<String> roles = new ArrayList<>();
+}

--- a/testsuite/testsuite-management/src/main/resources/project-defaults.yml
+++ b/testsuite/testsuite-management/src/main/resources/project-defaults.yml
@@ -8,15 +8,14 @@ swarm:
       security-realm: ManagementRealm
     security-realms:
       ManagementRealm:
-        plug-in-authentication:
-          name: swarm-in-memory
-          properties:
-            bob.hash:
-              value: 9b511b00aa7f2265621e38d2cf665f2f
-        plug-in-authorization:
-          name: swarm-in-memory
-          properties:
-            bob.roles:
-              value: admin
+        in-memory-authentication:
+          users:
+            bob:
+              password: tacos!
+        in-memory-authorization:
+          users:
+            bob:
+              roles:
+                - admin
 
 

--- a/testsuite/testsuite-management/src/test/java/org/wildfly/swarm/management/test/ArqSecuredManagementInterfaceTest.java
+++ b/testsuite/testsuite-management/src/test/java/org/wildfly/swarm/management/test/ArqSecuredManagementInterfaceTest.java
@@ -25,10 +25,8 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.swarm.Swarm;
 import org.wildfly.swarm.arquillian.DefaultDeployment;
 import org.wildfly.swarm.management.AuthCallbackHandler;
-import org.wildfly.swarm.management.ManagementFraction;
 
 import static org.fest.assertions.Assertions.assertThat;
 


### PR DESCRIPTION
Motivation
----------

We provide some helper configuration classes, such as InMemoryAuthentication,
which hang off enhanced classes, such as EnhancedSecurityRealm.

As we move away from main(), these become less useful from the YAML.

We should fix that.

Modifications
-------------
In addition to scrubbing around in the config-api for generated things, also
inspect @Configurable methods when added to our classes, and use them to configure
things through the EnhancedWhatnot classes.

Result
------
You can in-memory-(authentication|authorization) from YAML now with friendly ways
to configure them.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
