### PR TITLE
SWARM-1358 - Support YAML for opentracing-hawkular

### DIFF
--- a/fractions/opentracing-hawkular-jaxrs/src/main/java/org/wildfly/swarm/opentracing/hawkular/jaxrs/HTTPTracePublisher.java
+++ b/fractions/opentracing-hawkular-jaxrs/src/main/java/org/wildfly/swarm/opentracing/hawkular/jaxrs/HTTPTracePublisher.java
@@ -1,0 +1,44 @@
+package org.wildfly.swarm.opentracing.hawkular.jaxrs;
+
+/**
+ * Created by bob on 5/23/17.
+ */
+public class HTTPTracePublisher {
+
+    public HTTPTracePublisher() {
+
+    }
+
+    public HTTPTracePublisher userName(String userName) {
+        this.userName = userName;
+        return this;
+    }
+
+    public String userName() {
+        return this.userName;
+    }
+
+    public HTTPTracePublisher password(String password) {
+        this.password = password;
+        return this;
+    }
+
+    public String password() {
+        return this.password;
+    }
+
+    public HTTPTracePublisher url(String url) {
+        this.url = url;
+        return this;
+    }
+
+    public String url() {
+        return this.url;
+    }
+
+    private String userName;
+
+    private String password;
+
+    private String url;
+}

--- a/fractions/opentracing-hawkular-jaxrs/src/main/java/org/wildfly/swarm/opentracing/hawkular/jaxrs/TraceRecorder.java
+++ b/fractions/opentracing-hawkular-jaxrs/src/main/java/org/wildfly/swarm/opentracing/hawkular/jaxrs/TraceRecorder.java
@@ -1,0 +1,85 @@
+package org.wildfly.swarm.opentracing.hawkular.jaxrs;
+
+import java.util.function.Consumer;
+
+import org.wildfly.swarm.config.runtime.SubresourceInfo;
+import org.wildfly.swarm.spi.api.Defaultable;
+
+import static org.wildfly.swarm.spi.api.Defaultable.integer;
+
+/**
+ * Created by bob on 5/23/17.
+ */
+public class TraceRecorder {
+
+
+    private TraceRecorderResources subresources = new TraceRecorderResources();
+
+    public TraceRecorder() {
+
+    }
+
+    public TraceRecorder batchSize(Integer batchSize) {
+        this.batchSize.set(batchSize);
+        return this;
+    }
+
+    public Integer batchSize() {
+        return this.batchSize.get();
+    }
+
+    public TraceRecorder batchTime(Integer batchTime) {
+        this.batchTime.set(batchTime);
+        return this;
+    }
+
+    public Integer batchTime() {
+        return this.batchTime.get();
+    }
+
+    public TraceRecorder threadPoolSize(Integer threadPoolSize) {
+        this.threadPoolSize.set(threadPoolSize);
+        return this;
+    }
+
+    public Integer threadPoolSize() {
+        return this.threadPoolSize.get();
+    }
+
+    public TraceRecorder tenantId(String tenantId) {
+        this.tenantId = tenantId;
+        return this;
+    }
+
+    public String tenantId() {
+        return this.tenantId;
+    }
+
+    public TraceRecorderResources subresources() {
+        return this.subresources;
+    }
+
+    public TraceRecorder httpTracePublisher(Consumer<HTTPTracePublisher> config) {
+        HTTPTracePublisher publisher = new HTTPTracePublisher();
+        config.accept(publisher);
+        this.subresources.httpTracePublisher = publisher;
+        return this;
+    }
+
+    public HTTPTracePublisher httpTracePublisher() {
+        return this.subresources.httpTracePublisher;
+    }
+
+    private Defaultable<Integer> batchSize = integer(1000);
+
+    private Defaultable<Integer> batchTime = integer(500);
+
+    private Defaultable<Integer> threadPoolSize = integer(5);
+
+    private String tenantId;
+
+    public static class TraceRecorderResources {
+        @SubresourceInfo("http-publisher")
+        private HTTPTracePublisher httpTracePublisher;
+    }
+}

--- a/fractions/opentracing-hawkular-jaxrs/src/main/java/org/wildfly/swarm/opentracing/hawkular/jaxrs/Tracing.java
+++ b/fractions/opentracing-hawkular-jaxrs/src/main/java/org/wildfly/swarm/opentracing/hawkular/jaxrs/Tracing.java
@@ -1,0 +1,83 @@
+package org.wildfly.swarm.opentracing.hawkular.jaxrs;
+
+import java.util.function.Consumer;
+
+import org.wildfly.swarm.config.runtime.SubresourceInfo;
+import org.wildfly.swarm.spi.api.Defaultable;
+
+import static org.wildfly.swarm.spi.api.Defaultable.bool;
+import static org.wildfly.swarm.spi.api.Defaultable.integer;
+
+/**
+ * Created by bob on 5/23/17.
+ */
+public class Tracing {
+
+
+    private Defaultable<Integer> percentageSampling = integer(100);
+
+    private String serviceName;
+
+    private String buildStamp;
+
+    private Defaultable<Boolean> consoleRecorder = bool(false);
+
+    private TracingSubresources subresources = new TracingSubresources();
+
+    public Tracing sampleRate(Integer percentage) {
+        this.percentageSampling.set(percentage);
+        return this;
+    }
+
+    public TracingSubresources subresources() {
+        return this.subresources;
+    }
+
+    public Integer sampleRate() {
+        return this.percentageSampling.get();
+    }
+
+    public Tracing serviceName(String serviceName) {
+        this.serviceName = serviceName;
+        return this;
+    }
+
+    public String serviceName() {
+        return this.serviceName;
+    }
+
+    public Tracing buildStamp(String buildStamp) {
+        this.buildStamp = buildStamp;
+        return this;
+    }
+
+    public String buildStamp() {
+        return this.buildStamp;
+    }
+
+    public Tracing consoleRecorder(Boolean consoleRecorder) {
+        this.consoleRecorder.set(consoleRecorder);
+        return this;
+    }
+
+    public Boolean consoleRecorder() {
+        return this.consoleRecorder.get();
+    }
+
+    public Tracing traceRecorder(Consumer<TraceRecorder> config) {
+        TraceRecorder traceRecorder = new TraceRecorder();
+        config.accept(traceRecorder);
+        this.subresources.traceRecorder = traceRecorder;
+        return this;
+    }
+
+    public TraceRecorder traceRecorder() {
+        return this.subresources.traceRecorder;
+    }
+
+    public static class TracingSubresources {
+        @SubresourceInfo("trace-recorder")
+        private TraceRecorder traceRecorder;
+    }
+
+}

--- a/fractions/opentracing-hawkular-jaxrs/src/main/java/org/wildfly/swarm/opentracing/hawkular/jaxrs/runtime/MultiTraceRecorder.java
+++ b/fractions/opentracing-hawkular-jaxrs/src/main/java/org/wildfly/swarm/opentracing/hawkular/jaxrs/runtime/MultiTraceRecorder.java
@@ -1,0 +1,38 @@
+package org.wildfly.swarm.opentracing.hawkular.jaxrs.runtime;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hawkular.apm.api.model.trace.Trace;
+import org.hawkular.apm.client.api.recorder.TraceRecorder;
+
+/**
+ * Created by bob on 5/24/17.
+ */
+public class MultiTraceRecorder implements TraceRecorder {
+
+    public MultiTraceRecorder() {
+
+    }
+
+    public void add(TraceRecorder recorder) {
+        this.recorders.add(recorder);
+    }
+
+    public int size() {
+        return this.recorders.size();
+    }
+
+    public boolean isEmpty() {
+        return this.recorders.isEmpty();
+    }
+
+    @Override
+    public void record(Trace trace) {
+        this.recorders.forEach(r -> {
+            r.record(trace);
+        });
+    }
+
+    private List<TraceRecorder> recorders = new ArrayList<>();
+}

--- a/fractions/opentracing-hawkular-jaxrs/src/main/java/org/wildfly/swarm/opentracing/hawkular/jaxrs/runtime/OpenTracingServiceActivator.java
+++ b/fractions/opentracing-hawkular-jaxrs/src/main/java/org/wildfly/swarm/opentracing/hawkular/jaxrs/runtime/OpenTracingServiceActivator.java
@@ -1,9 +1,20 @@
 package org.wildfly.swarm.opentracing.hawkular.jaxrs.runtime;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Any;
-import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
+import io.opentracing.contrib.global.GlobalTracer;
+import io.opentracing.contrib.jaxrs2.server.ServerTracingDynamicFeature;
+import org.hawkular.apm.api.services.TracePublisher;
+import org.hawkular.apm.client.api.recorder.BatchTraceRecorder;
+import org.hawkular.apm.client.api.recorder.LoggingRecorder;
+import org.hawkular.apm.client.api.recorder.TraceRecorder;
+import org.hawkular.apm.client.api.sampler.PercentageSampler;
+import org.hawkular.apm.client.api.sampler.Sampler;
+import org.hawkular.apm.client.opentracing.APMTracer;
+import org.hawkular.apm.client.opentracing.DeploymentMetaData;
+import org.hawkular.apm.trace.publisher.rest.client.TracePublisherRESTClient;
 import org.jboss.as.naming.ImmediateManagedReferenceFactory;
 import org.jboss.as.naming.ServiceBasedNamingStore;
 import org.jboss.as.naming.deployment.ContextNames;
@@ -14,24 +25,26 @@ import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceRegistryException;
 import org.jboss.msc.service.ServiceTarget;
+import org.wildfly.swarm.opentracing.hawkular.jaxrs.HTTPTracePublisher;
 import org.wildfly.swarm.opentracing.hawkular.jaxrs.OpenTracingHawkularFraction;
 import org.wildfly.swarm.opentracing.hawkular.jaxrs.TracerLookup;
+import org.wildfly.swarm.opentracing.hawkular.jaxrs.Tracing;
 
 /**
  * @author Pavol Loffay
  */
+@ApplicationScoped
 public class OpenTracingServiceActivator implements ServiceActivator {
 
     @Inject
     @Any
-    private Instance<OpenTracingHawkularFraction> openTracingHawkularFraction;
+    private OpenTracingHawkularFraction fraction;
 
     @Override
     public void activate(ServiceActivatorContext serviceActivatorContext) throws ServiceRegistryException {
         ServiceTarget target = serviceActivatorContext.getServiceTarget();
 
-        OpenTracingHawkularJaxRsService openTracingHawkularJaxRsService =
-                new OpenTracingHawkularJaxRsService(openTracingHawkularFraction.get().getJaxrsTraceBuilder());
+        OpenTracingHawkularJaxRsService openTracingHawkularJaxRsService = new OpenTracingHawkularJaxRsService(build(fraction.tracing()));
 
         ServiceBuilder<OpenTracingHawkularJaxRsService> serviceBuilder = target.addService(
                 OpenTracingHawkularJaxRsService.SERVICE_NAME,
@@ -42,11 +55,59 @@ public class OpenTracingServiceActivator implements ServiceActivator {
         BinderService binderService = new BinderService(TracerLookup.JNDI_NAME, null, true);
 
         target.addService(ContextNames.buildServiceName(ContextNames.JBOSS_CONTEXT_SERVICE_NAME, TracerLookup.JNDI_NAME),
-                binderService)
+                          binderService)
                 .addDependency(ContextNames.JBOSS_CONTEXT_SERVICE_NAME, ServiceBasedNamingStore.class, binderService.getNamingStoreInjector())
                 .addInjection(binderService.getManagedObjectInjector(), new ImmediateManagedReferenceFactory(
                         openTracingHawkularJaxRsService))
                 .setInitialMode(ServiceController.Mode.ACTIVE)
                 .install();
+    }
+
+    public ServerTracingDynamicFeature.Builder build(Tracing tracing) {
+        MultiTraceRecorder traceRecorder = new MultiTraceRecorder();
+
+        if (tracing.consoleRecorder()) {
+            traceRecorder.add(new LoggingRecorder());
+        }
+
+        if (tracing.traceRecorder() != null) {
+            traceRecorder.add(build(tracing.traceRecorder()));
+        }
+
+        if (traceRecorder.isEmpty()) {
+            traceRecorder.add(new BatchTraceRecorder());
+        }
+
+        Sampler sampler = PercentageSampler.withPercentage(tracing.sampleRate());
+        DeploymentMetaData deploymentMetaData = new DeploymentMetaData(tracing.serviceName(), tracing.buildStamp());
+
+        APMTracer apmTracer = new APMTracer(traceRecorder,
+                                            sampler,
+                                            deploymentMetaData);
+
+        GlobalTracer.register(apmTracer);
+
+        return ServerTracingDynamicFeature.Builder
+                .traceAll(apmTracer);
+    }
+
+    public TraceRecorder build(org.wildfly.swarm.opentracing.hawkular.jaxrs.TraceRecorder recorder) {
+        BatchTraceRecorder.BatchTraceRecorderBuilder builder = new BatchTraceRecorder.BatchTraceRecorderBuilder();
+        builder.withBatchSize(recorder.batchSize());
+        builder.withBatchTime(recorder.batchTime());
+        builder.withBatchPoolSize(recorder.threadPoolSize());
+        if (recorder.tenantId() != null) {
+            builder.withTenantId(recorder.tenantId());
+        }
+
+        if (recorder.httpTracePublisher() != null) {
+            builder.withTracePublisher(build(recorder.httpTracePublisher()));
+        }
+
+        return builder.build();
+    }
+
+    public TracePublisher build(HTTPTracePublisher publisher) {
+        return new TracePublisherRESTClient(publisher.userName(), publisher.password(), publisher.url());
     }
 }


### PR DESCRIPTION
Motivation
==========

The OpenTracingHawkular bits were only useful via main().

Changes
=======
Refactor the general API to be more fraction-like, and rework the structure
to allow for configuring all aspects of it via YAML.

Additionally, provide for multiple recorders (console and batch) being
configured.

Results
=======

You can now YAML swarm.opentracing-hawkular

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
