### PR TITLE
SWARM-1361: boms/bom-certified point to an old parent version

### DIFF
--- a/boms/bom-certified/pom.xml
+++ b/boms/bom-certified/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>boms</artifactId>
-    <version>2017.5.0-SNAPSHOT</version>
+    <version>2017.6.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 


### PR DESCRIPTION
Motivation
----------
The `boms/bom-certified` module is only built in the
`-Dswarm.product.build` profile, so when Swarm 2017.5.0
was released and all modules were reversioned, this one
was skipped (it wasn't in the Maven reactor).

This means `mvn clean install -Dswarm.product.build` fails.

Modifications
-------------
Fix the parent version in the `boms/bom-certified` module.

Result
------
`mvn clean install -Dswarm.product.build` is now possible.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
