### PR TITLE
SWARM-1362: boms/bom-certified should NOT contain the ShrinkWrap bits

### DIFF
--- a/boms/src/main/resources/bom-template.xml
+++ b/boms/src/main/resources/bom-template.xml
@@ -54,6 +54,7 @@
   <dependencyManagement>
     <dependencies>
 #{dependencies}
+#{remove-if-bom-certified}
       <dependency>
         <groupId>org.jboss.shrinkwrap</groupId>
         <artifactId>shrinkwrap-bom</artifactId>
@@ -68,6 +69,7 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+#{/remove-if-bom-certified}
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
DEPENDS ON https://github.com/wildfly-swarm/wildfly-swarm-fraction-plugin/pull/34 (and a release of the Swarm Fraction plugin)

Motivation
----------
The template from which all the BOMs are created unconditionally
adds the ShrinkWrap pieces. However, the `bom-certified` shouldn't
contain them -- assuming there is a product, the main product BOM
would point to different version of the ShrinkWrap bits than
the certified BOM.

Modifications
-------------
Remove the ShrinkWrap pieces when building `bom-certified`.

Result
------
Main `bom` and `bom-certified` don't specify different versions
of ShrinkWrap in a product.

- [ ] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
