### PR TITLE
SWARM-1359 - Handle YAML-based artifact deployments.

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/ArtifactDeployer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/ArtifactDeployer.java
@@ -1,0 +1,45 @@
+package org.wildfly.swarm.container.runtime;
+
+import java.util.Set;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.spi.api.config.ConfigKey;
+import org.wildfly.swarm.spi.api.config.ConfigView;
+import org.wildfly.swarm.spi.api.config.SimpleKey;
+
+/**
+ * Created by bob on 5/24/17.
+ */
+@ApplicationScoped
+public class ArtifactDeployer {
+
+    @Inject
+    ConfigView configView;
+
+    @Inject
+    private Instance<RuntimeDeployer> deployer;
+
+    public void deploy() throws Exception {
+        Set<SimpleKey> subkeys = configView.simpleSubkeys(ConfigKey.of("swarm", "deployment"));
+
+        for (SimpleKey subkey : subkeys) {
+            String spec = subkey.name();
+            if (spec.contains(":")) {
+                String[] parts = spec.split(":");
+                String groupId = parts[0];
+                parts = parts[1].split("\\.");
+                String artifactId = parts[0];
+                String packaging = parts[1];
+
+                JavaArchive artifact = Swarm.artifact(groupId + ":" + artifactId + ":" + packaging + ":*", artifactId + "." + packaging);
+                deployer.get().deploy(artifact, spec);
+            }
+        }
+
+    }
+}

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/ConfigurableManager.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/ConfigurableManager.java
@@ -447,7 +447,7 @@ public class ConfigurableManager implements AutoCloseable {
         }
 
         if (in.isChildOf(DEPLOYMENT_PREFIX)) {
-            in.replace(2, this.deploymentContext.getCurrentArchive().getName());
+            in.replace(2, this.deploymentContext.getCurrentName());
         }
 
         return in;

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
@@ -234,6 +234,8 @@ public class RuntimeServer implements Server {
                 }
             }
 
+            this.artifactDeployer.deploy();
+
             return deployer;
         }
     }
@@ -277,6 +279,9 @@ public class RuntimeServer implements Server {
 
     // Container does not expose this state and it's class is final so it cannot be subclassed.
     private boolean containerStarted;
+
+    @Inject
+    private ArtifactDeployer artifactDeployer;
 
     private ModelControllerClient client;
 }

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/DeploymentContext.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/DeploymentContext.java
@@ -8,9 +8,10 @@ import org.jboss.shrinkwrap.api.Archive;
  * Created by bob on 5/12/17.
  */
 public interface DeploymentContext extends AlterableContext {
-    void activate(Archive<?> archive);
+    void activate(Archive<?> archive, String asName);
     void deactivate();
 
     Archive<?> getCurrentArchive();
+    String getCurrentName();
 
 }

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/DeploymentContextImpl.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/DeploymentContextImpl.java
@@ -25,6 +25,7 @@ public class DeploymentContextImpl implements DeploymentContext {
     private final ThreadLocal<Map<Contextual<?>, ContextualInstance<?>>> currentContext = new ThreadLocal<>();
 
     private final ThreadLocal<Archive> currentArchive = new ThreadLocal<>();
+    private final ThreadLocal<String> currentName = new ThreadLocal<>();
 
     public Class<? extends Annotation> getScope() {
         return DeploymentScoped.class;
@@ -66,9 +67,10 @@ public class DeploymentContextImpl implements DeploymentContext {
         ctx.remove(contextual);
     }
 
-    public void activate(Archive archive) {
+    public void activate(Archive archive, String asName) {
         currentContext.set(new HashMap<>());
         currentArchive.set(archive);
+        currentName.set(asName);
     }
 
     public void deactivate() {
@@ -86,10 +88,15 @@ public class DeploymentContextImpl implements DeploymentContext {
         ctx.clear();
         currentContext.remove();
         currentArchive.set(null);
+        currentName.set(null);
     }
 
     public Archive getCurrentArchive() {
         return currentArchive.get();
+    }
+
+    public String getCurrentName() {
+        return currentName.get();
     }
 
     /**
@@ -143,13 +150,13 @@ public class DeploymentContextImpl implements DeploymentContext {
         }
 
         @Override
-        public void activate(Archive archive) {
+        public void activate(Archive archive, String asName) {
             try {
                 beanManager.getContext(delegate.getScope());
                 LOGGER.info("Command context already active");
             } catch (ContextNotActiveException e) {
                 // Only activate the context if not already active
-                delegate.activate(archive);
+                delegate.activate(archive, asName);
                 isActivator = true;
             }
         }
@@ -166,6 +173,11 @@ public class DeploymentContextImpl implements DeploymentContext {
         @Override
         public Archive getCurrentArchive() {
             return this.delegate.getCurrentArchive();
+        }
+
+        @Override
+        public String getCurrentName() {
+            return this.delegate.getCurrentName();
         }
     }
 

--- a/core/container/src/test/java/org/wildfly/swarm/container/runtime/ConfigurableManagerTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/container/runtime/ConfigurableManagerTest.java
@@ -34,7 +34,7 @@ public class ConfigurableManagerTest {
 
         Archive archive = ShrinkWrap.create(JavaArchive.class, "myapp.war");
         try {
-            context.activate(archive);
+            context.activate(archive, archive.getName());
             Component component = new Component();
             manager.scan(component);
             assertThat(component.context.get()).isEqualTo("/myapp");
@@ -56,7 +56,7 @@ public class ConfigurableManagerTest {
 
         Archive archive = ShrinkWrap.create(JavaArchive.class, "myapp.war");
         try {
-            context.activate(archive);
+            context.activate(archive, archive.getName());
             Component component = new Component();
             manager.scan(component);
             assertThat(component.context.get()).isEqualTo("/myapp");
@@ -79,7 +79,7 @@ public class ConfigurableManagerTest {
 
         Archive archive = ShrinkWrap.create(JavaArchive.class, "myapp.war");
         try {
-            context.activate(archive);
+            context.activate(archive, archive.getName());
             Component component = new Component();
             manager.scan(component);
             assertThat(component.context.get()).isEqualTo("/my-specific-app");
@@ -89,7 +89,7 @@ public class ConfigurableManagerTest {
 
         Archive archiveToo = ShrinkWrap.create(JavaArchive.class, "otherapp.war");
         try {
-            context.activate(archiveToo);
+            context.activate(archiveToo, archiveToo.getName());
             Component component = new Component();
             manager.scan(component);
             assertThat(component.context.get()).isEqualTo("/my-alias-app");


### PR DESCRIPTION
Motivation
----------
If we don't have a main(), how do you deploy a random dependency
via GAV, such as xadisk.rar?

Modifications
-------------
Support:

    swarm:
      deployment:
        some.groupId:artifactId.ext:

Additionally, if one of those things happens to be a .rar,
go ahead and include it in the dependencies (via jboss-modules)
for any non-.rar deployment that follows.

Result
------
Supports more use-cases without main().

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
