### PR TITLE
SWARM-1364: Make versions used only in module.xml's applicable for alignment

### DIFF
--- a/core/container/pom.xml
+++ b/core/container/pom.xml
@@ -40,6 +40,13 @@
   </build>
 
   <dependencies>
+    <!-- not used, only to make PME align version.weld-api-->
+    <dependency>
+      <groupId>org.jboss.weld</groupId>
+      <artifactId>weld-api</artifactId>
+      <version>${version.weld-api}</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>spi</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -311,7 +311,6 @@
 
   <dependencyManagement>
     <dependencies>
-
       <dependency>
         <groupId>org.wildfly.core</groupId>
         <artifactId>wildfly-core-parent</artifactId>
@@ -1169,7 +1168,7 @@
       <dependency>
         <groupId>org.ow2.asm</groupId>
         <artifactId>asm-all</artifactId>
-        <version>5.0.4</version>
+        <version>${version.org.objectweb.asm}</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>
@@ -1250,6 +1249,31 @@
         </exclusions>
       </dependency>
       <!--Teiid integration end-->
+
+      
+      <!-- The following are not used, they are here to make PME align proper versions-->
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp</artifactId>
+        <version>${version.com.squareup.okhttp}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp-ws</artifactId>
+        <version>${version.com.squareup.okhttp}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.squareup.okio</groupId>
+        <artifactId>okio</artifactId>
+        <version>${version.com.squareup.okio}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.msc</groupId>
+        <artifactId>jboss-msc</artifactId>
+        <version>${version.org.jboss.msc.jboss-msc}</version>
+      </dependency>
+      <!-- end of unused dependencies -->
+
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Motivation
----------
Dependency versions that are used only in module.xml's are not aligned by the PME.
The point of this change is to make PME align them.

Modifications
-------------
The version properties that were defined in the top pom, have been given an entry in the dependency management section.
The versions from specific modules have now `provided` dependencies.

Result
------
All the versions but jboss-msc get aligned. jboss-msc requires further investigation

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
