### PR TITLE
SWARM-1369: User projects with different dependencies

### DIFF
--- a/boms/src/main/resources/bom-template.xml
+++ b/boms/src/main/resources/bom-template.xml
@@ -55,6 +55,20 @@
     <dependencies>
 #{dependencies}
       <dependency>
+        <groupId>org.wildfly.core</groupId>
+        <artifactId>wildfly-core-parent</artifactId>
+        <version>${version.org.wildfly.core}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-parent</artifactId>
+        <version>${version.wildfly}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.jboss.shrinkwrap</groupId>
         <artifactId>shrinkwrap-bom</artifactId>
         <version>${version.shrinkwrap}</version>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
User projects that depend on WF Swarm fractions can bring in different versions of dependent artifacts if WF has adjusted those versions.

Modifications
-------------
Add WF Core and WF parent POMs into WF Swarm BOMs to ensure correct versions.

Result
------
User projects now have correct dependent artifact versions, and removes duplicate versions in m2repo of uber jar where this occured.
