### PR TITLE
SWARM-1371 - Don't resolve snapshots from repo.jboss.org.

### DIFF
--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelper.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelper.java
@@ -59,7 +59,9 @@ import java.util.stream.Collectors;
  */
 public class MavenArtifactResolvingHelper implements ArtifactResolvingHelper {
 
-    public static final ArtifactRepositoryPolicy DEFAULT_ARTIFACT_REPOSITORY_POLICY = new ArtifactRepositoryPolicy();
+    public static final ArtifactRepositoryPolicy ENABLED_POLICY = new ArtifactRepositoryPolicy(true, null, null);
+
+    public static final ArtifactRepositoryPolicy DISABLED_POLICY = new ArtifactRepositoryPolicy(false, null, null);
 
     public MavenArtifactResolvingHelper(ArtifactResolver resolver,
                                         RepositorySystem system,
@@ -72,8 +74,8 @@ public class MavenArtifactResolvingHelper implements ArtifactResolvingHelper {
         this.remoteRepositories.add(buildRemoteRepository("jboss-public-repository-group",
                                                           "https://repository.jboss.org/nexus/content/groups/public/",
                                                           null,
-                                                          DEFAULT_ARTIFACT_REPOSITORY_POLICY,
-                                                          DEFAULT_ARTIFACT_REPOSITORY_POLICY));
+                                                          ENABLED_POLICY,
+                                                          DISABLED_POLICY));
     }
 
     public void remoteRepository(ArtifactRepository repo) {


### PR DESCRIPTION
Motivation
----------
It's a bad idea.

Modifications
-------------
Stop resolving snapshots from repo.jboss.org.

Result
------
We no longer resolve snapshots from repo.jboss.org.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
