### PR TITLE
SWARM-1327: Fix file leaks in tests and add new maven enforcer rule to check if a file exist by pattern to avoid same problem in future

### DIFF
--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.io.InputStreamReader;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -53,6 +52,7 @@ import org.wildfly.swarm.arquillian.CreateSwarm;
 import org.wildfly.swarm.arquillian.adapter.resources.ContextRoot;
 import org.wildfly.swarm.arquillian.resolver.ShrinkwrapArtifactResolvingHelper;
 import org.wildfly.swarm.bootstrap.util.BootstrapProperties;
+import org.wildfly.swarm.bootstrap.util.TempFileManager;
 import org.wildfly.swarm.internal.FileSystemLayout;
 import org.wildfly.swarm.spi.api.DependenciesContainer;
 import org.wildfly.swarm.spi.api.JARArchive;
@@ -282,10 +282,8 @@ public class UberjarSimpleContainer implements SimpleContainer {
         executor.withJVMArguments(getJavaVmArgumentsList());
         executor.withExecutableJar(executable.toPath());
 
-        File workingDirectory = Files.createTempDirectory("arquillian").toFile();
-        workingDirectory.deleteOnExit();
+        File workingDirectory = TempFileManager.INSTANCE.newTempDirectory("arquillian", null);
         executor.withWorkingDirectory(workingDirectory.toPath());
-
 
         this.process = executor.execute();
         this.process.getOutputStream().close();

--- a/arquillian/test/pom.xml
+++ b/arquillian/test/pom.xml
@@ -40,6 +40,16 @@
           </systemPropertyVariables>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+               <id>enforce</id>
+               <phase>none</phase>
+            </execution>
+         </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/core/bootstrap/src/test/java/org/wildfly/swarm/bootstrap/modules/GradleResolverTest.java
+++ b/core/bootstrap/src/test/java/org/wildfly/swarm/bootstrap/modules/GradleResolverTest.java
@@ -2,6 +2,7 @@ package org.wildfly.swarm.bootstrap.modules;
 
 import org.jboss.modules.maven.ArtifactCoordinates;
 import org.junit.Test;
+import org.wildfly.swarm.bootstrap.util.TempFileManager;
 
 import java.io.File;
 import java.io.IOException;
@@ -25,7 +26,8 @@ public class GradleResolverTest {
     @Test
     public void downloadFromRemoteRepository() throws IOException {
         //GIVEN
-        Path gradleCachePath = Files.createTempDirectory(".gradle");
+        File dirFile = TempFileManager.INSTANCE.newTempDirectory(".gradle", null);
+        Path gradleCachePath = dirFile.toPath();
         String group = "org.wildfly.swarm";
         String packaging = "jar";
         String artifact = "bootstrap";
@@ -48,7 +50,8 @@ public class GradleResolverTest {
     @Test
     public void downloadFromRemoteRepository_unknown() throws IOException {
         //GIVEN
-        Path gradleCachePath = Files.createTempDirectory(".gradle");
+        File dirFile = TempFileManager.INSTANCE.newTempDirectory(".gradle", null);
+        Path gradleCachePath = dirFile.toPath();
         String group = "org.wildfly.swarm";
         String packaging = "jar";
         String artifact = "test";
@@ -104,7 +107,8 @@ public class GradleResolverTest {
     @Test
     public void testResolveArtifact() throws IOException {
         //GIVEN
-        Path gradleCachePath = Files.createTempDirectory("gradle");
+        File dirFile = TempFileManager.INSTANCE.newTempDirectory("gradle", null);
+        Path gradleCachePath = dirFile.toPath();
         String group = "org.wildfly.swarm";
         String packaging = "jar";
         String artifact = "test";
@@ -126,7 +130,8 @@ public class GradleResolverTest {
     @Test
     public void testResolveArtifact_latest() throws IOException, InterruptedException {
         //GIVEN
-        Path gradleCachePath = Files.createTempDirectory("gradle");
+        File dirFile = TempFileManager.INSTANCE.newTempDirectory("gradle", null);
+        Path gradleCachePath = dirFile.toPath();
         String group = "org.wildfly.swarm";
         String packaging = "jar";
         String artifact = "test";
@@ -151,7 +156,8 @@ public class GradleResolverTest {
     @Test
     public void testResolveArtifact_notExists() throws IOException {
         //GIVEN
-        Path gradleCachePath = Files.createTempDirectory("gradle");
+        File dirFile = TempFileManager.INSTANCE.newTempDirectory("gradle", null);
+        Path gradleCachePath = dirFile.toPath();
         String group = "org.wildfly.swarm";
         String packaging = "jar";
         String artifact = "test";

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeDeployer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeDeployer.java
@@ -284,6 +284,10 @@ public class RuntimeDeployer implements Deployer {
     void stop() {
     }
 
+    public void removeAllContent() throws IOException {
+        this.contentRepository.removeAllContent();
+    }
+
     @Inject
     DeploymentContext deploymentContext;
 

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
@@ -256,6 +256,7 @@ public class RuntimeServer implements Server {
         this.containerStarted = false;
         this.container = null;
         this.client = null;
+        this.deployer.get().removeAllContent();
         this.deployer = null;
     }
 

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/TempFileProviderProducer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/TempFileProviderProducer.java
@@ -21,8 +21,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
 import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Disposes;
 import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
 
@@ -61,14 +61,12 @@ public class TempFileProviderProducer {
         return this.tempFileProvider;
     }
 
-    void dispose(@Disposes TempFileProvider provider) {
-        // To ensure we only close the one we produce
-        if (this.tempFileProvider == provider) {
-            try {
-                this.tempFileProvider.close();
-            } catch (IOException e) {
-                SwarmMessages.MESSAGES.errorCleaningUpTempFileProvider(e);
-            }
+    @PreDestroy
+    void close() {
+        try {
+            this.tempFileProvider.close();
+        } catch (IOException e) {
+            SwarmMessages.MESSAGES.errorCleaningUpTempFileProvider(e);
         }
     }
 

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/wildfly/SwarmContentRepository.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/wildfly/SwarmContentRepository.java
@@ -133,6 +133,21 @@ public class SwarmContentRepository implements ContentRepository, Service<Conten
 
     }
 
+    public void removeAllContent() throws IOException {
+        IOException exception = null;
+        for (Path path: this.index.values()) {
+            try {
+                Files.delete(path);
+            } catch (IOException e) {
+                exception = e;
+            }
+        }
+
+        if (exception != null) {
+            throw exception;
+        }
+    }
+
     @Override
     public Map<String, Set<String>> cleanObsoleteContent() {
         HashMap<String, Set<String>> result = new HashMap<>();

--- a/meta/fraction-metadata/src/test/java/org/wildfly/swarm/fractions/FractionUsageAnalyzerTest.java
+++ b/meta/fraction-metadata/src/test/java/org/wildfly/swarm/fractions/FractionUsageAnalyzerTest.java
@@ -17,8 +17,6 @@ package org.wildfly.swarm.fractions;
 
 import java.io.File;
 import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -26,6 +24,7 @@ import org.jboss.shrinkwrap.api.exporter.ExplodedExporter;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
+import org.wildfly.swarm.bootstrap.util.TempFileManager;
 import org.wildfly.swarm.jaxrs.JAXRSArchive;
 
 import static org.fest.assertions.Assertions.assertThat;
@@ -40,6 +39,7 @@ public class FractionUsageAnalyzerTest {
 
         final File out = Files.createTempFile(archive.getName(), ".war").toFile();
         archive.as(ZipExporter.class).exportTo(out, true);
+        out.deleteOnExit();
 
         analyzer.source(out);
         assertThat(analyzer.detectNeededFractions()
@@ -55,10 +55,10 @@ public class FractionUsageAnalyzerTest {
         archive.addClass(MyResource.class);
         FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer();
 
-        Path dir = Files.createTempDirectory(archive.getName());
-        archive.as(ExplodedExporter.class).exportExplodedInto(dir.toFile());
+        File dirFile = TempFileManager.INSTANCE.newTempDirectory("fractionusagetest", null);
+        archive.as(ExplodedExporter.class).exportExplodedInto(dirFile);
 
-        analyzer.source(dir.toFile());
+        analyzer.source(dirFile);
         assertThat(analyzer.detectNeededFractions()
                            .stream()
                            .filter(fd -> fd.getArtifactId().equals("jaxrs"))
@@ -74,6 +74,7 @@ public class FractionUsageAnalyzerTest {
 
         final File out = Files.createTempFile(archive.getName(), ".war").toFile();
         archive.as(ZipExporter.class).exportTo(out, true);
+        out.deleteOnExit();
 
         analyzer.source(out);
         assertThat(analyzer.detectNeededFractions()

--- a/plugins/maven-enforcer-pattern-size/pom.xml
+++ b/plugins/maven-enforcer-pattern-size/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>wildfly-swarm-enforcer-pattern-size</artifactId>
+  <version>2017.7.0-SNAPSHOT</version>
+
+  <name>Maven enforcer pattern size rule</name>
+  <description>Maven enforcer pattern size rule</description>
+
+   <packaging>jar</packaging>
+
+   <dependencies>
+    <dependency>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.4.1</version>
+        <scope>provided</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/plugins/maven-enforcer-pattern-size/src/main/java/org/wildfly/swarm/plugin/enforcer/patternsize/RequireFilePatternSize.java
+++ b/plugins/maven-enforcer-pattern-size/src/main/java/org/wildfly/swarm/plugin/enforcer/patternsize/RequireFilePatternSize.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.plugin.enforcer.patternsize;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitOption;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRule;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
+
+/**
+ *
+ * @author Juan Gonzalez
+ *
+ */
+public class RequireFilePatternSize implements EnforcerRule {
+
+    private RequiredFilePattern[] filePatterns;
+
+    public RequiredFilePattern[] getRequiredFilePatterns() {
+        return filePatterns;
+    }
+
+    public void setRequiredFilePatterns(RequiredFilePattern[] filePatterns) {
+        this.filePatterns = filePatterns;
+    }
+
+    List<RequiredFilePatternFailure> checkFilePattern(final RequiredFilePattern requiredFilePattern) throws IOException {
+        if (requiredFilePattern == null || requiredFilePattern.getDirectory() == null) {
+            return null;
+        }
+
+        if (requiredFilePattern.getPattern() == null) {
+            return null;
+        }
+
+        final Pattern pattern = Pattern.compile(requiredFilePattern.getPattern());
+
+        String directory = requiredFilePattern.getDirectory();
+        File directoryFile = new File(directory);
+
+        final List<File> matchedFiles = new ArrayList<File>();
+
+        if (Files.isDirectory(directoryFile.toPath())) {
+            Files.walkFileTree(directoryFile.toPath(), EnumSet.of(FileVisitOption.FOLLOW_LINKS),
+                requiredFilePattern.isRecursive() ? Integer.MAX_VALUE : 1,
+                        new SimpleFileVisitor<Path>() {
+                        @Override
+                        public FileVisitResult visitFile(Path filePath, BasicFileAttributes attrs) throws IOException {
+                             Matcher matcher = pattern.matcher(filePath.toAbsolutePath().toString());
+                             if (matcher.matches()) {
+                                 File file = filePath.toFile();
+                                 matchedFiles.add(file);
+                             }
+
+                            return super.visitFile(filePath, attrs);
+                        }
+             });
+        }
+
+        List<RequiredFilePatternFailure> failures = new ArrayList<RequiredFilePatternFailure>();
+        for (File matchedFile : matchedFiles) {
+            long length = matchedFile.length();
+            if (requiredFilePattern.getMinSize() != -1 && length < requiredFilePattern.getMinSize()) {
+                failures.add(new RequiredFilePatternFailure(requiredFilePattern, matchedFile + " size(" + length + ") too small. Min. is " + requiredFilePattern.getMinSize()));
+            } else if (requiredFilePattern.getMaxSize() != -1 && length > requiredFilePattern.getMaxSize()) {
+                failures.add(new RequiredFilePatternFailure(requiredFilePattern, matchedFile + " size(" + length + ") too large. Max. is " + requiredFilePattern.getMaxSize()));
+            }
+        }
+
+        return failures;
+    }
+
+    public void execute(EnforcerRuleHelper helper)
+            throws EnforcerRuleException {
+
+        RequiredFilePattern[] requiredFilePatterns = getRequiredFilePatterns();
+        List<RequiredFilePatternFailure> failures = new ArrayList<RequiredFilePatternFailure>();
+
+        if (requiredFilePatterns.length > 0) {
+            for (RequiredFilePattern requiredFilePattern: requiredFilePatterns) {
+                if (requiredFilePattern == null) {
+                    failures.add(new RequiredFilePatternFailure(requiredFilePattern, "File pattern is empty"));
+                }
+
+                List<RequiredFilePatternFailure> failure = null;
+
+                try{
+                    failure = checkFilePattern(requiredFilePattern);
+                } catch (IOException e) {
+                    failures.add(new RequiredFilePatternFailure(requiredFilePattern, "Error while traversing files"));
+                }
+
+                if (failure != null && failure.size() > 0) {
+                    failures.addAll(failure);
+                }
+            }
+        }  else {
+            throw new EnforcerRuleException("The file pattern list is empty.");
+        }
+
+        if (!failures.isEmpty()) {
+            String message = "Some files does not fullfill provided pattern rules:\n";
+            StringBuilder buf = new StringBuilder();
+
+            if (message != null) {
+                buf.append(message + "\n");
+            }
+
+            for (RequiredFilePatternFailure fileFailure : failures) {
+                if (fileFailure != null) {
+                    buf.append("Failed pattern " + fileFailure.getPattern() + " in directory " + fileFailure.getDirectory() + "." + fileFailure.getMessage() + "\n");
+                } else {
+                    buf.append("(an empty file pattern or directory was given)\n");
+                }
+            }
+
+            throw new EnforcerRuleException(buf.toString());
+        }
+    }
+
+    @Override
+    public boolean isCacheable() {
+        return false;
+    }
+
+    @Override
+    public boolean isResultValid(EnforcerRule cachedRule) {
+        return false;
+    }
+
+    @Override
+    public String getCacheId() {
+        return null;
+    }
+}

--- a/plugins/maven-enforcer-pattern-size/src/main/java/org/wildfly/swarm/plugin/enforcer/patternsize/RequiredFilePattern.java
+++ b/plugins/maven-enforcer-pattern-size/src/main/java/org/wildfly/swarm/plugin/enforcer/patternsize/RequiredFilePattern.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.plugin.enforcer.patternsize;
+
+/**
+ *
+ * @author Juan Gonzalez
+ *
+ */
+public class RequiredFilePattern {
+
+    private String directory;
+    private String pattern;
+    private boolean recursive;
+    public boolean isRecursive() {
+        return recursive;
+    }
+
+    public void setRecursive(boolean recursive) {
+        this.recursive = recursive;
+    }
+
+    private long minSize = -1;
+    private long maxSize = -1;
+
+    public long getMinSize() {
+        return minSize;
+    }
+
+    public void setMinSize(long minSize) {
+        this.minSize = minSize;
+    }
+
+    public long getMaxSize() {
+        return maxSize;
+    }
+
+    public void setMaxSize(long maxSize) {
+        this.maxSize = maxSize;
+    }
+
+    public String getDirectory() {
+        return directory;
+    }
+
+    public void setDirectory(String directory) {
+        this.directory = directory;
+    }
+
+    public String getPattern() {
+        return pattern;
+    }
+
+    public void setPattern(String pattern) {
+        this.pattern = pattern;
+    }
+}

--- a/plugins/maven-enforcer-pattern-size/src/main/java/org/wildfly/swarm/plugin/enforcer/patternsize/RequiredFilePatternFailure.java
+++ b/plugins/maven-enforcer-pattern-size/src/main/java/org/wildfly/swarm/plugin/enforcer/patternsize/RequiredFilePatternFailure.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.plugin.enforcer.patternsize;
+
+/**
+ *
+ * @author Juan Gonzalez
+ *
+ */
+public class RequiredFilePatternFailure extends RequiredFilePattern {
+
+    public RequiredFilePatternFailure(RequiredFilePattern pattern, String message) {
+        super();
+        setDirectory(pattern.getDirectory());
+        setMaxSize(pattern.getMaxSize());
+        setMinSize(pattern.getMinSize());
+        setPattern(pattern.getPattern());
+        this.message = message;
+    }
+
+    private String message;
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/StartMojo.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/StartMojo.java
@@ -291,6 +291,7 @@ public class StartMojo extends AbstractSwarmMojo {
         }
     }
 
+    @SuppressWarnings("unchecked")
     List<Path> dependencies(final Path archiveContent,
                             final boolean scanDependencies) throws MojoFailureException {
         final List<Path> elements = new ArrayList<>();
@@ -329,6 +330,7 @@ public class StartMojo extends AbstractSwarmMojo {
                         Files.createTempFile("swarm-", "-cp.txt").toFile();
 
                 tmp.deleteOnExit();
+                getPluginContext().put("swarm-cp-file", tmp);
                 declaredDependencies.writeTo(tmp);
                 getLog().debug("dependency info stored at: " + tmp.getAbsolutePath());
                 this.properties.setProperty("swarm.cp.info", tmp.getAbsolutePath());

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/StopMojo.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/StopMojo.java
@@ -15,6 +15,7 @@
  */
 package org.wildfly.swarm.plugin.maven;
 
+import java.io.File;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -52,6 +53,12 @@ public class StopMojo extends AbstractMojo {
 
         for (SwarmProcess each : value) {
             stop(each);
+        }
+
+        File tmp = (File) getPluginContext().get("swarm-cp-file");
+
+        if (tmp != null && tmp.exists()) {
+            tmp.delete();
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -239,6 +239,41 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+	<groupId>org.apache.maven.plugins</groupId>
+	<artifactId>maven-enforcer-plugin</artifactId>
+	<version>1.4.1</version>
+	<dependencies>
+	  <dependency>
+	    <groupId>org.wildfly.swarm</groupId>
+	    <artifactId>wildfly-swarm-enforcer-pattern-size</artifactId>
+	    <version>2017.7.0-SNAPSHOT</version>
+	  </dependency>
+	</dependencies>
+	<executions>
+	  <execution>
+	    <id>enforce</id>
+	    <phase>verify</phase>
+	    <configuration>
+	      <rules>
+		<patternSizeRule implementation="org.wildfly.swarm.plugin.enforcer.patternsize.RequireFilePatternSize">
+		  <requiredFilePatterns>
+		      <requiredFilePattern>
+		        <maxSize>0</maxSize>
+		        <recursive>false</recursive>
+			<directory>${project.build.directory}</directory>
+			<pattern>\S+[0-9]{5,}.\S{5,}</pattern>
+		      </requiredFilePattern>
+		  </requiredFilePatterns>
+		</patternSizeRule>
+	      </rules>
+	    </configuration>
+	    <goals>
+	      <goal>enforce</goal>
+	    </goals>
+	  </execution>
+	</executions>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>
@@ -300,6 +335,10 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>build-resources</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>wildfly-swarm-enforcer-pattern-size</artifactId>
     </dependency>
   </dependencies>
 
@@ -478,6 +517,11 @@
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>build-resources</artifactId>
+        <version>2017.7.0-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>wildfly-swarm-enforcer-pattern-size</artifactId>
         <version>2017.7.0-SNAPSHOT</version>
       </dependency>
       <dependency>
@@ -1294,7 +1338,9 @@
   </pluginRepositories>
 
   <modules>
+    <module>plugins/maven-enforcer-pattern-size</module>
     <module>build-resources</module>
+
 
     <module>tools</module>
 

--- a/testsuite/testsuite-cdi/src/test/java/org/wildfly/swarm/cdi/test/basic/CDITest.java
+++ b/testsuite/testsuite-cdi/src/test/java/org/wildfly/swarm/cdi/test/basic/CDITest.java
@@ -20,6 +20,7 @@ public class CDITest {
         FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer();
 
         final File out = Files.createTempFile(archive.getName(), ".war").toFile();
+        out.deleteOnExit();
         archive.as(ZipExporter.class).exportTo(out, true);
         analyzer.source(out);
 
@@ -36,6 +37,7 @@ public class CDITest {
         FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer();
 
         final File out = Files.createTempFile(archive.getName(), ".war").toFile();
+        out.deleteOnExit();
         archive.as(ZipExporter.class).exportTo(out, true);
         analyzer.source(out);
 
@@ -52,6 +54,7 @@ public class CDITest {
         FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer();
 
         final File out = Files.createTempFile(archive.getName(), ".war").toFile();
+        out.deleteOnExit();
         archive.as(ZipExporter.class).exportTo(out, true);
         analyzer.source(out);
 

--- a/testsuite/testsuite-container/src/test/java/org/wildfly/swarm/container/test/DeploymentFailureTest.java
+++ b/testsuite/testsuite-container/src/test/java/org/wildfly/swarm/container/test/DeploymentFailureTest.java
@@ -1,0 +1,31 @@
+package org.wildfly.swarm.container.test;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.Test;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.container.DeploymentException;
+import org.wildfly.swarm.spi.api.JARArchive;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.fest.assertions.Fail.fail;
+
+public class DeploymentFailureTest {
+
+  @Test
+  public void testDeploymentFailure() throws Exception {
+      Swarm swarm = new Swarm();
+      swarm.start();
+      JARArchive a = ShrinkWrap.create(JARArchive.class, "bad-deployment.jar");
+      a.addModule("com.i.do.no.exist");
+      try {
+          swarm.deploy(a);
+          fail("should have throw a DeploymentException");
+      } catch (DeploymentException e) {
+          // expected and correct
+          assertThat(e.getArchive()).isSameAs(a);
+          assertThat(e.getMessage()).contains("org.jboss.modules.ModuleNotFoundException: com.i.do.no.exist:main");
+      }
+
+      swarm.stop();
+  }
+}

--- a/testsuite/testsuite-container/src/test/java/org/wildfly/swarm/container/test/DeploymentSuccessTest.java
+++ b/testsuite/testsuite-container/src/test/java/org/wildfly/swarm/container/test/DeploymentSuccessTest.java
@@ -18,34 +18,15 @@ package org.wildfly.swarm.container.test;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.junit.Test;
-import org.wildfly.swarm.Swarm;
-import org.wildfly.swarm.container.DeploymentException;
-import org.wildfly.swarm.spi.api.JARArchive;
 
-import static org.fest.assertions.Assertions.assertThat;
-import static org.fest.assertions.Fail.fail;
+import org.wildfly.swarm.Swarm;
+
+import org.wildfly.swarm.spi.api.JARArchive;
 
 /**
  * @author Bob McWhirter
  */
-public class DeploymentTest {
-
-    @Test
-    public void testDeploymentFailure() throws Exception {
-        Swarm swarm = new Swarm();
-        swarm.start();
-        JARArchive a = ShrinkWrap.create(JARArchive.class, "bad-deployment.jar");
-        a.addModule("com.i.do.no.exist");
-        try {
-            swarm.deploy(a);
-            fail("should have throw a DeploymentException");
-        } catch (DeploymentException e) {
-            // expected and correct
-            assertThat(e.getArchive()).isSameAs(a);
-            assertThat(e.getMessage()).contains("org.jboss.modules.ModuleNotFoundException: com.i.do.no.exist:main");
-        }
-        swarm.stop();
-    }
+public class DeploymentSuccessTest {
 
     @Test
     public void testDeploymentSuccess() throws Exception {

--- a/testsuite/testsuite-jpa/src/test/java/org/wildfly/swarm/jpa/JPATest.java
+++ b/testsuite/testsuite-jpa/src/test/java/org/wildfly/swarm/jpa/JPATest.java
@@ -8,6 +8,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.exporter.ExplodedExporter;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.junit.Test;
+import org.wildfly.swarm.bootstrap.util.TempFileManager;
 import org.wildfly.swarm.fractions.FractionUsageAnalyzer;
 import org.wildfly.swarm.spi.api.JARArchive;
 
@@ -22,6 +23,7 @@ public class JPATest {
         FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer();
 
         final File out = Files.createTempFile(archive.getName(), ".war").toFile();
+        out.deleteOnExit();
         archive.as(ZipExporter.class).exportTo(out, true);
 
         analyzer.source(out);
@@ -37,10 +39,10 @@ public class JPATest {
         archive.addAsResource("META-INF/persistence.xml");
         FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer();
 
-        Path dir = Files.createTempDirectory(archive.getName());
-        archive.as(ExplodedExporter.class).exportExplodedInto(dir.toFile());
+        File dirFile = TempFileManager.INSTANCE.newTempDirectory("jpatest", null);
+        archive.as(ExplodedExporter.class).exportExplodedInto(dirFile);
 
-        analyzer.source(dir.toFile());
+        analyzer.source(dirFile);
         assertThat(analyzer.detectNeededFractions()
                        .stream()
                        .filter(fd -> fd.getArtifactId().equals("jpa"))

--- a/testsuite/testsuite-jsf/src/test/java/org/wildfly/swarm/jsf/test/JsfIT.java
+++ b/testsuite/testsuite-jsf/src/test/java/org/wildfly/swarm/jsf/test/JsfIT.java
@@ -47,6 +47,7 @@ public class JsfIT {
         FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer();
 
         final File out = Files.createTempFile(archive.getName(), ".war").toFile();
+        out.deleteOnExit();
         archive.as(ZipExporter.class).exportTo(out, true);
         analyzer.source(out);
 
@@ -63,6 +64,7 @@ public class JsfIT {
         FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer();
 
         final File out = Files.createTempFile(archive.getName(), ".war").toFile();
+        out.deleteOnExit();
         archive.as(ZipExporter.class).exportTo(out, true);
         analyzer.source(out);
         assertThat(analyzer.detectNeededFractions()

--- a/testsuite/testsuite-messaging/src/test/java/org/wildfly/swarm/messaging/test/MessagingTest.java
+++ b/testsuite/testsuite-messaging/src/test/java/org/wildfly/swarm/messaging/test/MessagingTest.java
@@ -20,6 +20,7 @@ public class MessagingTest {
 	    FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer();
 
 	    final File out = Files.createTempFile(archive.getName(), ".war").toFile();
+	    out.deleteOnExit();
 	    archive.as(ZipExporter.class).exportTo(out, true);
 
 	    analyzer.source(out);

--- a/testsuite/testsuite-security/src/test/java/org/wildfly/swarm/security/SecurityTest.java
+++ b/testsuite/testsuite-security/src/test/java/org/wildfly/swarm/security/SecurityTest.java
@@ -40,6 +40,7 @@ public class SecurityTest {
         FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer();
 
         final File out = Files.createTempFile(archive.getName(), ".war").toFile();
+        out.deleteOnExit();
         archive.as(ZipExporter.class).exportTo(out, true);
         analyzer.source(out);
 
@@ -56,6 +57,7 @@ public class SecurityTest {
         FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer();
 
         final File out = Files.createTempFile(archive.getName(), ".war").toFile();
+        out.deleteOnExit();
         archive.as(ZipExporter.class).exportTo(out, true);
         analyzer.source(out);
 


### PR DESCRIPTION
Motivation
----------
Fix file leaks that can be left after tests. Additionally, create a maven plugin that would fail if a (temporal) file or directory isn't removed.

Modifications
-------------
Added new maven enforcer rule to verify that files/directories with an specific pattern (those having 5 or more numbers in its name) doesn't exist, hence, everything is left clean.

Thanks to these tests other (unexpected) file leaks issues were discovered and fixed as well.

Result
------
More control on which files should exist after test. Temporal files/directories are removed.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
Hi @bobmcwhirter @Ladicek. After adding these temporal files check, other unexpected errors appeared, like the one that needed a fix in RuntimeDeployer in order to remove all tmp files that were created in SwarmRepository.
Those projects that uses wildfly-swarm-plugin needs to change the file checking to a different phase ("stop" instead of "verify") so the Swarm plugin stops Swarm properly (and hence all resources are removed).

Hope it makes sense.