### PR TITLE
SWARM-1377: Move MicroProfile Server to not supported for now

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1357,9 +1357,6 @@
 
     <module>fractions/cdi-extensions/cdi-config</module>
 
-    <module>standalone-servers</module>
-    <module>standalone-servers/microprofile</module>
-
     <module>testsuite</module>
     <module>testsuite/testsuite-ajp</module>
     <module>testsuite/testsuite-buildtool</module>
@@ -1493,8 +1490,10 @@
 
         <module>fractions/cdi-extensions/cdi-jaxrsapi</module>
 
+        <module>standalone-servers</module>
         <module>standalone-servers/keycloak</module>
         <module>standalone-servers/management-console</module>
+        <module>standalone-servers/microprofile</module>
         <module>standalone-servers/swagger-ui</module>
 
         <module>testsuite/testsuite-batch-jberet</module>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
To simplify support, move MicroProfile Server to not supported for now.

Modifications
-------------
Adjust which profile the module is part of.

Result
------
No change to product behavior.
