### PR TITLE
SWARM-1381: add test for using the RESTEasy Client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1375,6 +1375,7 @@
     <module>testsuite/testsuite-io</module>
     <module>testsuite/testsuite-jaxrs</module>
     <module>testsuite/testsuite-jaxrs-cdi</module>
+    <module>testsuite/testsuite-jaxrs-client</module>
     <module>testsuite/testsuite-jaxrs-ejb</module>
     <module>testsuite/testsuite-jca</module>
     <module>testsuite/testsuite-jgroups</module>

--- a/testsuite/testsuite-jaxrs-client/pom.xml
+++ b/testsuite/testsuite-jaxrs-client/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>testsuite</artifactId>
+    <version>2017.7.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>testsuite-jaxrs-client</artifactId>
+
+  <name>Test Suite: JAX-RS Client</name>
+  <description>Test Suite: JAX-RS Client</description>
+
+  <packaging>war</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>arquillian</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-client</artifactId>
+      <version>${version.resteasy}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!--
+      - This module tests the functionality of JAX-RS Client, using the RESTEasy implementation.
+      - The resteasy-client artifact (see above) needs a bunch of dependencies that Swarm somehow
+      - can filter out. Which is wrong. But the inherited dependency on graphene-webdriver
+      - would bring them in again, which totally defeats the test. Hence the exclusions.
+      -->
+    <dependency>
+      <groupId>org.jboss.arquillian.graphene</groupId>
+      <artifactId>graphene-webdriver</artifactId>
+      <type>pom</type>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/testsuite/testsuite-jaxrs-client/src/main/java/org/wildfly/swarm/jaxrs/client/test/GreeterApplication.java
+++ b/testsuite/testsuite-jaxrs-client/src/main/java/org/wildfly/swarm/jaxrs/client/test/GreeterApplication.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2017 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.jaxrs.client.test;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class GreeterApplication extends Application {
+}

--- a/testsuite/testsuite-jaxrs-client/src/main/java/org/wildfly/swarm/jaxrs/client/test/GreeterResource.java
+++ b/testsuite/testsuite-jaxrs-client/src/main/java/org/wildfly/swarm/jaxrs/client/test/GreeterResource.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2017 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.jaxrs.client.test;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+
+@Path("/hello")
+public class GreeterResource {
+    @GET
+    public String hello(@QueryParam("name") String name) {
+        return "Hello, " + name + "!";
+    }
+}

--- a/testsuite/testsuite-jaxrs-client/src/main/webapp/WEB-INF/web.xml
+++ b/testsuite/testsuite-jaxrs-client/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
+
+</web-app>

--- a/testsuite/testsuite-jaxrs-client/src/test/java/org/wildfly/swarm/jaxrs/client/test/JaxrsClientTest.java
+++ b/testsuite/testsuite-jaxrs-client/src/test/java/org/wildfly/swarm/jaxrs/client/test/JaxrsClientTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2017 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.jaxrs.client.test;
+
+import java.io.IOException;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.arquillian.DefaultDeployment;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Arquillian.class)
+@DefaultDeployment
+public class JaxrsClientTest {
+    @Test
+    @RunAsClient
+    public void hello() throws IOException {
+        Client client = ClientBuilder.newClient();
+        try {
+            WebTarget target = client.target("http://localhost:8080").path("hello").queryParam("name", "TEST");
+            Response response = target.request().get();
+            assertEquals("Hello, TEST!", response.readEntity(String.class));
+        } finally {
+            client.close();
+        }
+    }
+}


### PR DESCRIPTION
Motivation
----------
Some dependency handling changes that went into Swarm 2017.6.0
broke the RESTEasy Client. A test that reproduces this is needed.

Modifications
-------------
Added `testsuite-jaxrs-client` which uses the JAX-RS Client,
provided by RESTEasy, to access a simple JAX-RS resource.

Result
------
More test coverage, no change to product.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
