### PR TITLE
SWARM-1386 - Handle maven mirror better.

### DIFF
--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelper.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelper.java
@@ -230,7 +230,6 @@ public class MavenArtifactResolvingHelper implements ArtifactResolvingHelper {
                                               .addPassword(auth.getPassword()).build());
         }
 
-        System.err.println("Adding repository: " + id + " - " + url + " - releases=" + releasesPolicy.isEnabled() + ", snapshots=" + snapshotsPolicy.isEnabled());
         builder.setSnapshotPolicy(new RepositoryPolicy(snapshotsPolicy.isEnabled(), snapshotsPolicy.getUpdatePolicy(), snapshotsPolicy.getChecksumPolicy()));
         builder.setReleasePolicy(new RepositoryPolicy(releasesPolicy.isEnabled(), releasesPolicy.getUpdatePolicy(), releasesPolicy.getChecksumPolicy()));
 
@@ -241,9 +240,14 @@ public class MavenArtifactResolvingHelper implements ArtifactResolvingHelper {
         if (mirror != null) {
             final org.eclipse.aether.repository.Authentication mirrorAuth = session.getAuthenticationSelector()
                     .getAuthentication(mirror);
-            repository = mirrorAuth != null
-                    ? new RemoteRepository.Builder(mirror).setAuthentication(mirrorAuth).build()
-                    : mirror;
+            RemoteRepository.Builder mirrorBuilder = new RemoteRepository.Builder(mirror)
+                    .setId(repository.getId())
+                    .setSnapshotPolicy(new RepositoryPolicy(snapshotsPolicy.isEnabled(), snapshotsPolicy.getUpdatePolicy(), snapshotsPolicy.getChecksumPolicy()))
+                    .setReleasePolicy(new RepositoryPolicy(releasesPolicy.isEnabled(), releasesPolicy.getUpdatePolicy(), releasesPolicy.getChecksumPolicy()));
+            if (mirrorAuth != null) {
+                mirrorBuilder.setAuthentication(mirrorAuth);
+            }
+            repository = mirrorBuilder.build();
         }
 
         Proxy proxy = session.getProxySelector().getProxy(repository);
@@ -251,7 +255,6 @@ public class MavenArtifactResolvingHelper implements ArtifactResolvingHelper {
         if (proxy != null) {
             repository = new RemoteRepository.Builder(repository).setProxy(proxy).build();
         }
-        System.err.println("--" + repository);
 
         return repository;
     }


### PR DESCRIPTION
Motivation
----------
Because multiple repositories that were mirrored by a single
mirror resulted in trampled maven-metadata.xml, there are times
that some artifacts could not be resolved.

Modifications
-------------
Ensure that if a repository is added to our tool and is wrapped
in a mirror, that the resulting wrapped repository contains the
ID of the inner repository, and not the mirror's ID.

Result
------
JSF example should now pass.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
