### PR TITLE
SWARM-1390 - Allow mail fraction to be configured nicely w/o main()

### DIFF
--- a/fractions/javaee/mail/src/main/java/org/wildfly/swarm/mail/MailFraction.java
+++ b/fractions/javaee/mail/src/main/java/org/wildfly/swarm/mail/MailFraction.java
@@ -15,10 +15,9 @@
  */
 package org.wildfly.swarm.mail;
 
-import javax.annotation.PostConstruct;
-
 import org.wildfly.swarm.config.Mail;
 import org.wildfly.swarm.spi.api.Fraction;
+import org.wildfly.swarm.spi.api.annotations.Configurable;
 import org.wildfly.swarm.spi.api.annotations.MarshalDMR;
 import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
 
@@ -28,11 +27,6 @@ import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
 @WildFlyExtension(module = "org.jboss.as.mail")
 @MarshalDMR
 public class MailFraction extends Mail<MailFraction> implements Fraction<MailFraction> {
-
-    @PostConstruct
-    public void postConstruct() {
-        applyDefaults();
-    }
 
     public static MailFraction defaultFraction() {
         return new MailFraction().applyDefaults();
@@ -44,6 +38,7 @@ public class MailFraction extends Mail<MailFraction> implements Fraction<MailFra
         return this;
     }
 
+    @Configurable
     public MailFraction mailSession(String key, EnhancedMailSessionConsumer consumer) {
         EnhancedMailSession session = new EnhancedMailSession(key);
         return super.mailSession(() -> {
@@ -57,6 +52,7 @@ public class MailFraction extends Mail<MailFraction> implements Fraction<MailFra
         });
     }
 
+    @Configurable
     public MailFraction smtpServer(String key, EnhancedSMTPServerConsumer consumer) {
         return this.mailSession(key, (session) -> {
             session.smtpServer(consumer);


### PR DESCRIPTION
Motivation
----------
YAML can be cleaner if we expose the Enhanced* classes.

Modifications
-------------
We have Enhanced* classes for the mail fraction, so mark the relevant
methods as @Configurable to allow them to be used from the YAML.

Result
------
Simpler YAML!

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
