### PR TITLE
SWARM-1206 (again): Fix JAXRS Deployment Processor.

### DIFF
--- a/core/container/src/main/resources/modules/org/ow2/asm/impl/module.xml
+++ b/core/container/src/main/resources/modules/org/ow2/asm/impl/module.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+
+<module xmlns="urn:jboss:module:1.3" name="org.ow2.asm" slot="impl">
+  <resources>
+    <artifact name="org.ow2.asm:asm-all:${version.org.objectweb.asm}"/>
+  </resources>
+
+</module>

--- a/core/container/src/main/resources/modules/org/ow2/asm/main/module.xml
+++ b/core/container/src/main/resources/modules/org/ow2/asm/main/module.xml
@@ -6,8 +6,20 @@
   -->
 
 <module xmlns="urn:jboss:module:1.3" name="org.ow2.asm">
-  <resources>
-    <artifact name="org.ow2.asm:asm-all:${version.org.objectweb.asm}"/>
-  </resources>
+
+  <dependencies>
+    <system export="true">
+      <paths>
+        <path name="org/objectweb/asm"/>
+        <path name="org/objectweb/asm/commons"/>
+        <path name="org/objectweb/asm/commons"/>
+        <path name="org/objectweb/asm/signature"/>
+        <path name="org/objectweb/asm/tree"/>
+        <path name="org/objectweb/asm/util"/>
+        <path name="org/objectweb/asm/xml"/>
+      </paths>
+    </system>
+    <module name="org.ow2.asm" slot="impl" services="import" export="true"/>
+  </dependencies>
 
 </module>


### PR DESCRIPTION
Motivation
----------
Deployment processor fails to load when run in non-uberjar.

Modifications
-------------
Adjust our ASM module.xml tree to have a :main and :impl
module.xml in order to satisfy both classloading methods.

Result
------
Examples should now pass, for realio.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
