### PR TITLE
SWARM-1398 - Added OpenTracing fraction

### DIFF
--- a/fractions/opentracing/module.conf
+++ b/fractions/opentracing/module.conf
@@ -1,0 +1,4 @@
+org.wildfly.swarm.logging
+org.wildfly.swarm.undertow
+org.jboss.logging
+io.opentracing export=true

--- a/fractions/opentracing/pom.xml
+++ b/fractions/opentracing/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+~
+~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>wildfly-swarm</artifactId>
+    <version>2017.7.0-SNAPSHOT</version>
+    <relativePath>../../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>opentracing</artifactId>
+
+  <name>OpenTracing</name>
+  <description>OpenTracing integration via TraceResolver and GlobalTracer</description>
+
+  <packaging>jar</packaging>
+
+  <properties>
+    <version.opentracing>0.22.0</version.opentracing>
+    <version.globaltracer>0.1.2</version.globaltracer>
+    <version.tracerresolver>0.1.0</version.tracerresolver>
+
+    <swarm.fraction.stability>experimental</swarm.fraction.stability>
+    <swarm.fraction.tags>OpenTracing, Tracing, Monitoring</swarm.fraction.tags>
+  </properties>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>container</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>spi</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>undertow</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-api</artifactId>
+      <version>${version.opentracing}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-util</artifactId>
+      <version>${version.opentracing}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-noop</artifactId>
+      <version>${version.opentracing}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-globaltracer</artifactId>
+      <version>${version.globaltracer}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-tracerresolver</artifactId>
+      <version>${version.tracerresolver}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/fractions/opentracing/pom.xml
+++ b/fractions/opentracing/pom.xml
@@ -23,10 +23,6 @@
   <packaging>jar</packaging>
 
   <properties>
-    <version.opentracing>0.22.0</version.opentracing>
-    <version.globaltracer>0.1.2</version.globaltracer>
-    <version.tracerresolver>0.1.0</version.tracerresolver>
-
     <swarm.fraction.stability>experimental</swarm.fraction.stability>
     <swarm.fraction.tags>OpenTracing, Tracing, Monitoring</swarm.fraction.tags>
   </properties>

--- a/fractions/opentracing/src/main/java/org/wildfly/swarm/opentracing/OpenTracingFraction.java
+++ b/fractions/opentracing/src/main/java/org/wildfly/swarm/opentracing/OpenTracingFraction.java
@@ -1,0 +1,11 @@
+package org.wildfly.swarm.opentracing;
+
+import org.wildfly.swarm.spi.api.Fraction;
+import org.wildfly.swarm.spi.api.annotations.DeploymentModule;
+
+/**
+ * @author Juraci Paixão Kröhling
+ */
+@DeploymentModule(name = "org.wildfly.swarm.opentracing", slot = "deployment")
+public class OpenTracingFraction implements Fraction<OpenTracingFraction> {
+}

--- a/fractions/opentracing/src/main/java/org/wildfly/swarm/opentracing/deployment/OpenTracingInitializer.java
+++ b/fractions/opentracing/src/main/java/org/wildfly/swarm/opentracing/deployment/OpenTracingInitializer.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.opentracing.deployment;
+
+import io.opentracing.Tracer;
+import io.opentracing.contrib.tracerresolver.TracerResolver;
+import io.opentracing.util.GlobalTracer;
+import org.jboss.logging.Logger;
+
+import javax.enterprise.inject.Vetoed;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.annotation.WebListener;
+
+/**
+ * @author Juraci Paixão Kröhling
+ */
+@Vetoed
+@WebListener
+public class OpenTracingInitializer implements ServletContextListener {
+    private static final Logger logger = Logger.getLogger(OpenTracingInitializer.class);
+
+    @Override
+    public void contextInitialized(ServletContextEvent servletContextEvent) {
+        if (GlobalTracer.isRegistered()) {
+            logger.info("A Tracer is already registered at the GlobalTracer. Skipping resolution via TraceResolver.");
+            return;
+        }
+
+        Tracer tracer = TracerResolver.resolveTracer();
+        if (null == tracer) {
+            logger.info("Could not get a valid OpenTracing Tracer from the classpath. Skipping.");
+            return;
+        }
+
+        logger.info(String.format("Registering %s as the OpenTracing Tracer", tracer.getClass().getName()));
+        GlobalTracer.register(tracer);
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent servletContextEvent) {
+    }
+}

--- a/fractions/opentracing/src/main/java/org/wildfly/swarm/opentracing/runtime/OpenTracingInstaller.java
+++ b/fractions/opentracing/src/main/java/org/wildfly/swarm/opentracing/runtime/OpenTracingInstaller.java
@@ -1,0 +1,37 @@
+package org.wildfly.swarm.opentracing.runtime;
+
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.wildfly.swarm.spi.api.DeploymentProcessor;
+import org.wildfly.swarm.spi.runtime.annotations.DeploymentScoped;
+import org.wildfly.swarm.undertow.WARArchive;
+import org.wildfly.swarm.undertow.descriptors.WebXmlAsset;
+
+import javax.inject.Inject;
+
+/**
+ * @author Juraci Paixão Kröhling
+ */
+@DeploymentScoped
+public class OpenTracingInstaller implements DeploymentProcessor {
+    private static final Logger logger = Logger.getLogger(OpenTracingInstaller.class);
+    private final Archive<?> archive;
+
+    @Inject
+    public OpenTracingInstaller(Archive archive) {
+        this.archive = archive;
+    }
+
+    @Override
+    public void process() throws Exception {
+        logger.info("Determining whether to install OpenTracing integration or not.");
+        if (archive.getName().endsWith(".war")) {
+            logger.logf(Logger.Level.INFO, "Installing the OpenTracing integration for the deployment %s", archive.getName());
+            WARArchive webArchive = archive.as(WARArchive.class);
+            WebXmlAsset webXml = webArchive.findWebXmlAsset();
+
+            logger.logf(Logger.Level.INFO, "Adding the listener org.wildfly.swarm.opentracing.deployment.OpenTracingInitializer");
+            webXml.addListener("org.wildfly.swarm.opentracing.deployment.OpenTracingInitializer");
+        }
+    }
+}

--- a/fractions/opentracing/src/main/resources/modules/io/opentracing/main/module.xml
+++ b/fractions/opentracing/src/main/resources/modules/io/opentracing/main/module.xml
@@ -1,0 +1,14 @@
+<module xmlns="urn:jboss:module:1.3" name="io.opentracing">
+  <resources>
+    <artifact name="io.opentracing:opentracing-api:${version.opentracing}"/>
+    <artifact name="io.opentracing:opentracing-util:${version.opentracing}"/>
+    <artifact name="io.opentracing:opentracing-noop:${version.opentracing}"/>
+    <artifact name="io.opentracing.contrib:opentracing-globaltracer:${version.globaltracer}"/>
+    <artifact name="io.opentracing.contrib:opentracing-tracerresolver:${version.tracerresolver}"/>
+  </resources>
+
+  <dependencies>
+    <module name="javax.api"/>
+    <module name="javax.servlet.api"/>
+  </dependencies>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -1349,7 +1349,6 @@
     <module>fractions/keycloak</module>
     <module>fractions/microprofile</module>
     <module>fractions/monitor</module>
-    <module>fractions/opentracing</module>
     <module>fractions/topology</module>
     <module>fractions/topology-openshift</module>
     <module>fractions/topology-webapp</module>
@@ -1449,6 +1448,7 @@
         <module>fractions/jolokia</module>
         <module>fractions/logstash</module>
         <module>fractions/keycloak-server</module>
+        <module>fractions/opentracing</module>
         <module>fractions/spring</module>
         <module>fractions/swagger</module>
         <module>fractions/swagger-webapp</module>

--- a/pom.xml
+++ b/pom.xml
@@ -1349,6 +1349,7 @@
     <module>fractions/keycloak</module>
     <module>fractions/microprofile</module>
     <module>fractions/monitor</module>
+    <module>fractions/opentracing</module>
     <module>fractions/topology</module>
     <module>fractions/topology-openshift</module>
     <module>fractions/topology-webapp</module>

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,11 @@
     <version.zipkin.reporter>0.6.1</version.zipkin.reporter>
     <version.zipkin>1.13.1</version.zipkin>
 
+    <!-- OpenTracing related versions -->
+    <version.opentracing>0.22.0</version.opentracing>
+    <version.globaltracer>0.1.2</version.globaltracer>
+    <version.tracerresolver>0.1.0</version.tracerresolver>
+
     <version.jruby-maven-plugin>1.1.3</version.jruby-maven-plugin>
     <version.maven-plugin-plugin>3.4</version.maven-plugin-plugin>
     <version.maven-shade-plugin>2.4.1</version.maven-shade-plugin>
@@ -933,6 +938,12 @@
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
+        <artifactId>opentracing</artifactId>
+        <version>2017.7.0-SNAPSHOT</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.wildfly.swarm</groupId>
         <artifactId>remoting</artifactId>
         <version>2017.7.0-SNAPSHOT</version>
       </dependency>
@@ -1504,6 +1515,7 @@
         <module>testsuite/testsuite-messaging</module>
         <module>testsuite/testsuite-messaging-remote</module>
         <module>testsuite/testsuite-mod_cluster</module>
+        <module>testsuite/testsuite-opentracing</module>
         <module>testsuite/testsuite-resource-adapters</module>
         <module>testsuite/testsuite-ribbon</module>
         <module>testsuite/testsuite-ribbon-secured</module>

--- a/testsuite/testsuite-opentracing/pom.xml
+++ b/testsuite/testsuite-opentracing/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>testsuite</artifactId>
+    <version>2017.7.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>testsuite-opentracing</artifactId>
+
+  <name>Test Suite: OpenTracing</name>
+  <description>Test Suite: OpenTracing</description>
+
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>opentracing</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-mock</artifactId>
+      <version>${version.opentracing}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>arquillian</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.junit</groupId>
+      <artifactId>arquillian-junit-container</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/testsuite/testsuite-opentracing/src/test/java/org/wildfly/swarm/opentracing/MockTracerResolver.java
+++ b/testsuite/testsuite-opentracing/src/test/java/org/wildfly/swarm/opentracing/MockTracerResolver.java
@@ -1,0 +1,15 @@
+package org.wildfly.swarm.opentracing;
+
+import io.opentracing.Tracer;
+import io.opentracing.contrib.tracerresolver.TracerResolver;
+import io.opentracing.mock.MockTracer;
+
+/**
+ * @author Juraci Paixão Kröhling
+ */
+public class MockTracerResolver extends TracerResolver {
+    @Override
+    protected Tracer resolve() {
+        return new MockTracer();
+    }
+}

--- a/testsuite/testsuite-opentracing/src/test/java/org/wildfly/swarm/opentracing/OpenTracingWithTraceResolverOnDeploymentTest.java
+++ b/testsuite/testsuite-opentracing/src/test/java/org/wildfly/swarm/opentracing/OpenTracingWithTraceResolverOnDeploymentTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.opentracing;
+
+import io.opentracing.Tracer;
+import io.opentracing.contrib.tracerresolver.TracerResolver;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.util.GlobalTracer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.arquillian.CreateSwarm;
+import org.wildfly.swarm.undertow.WARArchive;
+
+import javax.naming.NamingException;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Juraci Paixão Kröhling
+ */
+@RunWith(Arquillian.class)
+public class OpenTracingWithTraceResolverOnDeploymentTest {
+
+    @Deployment
+    public static Archive createDeployment() {
+        WARArchive deployment = ShrinkWrap.create(WARArchive.class);
+
+        // on real world deployments, these parts would come from a dependency of the target application
+        deployment.addClass(MockTracerResolver.class);
+        deployment.addPackage(Tracer.class.getPackage());
+        deployment.addPackage(MockTracer.class.getPackage());
+        deployment.addAsServiceProvider(TracerResolver.class, MockTracerResolver.class);
+
+        return deployment;
+    }
+
+    @CreateSwarm
+    public static Swarm newContainer() throws Exception {
+        return new Swarm().fraction(new OpenTracingFraction());
+    }
+
+    @Test
+    public void testMockTracerIsAvailable() throws NamingException {
+        assertTrue(GlobalTracer.isRegistered());
+    }
+}

--- a/testsuite/testsuite-opentracing/src/test/java/org/wildfly/swarm/opentracing/OpenTracingWithoutTraceResolverOnDeploymentTest.java
+++ b/testsuite/testsuite-opentracing/src/test/java/org/wildfly/swarm/opentracing/OpenTracingWithoutTraceResolverOnDeploymentTest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.opentracing;
+
+import io.opentracing.util.GlobalTracer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.arquillian.CreateSwarm;
+import org.wildfly.swarm.undertow.WARArchive;
+
+import javax.naming.NamingException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Juraci Paixão Kröhling
+ */
+@RunWith(Arquillian.class)
+public class OpenTracingWithoutTraceResolverOnDeploymentTest {
+
+    @Deployment
+    public static Archive createDeployment() {
+        return ShrinkWrap.create(WARArchive.class);
+    }
+
+    @CreateSwarm
+    public static Swarm newContainer() throws Exception {
+        return new Swarm().fraction(new OpenTracingFraction());
+    }
+
+    @Test
+    public void testMockTracerIsNotAvailable() throws NamingException {
+        assertFalse(GlobalTracer.isRegistered());
+    }
+}


### PR DESCRIPTION
Motivation
----------
Adds OpenTracing to a deployment setting the GlobalTracer to a Tracer
resolved via the TraceResolver. This means that it gets concrete Tracer
implementation from the application being deployed.

Modifications
-------------
A new fraction was added, under fractions/opentracing.

Result
------
A new fraction is available, under the GA org.wildfly.swarm:opentracing