### PR TITLE
SWARM-1407 - Ordering of auth-modules incorrect

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigNode.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigNode.java
@@ -1,6 +1,7 @@
 package org.wildfly.swarm.container.config;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -243,7 +244,7 @@ public class ConfigNode implements ConfigTree {
         return "[ConfigNode: (" + System.identityHashCode(this.children) + ") children=" + this.children + "; value=" + this.value + "]";
     }
 
-    private Map<SimpleKey, ConfigNode> children = new HashMap<>();
+    private Map<SimpleKey, ConfigNode> children = new LinkedHashMap<>();
 
     private Object value;
 

--- a/core/container/src/test/java/org/wildfly/swarm/container/config/ConfigNodeTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/container/config/ConfigNodeTest.java
@@ -1,5 +1,7 @@
 package org.wildfly.swarm.container.config;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -134,5 +136,32 @@ public class ConfigNodeTest {
         assertThat(config.valueOf(ConfigKey.parse("company.name"))).isEqualTo("cheeseCorp");
         config.recursiveChild(ConfigKey.parse("company.name"), "Wheel O'Cheese");
         assertThat(config.valueOf(ConfigKey.parse("company.name"))).isEqualTo("Wheel O'Cheese");
+    }
+
+    @Test
+    public void testOrderingOfChildren() {
+        ConfigNode config = new ConfigNode();
+
+        config.child( "Z", "26");
+        config.child( "A", "1");
+
+        List<SimpleKey> keys = new ArrayList<>();
+        keys.addAll( config.childrenKeys() );
+
+        assertThat( keys.get(0).toString()).isEqualTo("Z");
+        assertThat( keys.get(1).toString()).isEqualTo("A");
+    }
+
+    @Test
+    public void testOrderingOfChildrenRecursively() {
+        ConfigNode config = new ConfigNode();
+
+        config.child( "Z", "26");
+        config.child( "A", "1");
+
+        List<ConfigKey> keys = config.allKeysRecursively().collect(Collectors.toList());
+
+        assertThat( keys.get(0).toString()).isEqualTo("Z");
+        assertThat( keys.get(1).toString()).isEqualTo("A");
     }
 }

--- a/core/container/src/test/java/org/wildfly/swarm/container/config/ConfigViewFactoryTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/container/config/ConfigViewFactoryTest.java
@@ -3,7 +3,9 @@ package org.wildfly.swarm.container.config;
 import org.junit.Test;
 
 import java.io.InputStream;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 
 import static org.fest.assertions.Assertions.assertThat;
 
@@ -20,5 +22,22 @@ public class ConfigViewFactoryTest {
         Map<String, ?> foo = (Map<String, ?>) doc.get("foo");
         Map<String, ?> on = (Map<String, ?>) foo.get("on");
         assertThat((Boolean) on.get("startup")).isTrue();
+    }
+
+    @Test
+    public void testLucasesYaml() {
+        InputStream in = getClass().getResourceAsStream("/lucas.yml");
+        Map<String, ?> doc = ConfigViewFactory.loadYaml(in);
+        Map<String, ?> swarm = (Map<String, ?>) doc.get("swarm");
+        Map<String, ?> security = (Map<String, ?>) swarm.get("security");
+        Map<String, ?> securityDomains = (Map<String, ?>) security.get("security-domains");
+        Map<String, ?> jaspioauth = (Map<String, ?>) securityDomains.get("jaspioauth");
+        Map<String, ?> jaspiAuthentication = (Map<String, ?>) jaspioauth.get("jaspi-authentication");
+        Map<String, ?> authModules = (Map<String, ?>) jaspiAuthentication.get("auth-modules");
+
+        Set<String> keys = authModules.keySet();
+        Iterator<String> keysIter = keys.iterator();
+        assertThat( keysIter.next() ).isEqualTo("2-OAuth2");
+        assertThat( keysIter.next() ).isEqualTo("1-JWT");
     }
 }

--- a/core/container/src/test/resources/lucas.yml
+++ b/core/container/src/test/resources/lucas.yml
@@ -1,0 +1,20 @@
+swarm:
+  security:
+    security-domains:
+      jaspioauth:
+        jaspi-authentication:
+          auth-modules:
+            2-OAuth2:
+              code: xxxxx.OpenIDConnectAuthModule
+              flag: sufficient
+              module-options:
+                client_id: SwarmOAth
+                client_secret: secret
+                scope: openid profile email
+                redirection_endpoint: /mycontext
+                cookie_context: /
+                issuer_uri: https://stst.xxx.it:9031/as/token.oauth2
+                disable_certificate_checks: true
+            1-JWT:
+              code: it.xxx.jaspic.ValidationServerAuthModule
+              flag: sufficient

--- a/fractions/wildfly/security/pom.xml
+++ b/fractions/wildfly/security/pom.xml
@@ -83,6 +83,17 @@
       <artifactId>jboss-annotations-api_1.2_spec</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.jboss</groupId>
+      <artifactId>jboss-dmr</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.core</groupId>
+      <artifactId>wildfly-controller</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/fractions/wildfly/security/src/test/java/org/wildfly/swarm/security/SecurityFractionTest.java
+++ b/fractions/wildfly/security/src/test/java/org/wildfly/swarm/security/SecurityFractionTest.java
@@ -1,0 +1,55 @@
+package org.wildfly.swarm.security;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.dmr.ModelNode;
+import org.junit.Test;
+import org.wildfly.swarm.config.runtime.invocation.Marshaller;
+import org.wildfly.swarm.config.security.security_domain.authentication.AuthModule;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * Created by bob on 6/23/17.
+ */
+public class SecurityFractionTest {
+
+    @Test
+    public void testCorrectOrderingOfAuthModules() throws Exception {
+        SecurityFraction fraction = new SecurityFraction();
+
+        fraction.securityDomain("jaspioauth", (domain) -> {
+            domain.jaspiAuthentication((authn) -> {
+                authn.authModule("2-OAuth", (module) -> {
+                    // nothing
+                });
+                authn.authModule("1-JWT", (module) -> {
+                    // nothing
+                });
+            });
+        });
+
+        List<AuthModule> modules = fraction.subresources().securityDomain("jaspioauth").subresources().jaspiAuthentication().subresources().authModules();
+
+        assertThat(modules).hasSize(2);
+        assertThat(modules.get(0).getKey()).isEqualTo("2-OAuth");
+        assertThat(modules.get(1).getKey()).isEqualTo("1-JWT");
+
+        List<ModelNode> result = Marshaller.marshal(fraction);
+
+        PathAddress baseAddr = PathAddress.pathAddress("subsystem", "security")
+                .append("security-domain", "jaspioauth")
+                .append("authentication", "jaspi");
+
+        List<PathAddress> addresses = result.stream()
+                .map(e -> PathAddress.pathAddress(e.get("address")))
+                .filter(e -> e.getParent().equals(baseAddr))
+                .collect(Collectors.toList());
+
+        assertThat( addresses.get(0).getLastElement().getValue()).isEqualTo("2-OAuth");
+        assertThat( addresses.get(1).getLastElement().getValue()).isEqualTo("1-JWT");
+    }
+}


### PR DESCRIPTION
Motivation
----------
auth-modules are being installed in the wrong order.

Modifications
-------------
No functional changes, simply tests to help identify the problem,
and failing to do so.

Result
------
Nothing.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
