### PR TITLE
SWARM-1417: JaxrsClientTest fails when custom Maven repos are required for build

### DIFF
--- a/testsuite/testsuite-jaxrs-client/pom.xml
+++ b/testsuite/testsuite-jaxrs-client/pom.xml
@@ -43,4 +43,33 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <forkCount>1</forkCount>
+          <reuseForks>false</reuseForks>
+          <runOrder>alphabetical</runOrder>
+          <failIfNoTests>false</failIfNoTests>
+          <systemPropertyVariables>
+            <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
+            <swarm.bind.address>127.0.0.1</swarm.bind.address>
+            <project.version>${project.version}</project.version>
+            <org.apache.maven.user-settings>${session.request.userSettingsFile.path}</org.apache.maven.user-settings>
+          </systemPropertyVariables>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>build-resources</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>


### PR DESCRIPTION
Motivation
----------
In case custom Maven repos are required for Swarm build,
being set up via custom settings.xml, the `JaxrsClientTest`
fails because it can't find artifacts from the custom Maven
repos. This is because the `testsuite-jaxrs-client` module
no longer inherits from the `testsuite` Maven module, and
indirectly from the root Swarm POM, and so the Maven Surefire
plugin configuration isn't propagated.

Modifications
-------------
Copy the Surefire plugin configuration from Swarm root POM
to `testsuite-jaxrs-client` POM.

Result
------
`JaxrsClientTest` passes even if custom Maven repos are required.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
