### PR TITLE
SWARM-1411 - Added Jaeger Fraction

### DIFF
--- a/fractions/jaeger/module.conf
+++ b/fractions/jaeger/module.conf
@@ -1,0 +1,6 @@
+org.wildfly.swarm.logging
+org.wildfly.swarm.undertow
+org.jboss.logging
+javax.api
+com.uber.jaeger
+io.opentracing export=true

--- a/fractions/jaeger/pom.xml
+++ b/fractions/jaeger/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+~
+~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>wildfly-swarm</artifactId>
+    <version>2017.7.0-SNAPSHOT</version>
+    <relativePath>../../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>jaeger</artifactId>
+
+  <name>Jaeger</name>
+  <description>Jaeger integration, including the OpenTracing fraction</description>
+
+  <packaging>jar</packaging>
+
+  <properties>
+    <swarm.fraction.stability>experimental</swarm.fraction.stability>
+    <swarm.fraction.tags>Jaeger, OpenTracing, Tracing, Monitoring</swarm.fraction.tags>
+  </properties>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>container</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>spi</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>undertow</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>opentracing</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.uber.jaeger</groupId>
+      <artifactId>jaeger-core</artifactId>
+      <version>${version.jaeger}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.uber.jaeger</groupId>
+      <artifactId>jaeger-tracerresolver</artifactId>
+      <version>${version.jaeger}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/fractions/jaeger/pom.xml
+++ b/fractions/jaeger/pom.xml
@@ -79,5 +79,42 @@
       <artifactId>jaeger-tracerresolver</artifactId>
       <version>${version.jaeger}</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.wildfly.core</groupId>
+      <artifactId>wildfly-core-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-servlet-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 </project>

--- a/fractions/jaeger/src/main/java/org/wildfly/swarm/jaeger/JaegerFraction.java
+++ b/fractions/jaeger/src/main/java/org/wildfly/swarm/jaeger/JaegerFraction.java
@@ -1,0 +1,84 @@
+package org.wildfly.swarm.jaeger;
+
+import org.jboss.logging.Logger;
+import org.wildfly.swarm.spi.api.Fraction;
+import org.wildfly.swarm.spi.api.annotations.Configurable;
+import org.wildfly.swarm.spi.api.annotations.DeploymentModule;
+
+import static com.uber.jaeger.Configuration.*;
+
+/**
+ * @author Juraci Paixão Kröhling
+ */
+@DeploymentModule(name = "org.wildfly.swarm.jaeger", slot = "deployment")
+@Configurable("swarm.jaeger")
+public class JaegerFraction implements Fraction<JaegerFraction> {
+    private static final Logger logger = Logger.getLogger(JaegerFraction.class);
+
+    private String serviceName = getDefault(JAEGER_SERVICE_NAME);
+
+    private String samplerType = getDefault(JAEGER_SAMPLER_TYPE);
+    private String samplerParameter = getDefault(JAEGER_SAMPLER_PARAM);
+    private String samplerManagerHost = getDefault(JAEGER_SAMPLER_MANAGER_HOST_PORT);
+
+    private String reporterLogSpans = getDefault(JAEGER_REPORTER_LOG_SPANS);
+    private String agentHost = getDefault(JAEGER_AGENT_HOST);
+    private String agentPort = getDefault(JAEGER_AGENT_PORT);
+    private String reporterFlushInterval = getDefault(JAEGER_REPORTER_FLUSH_INTERVAL);
+    private String reporterMaxQueueSize = getDefault(JAEGER_REPORTER_MAX_QUEUE_SIZE);
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public String getSamplerType() {
+        return samplerType;
+    }
+
+    public String getSamplerParameter() {
+        return samplerParameter;
+    }
+
+    public String getSamplerManagerHost() {
+        return samplerManagerHost;
+    }
+
+    public String getReporterLogSpans() {
+        return reporterLogSpans;
+    }
+
+    public String getAgentHost() {
+        return agentHost;
+    }
+
+    public String getAgentPort() {
+        return agentPort;
+    }
+
+    public String getReporterFlushInterval() {
+        return reporterFlushInterval;
+    }
+
+    public String getReporterMaxQueueSize() {
+        return reporterMaxQueueSize;
+    }
+
+    @Override
+    public String toString() {
+        return "JaegerFraction{" +
+                "serviceName='" + serviceName + '\'' +
+                ", samplerType='" + samplerType + '\'' +
+                ", samplerParameter='" + samplerParameter + '\'' +
+                ", samplerManagerHost='" + samplerManagerHost + '\'' +
+                ", reporterLogSpans='" + reporterLogSpans + '\'' +
+                ", agentHost='" + agentHost + '\'' +
+                ", agentPort='" + agentPort + '\'' +
+                ", reporterFlushInterval='" + reporterFlushInterval + '\'' +
+                ", reporterMaxQueueSize='" + reporterMaxQueueSize + '\'' +
+                '}';
+    }
+
+    private static String getDefault(String key) {
+        return System.getProperty(key, System.getenv(key));
+    }
+}

--- a/fractions/jaeger/src/main/java/org/wildfly/swarm/jaeger/JaegerFraction.java
+++ b/fractions/jaeger/src/main/java/org/wildfly/swarm/jaeger/JaegerFraction.java
@@ -1,9 +1,12 @@
 package org.wildfly.swarm.jaeger;
 
-import org.jboss.logging.Logger;
+import org.wildfly.swarm.config.runtime.AttributeDocumentation;
+import org.wildfly.swarm.spi.api.Defaultable;
 import org.wildfly.swarm.spi.api.Fraction;
 import org.wildfly.swarm.spi.api.annotations.Configurable;
 import org.wildfly.swarm.spi.api.annotations.DeploymentModule;
+
+import java.util.Optional;
 
 import static com.uber.jaeger.Configuration.*;
 
@@ -13,72 +16,79 @@ import static com.uber.jaeger.Configuration.*;
 @DeploymentModule(name = "org.wildfly.swarm.jaeger", slot = "deployment")
 @Configurable("swarm.jaeger")
 public class JaegerFraction implements Fraction<JaegerFraction> {
-    private static final Logger logger = Logger.getLogger(JaegerFraction.class);
+    @AttributeDocumentation("The service name. Required (via this parameter, system property or env var). Ex.: `order-manager`")
+    private Defaultable<String> serviceName = Defaultable.string(getDefault(JAEGER_SERVICE_NAME));
 
-    private String serviceName = getDefault(JAEGER_SERVICE_NAME);
+    @AttributeDocumentation("The sampler type. Ex.: `const`")
+    private Defaultable<String> samplerType = Defaultable.string(getDefault(JAEGER_SAMPLER_TYPE));
+    @AttributeDocumentation("The sampler parameter (number). Ex.: `1`")
+    private Defaultable<String> samplerParameter = Defaultable.string(getDefault(JAEGER_SAMPLER_PARAM));
+    @AttributeDocumentation("The host name and port when using the remote controlled sampler")
+    private Defaultable<String> samplerManagerHost = Defaultable.string(getDefault(JAEGER_SAMPLER_MANAGER_HOST_PORT));
 
-    private String samplerType = getDefault(JAEGER_SAMPLER_TYPE);
-    private String samplerParameter = getDefault(JAEGER_SAMPLER_PARAM);
-    private String samplerManagerHost = getDefault(JAEGER_SAMPLER_MANAGER_HOST_PORT);
-
-    private String reporterLogSpans = getDefault(JAEGER_REPORTER_LOG_SPANS);
-    private String agentHost = getDefault(JAEGER_AGENT_HOST);
-    private String agentPort = getDefault(JAEGER_AGENT_PORT);
-    private String reporterFlushInterval = getDefault(JAEGER_REPORTER_FLUSH_INTERVAL);
-    private String reporterMaxQueueSize = getDefault(JAEGER_REPORTER_MAX_QUEUE_SIZE);
+    @AttributeDocumentation("Whether the reporter should also log the spans")
+    private Defaultable<String> reporterLogSpans = Defaultable.string(getDefault(JAEGER_REPORTER_LOG_SPANS));
+    @AttributeDocumentation("The hostname for communicating with agent via UDP")
+    private Defaultable<String> agentHost = Defaultable.string(getDefault(JAEGER_AGENT_HOST));
+    @AttributeDocumentation("The port for communicating with agent via UDP")
+    private Defaultable<String> agentPort = Defaultable.string(getDefault(JAEGER_AGENT_PORT));
+    @AttributeDocumentation("The reporter's flush interval (ms)")
+    private Defaultable<String> reporterFlushInterval = Defaultable.string(getDefault(JAEGER_REPORTER_FLUSH_INTERVAL));
+    @AttributeDocumentation("The reporter's maximum queue size")
+    private Defaultable<String> reporterMaxQueueSize = Defaultable.string(getDefault(JAEGER_REPORTER_MAX_QUEUE_SIZE));
 
     public String getServiceName() {
-        return serviceName;
+        return serviceName.get();
     }
 
     public String getSamplerType() {
-        return samplerType;
+        return samplerType.get();
     }
 
     public String getSamplerParameter() {
-        return samplerParameter;
+        return samplerParameter.get();
     }
 
     public String getSamplerManagerHost() {
-        return samplerManagerHost;
+        return samplerManagerHost.get();
     }
 
     public String getReporterLogSpans() {
-        return reporterLogSpans;
+        return reporterLogSpans.get();
     }
 
     public String getAgentHost() {
-        return agentHost;
+        return agentHost.get();
     }
 
     public String getAgentPort() {
-        return agentPort;
+        return agentPort.get();
     }
 
     public String getReporterFlushInterval() {
-        return reporterFlushInterval;
+        return reporterFlushInterval.get();
     }
 
     public String getReporterMaxQueueSize() {
-        return reporterMaxQueueSize;
+        return reporterMaxQueueSize.get();
     }
 
     @Override
     public String toString() {
         return "JaegerFraction{" +
-                "serviceName='" + serviceName + '\'' +
-                ", samplerType='" + samplerType + '\'' +
-                ", samplerParameter='" + samplerParameter + '\'' +
-                ", samplerManagerHost='" + samplerManagerHost + '\'' +
-                ", reporterLogSpans='" + reporterLogSpans + '\'' +
-                ", agentHost='" + agentHost + '\'' +
-                ", agentPort='" + agentPort + '\'' +
-                ", reporterFlushInterval='" + reporterFlushInterval + '\'' +
-                ", reporterMaxQueueSize='" + reporterMaxQueueSize + '\'' +
+                "serviceName='" + serviceName.get() + '\'' +
+                ", samplerType='" + samplerType.get() + '\'' +
+                ", samplerParameter='" + samplerParameter.get() + '\'' +
+                ", samplerManagerHost='" + samplerManagerHost.get() + '\'' +
+                ", reporterLogSpans='" + reporterLogSpans.get() + '\'' +
+                ", agentHost='" + agentHost.get() + '\'' +
+                ", agentPort='" + agentPort.get() + '\'' +
+                ", reporterFlushInterval='" + reporterFlushInterval.get() + '\'' +
+                ", reporterMaxQueueSize='" + reporterMaxQueueSize.get() + '\'' +
                 '}';
     }
 
     private static String getDefault(String key) {
-        return System.getProperty(key, System.getenv(key));
+        return Optional.ofNullable(System.getProperty(key, System.getenv(key))).orElse("");
     }
 }

--- a/fractions/jaeger/src/main/java/org/wildfly/swarm/jaeger/deployment/JaegerInitializer.java
+++ b/fractions/jaeger/src/main/java/org/wildfly/swarm/jaeger/deployment/JaegerInitializer.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.jaeger.deployment;
+
+import com.uber.jaeger.Configuration;
+import io.opentracing.util.GlobalTracer;
+import org.jboss.logging.Logger;
+
+import javax.enterprise.inject.Vetoed;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.annotation.WebListener;
+
+import static com.uber.jaeger.Configuration.*;
+
+/**
+ * @author Juraci Paixão Kröhling
+ */
+@Vetoed
+@WebListener
+public class JaegerInitializer implements ServletContextListener {
+    private static final Logger logger = Logger.getLogger(JaegerInitializer.class);
+
+    @Override
+    public void contextInitialized(ServletContextEvent servletContextEvent) {
+        ServletContext sc = servletContextEvent.getServletContext();
+
+        String serviceName = getProperty(sc, JAEGER_SERVICE_NAME);
+        if (serviceName == null || serviceName.isEmpty()) {
+            logger.info("No Service Name set. Skipping initialization of the Jaeger Tracer.");
+            return;
+        }
+
+        Configuration configuration = new Configuration(
+                getProperty(sc, JAEGER_SERVICE_NAME),
+                new Configuration.SamplerConfiguration(
+                        getProperty(sc, JAEGER_SAMPLER_TYPE),
+                        getPropertyAsInt(sc, JAEGER_SAMPLER_PARAM),
+                        getProperty(sc, JAEGER_SAMPLER_MANAGER_HOST_PORT)),
+                new ReporterConfiguration(
+                        getPropertyAsBoolean(sc, JAEGER_REPORTER_LOG_SPANS),
+                        getProperty(sc, JAEGER_AGENT_HOST),
+                        getPropertyAsInt(sc, JAEGER_AGENT_PORT),
+                        getPropertyAsInt(sc, JAEGER_REPORTER_FLUSH_INTERVAL),
+                        getPropertyAsInt(sc, JAEGER_REPORTER_MAX_QUEUE_SIZE)
+                )
+        );
+        GlobalTracer.register(configuration.getTracer());
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent servletContextEvent) {
+    }
+
+    private static String getProperty(ServletContext sc, String name) {
+        return sc.getInitParameter(name);
+    }
+
+    private static Integer getPropertyAsInt(ServletContext sc, String name) {
+        String value = getProperty(sc, name);
+        if (value != null && !value.isEmpty()) {
+            try {
+                return Integer.parseInt(value);
+            } catch (NumberFormatException e) {
+                logger.error("Failed to parse integer for property '" + name + "' with value '" + value + "'", e);
+            }
+        }
+        return null;
+    }
+
+    private static Boolean getPropertyAsBoolean(ServletContext sc, String name) {
+        String value = getProperty(sc, name);
+        if (value != null && !value.isEmpty()) {
+            return Boolean.valueOf(value);
+        }
+        return null;
+    }
+
+}

--- a/fractions/jaeger/src/main/java/org/wildfly/swarm/jaeger/deployment/JaegerInitializer.java
+++ b/fractions/jaeger/src/main/java/org/wildfly/swarm/jaeger/deployment/JaegerInitializer.java
@@ -19,7 +19,6 @@ import com.uber.jaeger.Configuration;
 import io.opentracing.util.GlobalTracer;
 import org.jboss.logging.Logger;
 
-import javax.enterprise.inject.Vetoed;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
@@ -30,7 +29,6 @@ import static com.uber.jaeger.Configuration.*;
 /**
  * @author Juraci Paixão Kröhling
  */
-@Vetoed
 @WebListener
 public class JaegerInitializer implements ServletContextListener {
     private static final Logger logger = Logger.getLogger(JaegerInitializer.class);

--- a/fractions/jaeger/src/main/java/org/wildfly/swarm/jaeger/runtime/JaegerInstaller.java
+++ b/fractions/jaeger/src/main/java/org/wildfly/swarm/jaeger/runtime/JaegerInstaller.java
@@ -1,0 +1,68 @@
+package org.wildfly.swarm.jaeger.runtime;
+
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.wildfly.swarm.jaeger.JaegerFraction;
+import org.wildfly.swarm.spi.api.DeploymentProcessor;
+import org.wildfly.swarm.spi.runtime.annotations.DeploymentScoped;
+import org.wildfly.swarm.undertow.WARArchive;
+import org.wildfly.swarm.undertow.descriptors.WebXmlAsset;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import static com.uber.jaeger.Configuration.*;
+
+/**
+ * @author Juraci Paixão Kröhling
+ */
+@DeploymentScoped
+public class JaegerInstaller implements DeploymentProcessor {
+    private static final Logger logger = Logger.getLogger(JaegerInstaller.class);
+
+    private final Archive<?> archive;
+
+    @Inject
+    private Instance<JaegerFraction> jaegerFractionInstance;
+
+    @Inject
+    public JaegerInstaller(Archive archive) {
+        this.archive = archive;
+    }
+
+    @Override
+    public void process() throws Exception {
+        JaegerFraction fraction = jaegerFractionInstance.get();
+        logger.info("Determining whether to install Jaeger integration or not.");
+        logger.info("JaegerFraction instance: " + fraction);
+
+        if (archive.getName().endsWith(".war")) {
+            logger.logf(Logger.Level.INFO, "Installing the Jaeger integration for the deployment %s", archive.getName());
+            WARArchive webArchive = archive.as(WARArchive.class);
+            WebXmlAsset webXml = webArchive.findWebXmlAsset();
+
+            logger.logf(Logger.Level.INFO, "Adding the listener org.wildfly.swarm.jaeger.deployment.JaegerInitializer");
+            webXml.addListener("org.wildfly.swarm.jaeger.deployment.JaegerInitializer");
+
+            setContextParamIfNotNull(webXml, JAEGER_SERVICE_NAME, fraction.getServiceName());
+            setContextParamIfNotNull(webXml, JAEGER_SERVICE_NAME, fraction.getServiceName());
+            setContextParamIfNotNull(webXml, JAEGER_SAMPLER_TYPE, fraction.getSamplerType());
+            setContextParamIfNotNull(webXml, JAEGER_SAMPLER_PARAM, fraction.getSamplerParameter());
+            setContextParamIfNotNull(webXml, JAEGER_SAMPLER_MANAGER_HOST_PORT, fraction.getSamplerManagerHost());
+            setContextParamIfNotNull(webXml, JAEGER_REPORTER_LOG_SPANS, fraction.getReporterLogSpans());
+            setContextParamIfNotNull(webXml, JAEGER_AGENT_HOST, fraction.getAgentHost());
+            setContextParamIfNotNull(webXml, JAEGER_AGENT_PORT, fraction.getAgentPort());
+            setContextParamIfNotNull(webXml, JAEGER_REPORTER_FLUSH_INTERVAL, fraction.getReporterFlushInterval());
+            setContextParamIfNotNull(webXml, JAEGER_REPORTER_MAX_QUEUE_SIZE, fraction.getReporterMaxQueueSize());
+            webXml.setContextParam("skipOpenTracingResolver", "true");
+        }
+    }
+
+    private void setContextParamIfNotNull(WebXmlAsset webXml, String key, String value) {
+        if (value == null || value.isEmpty()) {
+            return;
+        }
+
+        webXml.setContextParam(key, value);
+    }
+}

--- a/fractions/jaeger/src/main/resources/modules/com/google/code/gson/jaeger/module.xml
+++ b/fractions/jaeger/src/main/resources/modules/com/google/code/gson/jaeger/module.xml
@@ -1,0 +1,5 @@
+<module xmlns="urn:jboss:module:1.3" name="com.google.code.gson" slot="jaeger">
+  <resources>
+    <artifact name="com.google.code.gson:gson:${version.jaeger.gson}"/>
+  </resources>
+</module>

--- a/fractions/jaeger/src/main/resources/modules/com/uber/jaeger/main/module.xml
+++ b/fractions/jaeger/src/main/resources/modules/com/uber/jaeger/main/module.xml
@@ -3,16 +3,13 @@
     <artifact name="com.uber.jaeger:jaeger-core:${version.jaeger}"/>
     <artifact name="com.uber.jaeger:jaeger-tracerresolver:${version.jaeger}"/>
     <artifact name="com.uber.jaeger:jaeger-thrift:${version.jaeger}"/>
-    <artifact name="org.apache.thrift:libthrift:0.9.2"/>
-    <artifact name="org.apache.httpcomponents:httpclient:4.2.5"/>
-    <artifact name="commons-logging:commons-logging:1.1.1"/>
-    <artifact name="commons-codec:commons-codec:1.6"/>
-    <artifact name="org.apache.httpcomponents:httpcore:4.2.4"/>
-    <artifact name="com.google.code.gson:gson:2.8.0"/>
   </resources>
 
   <dependencies>
     <module name="org.slf4j"/>
     <module name="io.opentracing"/>
+    <module name="org.apache.httpcomponents"/>
+    <module name="org.apache.thrift" slot="jaeger"/>
+    <module name="com.google.code.gson" slot="jaeger"/>
   </dependencies>
 </module>

--- a/fractions/jaeger/src/main/resources/modules/com/uber/jaeger/main/module.xml
+++ b/fractions/jaeger/src/main/resources/modules/com/uber/jaeger/main/module.xml
@@ -1,0 +1,18 @@
+<module xmlns="urn:jboss:module:1.3" name="com.uber.jaeger">
+  <resources>
+    <artifact name="com.uber.jaeger:jaeger-core:${version.jaeger}"/>
+    <artifact name="com.uber.jaeger:jaeger-tracerresolver:${version.jaeger}"/>
+    <artifact name="com.uber.jaeger:jaeger-thrift:${version.jaeger}"/>
+    <artifact name="org.apache.thrift:libthrift:0.9.2"/>
+    <artifact name="org.apache.httpcomponents:httpclient:4.2.5"/>
+    <artifact name="commons-logging:commons-logging:1.1.1"/>
+    <artifact name="commons-codec:commons-codec:1.6"/>
+    <artifact name="org.apache.httpcomponents:httpcore:4.2.4"/>
+    <artifact name="com.google.code.gson:gson:2.8.0"/>
+  </resources>
+
+  <dependencies>
+    <module name="org.slf4j"/>
+    <module name="io.opentracing"/>
+  </dependencies>
+</module>

--- a/fractions/jaeger/src/main/resources/modules/org/apache/thrift/jaeger/module.xml
+++ b/fractions/jaeger/src/main/resources/modules/org/apache/thrift/jaeger/module.xml
@@ -1,0 +1,5 @@
+<module xmlns="urn:jboss:module:1.3" name="org.apache.thrift" slot="jaeger">
+  <resources>
+    <artifact name="org.apache.thrift:libthrift:${version.jaeger.apache.thrift}"/>
+  </resources>
+</module>

--- a/fractions/opentracing/src/main/java/org/wildfly/swarm/opentracing/deployment/OpenTracingInitializer.java
+++ b/fractions/opentracing/src/main/java/org/wildfly/swarm/opentracing/deployment/OpenTracingInitializer.java
@@ -21,7 +21,6 @@ import io.opentracing.contrib.web.servlet.filter.TracingFilter;
 import io.opentracing.util.GlobalTracer;
 import org.jboss.logging.Logger;
 
-import javax.enterprise.inject.Vetoed;
 import javax.servlet.DispatcherType;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
@@ -32,7 +31,6 @@ import java.util.EnumSet;
 /**
  * @author Juraci Paixão Kröhling
  */
-@Vetoed
 @WebListener
 public class OpenTracingInitializer implements ServletContextListener {
     private static final Logger logger = Logger.getLogger(OpenTracingInitializer.class);

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,12 @@
     <version.opentracing.servlet>0.0.9</version.opentracing.servlet>
     <version.opentracing.spanmanager>0.0.5</version.opentracing.spanmanager>
     <version.jaeger>0.20.0</version.jaeger>
+    <version.jaeger.apache.thrift>0.9.2</version.jaeger.apache.thrift>
+    <version.jaeger.apache.httpclient>4.2.5</version.jaeger.apache.httpclient>
+    <version.jaeger.commons.logging>1.1.1</version.jaeger.commons.logging>
+    <version.jaeger.commons.codec>1.6</version.jaeger.commons.codec>
+    <version.jaeger.apache.httpcore>4.2.4</version.jaeger.apache.httpcore>
+    <version.jaeger.gson>2.8.0</version.jaeger.gson>
 
     <version.jruby-maven-plugin>1.1.3</version.jruby-maven-plugin>
     <version.maven-plugin-plugin>3.4</version.maven-plugin-plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -100,10 +100,11 @@
     <version.zipkin>1.13.1</version.zipkin>
 
     <!-- OpenTracing related versions -->
-    <version.opentracing>0.22.0</version.opentracing>
+    <version.opentracing>0.30.0</version.opentracing>
     <version.opentracing.tracerresolver>0.1.0</version.opentracing.tracerresolver>
-    <version.opentracing.servlet>0.0.8</version.opentracing.servlet>
+    <version.opentracing.servlet>0.0.9</version.opentracing.servlet>
     <version.opentracing.spanmanager>0.0.5</version.opentracing.spanmanager>
+    <version.jaeger>0.20.0</version.jaeger>
 
     <version.jruby-maven-plugin>1.1.3</version.jruby-maven-plugin>
     <version.maven-plugin-plugin>3.4</version.maven-plugin-plugin>
@@ -877,6 +878,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>jaeger</artifactId>
+        <version>2017.7.0-SNAPSHOT</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.jboss.logmanager</groupId>
         <artifactId>jboss-logmanager-ext</artifactId>
         <version>${version.jboss-logmanager-ext}</version>
@@ -1450,6 +1457,7 @@
         <module>fractions/drools-server</module>
         <module>fractions/fluentd</module>
         <module>fractions/flyway</module>
+        <module>fractions/jaeger</module>
         <module>fractions/javafx</module>
         <module>fractions/jolokia</module>
         <module>fractions/logstash</module>

--- a/testsuite/testsuite-opentracing/src/test/java/org/wildfly/swarm/opentracing/MockTracerResolver.java
+++ b/testsuite/testsuite-opentracing/src/test/java/org/wildfly/swarm/opentracing/MockTracerResolver.java
@@ -3,12 +3,13 @@ package org.wildfly.swarm.opentracing;
 import io.opentracing.Tracer;
 import io.opentracing.contrib.tracerresolver.TracerResolver;
 import io.opentracing.mock.MockTracer;
+import io.opentracing.util.ThreadLocalActiveSpanSource;
 
 /**
  * @author Juraci Paixão Kröhling
  */
 public class MockTracerResolver extends TracerResolver {
-    static final MockTracer TRACER_INSTANCE = new MockTracer();
+    static final MockTracer TRACER_INSTANCE = new MockTracer(new ThreadLocalActiveSpanSource(), MockTracer.Propagator.TEXT_MAP);
 
     @Override
     protected Tracer resolve() {

--- a/testsuite/testsuite-opentracing/src/test/java/org/wildfly/swarm/opentracing/SimpleServlet.java
+++ b/testsuite/testsuite-opentracing/src/test/java/org/wildfly/swarm/opentracing/SimpleServlet.java
@@ -23,7 +23,7 @@ public class SimpleServlet extends HttpServlet {
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         Tracer tracer = GlobalTracer.get();
         SpanContext context = (SpanContext) req.getAttribute(SERVER_SPAN_CONTEXT);
-        tracer.buildSpan("business-operation-1").asChildOf(context).start().close();
+        tracer.buildSpan("business-operation-1").asChildOf(context).startActive().close();
         resp.getWriter().write("world");
     }
 }


### PR DESCRIPTION
Motivation
----------
This Fraction brings the Jaeger and OpenTracing dependencies and gives
a Swarm-way to configure the tracer.

The main advantage of using this fraction vs. the OpenTracing fraction
plus the Jaeger dependencies is that this brings the correct versions of
all the components required to have a fully working OpenTracing solution.

Modifications
-------------
* Added Jaeger fraction
* Added a property to the OpenTracing fraction to skip automatic resolution
of tracers

Result
------
Applications consuming this fraction now get automatic and effortless support
for a complete OpenTracing solution, including automatic capture of request
data, thanks to the TracingFilter from the OpenTracing fraction.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
