### PR TITLE
SWARM-1420: Add dependencies that don't get aligned to bom-dependency

### DIFF
--- a/boms/bom-dependency/pom.xml
+++ b/boms/bom-dependency/pom.xml
@@ -25,6 +25,16 @@
 
   <properties>
     <version.openjdk.orb>8.0.6.Final</version.openjdk.orb>
+    <version.classmate>1.1</version.classmate>
+    <version.jackson-module-jaxb-annotations>2.5.4</version.jackson-module-jaxb-annotations>
+    <version.jcip-annotations>1.0</version.jcip-annotations>
+    <version.xnio-api>3.3.6.Final</version.xnio-api>
+    <version.httpclient>4.5</version.httpclient>
+    <version.httpcore>4.4.1</version.httpcore>
+    <version.apache-mime4j>0.6</version.apache-mime4j>
+    <version.commons-logging>1.1.1</version.commons-logging>
+    <version.commons-io>2.1</version.commons-io>
+    <version.commons-codec>1.10</version.commons-codec>
   </properties>
 
   <url>http://wildfly-swarm.io/</url>
@@ -56,6 +66,61 @@
         <groupId>org.jboss.openjdk-orb</groupId>
         <artifactId>openjdk-orb</artifactId>
         <version>${version.openjdk.orb}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml</groupId>
+        <artifactId>classmate</artifactId>
+        <version>${version.classmate}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-module-jaxb-annotations</artifactId>
+        <version>${version.jackson-module-jaxb-annotations}</version>
+      </dependency>
+      <dependency>
+          <groupId>commons-codec</groupId>
+          <artifactId>commons-codec</artifactId>
+          <version>${version.commons-codec}</version>
+      </dependency>
+      <dependency>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+          <version>${version.commons-io}</version>
+      </dependency>
+      <dependency>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+          <version>${version.commons-logging}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.jcip</groupId>
+        <artifactId>jcip-annotations</artifactId>
+        <version>${version.jcip-annotations}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>${version.httpclient}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpcore</artifactId>
+        <version>${version.httpcore}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.james</groupId>
+        <artifactId>apache-mime4j</artifactId>
+        <version>${version.apache-mime4j}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.xnio</groupId>
+        <artifactId>xnio-api</artifactId>
+        <version>${version.xnio-api}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.xnio</groupId>
+        <artifactId>xnio-nio</artifactId>
+        <version>${version.xnio-api}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -25,6 +25,8 @@
   <properties>
     <browser>phantomjs</browser>
     <version.resteasy>3.0.11.Final</version.resteasy>
+    <httpclient.version>4.5</httpclient.version>
+    <fluent-hc.version>4.5</fluent-hc.version>
   </properties>
 
   <build>
@@ -75,6 +77,21 @@
          ANY MODULES SHOULD BE ADDED, AS APPROPRIATE, TO THE ROOT
          pom.xml OF THIS PROJECT. -->
   </modules>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>${httpclient.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>fluent-hc</artifactId>
+        <version>${fluent-hc.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>

--- a/testsuite/testsuite-buildtool/multi-module/api/pom.xml
+++ b/testsuite/testsuite-buildtool/multi-module/api/pom.xml
@@ -30,7 +30,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.2</version>
     </dependency>
 
     <!-- http://mvnrepository.com/artifact/com.google.code.gson/gson -->

--- a/testsuite/testsuite-https/pom.xml
+++ b/testsuite/testsuite-https/pom.xml
@@ -39,7 +39,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>fluent-hc</artifactId>
-      <version>4.5.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/testsuite/testsuite-jaxrs-cdi/pom.xml
+++ b/testsuite/testsuite-jaxrs-cdi/pom.xml
@@ -39,7 +39,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>fluent-hc</artifactId>
-      <version>4.5.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/testsuite/testsuite-jaxrs-ejb/pom.xml
+++ b/testsuite/testsuite-jaxrs-ejb/pom.xml
@@ -39,7 +39,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>fluent-hc</artifactId>
-      <version>4.5.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/testsuite/testsuite-jaxrs/pom.xml
+++ b/testsuite/testsuite-jaxrs/pom.xml
@@ -53,7 +53,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/testsuite/testsuite-jolokia-keycloak/pom.xml
+++ b/testsuite/testsuite-jolokia-keycloak/pom.xml
@@ -45,7 +45,6 @@
     <dependency>
     	<groupId>org.apache.httpcomponents</groupId>
     	<artifactId>httpclient</artifactId>
-    	<version>4.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/testsuite/testsuite-jolokia/pom.xml
+++ b/testsuite/testsuite-jolokia/pom.xml
@@ -41,7 +41,6 @@
     <dependency>
     	<groupId>org.apache.httpcomponents</groupId>
     	<artifactId>httpclient</artifactId>
-    	<version>4.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/testsuite/testsuite-jsf/pom.xml
+++ b/testsuite/testsuite-jsf/pom.xml
@@ -34,7 +34,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>fluent-hc</artifactId>
-      <version>4.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/testsuite/testsuite-jsp/pom.xml
+++ b/testsuite/testsuite-jsp/pom.xml
@@ -30,7 +30,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>fluent-hc</artifactId>
-      <version>4.5.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/testsuite/testsuite-maven-plugin/pom.xml
+++ b/testsuite/testsuite-maven-plugin/pom.xml
@@ -32,7 +32,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>fluent-hc</artifactId>
-      <version>4.5.2</version>
       <scope>test</scope>
     </dependency>
 

--- a/testsuite/testsuite-maven-plugin/src/test/resources/testing-project/pom.xml
+++ b/testsuite/testsuite-maven-plugin/src/test/resources/testing-project/pom.xml
@@ -45,8 +45,8 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>fluent-hc</artifactId>
-      <version>4.5.2</version>
       <scope>test</scope>
+      <version>4.5.2</version>
     </dependency>
   </dependencies>
 

--- a/testsuite/testsuite-mod_cluster/pom.xml
+++ b/testsuite/testsuite-mod_cluster/pom.xml
@@ -46,7 +46,6 @@
     <dependency>
     	<groupId>org.apache.httpcomponents</groupId>
     	<artifactId>httpclient</artifactId>
-    	<version>4.5.2</version>
       <scope>test</scope>
     </dependency>
 

--- a/testsuite/testsuite-servlet-cdi/pom.xml
+++ b/testsuite/testsuite-servlet-cdi/pom.xml
@@ -39,7 +39,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>fluent-hc</artifactId>
-      <version>4.5.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/testsuite/testsuite-servlet-ejb/pom.xml
+++ b/testsuite/testsuite-servlet-ejb/pom.xml
@@ -39,7 +39,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>fluent-hc</artifactId>
-      <version>4.5.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/testsuite/testsuite-servlet-jpa-jta/pom.xml
+++ b/testsuite/testsuite-servlet-jpa-jta/pom.xml
@@ -48,7 +48,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>fluent-hc</artifactId>
-      <version>4.5.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/testsuite/testsuite-zipkin-jaxrs/pom.xml
+++ b/testsuite/testsuite-zipkin-jaxrs/pom.xml
@@ -52,7 +52,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Motivation
----------
Enable prod alignment of the affected dependencies

Modifications
-------------
The affected dependencies have been added to bom-dependency/pom.xml
Additionally, org.apache.httpcomponents:httpclient has been downgraded to 4.5.0 (from 4.5.2)
and its version has been moved to the parent pom

Result
------
All the dependencies of the prod build are now aligned.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
