### PR TITLE
SWARM-1327: Fix file leaks in tests and add new maven enforcer rule to check if a file exist by pattern to avoid same problem in future

### DIFF
--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/AnnotationBasedMain.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/AnnotationBasedMain.java
@@ -29,6 +29,8 @@ import org.wildfly.swarm.arquillian.CreateSwarm;
 public class AnnotationBasedMain {
     public static final String ANNOTATED_CLASS_NAME = "swarm.arquillian.createswarm.class";
 
+    private static Swarm swarm;
+
     protected AnnotationBasedMain() {
     }
 
@@ -54,8 +56,13 @@ public class AnnotationBasedMain {
             }
 
             boolean startEagerly = anno.startEagerly();
-            ((Swarm) method.invoke(null)).start().deploy();
+            swarm = ((Swarm) method.invoke(null));
+            swarm.start().deploy();
         }
 
+    }
+
+    public static void stopMain() throws Exception {
+        swarm.stop();
     }
 }

--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.io.InputStreamReader;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -53,6 +52,7 @@ import org.wildfly.swarm.arquillian.CreateSwarm;
 import org.wildfly.swarm.arquillian.adapter.resources.ContextRoot;
 import org.wildfly.swarm.arquillian.resolver.ShrinkwrapArtifactResolvingHelper;
 import org.wildfly.swarm.bootstrap.util.BootstrapProperties;
+import org.wildfly.swarm.bootstrap.util.TempFileManager;
 import org.wildfly.swarm.internal.FileSystemLayout;
 import org.wildfly.swarm.spi.api.DependenciesContainer;
 import org.wildfly.swarm.spi.api.JARArchive;
@@ -279,13 +279,17 @@ public class UberjarSimpleContainer implements SimpleContainer {
         }
 
         executor.withProperty("java.net.preferIPv4Stack", "true");
+
+        File processFile = File.createTempFile("mainprocessfile", null);
+        processFile.deleteOnExit();
+
+        executor.withProcessFile(processFile);
+
         executor.withJVMArguments(getJavaVmArgumentsList());
         executor.withExecutableJar(executable.toPath());
 
-        File workingDirectory = Files.createTempDirectory("arquillian").toFile();
-        workingDirectory.deleteOnExit();
+        File workingDirectory = TempFileManager.INSTANCE.newTempDirectory("arquillian", null);
         executor.withWorkingDirectory(workingDirectory.toPath());
-
 
         this.process = executor.execute();
         this.process.getOutputStream().close();

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/Main.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/Main.java
@@ -15,6 +15,21 @@
  */
 package org.wildfly.swarm.bootstrap;
 
+import static java.nio.file.StandardWatchEventKinds.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.nio.file.WatchEvent.Kind;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 import org.wildfly.swarm.bootstrap.env.ApplicationEnvironment;
 import org.wildfly.swarm.bootstrap.modules.BootModuleLoader;
 import org.wildfly.swarm.bootstrap.performance.Performance;
@@ -25,6 +40,16 @@ import org.wildfly.swarm.bootstrap.util.BootstrapProperties;
  */
 public class Main {
 
+    public static final String MAIN_PROCESS_FILE = "org.wildfly.swarm.mainProcessFile";
+
+    private static WatchService watcher;
+
+    private static Map<WatchKey,Path> keys;
+
+    private static ExecutorService shutdownService;
+
+    private static MainInvoker mainInvoker;
+
     public Main(String... args) throws Throwable {
         this.args = args;
     }
@@ -34,6 +59,30 @@ public class Main {
             Performance.start();
             //TODO Move property key to -spi
             System.setProperty(BootstrapProperties.IS_UBERJAR, Boolean.TRUE.toString());
+
+            String processFile = System.getProperty(MAIN_PROCESS_FILE);
+
+            if (processFile != null) {
+                shutdownService = Executors.newSingleThreadExecutor();
+                shutdownService.submit(() -> {
+                        File uuidFile = new File(processFile);
+                        try {
+                            register(uuidFile.getParentFile(), uuidFile.toPath());
+                            processEvents(uuidFile.toPath());
+                            if (mainInvoker != null) {
+                                mainInvoker.stop();
+                            }
+                            //Exit gracefully
+                            System.exit(0);
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        }
+
+                        return null;
+                    }
+                );
+            }
+
             new Main(args).run();
         } catch (Throwable t) {
             t.printStackTrace();
@@ -41,9 +90,55 @@ public class Main {
         }
     }
 
+    private static void register(File directory, Path file) throws IOException {
+        watcher = FileSystems.getDefault().newWatchService();
+        keys = new HashMap<WatchKey,Path>();
+        WatchKey key = directory.toPath().register(watcher, ENTRY_DELETE);
+        keys.put(key, directory.toPath());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void processEvents(Path file) {
+        for (;;) {
+
+            WatchKey key;
+            try {
+                key = watcher.take();
+            } catch (InterruptedException x) {
+                return;
+            }
+
+            Path dir = keys.get(key);
+            if (dir == null) {
+                continue;
+            }
+
+            for (WatchEvent<?> event: key.pollEvents()) {
+                Kind<?> kind = event.kind();
+
+                WatchEvent<Path> ev = (WatchEvent<Path>)event;
+                Path name = ev.context();
+                Path child = dir.resolve(name);
+
+                if (kind == ENTRY_DELETE && child.equals(file)) {
+                    return;
+                }
+            }
+
+            boolean valid = key.reset();
+            if (!valid) {
+                keys.remove(key);
+                if (keys.isEmpty()) {
+                    break;
+                }
+            }
+        }
+    }
+
     public void run() throws Throwable {
         setupBootModuleLoader();
-        new MainInvoker(ApplicationEnvironment.get().getMainClassName(), this.args).invoke();
+        mainInvoker = new MainInvoker(ApplicationEnvironment.get().getMainClassName(), this.args);
+        mainInvoker.invoke();
     }
 
     public void setupBootModuleLoader() {

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/MainInvoker.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/MainInvoker.java
@@ -40,6 +40,19 @@ public class MainInvoker {
         emitReady();
     }
 
+    public void stop() throws Exception {
+        Method stopMethod = null;
+        Class<?> mainClass = mainMethod.getDeclaringClass();
+        try {
+            stopMethod = mainClass.getDeclaredMethod("stopMain");
+        } catch (NoSuchMethodException e) {
+        }
+
+        if (stopMethod != null) {
+            stopMethod.invoke(mainClass, (Object[]) null);
+        }
+    }
+
     protected void emitReady() throws Exception {
         Module module = Module.getBootModuleLoader().loadModule(ModuleIdentifier.create("swarm.container"));
         Class<?> messagesClass = module.getClassLoader().loadClass("org.wildfly.swarm.internal.SwarmMessages");

--- a/core/bootstrap/src/test/java/org/wildfly/swarm/bootstrap/modules/GradleResolverTest.java
+++ b/core/bootstrap/src/test/java/org/wildfly/swarm/bootstrap/modules/GradleResolverTest.java
@@ -2,6 +2,7 @@ package org.wildfly.swarm.bootstrap.modules;
 
 import org.jboss.modules.maven.ArtifactCoordinates;
 import org.junit.Test;
+import org.wildfly.swarm.bootstrap.util.TempFileManager;
 
 import java.io.File;
 import java.io.IOException;
@@ -25,7 +26,8 @@ public class GradleResolverTest {
     @Test
     public void downloadFromRemoteRepository() throws IOException {
         //GIVEN
-        Path gradleCachePath = Files.createTempDirectory(".gradle");
+        File dirFile = TempFileManager.INSTANCE.newTempDirectory(".gradle", null);
+        Path gradleCachePath = dirFile.toPath();
         String group = "org.wildfly.swarm";
         String packaging = "jar";
         String artifact = "bootstrap";
@@ -48,7 +50,8 @@ public class GradleResolverTest {
     @Test
     public void downloadFromRemoteRepository_unknown() throws IOException {
         //GIVEN
-        Path gradleCachePath = Files.createTempDirectory(".gradle");
+        File dirFile = TempFileManager.INSTANCE.newTempDirectory(".gradle", null);
+        Path gradleCachePath = dirFile.toPath();
         String group = "org.wildfly.swarm";
         String packaging = "jar";
         String artifact = "test";
@@ -104,7 +107,8 @@ public class GradleResolverTest {
     @Test
     public void testResolveArtifact() throws IOException {
         //GIVEN
-        Path gradleCachePath = Files.createTempDirectory("gradle");
+        File dirFile = TempFileManager.INSTANCE.newTempDirectory("gradle", null);
+        Path gradleCachePath = dirFile.toPath();
         String group = "org.wildfly.swarm";
         String packaging = "jar";
         String artifact = "test";
@@ -126,7 +130,8 @@ public class GradleResolverTest {
     @Test
     public void testResolveArtifact_latest() throws IOException, InterruptedException {
         //GIVEN
-        Path gradleCachePath = Files.createTempDirectory("gradle");
+        File dirFile = TempFileManager.INSTANCE.newTempDirectory("gradle", null);
+        Path gradleCachePath = dirFile.toPath();
         String group = "org.wildfly.swarm";
         String packaging = "jar";
         String artifact = "test";
@@ -151,7 +156,8 @@ public class GradleResolverTest {
     @Test
     public void testResolveArtifact_notExists() throws IOException {
         //GIVEN
-        Path gradleCachePath = Files.createTempDirectory("gradle");
+        File dirFile = TempFileManager.INSTANCE.newTempDirectory("gradle", null);
+        Path gradleCachePath = dirFile.toPath();
         String group = "org.wildfly.swarm";
         String packaging = "jar";
         String artifact = "test";

--- a/core/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/core/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -130,6 +130,8 @@ public class Swarm {
 
     private static final String PROJECT_STAGES_FILE = "project-stages.yml";
 
+    private static Swarm swarm;
+
     private final CommandLine commandLine;
 
     /**
@@ -394,6 +396,7 @@ public class Swarm {
      * @throws Exception If an error occurs.
      */
     public Swarm stop() throws Exception {
+
         if (this.server == null) {
             throw SwarmMessages.MESSAGES.containerNotStarted("stop()");
         }
@@ -618,7 +621,8 @@ public class Swarm {
             System.setProperty(BOOT_MODULE_PROPERTY, "org.wildfly.swarm.bootstrap.modules.BootModuleLoader");
         }
 
-        Swarm swarm = new Swarm(args);
+        swarm = new Swarm(args);
+
         try {
             swarm.start();
             if (System.getProperty("swarm.inhibit.default-deployment") == null) {
@@ -632,6 +636,15 @@ public class Swarm {
             tryToStopAfterStartupError(t, swarm);
             throw t;
         }
+    }
+
+    public static void stopMain() throws Exception {
+       try {
+            if (swarm != null) {
+                swarm.stop();
+            }
+       } catch (Exception e) {
+       }
     }
 
     private static void tryToStopAfterStartupError(final Throwable errorCause, final Swarm swarm) {

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeDeployer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeDeployer.java
@@ -284,6 +284,10 @@ public class RuntimeDeployer implements Deployer {
     void stop() {
     }
 
+    public void removeAllContent() throws IOException {
+        this.contentRepository.removeAllContent();
+    }
+
     @Inject
     DeploymentContext deploymentContext;
 

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
@@ -256,6 +256,7 @@ public class RuntimeServer implements Server {
         this.containerStarted = false;
         this.container = null;
         this.client = null;
+        this.deployer.get().removeAllContent();
         this.deployer = null;
     }
 

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/TempFileProviderProducer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/TempFileProviderProducer.java
@@ -21,8 +21,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
 import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Disposes;
 import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
 
@@ -61,14 +61,12 @@ public class TempFileProviderProducer {
         return this.tempFileProvider;
     }
 
-    void dispose(@Disposes TempFileProvider provider) {
-        // To ensure we only close the one we produce
-        if (this.tempFileProvider == provider) {
-            try {
-                this.tempFileProvider.close();
-            } catch (IOException e) {
-                SwarmMessages.MESSAGES.errorCleaningUpTempFileProvider(e);
-            }
+    @PreDestroy
+    void close() {
+        try {
+            this.tempFileProvider.close();
+        } catch (IOException e) {
+            SwarmMessages.MESSAGES.errorCleaningUpTempFileProvider(e);
         }
     }
 

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/wildfly/SwarmContentRepository.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/wildfly/SwarmContentRepository.java
@@ -133,6 +133,21 @@ public class SwarmContentRepository implements ContentRepository, Service<Conten
 
     }
 
+    public void removeAllContent() throws IOException {
+        IOException exception = null;
+        for (Path path: this.index.values()) {
+            try {
+                Files.delete(path);
+            } catch (IOException e) {
+                exception = e;
+            }
+        }
+
+        if (exception != null) {
+            throw exception;
+        }
+    }
+
     @Override
     public Map<String, Set<String>> cleanObsoleteContent() {
         HashMap<String, Set<String>> result = new HashMap<>();

--- a/meta/fraction-metadata/src/test/java/org/wildfly/swarm/fractions/FractionUsageAnalyzerTest.java
+++ b/meta/fraction-metadata/src/test/java/org/wildfly/swarm/fractions/FractionUsageAnalyzerTest.java
@@ -17,8 +17,6 @@ package org.wildfly.swarm.fractions;
 
 import java.io.File;
 import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -26,6 +24,7 @@ import org.jboss.shrinkwrap.api.exporter.ExplodedExporter;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
+import org.wildfly.swarm.bootstrap.util.TempFileManager;
 import org.wildfly.swarm.jaxrs.JAXRSArchive;
 
 import static org.fest.assertions.Assertions.assertThat;
@@ -40,6 +39,7 @@ public class FractionUsageAnalyzerTest {
 
         final File out = Files.createTempFile(archive.getName(), ".war").toFile();
         archive.as(ZipExporter.class).exportTo(out, true);
+        out.deleteOnExit();
 
         analyzer.source(out);
         assertThat(analyzer.detectNeededFractions()
@@ -55,10 +55,10 @@ public class FractionUsageAnalyzerTest {
         archive.addClass(MyResource.class);
         FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer();
 
-        Path dir = Files.createTempDirectory(archive.getName());
-        archive.as(ExplodedExporter.class).exportExplodedInto(dir.toFile());
+        File dirFile = TempFileManager.INSTANCE.newTempDirectory("fractionusagetest", null);
+        archive.as(ExplodedExporter.class).exportExplodedInto(dirFile);
 
-        analyzer.source(dir.toFile());
+        analyzer.source(dirFile);
         assertThat(analyzer.detectNeededFractions()
                            .stream()
                            .filter(fd -> fd.getArtifactId().equals("jaxrs"))
@@ -74,6 +74,7 @@ public class FractionUsageAnalyzerTest {
 
         final File out = Files.createTempFile(archive.getName(), ".war").toFile();
         archive.as(ZipExporter.class).exportTo(out, true);
+        out.deleteOnExit();
 
         analyzer.source(out);
         assertThat(analyzer.detectNeededFractions()

--- a/plugins/maven-enforcer-pattern-size/pom.xml
+++ b/plugins/maven-enforcer-pattern-size/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>wildfly-swarm-enforcer-pattern-size</artifactId>
+  <version>2017.7.0-SNAPSHOT</version>
+
+  <name>Maven enforcer pattern size rule</name>
+  <description>Maven enforcer pattern size rule</description>
+
+   <packaging>jar</packaging>
+
+   <dependencies>
+    <dependency>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.4.1</version>
+        <scope>provided</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/plugins/maven-enforcer-pattern-size/src/main/java/org/wildfly/swarm/plugin/enforcer/patternsize/RequireFilePatternSize.java
+++ b/plugins/maven-enforcer-pattern-size/src/main/java/org/wildfly/swarm/plugin/enforcer/patternsize/RequireFilePatternSize.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.plugin.enforcer.patternsize;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitOption;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRule;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
+
+/**
+ *
+ * @author Juan Gonzalez
+ *
+ */
+public class RequireFilePatternSize implements EnforcerRule {
+
+    private RequiredFilePattern[] filePatterns;
+
+    public RequiredFilePattern[] getRequiredFilePatterns() {
+        return filePatterns;
+    }
+
+    public void setRequiredFilePatterns(RequiredFilePattern[] filePatterns) {
+        this.filePatterns = filePatterns;
+    }
+
+    List<RequiredFilePatternFailure> checkFilePattern(final RequiredFilePattern requiredFilePattern) throws IOException {
+        if (requiredFilePattern == null || requiredFilePattern.getDirectory() == null) {
+            return null;
+        }
+
+        if (requiredFilePattern.getPattern() == null) {
+            return null;
+        }
+
+        final Pattern pattern = Pattern.compile(requiredFilePattern.getPattern());
+
+        String directory = requiredFilePattern.getDirectory();
+        File directoryFile = new File(directory);
+
+        final List<File> matchedFiles = new ArrayList<File>();
+
+        if (Files.isDirectory(directoryFile.toPath())) {
+            Files.walkFileTree(directoryFile.toPath(), EnumSet.of(FileVisitOption.FOLLOW_LINKS),
+                requiredFilePattern.isRecursive() ? Integer.MAX_VALUE : 1,
+                        new SimpleFileVisitor<Path>() {
+                        @Override
+                        public FileVisitResult visitFile(Path filePath, BasicFileAttributes attrs) throws IOException {
+                             Matcher matcher = pattern.matcher(filePath.toAbsolutePath().toString());
+                             if (matcher.matches()) {
+                                 File file = filePath.toFile();
+                                 matchedFiles.add(file);
+                             }
+
+                            return super.visitFile(filePath, attrs);
+                        }
+             });
+        }
+
+        List<RequiredFilePatternFailure> failures = new ArrayList<RequiredFilePatternFailure>();
+        for (File matchedFile : matchedFiles) {
+            long length = matchedFile.length();
+            if (requiredFilePattern.getMinSize() != -1 && length < requiredFilePattern.getMinSize()) {
+                failures.add(new RequiredFilePatternFailure(requiredFilePattern, matchedFile + " size(" + length + ") too small. Min. is " + requiredFilePattern.getMinSize()));
+            } else if (requiredFilePattern.getMaxSize() != -1 && length > requiredFilePattern.getMaxSize()) {
+                failures.add(new RequiredFilePatternFailure(requiredFilePattern, matchedFile + " size(" + length + ") too large. Max. is " + requiredFilePattern.getMaxSize()));
+            }
+        }
+
+        return failures;
+    }
+
+    public void execute(EnforcerRuleHelper helper)
+            throws EnforcerRuleException {
+
+        RequiredFilePattern[] requiredFilePatterns = getRequiredFilePatterns();
+        List<RequiredFilePatternFailure> failures = new ArrayList<RequiredFilePatternFailure>();
+
+        if (requiredFilePatterns.length > 0) {
+            for (RequiredFilePattern requiredFilePattern: requiredFilePatterns) {
+                if (requiredFilePattern == null) {
+                    failures.add(new RequiredFilePatternFailure(requiredFilePattern, "File pattern is empty"));
+                }
+
+                List<RequiredFilePatternFailure> failure = null;
+
+                try{
+                    failure = checkFilePattern(requiredFilePattern);
+                } catch (IOException e) {
+                    failures.add(new RequiredFilePatternFailure(requiredFilePattern, "Error while traversing files"));
+                }
+
+                if (failure != null && failure.size() > 0) {
+                    failures.addAll(failure);
+                }
+            }
+        }  else {
+            throw new EnforcerRuleException("The file pattern list is empty.");
+        }
+
+        if (!failures.isEmpty()) {
+            String message = "Some files does not fullfill provided pattern rules:\n";
+            StringBuilder buf = new StringBuilder();
+
+            if (message != null) {
+                buf.append(message + "\n");
+            }
+
+            for (RequiredFilePatternFailure fileFailure : failures) {
+                if (fileFailure != null) {
+                    buf.append("Failed pattern " + fileFailure.getPattern() + " in directory " + fileFailure.getDirectory() + "." + fileFailure.getMessage() + "\n");
+                } else {
+                    buf.append("(an empty file pattern or directory was given)\n");
+                }
+            }
+
+            throw new EnforcerRuleException(buf.toString());
+        }
+    }
+
+    @Override
+    public boolean isCacheable() {
+        return false;
+    }
+
+    @Override
+    public boolean isResultValid(EnforcerRule cachedRule) {
+        return false;
+    }
+
+    @Override
+    public String getCacheId() {
+        return null;
+    }
+}

--- a/plugins/maven-enforcer-pattern-size/src/main/java/org/wildfly/swarm/plugin/enforcer/patternsize/RequiredFilePattern.java
+++ b/plugins/maven-enforcer-pattern-size/src/main/java/org/wildfly/swarm/plugin/enforcer/patternsize/RequiredFilePattern.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.plugin.enforcer.patternsize;
+
+/**
+ *
+ * @author Juan Gonzalez
+ *
+ */
+public class RequiredFilePattern {
+
+    private String directory;
+    private String pattern;
+    private boolean recursive;
+    public boolean isRecursive() {
+        return recursive;
+    }
+
+    public void setRecursive(boolean recursive) {
+        this.recursive = recursive;
+    }
+
+    private long minSize = -1;
+    private long maxSize = -1;
+
+    public long getMinSize() {
+        return minSize;
+    }
+
+    public void setMinSize(long minSize) {
+        this.minSize = minSize;
+    }
+
+    public long getMaxSize() {
+        return maxSize;
+    }
+
+    public void setMaxSize(long maxSize) {
+        this.maxSize = maxSize;
+    }
+
+    public String getDirectory() {
+        return directory;
+    }
+
+    public void setDirectory(String directory) {
+        this.directory = directory;
+    }
+
+    public String getPattern() {
+        return pattern;
+    }
+
+    public void setPattern(String pattern) {
+        this.pattern = pattern;
+    }
+}

--- a/plugins/maven-enforcer-pattern-size/src/main/java/org/wildfly/swarm/plugin/enforcer/patternsize/RequiredFilePatternFailure.java
+++ b/plugins/maven-enforcer-pattern-size/src/main/java/org/wildfly/swarm/plugin/enforcer/patternsize/RequiredFilePatternFailure.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.plugin.enforcer.patternsize;
+
+/**
+ *
+ * @author Juan Gonzalez
+ *
+ */
+public class RequiredFilePatternFailure extends RequiredFilePattern {
+
+    public RequiredFilePatternFailure(RequiredFilePattern pattern, String message) {
+        super();
+        setDirectory(pattern.getDirectory());
+        setMaxSize(pattern.getMaxSize());
+        setMinSize(pattern.getMinSize());
+        setPattern(pattern.getPattern());
+        this.message = message;
+    }
+
+    private String message;
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/StartMojo.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/StartMojo.java
@@ -291,6 +291,7 @@ public class StartMojo extends AbstractSwarmMojo {
         }
     }
 
+    @SuppressWarnings("unchecked")
     List<Path> dependencies(final Path archiveContent,
                             final boolean scanDependencies) throws MojoFailureException {
         final List<Path> elements = new ArrayList<>();
@@ -329,6 +330,7 @@ public class StartMojo extends AbstractSwarmMojo {
                         Files.createTempFile("swarm-", "-cp.txt").toFile();
 
                 tmp.deleteOnExit();
+                getPluginContext().put("swarm-cp-file", tmp);
                 declaredDependencies.writeTo(tmp);
                 getLog().debug("dependency info stored at: " + tmp.getAbsolutePath());
                 this.properties.setProperty("swarm.cp.info", tmp.getAbsolutePath());

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/StopMojo.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/StopMojo.java
@@ -15,6 +15,7 @@
  */
 package org.wildfly.swarm.plugin.maven;
 
+import java.io.File;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -52,6 +53,12 @@ public class StopMojo extends AbstractMojo {
 
         for (SwarmProcess each : value) {
             stop(each);
+        }
+
+        File tmp = (File) getPluginContext().get("swarm-cp-file");
+
+        if (tmp != null && tmp.exists()) {
+            tmp.delete();
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -251,6 +251,41 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+	<groupId>org.apache.maven.plugins</groupId>
+	<artifactId>maven-enforcer-plugin</artifactId>
+	<version>1.4.1</version>
+	<dependencies>
+	  <dependency>
+	    <groupId>org.wildfly.swarm</groupId>
+	    <artifactId>wildfly-swarm-enforcer-pattern-size</artifactId>
+	    <version>2017.7.0-SNAPSHOT</version>
+	  </dependency>
+	</dependencies>
+	<executions>
+	  <execution>
+	    <id>enforce</id>
+	    <phase>verify</phase>
+	    <configuration>
+	      <rules>
+		<patternSizeRule implementation="org.wildfly.swarm.plugin.enforcer.patternsize.RequireFilePatternSize">
+		  <requiredFilePatterns>
+		      <requiredFilePattern>
+		        <maxSize>0</maxSize>
+		        <recursive>false</recursive>
+			<directory>${project.build.directory}</directory>
+			<pattern>\S+[0-9]{5,}.\S{5,}</pattern>
+		      </requiredFilePattern>
+		  </requiredFilePatterns>
+		</patternSizeRule>
+	      </rules>
+	    </configuration>
+	    <goals>
+	      <goal>enforce</goal>
+	    </goals>
+	  </execution>
+	</executions>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>
@@ -312,6 +347,10 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>build-resources</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>wildfly-swarm-enforcer-pattern-size</artifactId>
     </dependency>
   </dependencies>
 
@@ -490,6 +529,11 @@
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>build-resources</artifactId>
+        <version>2017.7.0-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>wildfly-swarm-enforcer-pattern-size</artifactId>
         <version>2017.7.0-SNAPSHOT</version>
       </dependency>
       <dependency>
@@ -1313,7 +1357,9 @@
   </pluginRepositories>
 
   <modules>
+    <module>plugins/maven-enforcer-pattern-size</module>
     <module>build-resources</module>
+
 
     <module>tools</module>
 

--- a/testsuite/testsuite-camel-jms/src/main/java/org/wildfly/swarm/camel/test/jms/Main.java
+++ b/testsuite/testsuite-camel-jms/src/main/java/org/wildfly/swarm/camel/test/jms/Main.java
@@ -40,9 +40,11 @@ public class Main {
 
     static final String QUEUE_JNDI_NAME = "java:/" + QUEUE_NAME;
 
+    private static Swarm container;
+
     public static void main(String... args) throws Exception {
         System.err.println("RUNNING MAIN!");
-        Swarm container = new Swarm().fraction(new CamelFraction());
+        container = new Swarm().fraction(new CamelFraction());
         container.fraction(MessagingFraction.createDefaultFraction()
                                    .defaultServer((s) -> {
                                        s.jmsQueue(new JMSQueue<>(QUEUE_NAME).entry(QUEUE_JNDI_NAME));
@@ -51,4 +53,7 @@ public class Main {
         container.start().deploy();
     }
 
+    public static void stopMain() throws Exception {
+        container.stop();
+    }
 }

--- a/testsuite/testsuite-camel-jmx/src/main/java/org/wildfly/swarm/camel/test/jmx/Main.java
+++ b/testsuite/testsuite-camel-jmx/src/main/java/org/wildfly/swarm/camel/test/jmx/Main.java
@@ -32,11 +32,13 @@ import org.wildfly.swarm.camel.core.CamelFraction;
  */
 public class Main {
 
+    private static Swarm swarm;
+
     protected Main() {
     }
 
     public static void main(String... args) throws Exception {
-        Swarm swarm = new Swarm(args).fraction(new CamelFraction().addRouteBuilder(new RouteBuilder() {
+        swarm = new Swarm(args).fraction(new CamelFraction().addRouteBuilder(new RouteBuilder() {
             @Override
             public void configure() throws Exception {
                 from("direct:start")
@@ -46,4 +48,9 @@ public class Main {
 
         swarm.start().deploy();
     }
+
+    public static void stopMain() throws Exception {
+        swarm.stop();
+    }
+
 }

--- a/testsuite/testsuite-cdi/src/test/java/org/wildfly/swarm/cdi/test/basic/CDITest.java
+++ b/testsuite/testsuite-cdi/src/test/java/org/wildfly/swarm/cdi/test/basic/CDITest.java
@@ -20,6 +20,7 @@ public class CDITest {
         FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer();
 
         final File out = Files.createTempFile(archive.getName(), ".war").toFile();
+        out.deleteOnExit();
         archive.as(ZipExporter.class).exportTo(out, true);
         analyzer.source(out);
 
@@ -36,6 +37,7 @@ public class CDITest {
         FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer();
 
         final File out = Files.createTempFile(archive.getName(), ".war").toFile();
+        out.deleteOnExit();
         archive.as(ZipExporter.class).exportTo(out, true);
         analyzer.source(out);
 
@@ -52,6 +54,7 @@ public class CDITest {
         FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer();
 
         final File out = Files.createTempFile(archive.getName(), ".war").toFile();
+        out.deleteOnExit();
         archive.as(ZipExporter.class).exportTo(out, true);
         analyzer.source(out);
 

--- a/testsuite/testsuite-container/src/test/java/org/wildfly/swarm/container/test/DeploymentFailureTest.java
+++ b/testsuite/testsuite-container/src/test/java/org/wildfly/swarm/container/test/DeploymentFailureTest.java
@@ -1,0 +1,31 @@
+package org.wildfly.swarm.container.test;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.Test;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.container.DeploymentException;
+import org.wildfly.swarm.spi.api.JARArchive;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.fest.assertions.Fail.fail;
+
+public class DeploymentFailureTest {
+
+  @Test
+  public void testDeploymentFailure() throws Exception {
+      Swarm swarm = new Swarm();
+      swarm.start();
+      JARArchive a = ShrinkWrap.create(JARArchive.class, "bad-deployment.jar");
+      a.addModule("com.i.do.no.exist");
+      try {
+          swarm.deploy(a);
+          fail("should have throw a DeploymentException");
+      } catch (DeploymentException e) {
+          // expected and correct
+          assertThat(e.getArchive()).isSameAs(a);
+          assertThat(e.getMessage()).contains("org.jboss.modules.ModuleNotFoundException: com.i.do.no.exist:main");
+      }
+
+      swarm.stop();
+  }
+}

--- a/testsuite/testsuite-container/src/test/java/org/wildfly/swarm/container/test/DeploymentSuccessTest.java
+++ b/testsuite/testsuite-container/src/test/java/org/wildfly/swarm/container/test/DeploymentSuccessTest.java
@@ -18,34 +18,15 @@ package org.wildfly.swarm.container.test;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.junit.Test;
-import org.wildfly.swarm.Swarm;
-import org.wildfly.swarm.container.DeploymentException;
-import org.wildfly.swarm.spi.api.JARArchive;
 
-import static org.fest.assertions.Assertions.assertThat;
-import static org.fest.assertions.Fail.fail;
+import org.wildfly.swarm.Swarm;
+
+import org.wildfly.swarm.spi.api.JARArchive;
 
 /**
  * @author Bob McWhirter
  */
-public class DeploymentTest {
-
-    @Test
-    public void testDeploymentFailure() throws Exception {
-        Swarm swarm = new Swarm();
-        swarm.start();
-        JARArchive a = ShrinkWrap.create(JARArchive.class, "bad-deployment.jar");
-        a.addModule("com.i.do.no.exist");
-        try {
-            swarm.deploy(a);
-            fail("should have throw a DeploymentException");
-        } catch (DeploymentException e) {
-            // expected and correct
-            assertThat(e.getArchive()).isSameAs(a);
-            assertThat(e.getMessage()).contains("org.jboss.modules.ModuleNotFoundException: com.i.do.no.exist:main");
-        }
-        swarm.stop();
-    }
+public class DeploymentSuccessTest {
 
     @Test
     public void testDeploymentSuccess() throws Exception {

--- a/testsuite/testsuite-datasources/src/main/java/org/wildfly/swarm/datasources/test/Main.java
+++ b/testsuite/testsuite-datasources/src/main/java/org/wildfly/swarm/datasources/test/Main.java
@@ -23,11 +23,13 @@ import org.wildfly.swarm.datasources.DatasourcesFraction;
  */
 public class Main {
 
+    private static Swarm swarm;
+
     protected Main() {
     }
 
     public static void main(String... args) throws Exception {
-        Swarm swarm = new Swarm(args);
+        swarm = new Swarm(args);
 
         swarm.fraction(
                 new DatasourcesFraction()
@@ -46,5 +48,10 @@ public class Main {
 
         swarm.start().deploy();
     }
+
+    public static void stopMain() throws Exception {
+        swarm.stop();
+    }
+
 }
 

--- a/testsuite/testsuite-default-deployment/src/main/java/org/wildfly/swarm/defaultdeployment/Main.java
+++ b/testsuite/testsuite-default-deployment/src/main/java/org/wildfly/swarm/defaultdeployment/Main.java
@@ -9,12 +9,14 @@ import org.wildfly.swarm.Swarm;
  */
 public class Main {
 
+    private static Swarm swarm;
+
     private Main() {
 
     }
 
     public static void main(String... args) throws Exception {
-        Swarm swarm = new Swarm(args);
+        swarm = new Swarm(args);
         swarm.start();
         Archive<?> deployment = swarm.createDefaultDeployment();
 
@@ -29,5 +31,9 @@ public class Main {
         }
 
         swarm.deploy(deployment);
+    }
+
+    public static void stopMain() throws Exception {
+        swarm.stop();
     }
 }

--- a/testsuite/testsuite-jpa/src/test/java/org/wildfly/swarm/jpa/JPATest.java
+++ b/testsuite/testsuite-jpa/src/test/java/org/wildfly/swarm/jpa/JPATest.java
@@ -8,6 +8,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.exporter.ExplodedExporter;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.junit.Test;
+import org.wildfly.swarm.bootstrap.util.TempFileManager;
 import org.wildfly.swarm.fractions.FractionUsageAnalyzer;
 import org.wildfly.swarm.spi.api.JARArchive;
 
@@ -22,6 +23,7 @@ public class JPATest {
         FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer();
 
         final File out = Files.createTempFile(archive.getName(), ".war").toFile();
+        out.deleteOnExit();
         archive.as(ZipExporter.class).exportTo(out, true);
 
         analyzer.source(out);
@@ -37,10 +39,10 @@ public class JPATest {
         archive.addAsResource("META-INF/persistence.xml");
         FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer();
 
-        Path dir = Files.createTempDirectory(archive.getName());
-        archive.as(ExplodedExporter.class).exportExplodedInto(dir.toFile());
+        File dirFile = TempFileManager.INSTANCE.newTempDirectory("jpatest", null);
+        archive.as(ExplodedExporter.class).exportExplodedInto(dirFile);
 
-        analyzer.source(dir.toFile());
+        analyzer.source(dirFile);
         assertThat(analyzer.detectNeededFractions()
                        .stream()
                        .filter(fd -> fd.getArtifactId().equals("jpa"))

--- a/testsuite/testsuite-jsf/src/test/java/org/wildfly/swarm/jsf/test/JsfIT.java
+++ b/testsuite/testsuite-jsf/src/test/java/org/wildfly/swarm/jsf/test/JsfIT.java
@@ -47,6 +47,7 @@ public class JsfIT {
         FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer();
 
         final File out = Files.createTempFile(archive.getName(), ".war").toFile();
+        out.deleteOnExit();
         archive.as(ZipExporter.class).exportTo(out, true);
         analyzer.source(out);
 
@@ -63,6 +64,7 @@ public class JsfIT {
         FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer();
 
         final File out = Files.createTempFile(archive.getName(), ".war").toFile();
+        out.deleteOnExit();
         archive.as(ZipExporter.class).exportTo(out, true);
         analyzer.source(out);
         assertThat(analyzer.detectNeededFractions()

--- a/testsuite/testsuite-logging/src/main/java/org/wildfly/swarm/logging/test/MainWithProperties.java
+++ b/testsuite/testsuite-logging/src/main/java/org/wildfly/swarm/logging/test/MainWithProperties.java
@@ -7,6 +7,8 @@ import org.wildfly.swarm.Swarm;
  */
 public class MainWithProperties {
 
+    private static Swarm swarm;
+
     private MainWithProperties() {
     }
 
@@ -14,8 +16,12 @@ public class MainWithProperties {
         System.setProperty("swarm.logging", "TRACE");
         System.setProperty("swarm.logging.custom.category", "DEBUG");
         System.setProperty("swarm.logging.pattern-formatters.MY_COLOR_PATTERN.pattern", "%K{level}%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p (%t) [%c.%M()] %s%e%n");
-        Swarm swarm = new Swarm(args);
+        swarm = new Swarm(args);
         swarm.start().deploy();
+    }
+
+    public static void stopMain() throws Exception {
+        swarm.stop();
     }
 
 }

--- a/testsuite/testsuite-maven-plugin/src/test/resources/testing-project/src/main/java/org/wildfly/swarm/test/Main.java
+++ b/testsuite/testsuite-maven-plugin/src/test/resources/testing-project/src/main/java/org/wildfly/swarm/test/Main.java
@@ -25,16 +25,25 @@ import org.wildfly.swarm.undertow.descriptors.WebXmlAsset;
 /*END:custom main:JAR_WITH_MAIN*/
 
 public class Main {
+    
+    private static Swarm swarm;
+    private static Swarm swarm2;
+
     public static void main(String[] args) throws Exception {
         /*BEGIN:custom main:JAR_WITH_MAIN*/
-        Swarm swarm = new Swarm();
+        swarm = new Swarm();
         WARArchive war = ShrinkWrap.create(WARArchive.class)
                 .addPackage(Main.class.getPackage())
                 .addAsWebInfResource(new ClassLoaderAsset("web.xml", Main.class.getClassLoader()), WebXmlAsset.NAME);
         swarm.start().deploy(war);
         /*END:custom main:JAR_WITH_MAIN*/
         /*BEGIN:custom main:WAR_WITH_MAIN*/
-        new Swarm().start().deploy();
+        swarm2 = new Swarm().start().deploy();
         /*END:custom main:WAR_WITH_MAIN*/
+    }
+
+    public static void stopMain() throws Exception {
+        swarm.stop();
+        swarm2.stop();
     }
 }

--- a/testsuite/testsuite-messaging/src/test/java/org/wildfly/swarm/messaging/test/MessagingTest.java
+++ b/testsuite/testsuite-messaging/src/test/java/org/wildfly/swarm/messaging/test/MessagingTest.java
@@ -20,6 +20,7 @@ public class MessagingTest {
 	    FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer();
 
 	    final File out = Files.createTempFile(archive.getName(), ".war").toFile();
+	    out.deleteOnExit();
 	    archive.as(ZipExporter.class).exportTo(out, true);
 
 	    analyzer.source(out);

--- a/testsuite/testsuite-security/src/test/java/org/wildfly/swarm/security/SecurityTest.java
+++ b/testsuite/testsuite-security/src/test/java/org/wildfly/swarm/security/SecurityTest.java
@@ -40,6 +40,7 @@ public class SecurityTest {
         FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer();
 
         final File out = Files.createTempFile(archive.getName(), ".war").toFile();
+        out.deleteOnExit();
         archive.as(ZipExporter.class).exportTo(out, true);
         analyzer.source(out);
 
@@ -56,6 +57,7 @@ public class SecurityTest {
         FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer();
 
         final File out = Files.createTempFile(archive.getName(), ".war").toFile();
+        out.deleteOnExit();
         archive.as(ZipExporter.class).exportTo(out, true);
         analyzer.source(out);
 

--- a/tools/src/main/java/org/wildfly/swarm/tools/exec/SwarmExecutor.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/exec/SwarmExecutor.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.wildfly.swarm.bootstrap.Main;
 
 /**
  * @author Bob McWhirter
@@ -206,6 +207,12 @@ public class SwarmExecutor {
         return this;
     }
 
+    public SwarmExecutor withProcessFile(File processFile) {
+        this.processFile = processFile;
+        withProperty(Main.MAIN_PROCESS_FILE, processFile.getAbsolutePath());
+        return this;
+    }
+
     public SwarmProcess execute() throws IOException {
         if (this.executable == null) {
             throw new RuntimeException("An executable jar or a main-class must be specified");
@@ -243,7 +250,7 @@ public class SwarmExecutor {
         Process process = processBuilder.start();
 
         return new SwarmProcess(
-                process,
+                process, processFile,
                 this.stdout, this.stdoutFile,
                 this.stderr, this.stderrFile);
     }
@@ -294,5 +301,7 @@ public class SwarmExecutor {
     private Path workingDirectory;
 
     private Integer debugPort;
+
+    private File processFile;
 
 }


### PR DESCRIPTION
Motivation
----------
Fix file leaks that can be left after tests. Additionally, create a maven plugin that would fail if a (temporal) file or directory isn't removed.

Modifications
-------------
Added new maven enforcer rule to verify that files/directories with an specific pattern (those having 5 or more numbers in its name) doesn't exist, hence, everything is left clean.

Thanks to these tests other (unexpected) file leaks issues were discovered and fixed as well.

Result
------
More control on which files should exist after test. Temporal files/directories are removed.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [] Have you built the project locally prior to submission with `mvn clean install`?

-----
@Ladicek @bobmcwhirter have other branches with different levels of changes for windows. This one fails in my environment, but as some tests doesn't fail always, let's see how it behaves in CI.

Together with this Pull I have other 2 options in a branch each:
- One with failing Windows tests disabling maven enforcer check. There are 16 tests in this situation. Not sure if this can be acceptable.
- Other where I just had to disable maven enforcer plugin for file leaks in just 1 test. A drawback is all jar files are exploded (even nested ones) in order to those files to be removed completely. BUT this option makes all tests execution soooooo slow in Windows I want to let it as the last option.