### PR TITLE
SWARM-1374: Fix Weld version mismatch

### DIFF
--- a/core/container/pom.xml
+++ b/core/container/pom.xml
@@ -14,7 +14,6 @@
     <relativePath>../../</relativePath>
   </parent>
 
-  <groupId>org.wildfly.swarm</groupId>
   <artifactId>container</artifactId>
 
   <name>Container</name>
@@ -25,26 +24,75 @@
   <properties>
     <swarm.fraction.internal>true</swarm.fraction.internal>
     <swarm.fraction.stability>stable</swarm.fraction.stability>
-    <version.weld-api>2.3.SP2</version.weld-api>
-    <version.weld>2.3.5.Final</version.weld>
-    <version.cdi>1.2</version.cdi>
   </properties>
 
-  <build>
-    <resources>
-      <resource>
-        <directory>${project.basedir}/src/main/resources</directory>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
-  </build>
+   <build>
+      <resources>
+         <resource>
+            <directory>${project.basedir}/src/main/resources</directory>
+            <filtering>true</filtering>
+         </resource>
+      </resources>
+      <plugins>
+         <!-- Used to verify the Weld version used for weld-se-core is the
+            same as the version provided by WildFly feature pack -->
+         <plugin>
+            <groupId>io.reformanda.semper</groupId>
+            <artifactId>dependencyversion-maven-plugin</artifactId>
+            <version>1.0.1</version>
+            <executions>
+               <execution>
+                  <id>set-versions</id>
+                  <goals>
+                     <goal>set-version</goal>
+                  </goals>
+               </execution>
+            </executions>
+            <configuration>
+               <propertySets>
+                  <propertySet>
+                     <includes>
+                        <include>org.jboss.weld:weld-core-impl:jar</include>
+                        <include>org.jboss.weld:weld-api:jar</include>
+                     </includes>
+                  </propertySet>
+               </propertySets>
+            </configuration>
+         </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>verify-weld-version</id>
+                  <phase>package</phase>
+                  <goals>
+                     <goal>run</goal>
+                  </goals>
+                  <configuration>
+                     <tasks>
+                        <fail
+                           message="Weld SE version ${version.weld-se} does not align with version provided by the WildFly feature pack!">
+                           <condition>
+                              <not>
+                                 <equals arg1="${version.weld-se}"
+                                    arg2="${org.jboss.weld:weld-core-impl:jar.version}" />
+                              </not>
+                           </condition>
+                        </fail>
+                     </tasks>
+                  </configuration>
+               </execution>
+            </executions>
+         </plugin>
+      </plugins>
+   </build>
 
   <dependencies>
     <!-- not used, only to make PME align version.weld-api-->
     <dependency>
       <groupId>org.jboss.weld</groupId>
       <artifactId>weld-api</artifactId>
-      <version>${version.weld-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -94,7 +142,6 @@
     <dependency>
       <groupId>javax.enterprise</groupId>
       <artifactId>cdi-api</artifactId>
-      <version>${version.cdi}</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>
@@ -110,7 +157,7 @@
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
       <artifactId>weld-se-core</artifactId>
-      <version>${version.weld}</version>
+      <version>${version.weld-se}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/core/container/src/main/resources/modules/org/jboss/weld/se/main/module.xml
+++ b/core/container/src/main/resources/modules/org/jboss/weld/se/main/module.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module xmlns="urn:jboss:module:1.5" name="org.jboss.weld.se">
   <resources>
-    <!--<resource-root path="weld-se-core-${version.weld}.jar"/>-->
-    <artifact name="org.jboss.weld.environment:weld-environment-common:${version.weld}"/>
-    <artifact name="org.jboss.weld:weld-api:${version.weld-api}"/>
-    <artifact name="org.jboss.weld:weld-spi:${version.weld-api}"/>
-    <artifact name="org.jboss.weld:weld-core-impl:${version.weld}"/>
-    <artifact name="org.jboss.weld.se:weld-se-core:${version.weld}"/>
+    <artifact name="org.jboss.weld.environment:weld-environment-common:${version.weld-se}"/>
+    <artifact name="org.jboss.weld:weld-api:${org.jboss.weld:weld-api:jar.version}"/>
+    <artifact name="org.jboss.weld:weld-spi:${org.jboss.weld:weld-api:jar.version}"/>
+    <artifact name="org.jboss.weld:weld-core-impl:${org.jboss.weld:weld-core-impl:jar.version}"/>
+    <artifact name="org.jboss.weld.se:weld-se-core:${version.weld-se}"/>
   </resources>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,8 @@
     <version.wildfly>10.1.0.Final</version.wildfly>
     <version.org.wildfly.core>2.2.1.Final</version.org.wildfly.core>
     <version.jboss-logmanager-ext>1.0.0.Alpha3</version.jboss-logmanager-ext>
-
+    <!-- Weld SE version must be aligned with the version used in WildFly -->
+    <version.weld-se>2.3.5.Final</version.weld-se>
 
     <version.org.arquillian>1.1.12.Final</version.org.arquillian>
     <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>
@@ -252,39 +253,39 @@
         </executions>
       </plugin>
       <plugin>
-	<groupId>org.apache.maven.plugins</groupId>
-	<artifactId>maven-enforcer-plugin</artifactId>
-	<version>1.4.1</version>
-	<dependencies>
-	  <dependency>
-	    <groupId>org.wildfly.swarm</groupId>
-	    <artifactId>wildfly-swarm-enforcer-pattern-size</artifactId>
-	    <version>2017.7.0-SNAPSHOT</version>
-	  </dependency>
-	</dependencies>
-	<executions>
-	  <execution>
-	    <id>enforce</id>
-	    <phase>verify</phase>
-	    <configuration>
-	      <rules>
-		<patternSizeRule implementation="org.wildfly.swarm.plugin.enforcer.patternsize.RequireFilePatternSize">
-		  <requiredFilePatterns>
-		      <requiredFilePattern>
-		        <maxSize>0</maxSize>
-		        <recursive>false</recursive>
-			<directory>${project.build.directory}</directory>
-			<pattern>\S+[0-9]{5,}.\S{5,}</pattern>
-		      </requiredFilePattern>
-		  </requiredFilePatterns>
-		</patternSizeRule>
-	      </rules>
-	    </configuration>
-	    <goals>
-	      <goal>enforce</goal>
-	    </goals>
-	  </execution>
-	</executions>
+         <groupId>org.apache.maven.plugins</groupId>
+         <artifactId>maven-enforcer-plugin</artifactId>
+         <version>1.4.1</version>
+         <dependencies>
+            <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>wildfly-swarm-enforcer-pattern-size</artifactId>
+            <version>2017.7.0-SNAPSHOT</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <phase>verify</phase>
+            <configuration>
+              <rules>
+          <patternSizeRule implementation="org.wildfly.swarm.plugin.enforcer.patternsize.RequireFilePatternSize">
+            <requiredFilePatterns>
+                <requiredFilePattern>
+                  <maxSize>0</maxSize>
+                  <recursive>false</recursive>
+            <directory>${project.build.directory}</directory>
+            <pattern>\S+[0-9]{5,}.\S{5,}</pattern>
+                </requiredFilePattern>
+            </requiredFilePatterns>
+          </patternSizeRule>
+              </rules>
+            </configuration>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
     <pluginManagement>
@@ -1530,7 +1531,7 @@
         <module>fractions/wildfly/management-console</module>
         <module>fractions/wildfly/mod_cluster</module>
         <module>fractions/wildfly/scanner</module>
-        
+
         <module>fractions/netflix</module>
         <module>fractions/teiid</module>
 


### PR DESCRIPTION
Motivation
----------
Swarm core depends on weld-se artifacts which are not managed in WildFly feature packs.

Modifications
-------------
Remove weld-api and cdi-api version properties. Verify that Weld SE version is aligned
with version provided by the WildFly feature pack. Move version.weld-se property to root pom.

Result
------
It is not possible to remove the version.weld-se property completely. However, we can
minimize its impact and verify the correct version is used.