### PR TITLE
SWARM-1327: Fix deploy maven task for maven enforcer rule

### DIFF
--- a/plugins/maven-enforcer-pattern-size/pom.xml
+++ b/plugins/maven-enforcer-pattern-size/pom.xml
@@ -7,6 +7,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>parent</artifactId>
+    <version>8</version>
+    <relativePath />
+  </parent>
+
   <groupId>org.wildfly.swarm</groupId>
   <artifactId>wildfly-swarm-enforcer-pattern-size</artifactId>
   <version>2017.7.0-SNAPSHOT</version>


### PR DESCRIPTION
Motivation
----------
There were some CI test failures when using "deploy" maven task caused by maven enforcer rule, as it didn't have any scm information because it wasn't using any wildfly-swarm parent config.

Modifications
-------------
Added wildfly-swarm parent to enforcer plugin pom.xml without relative path, in order to not cause a dependency cycle (same approach as build-resources pom.xml).

Result
------
deploy task should be working now

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
