### PR TITLE
SWARM-1433 - Provide a method for configuring socket-binding-groups.

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
@@ -162,6 +162,8 @@ public class RuntimeServer implements Server {
             }
         }
 
+        this.socketBindingGroupConfigurer.configure();
+
         /*
         this.archivePreparers.forEach(e -> {
             // Log it to prevent dead-code elimination.
@@ -283,6 +285,9 @@ public class RuntimeServer implements Server {
 
     @Inject
     private ArtifactDeployer artifactDeployer;
+
+    @Inject
+    private SocketBindingGroupConfigurer socketBindingGroupConfigurer;
 
     private ModelControllerClient client;
 }

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/SocketBindingGroupConfigurer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/SocketBindingGroupConfigurer.java
@@ -1,0 +1,121 @@
+package org.wildfly.swarm.container.runtime;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.wildfly.swarm.spi.api.OutboundSocketBinding;
+import org.wildfly.swarm.spi.api.SocketBinding;
+import org.wildfly.swarm.spi.api.SocketBindingGroup;
+import org.wildfly.swarm.spi.api.config.ConfigKey;
+import org.wildfly.swarm.spi.api.config.ConfigView;
+import org.wildfly.swarm.spi.api.config.SimpleKey;
+
+/**
+ * Created by bob on 7/5/17.
+ */
+@ApplicationScoped
+public class SocketBindingGroupConfigurer {
+
+    private static ConfigKey ROOT = ConfigKey.of("swarm", "network", "socket-binding-groups");
+
+    public void configure() {
+        for (SocketBindingGroup each : this.socketBindingGroups) {
+            configure(each);
+        }
+    }
+
+    protected void configure(SocketBindingGroup group) {
+        ConfigKey key = ROOT.append(group.name());
+
+        fixSocketBindings(group);
+        fixOutboundSocketBindings(group);
+    }
+
+    protected void fixSocketBindings(SocketBindingGroup group) {
+        ConfigKey key = ROOT.append(group.name()).append("socket-bindings");
+
+        List<SimpleKey> names = this.configView.simpleSubkeys(key);
+
+        names.stream()
+                .map(e -> e.name())
+                .map(name ->
+                             group.socketBindings()
+                                     .stream()
+                                     .filter(e -> e.name().equals(name))
+                                     .findFirst()
+                                     .orElseGet(() -> new SocketBinding(name)))
+                .forEach(e -> {
+                    applyConfiguration(key, e);
+                });
+    }
+
+    protected void fixOutboundSocketBindings(SocketBindingGroup group) {
+        ConfigKey key = ROOT.append(group.name()).append("outbound-socket-bindings");
+
+        List<SimpleKey> names = this.configView.simpleSubkeys(key);
+
+        names.stream()
+                .map(e -> e.name())
+                .map(name ->
+                             group.outboundSocketBindings()
+                                     .stream()
+                                     .filter(e -> e.name().equals(name))
+                                     .findFirst()
+                                     .orElseGet(() -> new OutboundSocketBinding(name)))
+                .forEach(e -> {
+                    applyConfiguration(key, e);
+                });
+    }
+
+    protected void applyConfiguration(ConfigKey root, SocketBinding binding) {
+        ConfigKey key = root.append(binding.name());
+
+        applyConfiguration(key.append("port"), (port) -> {
+            binding.port(port.toString());
+        });
+
+        applyConfiguration(key.append("multicast-port"), (port) -> {
+            binding.multicastPort(port.toString());
+        });
+
+        applyConfiguration(key.append("multicast-address"), (addr) -> {
+            binding.multicastAddress(addr.toString());
+        });
+
+        applyConfiguration(key.append("interface"), (iface) -> {
+            binding.iface(iface.toString());
+        });
+    }
+
+    protected void applyConfiguration(ConfigKey root, OutboundSocketBinding binding) {
+        ConfigKey key = root.append(binding.name());
+
+        applyConfiguration(key.append("remote-host"), (host) -> {
+            binding.remoteHost(host.toString());
+        });
+
+        applyConfiguration(key.append("remote-port"), (port) -> {
+            binding.remotePort(port.toString());
+        });
+
+    }
+
+    protected void applyConfiguration(ConfigKey key, Consumer<Object> consumer) {
+        Object value = this.configView.valueOf(key);
+        if (value != null) {
+            consumer.accept(value);
+        }
+    }
+
+    @Inject
+    private ConfigView configView;
+
+    @Inject
+    @Any
+    private Instance<SocketBindingGroup> socketBindingGroups;
+}

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/AbstractNetworkExtension.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/AbstractNetworkExtension.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.container.runtime.cdi;
+
+import java.util.Set;
+import java.util.function.Consumer;
+
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.enterprise.inject.spi.ProcessProducer;
+import javax.enterprise.inject.spi.Producer;
+
+import org.wildfly.swarm.spi.api.config.ConfigKey;
+import org.wildfly.swarm.spi.api.config.ConfigView;
+
+/**
+ * @author Bob McWhirter
+ */
+public abstract class AbstractNetworkExtension<T> implements Extension {
+
+    protected AbstractNetworkExtension(ConfigView configView) {
+        this.configView = configView;
+    }
+
+    protected abstract void applyConfiguration(T instance);
+
+    @SuppressWarnings("unused")
+    void process(@Observes ProcessProducer<?, T> p, BeanManager beanManager) throws Exception {
+        p.setProducer(producer(p.getProducer()));
+    }
+
+    protected void applyConfiguration(ConfigKey key, Consumer<Object> consumer) {
+        Object value = this.configView.valueOf(key);
+        if (value != null) {
+            consumer.accept(value);
+        }
+    }
+
+    protected Producer<T> producer(Producer<T> delegate) {
+        return new Producer<T>() {
+            @Override
+            public T produce(CreationalContext<T> ctx) {
+                T instance = delegate.produce(ctx);
+                applyConfiguration(instance);
+                return instance;
+            }
+
+            @Override
+            public void dispose(T instance) {
+                delegate.dispose(instance);
+            }
+
+            @Override
+            public Set<InjectionPoint> getInjectionPoints() {
+                return delegate.getInjectionPoints();
+            }
+        };
+    }
+
+    protected final ConfigView configView;
+}

--- a/core/spi/src/main/java/org/wildfly/swarm/spi/api/SocketBinding.java
+++ b/core/spi/src/main/java/org/wildfly/swarm/spi/api/SocketBinding.java
@@ -15,16 +15,16 @@
  */
 package org.wildfly.swarm.spi.api;
 
-/** An inbound socket-binding.
+/**
+ * An inbound socket-binding.
  *
  * <p>Defines a named inbound normal or multicast socket-binding.</p>
  *
  * <p>Inbound socket-bindings are used to define open ports for functionality
  * such as HTTP listeners, JGroups multicast groups, etc.</p>
  *
- * @see SocketBindingGroup
- *
  * @author Bob McWhirter
+ * @see SocketBindingGroup
  */
 public class SocketBinding {
 
@@ -38,7 +38,8 @@ public class SocketBinding {
 
     private String multicastPortExpression;
 
-    /** Construct a new socket-binding.
+    /**
+     * Construct a new socket-binding.
      *
      * @param name The name of the binding.
      */
@@ -46,7 +47,8 @@ public class SocketBinding {
         this.name = name;
     }
 
-    /** Retrieve the name of the binding.
+    /**
+     * Retrieve the name of the binding.
      *
      * @return the name of the binding.
      */
@@ -54,7 +56,8 @@ public class SocketBinding {
         return this.name;
     }
 
-    /** Set the interface for this binding.
+    /**
+     * Set the interface for this binding.
      *
      * @param iface The name of the interface.
      * @return This binding.
@@ -64,7 +67,8 @@ public class SocketBinding {
         return this;
     }
 
-    /** Retrieve the interface for this binding.
+    /**
+     * Retrieve the interface for this binding.
      *
      * @return The name of the interface.
      */
@@ -72,7 +76,8 @@ public class SocketBinding {
         return this.iface;
     }
 
-    /** Set the port.
+    /**
+     * Set the port.
      *
      * @param port The port.
      * @return this binding.
@@ -82,7 +87,8 @@ public class SocketBinding {
         return this;
     }
 
-    /** Set the port expression
+    /**
+     * Set the port expression
      *
      * @param portExpression The port expression.
      * @return this binding.
@@ -92,7 +98,8 @@ public class SocketBinding {
         return this;
     }
 
-    /** Retrieve the port expression.
+    /**
+     * Retrieve the port expression.
      *
      * @return The port expression.
      */
@@ -100,7 +107,8 @@ public class SocketBinding {
         return this.portExpression;
     }
 
-    /** Set the multicast address or expression.
+    /**
+     * Set the multicast address or expression.
      *
      * @param multicastAddress The multicast address or expression.
      * @return this binding.
@@ -110,7 +118,8 @@ public class SocketBinding {
         return this;
     }
 
-    /** Retrieve the multicast address or expression.
+    /**
+     * Retrieve the multicast address or expression.
      *
      * @return The multicast address or expression.
      */
@@ -118,7 +127,8 @@ public class SocketBinding {
         return this.multicastAddress;
     }
 
-    /** Set the multicast port.
+    /**
+     * Set the multicast port.
      *
      * @param port The multicast port.
      * @return this binding.
@@ -128,7 +138,8 @@ public class SocketBinding {
         return this;
     }
 
-    /** Set the multicast port expression.
+    /**
+     * Set the multicast port expression.
      *
      * @param port The multicast port expression.
      * @return this binding.
@@ -138,7 +149,8 @@ public class SocketBinding {
         return this;
     }
 
-    /** Retrieve the multicast port expression.
+    /**
+     * Retrieve the multicast port expression.
      *
      * @return The multicast port expression.
      */

--- a/core/spi/src/main/java/org/wildfly/swarm/spi/api/SocketBindingGroup.java
+++ b/core/spi/src/main/java/org/wildfly/swarm/spi/api/SocketBindingGroup.java
@@ -35,9 +35,9 @@ public class SocketBindingGroup {
 
     private final String name;
 
-    private final String defaultInterace;
+    private String defaultInterace;
 
-    private final String portOffsetExpression;
+    private String portOffsetExpression;
 
     private List<SocketBinding> socketBindings = new ArrayList<>();
 
@@ -74,6 +74,11 @@ public class SocketBindingGroup {
         return this.defaultInterace;
     }
 
+    public SocketBindingGroup defaultInterface(String defaultInterface) {
+        this.defaultInterace = defaultInterface;
+        return this;
+    }
+
     /**
      * Retrieve the port-offset expression.
      *
@@ -81,6 +86,16 @@ public class SocketBindingGroup {
      */
     public String portOffsetExpression() {
         return this.portOffsetExpression;
+    }
+
+    public SocketBindingGroup portOffset(String expr) {
+        this.portOffsetExpression = expr;
+        return this;
+    }
+
+    public SocketBindingGroup portOffset(int offset) {
+        this.portOffsetExpression = "" + offset;
+        return this;
     }
 
     /**


### PR DESCRIPTION
Motivation
----------
We should be able to YAML-define socket things.

Modifications
-------------
Allow:

    swarm:
      network:
        socket-binding-groups:
          standard-sockets:
            socket-bindings:
              http:
                port: ...
            outbound-socket-bindings:
              mongodb:
                remote-host: ...
                remote-port: ...

To alter or create socket-binding-groups, socket-bindings,
and outbound-socket-bindings.

Result
------
More YAML.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
