### PR TITLE
SWARM-1447: default datasource not set in the EE subsystem

### DIFF
--- a/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/DefaultDatasourceCustomizer.java
+++ b/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/DefaultDatasourceCustomizer.java
@@ -13,14 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.swarm.jpa.runtime;
+package org.wildfly.swarm.datasources.runtime;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
-import org.wildfly.swarm.datasources.runtime.DefaultDatasource;
-import org.wildfly.swarm.jpa.JPAFraction;
+import org.wildfly.swarm.config.EE;
 import org.wildfly.swarm.spi.api.Customizer;
 import org.wildfly.swarm.spi.runtime.annotations.Post;
 
@@ -33,15 +32,16 @@ public class DefaultDatasourceCustomizer implements Customizer {
 
     @Inject
     @DefaultDatasource
-    Instance<String> defaultDatasourceInstance;
+    String defaultDatasource;
 
     @Inject
-    Instance<JPAFraction> jpaFractionInstance;
+    Instance<EE> eeInstance;
 
     @Override
     public void customize() {
-        if (!jpaFractionInstance.isUnsatisfied() && !defaultDatasourceInstance.isUnsatisfied()) {
-            jpaFractionInstance.get().defaultDatasource("jboss/datasources/" + defaultDatasourceInstance.get());
+        if (!eeInstance.isUnsatisfied() && defaultDatasource != null) {
+            eeInstance.get().subresources().defaultBindingsService()
+                    .datasource("java:jboss/datasources/" + defaultDatasource);
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1412,6 +1412,7 @@
     <module>testsuite/testsuite-container</module>
     <module>testsuite/testsuite-datasources</module>
     <module>testsuite/testsuite-datasources-config</module>
+    <module>testsuite/testsuite-datasources-defaultds</module>
     <module>testsuite/testsuite-default-deployment</module>
     <module>testsuite/testsuite-ee</module>
     <module>testsuite/testsuite-ejb</module>

--- a/testsuite/testsuite-datasources-defaultds/pom.xml
+++ b/testsuite/testsuite-datasources-defaultds/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>testsuite</artifactId>
+    <version>2017.8.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>testsuite-datasources-defaultds</artifactId>
+
+  <name>Test Suite: Datasources: Default DS</name>
+  <description>Test Suite: Datasources: Default DS</description>
+
+  <packaging>war</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <version>${version.h2}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>datasources</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>undertow</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>arquillian</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>fluent-hc</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/testsuite/testsuite-datasources-defaultds/src/main/java/org/wildfly/swarm/datasources/defaultds/test/DefaultDatasourceServlet.java
+++ b/testsuite/testsuite-datasources-defaultds/src/main/java/org/wildfly/swarm/datasources/defaultds/test/DefaultDatasourceServlet.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.datasources.defaultds.test;
+
+import java.io.IOException;
+
+import javax.annotation.Resource;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.sql.DataSource;
+
+@WebServlet("/")
+public class DefaultDatasourceServlet extends HttpServlet {
+    @Resource
+    private DataSource ds;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.getWriter().print("Default DataSource present: " + (ds != null));
+    }
+}

--- a/testsuite/testsuite-datasources-defaultds/src/main/webapp/WEB-INF/web.xml
+++ b/testsuite/testsuite-datasources-defaultds/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
+
+</web-app>

--- a/testsuite/testsuite-datasources-defaultds/src/test/java/org/wildfly/swarm/datasources/defaultds/test/DefaultDatasourceTest.java
+++ b/testsuite/testsuite-datasources-defaultds/src/test/java/org/wildfly/swarm/datasources/defaultds/test/DefaultDatasourceTest.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.datasources.defaultds.test;
+
+import java.io.IOException;
+
+import org.apache.http.client.fluent.Request;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.arquillian.DefaultDeployment;
+import org.wildfly.swarm.undertow.WARArchive;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+@RunWith(Arquillian.class)
+@DefaultDeployment
+public class DefaultDatasourceTest {
+    @Test
+    @RunAsClient
+    public void testDefaultDatasource() throws IOException {
+        String result = Request.Get("http://localhost:8080/").execute().returnContent().asString().trim();
+        assertThat(result).isEqualTo("Default DataSource present: true");
+    }
+}


### PR DESCRIPTION
Motivation
----------
When a default datasource is created (see
`DatasourceAndDriverCustomizer.customizeDefaultDatasource`),
it doesn't get set as the default datasource in the `ee` subsystem.
This is the primary place where WildFly goes to for the default
datasource.

Since databases are most often accessed via JPA, this issue wasn't
visible much, because the `jpa` fraction takes that default datasource
from the `datasources` fraction and sets it as a default for the `jpa`
subsystem. This means that JPA works with the default datasource just
fine, but other parts of the application server don't (e.g. injecting
`@Resource DataSource` into a servlet).

Modifications
-------------
The default datasource is set in the `ee` subsystem now.
It is no longer set in the `jpa` subsystem, which is now forced
to consult the `ee` subsystem.

Result
------
Default datasource, if exists, is properly available to the entirety
of the application server. This improves Java EE 7 compatibility.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
