### PR TITLE
Fix ReflectionUtil.getMethodsWithAnnotation()

### DIFF
--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/ReflectionUtil.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/ReflectionUtil.java
@@ -45,7 +45,7 @@ public final class ReflectionUtil {
         List<Method> declaredAccessableMethods = AccessController
                 .doPrivileged((PrivilegedAction<List<Method>>) () -> {
                     List<Method> foundMethods = new ArrayList<>();
-                    for (Method method : source.getDeclaredMethods()) {
+                    for (Method method : source.getMethods()) {
                         if (method.isAnnotationPresent(annotationClass)) {
                             if (!method.isAccessible()) {
                                 method.setAccessible(true);


### PR DESCRIPTION
SWARM-1449: Fix ReflectionUtil.getMethodsWithAnnotation()

Motivation
----------
To enable the use of DRY and SRP in tests, a superclass should handle container/deployment - setup.

Modifications
-------------
Changed call from getDeclaredMethods() to getMethods() to also get methods of superclasses.

Result
------
Now test classes can derive from superclasses that deal with the setup of swarm and the deployment.
