### PR TITLE
wildfly-swarm-enforcer-pattern-size dependency is not transitively required.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,10 +248,6 @@
       <artifactId>build-resources</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.wildfly.swarm</groupId>
-      <artifactId>wildfly-swarm-enforcer-pattern-size</artifactId>
-    </dependency>
   </dependencies>
 
   <dependencyManagement>


### PR DESCRIPTION
Motivation
----------
Apparently the wildfly-swarm-enforcer-pattern-size dependency is used in the maven-enforcer-plugin only
and the JAR is transitively resolved in the bundled application.

Modifications
-------------
Removed the wildfly-swarm-enforcer-pattern-size from the parent <dependency> tag

Result
------
wildfly-swarm-enforcer-pattern-size is no longer transitively resolved and maven-enforcer-plugin still uses it