### PR TITLE
SWARM-1466: fail fast when unable to create default deployment

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/DeploymentException.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/DeploymentException.java
@@ -30,6 +30,7 @@ import org.jboss.shrinkwrap.api.Archive;
 public class DeploymentException extends RuntimeException {
 
     public DeploymentException(String message) {
+        super(message);
         this.archive = null;
     }
 

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeDeployer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeDeployer.java
@@ -93,6 +93,10 @@ public class RuntimeDeployer implements Deployer {
     public void deploy() throws DeploymentException {
         Archive<?> deployment = createDefaultDeployment();
         if (deployment == null) {
+            String deploymentType = determineDeploymentType();
+            if ("war".equals(deploymentType)) {
+                throw DeployerMessages.MESSAGES.unableToCreateDefaultDeploymentWar();
+            }
             throw DeployerMessages.MESSAGES.unableToCreateDefaultDeployment();
         } else {
             deploy(deployment);

--- a/core/container/src/main/java/org/wildfly/swarm/internal/DeployerMessages.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/DeployerMessages.java
@@ -53,6 +53,8 @@ public interface DeployerMessages extends BasicLogger {
     @Message(id = 5, value = "Exporting deployment to %s")
     void exportingDeployment(String exportLocation);
 
+    @Message(id = 6, value = "Unable to create default deployment of type .war, maybe missing the 'undertow' or 'jaxrs' fraction")
+    DeploymentException unableToCreateDefaultDeploymentWar();
 
 
 }

--- a/core/container/src/test/java/org/wildfly/swarm/container/runtime/deployments/DefaultDeploymentCreatorTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/container/runtime/deployments/DefaultDeploymentCreatorTest.java
@@ -15,13 +15,7 @@ public class DefaultDeploymentCreatorTest {
     public void testNoDeploymentFactories() throws Exception {
         DefaultDeploymentCreator creator = new DefaultDeploymentCreator();
         DefaultDeploymentFactory factory = creator.getFactory("foo");
-        assertThat(factory).isNotNull();
-        assertThat(factory.getType()).isEqualTo("foo");
-
-        Archive archive = factory.create();
-        assertThat(archive).isNotNull();
-        assertThat(archive.getName()).endsWith(".foo");
-        assertThat(archive.getContent().size()).isGreaterThan(0);
+        assertThat(factory).isNull();
     }
 
     @Test
@@ -38,6 +32,9 @@ public class DefaultDeploymentCreatorTest {
         DefaultDeploymentFactory warFactory = creator.getFactory("war");
         assertThat(warFactory).isNotNull();
         assertThat(warFactory.getType()).isEqualTo("war");
+
+        DefaultDeploymentFactory fooFactory = creator.getFactory("foo");
+        assertThat(fooFactory).isNull();
     }
 
     @Test

--- a/testsuite/testsuite-default-deployment/src/main/java/org/wildfly/swarm/defaultdeployment/Main.java
+++ b/testsuite/testsuite-default-deployment/src/main/java/org/wildfly/swarm/defaultdeployment/Main.java
@@ -19,6 +19,9 @@ public class Main {
         swarm = new Swarm(args);
         swarm.start();
         Archive<?> deployment = swarm.createDefaultDeployment();
+        if (deployment == null) {
+            throw new Error("Couldn't create default deployment");
+        }
 
         Node persistenceXml = deployment.get("WEB-INF/classes/META-INF/persistence.xml");
 


### PR DESCRIPTION
Motivation
----------
If I create a WAR deployment (Maven `<packaging>war</packaging>`)
but don't include neither `undertow` nor `jaxrs` fraction, Swarm
won't be able to find the respective `DefaultDeploymentFactory`
(because it's brought in by those fractions). What it does instead
is that it creates and deploys an empty JAR. I strongly believe
that this is wrong -- the deployment process should end with an error.

Modifications
-------------
Instead of creating an empty JAR, `DefaultDeploymentCreator` returns
a `null` archive if it can't find a `DefaultDeploymentFactory`.
The `RuntimeDeployer` can actually already handle such situation,
so the only change there is that when the default deployment type
is `war`, it produces a better error message (with a hint that maybe
the `undertow` or `jaxrs` fraction are missing).

Result
------
Failing fast in case the default deployment can't be created,
instead of deploying an empty JAR (which is guaranteed to _not_
do what the user wants).

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
