### PR TITLE
SWARM-1469 upgrades Swagger/Jackson to address CVE-2016-3720

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -46,9 +46,9 @@
     <version.org.objectweb.asm>5.0.4</version.org.objectweb.asm>
 
     <version.jolokia>1.3.4</version.jolokia>
-    <version.io.swagger>1.5.5</version.io.swagger>
+    <version.io.swagger>1.5.11</version.io.swagger>
     <version.org.webjars.swagger-ui>2.1.4</version.org.webjars.swagger-ui>
-    <version.swagger.jackson>2.4.5</version.swagger.jackson>
+    <version.swagger.jackson>2.8.4</version.swagger.jackson>
     <version.swagger.reflections>0.9.10</version.swagger.reflections>
     <version.swagger.slf4j>1.6.3</version.swagger.slf4j>
     <version.swagger.guava>18.0</version.swagger.guava>

--- a/fractions/swagger/src/main/resources/modules/com/fasterxml/jackson/swagger/module.xml
+++ b/fractions/swagger/src/main/resources/modules/com/fasterxml/jackson/swagger/module.xml
@@ -13,5 +13,6 @@
 
   <dependencies>
     <module name="javax.ws.rs.api"/>
+    <module name="javax.api"/>
   </dependencies>
 </module>


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x ] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
https://issues.jboss.org/browse/SWARM-1469
- [ x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [it fails ] Have you built the project locally prior to submission with `mvn clean install`?
I get the following local failures off the latest commit during Test Suite: CDI. 2017-7.0 tag builds fine, but has merge conflicts with latest so I'm basing off that. Guessing local build failures reflect some issue with my local environment.

```
Failed pattern \S+[0-9]{5,}.\S{5,} in directory /Users/myuser/Documents/workspace/wildfly-swarm/testsuite/testsuite-cdi/target./Users/myuser/Documents/workspace/wildfly-swarm/testsuite/testsuite-cdi/target/CDIArquillianTest3838563954310901203.jar size(170) too large. Max. is 0
Failed pattern \S+[0-9]{5,}.\S{5,} in directory /Users/myuser/Documents/workspace/wildfly-swarm/testsuite/testsuite-cdi/target./Users/myuser/Documents/workspace/wildfly-swarm/testsuite/testsuite-cdi/target/content1857802163403016649.tmp size(2825426) too large. Max. is 0
Failed pattern \S+[0-9]{5,}.\S{5,} in directory /Users/myuser/Documents/workspace/wildfly-swarm/testsuite/testsuite-cdi/target./Users/myuser/Documents/workspace/wildfly-swarm/testsuite/testsuite-cdi/target/DefaultDeploymentProjectDependencyTest2264528666651977851.war size(170) too large. Max. is 0
Failed pattern \S+[0-9]{5,}.\S{5,} in directory /Users/myuser/Documents/workspace/wildfly-swarm/testsuite/testsuite-cdi/target./Users/myuser/Documents/workspace/wildfly-swarm/testsuite/testsuite-cdi/target/module-jar1392861242000681774.jar_d size(170) too large. Max. is 0
Failed pattern \S+[0-9]{5,}.\S{5,} in directory /Users/myuser/Documents/workspace/wildfly-swarm/testsuite/testsuite-cdi/target./Users/myuser/Documents/workspace/wildfly-swarm/testsuite/testsuite-cdi/target/module-jar3038382541476332706.jar_d size(204) too large. Max. is 0
Failed pattern \S+[0-9]{5,}.\S{5,} in directory /Users/myuser/Documents/workspace/wildfly-swarm/testsuite/testsuite-cdi/target./Users/myuser/Documents/workspace/wildfly-swarm/testsuite/testsuite-cdi/target/module-jar4012010225659388207.jar_d size(272) too large. Max. is 0
Failed pattern \S+[0-9]{5,}.\S{5,} in directory /Users/myuser/Documents/workspace/wildfly-swarm/testsuite/testsuite-cdi/target./Users/myuser/Documents/workspace/wildfly-swarm/testsuite/testsuite-cdi/target/module-jar5329294677976732618.jar_d size(170) too large. Max. is 0
Failed pattern \S+[0-9]{5,}.\S{5,} in directory /Users/myuser/Documents/workspace/wildfly-swarm/testsuite/testsuite-cdi/target./Users/myuser/Documents/workspace/wildfly-swarm/testsuite/testsuite-cdi/target/module-jar6613092441564289200.jar_d size(204) too large. Max. is 0
Failed pattern \S+[0-9]{5,}.\S{5,} in directory /Users/myuser/Documents/workspace/wildfly-swarm/testsuite/testsuite-cdi/target./Users/myuser/Documents/workspace/wildfly-swarm/testsuite/testsuite-cdi/target/swarm-config-3250341329240899587.xml size(8971) too large. Max. is 0
Failed pattern \S+[0-9]{5,}.\S{5,} in directory /Users/myuser/Documents/workspace/wildfly-swarm/testsuite/testsuite-cdi/target./Users/myuser/Documents/workspace/wildfly-swarm/testsuite/testsuite-cdi/target/wildfly-self-contained1369325063252566365.d size(238) too large. Max. is 0
Failed pattern \S+[0-9]{5,}.\S{5,} in directory /Users/myuser/Documents/workspace/wildfly-swarm/testsuite/testsuite-cdi/target./Users/myuser/Documents/workspace/wildfly-swarm/testsuite/testsuite-cdi/target/wildfly-swarm7845366242138028293.d size(68) too large. Max. is 0

[INFO] ------------------------------------------------
-----```
