### PR TITLE
SWARM-1470: topology-webapp doesn't work together with jaxrs

### DIFF
--- a/core/spi/src/main/java/org/wildfly/swarm/spi/api/JBossDeploymentStructureContainer.java
+++ b/core/spi/src/main/java/org/wildfly/swarm/spi/api/JBossDeploymentStructureContainer.java
@@ -72,6 +72,18 @@ public interface JBossDeploymentStructureContainer<T extends Archive<T>> extends
         return (T) this;
     }
 
+    /** Exclude a subsystem.
+     *
+     * @param name The name of the subsystem.
+     * @return this archive.
+     */
+    @SuppressWarnings("unchecked")
+    default T excludeSubsystem(String name) {
+        getDescriptorAsset().excludeSubsystem(name);
+
+        return (T) this;
+    }
+
     /** Retrieve the underlying {@code jboss-deployment-structure.xml} descriptor asset.
      *
      * <p>This method will effectively round-trip an existing {@code .xml} file into

--- a/fractions/topology-webapp/src/main/java/org/wildfly/swarm/topology/webapp/runtime/TopologyWebAppDeploymentProducer.java
+++ b/fractions/topology-webapp/src/main/java/org/wildfly/swarm/topology/webapp/runtime/TopologyWebAppDeploymentProducer.java
@@ -55,6 +55,7 @@ public class TopologyWebAppDeploymentProducer {
 
         if (fraction.exposeTopologyEndpoint()) {
             WARArchive war = ShrinkWrap.create(WARArchive.class, "topology-webapp.war");
+            war.excludeSubsystem("jaxrs");
             war.addAsWebInfResource(new StringAsset(getWebXml(fraction)), "web.xml");
             war.addClass(TopologySSEServlet.class);
             war.addModule("swarm.application");


### PR DESCRIPTION
Motivation
----------
When the `topology-webapp` fraction is included, a small deployment
`topology-webapp.war` is automatically generated by the fraction
and deployed.

When the `jaxrs` fraction is included, all `.war` deployments that
aren't JAX-RS-enabled explicitly, get a a class looking like

```
@ApplicationPath("/")
public class WildFlySwarmDefaultJAXRSApplication extends Application {
    ...
}
```

When the two fractions are included simultaneously, all the servlet
and static content from `topology-webapp.war` are shadowed by
the JAX-RS stuff, so `topology-webapp` can't possibly work.

Modifications
-------------
Exclude the `jaxrs` subsystem from `topology-webapp.war` via
`jboss-deployment-structure.xml`.

The existing code for manipulating `jboss-deployment-structure.xml`
didn't support that, so support for excluding subsystems
programmatically is also added.

Result
------
`topology-webapp` and `jaxrs` live in peace and harmony.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
