### PR TITLE
SWARM-1470 / SWARM-1462 - Overeager JAXRS (and other) processors

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeDeployer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeDeployer.java
@@ -85,9 +85,14 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUN
 @ApplicationScoped
 public class RuntimeDeployer implements Deployer {
 
+
     //private static Logger LOG = Logger.getLogger("org.wildfly.swarm.deployer");
 
     private static final String ALL_DEPENDENCIES_ADDED_MARKER = DependenciesContainer.ALL_DEPENDENCIES_MARKER + ".added";
+
+    void implicitDeploymentsComplete() {
+        this.implicitDeploymentsComplete = true;
+    }
 
     @Override
     public void deploy() throws DeploymentException {
@@ -221,12 +226,13 @@ public class RuntimeDeployer implements Deployer {
                 }
             }
 
-            this.deploymentContext.activate(deployment, asName);
+            this.deploymentContext.activate(deployment, asName, !this.implicitDeploymentsComplete);
 
             // 2. give fractions a chance to handle the deployment
             for (DeploymentProcessor processor : this.deploymentProcessors) {
                 processor.process();
             }
+
 
             this.deploymentContext.deactivate();
 
@@ -335,4 +341,6 @@ public class RuntimeDeployer implements Deployer {
     private Instance<DeploymentProcessor> deploymentProcessors;
 
     private List<String> rarDeploymentNames = new ArrayList<>();
+
+    private boolean implicitDeploymentsComplete = false;
 }

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
@@ -238,6 +238,8 @@ public class RuntimeServer implements Server {
 
             this.artifactDeployer.deploy();
 
+            deployer.implicitDeploymentsComplete();
+
             return deployer;
         }
     }

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/DeploymentContext.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/DeploymentContext.java
@@ -8,10 +8,11 @@ import org.jboss.shrinkwrap.api.Archive;
  * Created by bob on 5/12/17.
  */
 public interface DeploymentContext extends AlterableContext {
-    void activate(Archive<?> archive, String asName);
+    void activate(Archive<?> archive, String asName, boolean implicit);
     void deactivate();
 
     Archive<?> getCurrentArchive();
     String getCurrentName();
+    boolean isImplicit();
 
 }

--- a/core/container/src/test/java/org/wildfly/swarm/container/runtime/ConfigurableManagerTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/container/runtime/ConfigurableManagerTest.java
@@ -34,7 +34,7 @@ public class ConfigurableManagerTest {
 
         Archive archive = ShrinkWrap.create(JavaArchive.class, "myapp.war");
         try {
-            context.activate(archive, archive.getName());
+            context.activate(archive, archive.getName(), false);
             Component component = new Component();
             manager.scan(component);
             assertThat(component.context.get()).isEqualTo("/myapp");
@@ -56,7 +56,7 @@ public class ConfigurableManagerTest {
 
         Archive archive = ShrinkWrap.create(JavaArchive.class, "myapp.war");
         try {
-            context.activate(archive, archive.getName());
+            context.activate(archive, archive.getName(), false);
             Component component = new Component();
             manager.scan(component);
             assertThat(component.context.get()).isEqualTo("/myapp");
@@ -79,7 +79,7 @@ public class ConfigurableManagerTest {
 
         Archive archive = ShrinkWrap.create(JavaArchive.class, "myapp.war");
         try {
-            context.activate(archive, archive.getName());
+            context.activate(archive, archive.getName(), false);
             Component component = new Component();
             manager.scan(component);
             assertThat(component.context.get()).isEqualTo("/my-specific-app");
@@ -89,7 +89,7 @@ public class ConfigurableManagerTest {
 
         Archive archiveToo = ShrinkWrap.create(JavaArchive.class, "otherapp.war");
         try {
-            context.activate(archiveToo, archiveToo.getName());
+            context.activate(archiveToo, archiveToo.getName(), false);
             Component component = new Component();
             manager.scan(component);
             assertThat(component.context.get()).isEqualTo("/my-alias-app");

--- a/fractions/javaee/jaxrs/src/main/java/org/wildfly/swarm/jaxrs/runtime/DefaultApplicationDeploymentProcessor.java
+++ b/fractions/javaee/jaxrs/src/main/java/org/wildfly/swarm/jaxrs/runtime/DefaultApplicationDeploymentProcessor.java
@@ -16,6 +16,7 @@ import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
 import org.objectweb.asm.ClassReader;
 import org.wildfly.swarm.config.runtime.AttributeDocumentation;
+import org.wildfly.swarm.container.runtime.cdi.DeploymentContext;
 import org.wildfly.swarm.jaxrs.JAXRSArchive;
 import org.wildfly.swarm.jaxrs.JAXRSMessages;
 import org.wildfly.swarm.spi.api.Defaultable;
@@ -39,12 +40,19 @@ public class DefaultApplicationDeploymentProcessor implements DeploymentProcesso
     private final Archive archive;
 
     @Inject
+    DeploymentContext deploymentContext;
+
+    @Inject
     public DefaultApplicationDeploymentProcessor(Archive archive) {
         this.archive = archive;
     }
 
     @Override
     public void process() throws Exception {
+        if (this.deploymentContext != null && this.deploymentContext.isImplicit()) {
+            return;
+        }
+
         if (!archive.getName().endsWith(".war")) {
             return;
         }

--- a/fractions/swagger/src/main/java/org/wildfly/swarm/swagger/runtime/SwaggerArchivePreparer.java
+++ b/fractions/swagger/src/main/java/org/wildfly/swarm/swagger/runtime/SwaggerArchivePreparer.java
@@ -9,6 +9,7 @@ import javax.inject.Inject;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ArchivePath;
 import org.jboss.shrinkwrap.api.Node;
+import org.wildfly.swarm.container.runtime.cdi.DeploymentContext;
 import org.wildfly.swarm.spi.api.DeploymentProcessor;
 import org.wildfly.swarm.spi.api.annotations.Configurable;
 import org.wildfly.swarm.spi.runtime.annotations.DeploymentScoped;
@@ -55,12 +56,18 @@ public class SwaggerArchivePreparer implements DeploymentProcessor {
     private final Archive archive;
 
     @Inject
+    DeploymentContext deploymentContext;
+
+    @Inject
     public SwaggerArchivePreparer(Archive archive) {
         this.archive = archive;
     }
 
     @Override
     public void process() {
+        if (this.deploymentContext != null && this.deploymentContext.isImplicit()) {
+            return;
+        }
         if (archive.getName().endsWith(".war")) {
             // Create a JAX-RS deployment archive
             WARArchive deployment = archive.as(WARArchive.class);


### PR DESCRIPTION
Motivation
----------
When including some "complete" deployments, such as topology-webapp,
swagger-webapp, and probably others, our deployment processors get a
little vigorous, and apply themselves where they aren't wanted.

Modifications
-------------
For all implicit and GAV-centric deployments, set an isImplicit
flag upon the DeploymentContext.  Processors which should only
fire on the *user's* deployment can check this flag to determine
which flavor of deployment is currently under consideration.

Additionally, teach the JAXRS and Swagger processors to check
this flag, to ensure they process the *correct* archive deployment.

Result
------
swagger.json gets created correctly based upon the user's app (instead
of upon swagger-ui) and swagger-ui actually works because it's no longer
forced to masquerade as a JAXRS app.  Same should apply to topology-webapp,
management-console, and probably jolokia.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
