### PR TITLE
Move arquillian-bom within dependencyManagement out of a profile back…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.jboss.arquillian</groupId>
+        <artifactId>arquillian-bom</artifactId>
+        <version>${version.org.arquillian}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.easytesting</groupId>
         <artifactId>fest-assert</artifactId>
         <version>${version.fest-assert}</version>
@@ -998,18 +1005,6 @@
           <name>!swarm.product.build</name>
         </property>
       </activation>
-
-      <dependencyManagement>
-        <dependencies>
-          <dependency>
-            <groupId>org.jboss.arquillian</groupId>
-            <artifactId>arquillian-bom</artifactId>
-            <version>${version.org.arquillian}</version>
-            <type>pom</type>
-            <scope>import</scope>
-          </dependency>
-        </dependencies>
-      </dependencyManagement>
 
       <modules>
         <module>testsuite</module>


### PR DESCRIPTION
… into the root pom build.

Having it in a profile appears to be causing issues for arquillian fractions to resolve transitive dependencies correctly

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
