### PR TITLE
SWARM-1475: Transformer implementation class differs

### DIFF
--- a/testsuite/testsuite-jsp/src/test/java/org/wildfly/swarm/jsp/test/ArquillianTest.java
+++ b/testsuite/testsuite-jsp/src/test/java/org/wildfly/swarm/jsp/test/ArquillianTest.java
@@ -1,5 +1,7 @@
 package org.wildfly.swarm.jsp.test;
 
+import category.CommunityOnly;
+import category.ProductOnly;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.fluent.Request;
 import org.apache.http.util.EntityUtils;
@@ -10,6 +12,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.wildfly.swarm.undertow.WARArchive;
 
@@ -35,12 +38,24 @@ public class ArquillianTest {
     }
 
     @Test
+    @Category(CommunityOnly.class)
     @RunAsClient
-    public void testFactory() throws Exception {
+    public void verifyTransformerFactoryName_Community() throws Exception {
         HttpResponse response = Request.Get("http://localhost:8080/transformer").execute().returnResponse();
         String responseBody = EntityUtils.toString(response.getEntity());
-        System.out.println(responseBody);
         Assert.assertEquals(200, response.getStatusLine().getStatusCode());
-        Assert.assertTrue(responseBody.startsWith("org.apache.xalan.xsltc.trax.TransformerFactoryImpl"));
+        Assert.assertTrue("Expected transformer factory class to be org.apache.xalan.xsltc.trax.TransformerFactoryImpl but was " + responseBody,
+                          responseBody.startsWith("org.apache.xalan.xsltc.trax.TransformerFactoryImpl"));
+    }
+
+    @Test
+    @Category(ProductOnly.class)
+    @RunAsClient
+    public void verifyTransformerFactoryName_Product() throws Exception {
+        HttpResponse response = Request.Get("http://localhost:8080/transformer").execute().returnResponse();
+        String responseBody = EntityUtils.toString(response.getEntity());
+        Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+        Assert.assertTrue("Expected transformer factory class to be org.apache.xalan.processor.TransformerFactoryImpl but was " + responseBody,
+                          responseBody.startsWith("org.apache.xalan.processor.TransformerFactoryImpl"));
     }
 }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
WildFly and EAP use different transformer implementation classes.

Modifications
-------------
Create two tests from one and have each test the class name for WildFly or EAP, but only activate each during the appropriate builds.

Result
------
No impact to product, only testsuite
