### PR TITLE
SWARM-1476: topology-webapp formats a service URL with an IPv6 address incorrectly

### DIFF
--- a/fractions/topology-webapp/src/main/java/org/wildfly/swarm/topology/webapp/runtime/TopologySSEServlet.java
+++ b/fractions/topology-webapp/src/main/java/org/wildfly/swarm/topology/webapp/runtime/TopologySSEServlet.java
@@ -115,7 +115,7 @@ public class TopologySSEServlet extends HttpServlet {
                 tags.add(secure ? "https" : "http");
                 while (listIter.hasNext()) {
                     Topology.Entry server = listIter.next();
-                    tags.add(server.getAddress() + ":" + server.getPort());
+                    tags.add(formatMaybeIpv6(server.getAddress()) + ":" + server.getPort());
                 }
                 populateEndpointAndTagsJson(json, proxyContext, tags);
             } else {
@@ -131,7 +131,7 @@ public class TopologySSEServlet extends HttpServlet {
                     }
 
                     String endpoint = (!invalidServerAddress ? (server.getTags().contains("https") ? "https" : "http") + "://" : "")
-                            + server.getAddress() + ":" + server.getPort();
+                            + formatMaybeIpv6(server.getAddress()) + ":" + server.getPort();
                     populateEndpointAndTagsJson(json, endpoint, server.getTags());
                     if (listIter.hasNext()) {
                         json.append(",");
@@ -162,6 +162,18 @@ public class TopologySSEServlet extends HttpServlet {
         }
         json.append("]");
         json.append("}");
+    }
+
+    /** This isn't very precise; org.jboss.as.network.NetworkUtils has better implementation, but that's in a private module. */
+    private String formatMaybeIpv6(String address) {
+        String openBracket = "[";
+        String closeBracket = "]";
+
+        if (address.contains(":") && !address.startsWith(openBracket) && !address.endsWith(closeBracket)) {
+            return openBracket + address + closeBracket;
+        }
+
+        return address;
     }
 
     private Topology topology;


### PR DESCRIPTION
Motivation
----------
A URL with an IPv6 address should look like
`http://[my::ad:dr:es:s]:8080/`, but the SSE stream maintained
by the `topology-webapp` fraction doesn't add the brackets.
The URL looks like `http://my::ad:dr:es:s:8080/`, which is wrong
and doesn't work in browsers.

Modifications
-------------
Attempt to detect if the service address is an IPv6 address,
and if so, add the brackets.

Result
------
`topology-webapp` works in an IPv6 environment.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
