### PR TITLE
(minor) bump NoSQL tests to use 2017.9.0-SNAPSHOT

### DIFF
--- a/testsuite/testsuite-cassandra/pom.xml
+++ b/testsuite/testsuite-cassandra/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2017.8.0-SNAPSHOT</version>
+    <version>2017.9.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-mongodb/pom.xml
+++ b/testsuite/testsuite-mongodb/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2017.8.0-SNAPSHOT</version>
+    <version>2017.9.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-neo4j/pom.xml
+++ b/testsuite/testsuite-neo4j/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2017.8.0-SNAPSHOT</version>
+    <version>2017.9.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-orientdb/pom.xml
+++ b/testsuite/testsuite-orientdb/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wildfly.swarm.testsuite</groupId>
         <artifactId>testsuite-parent</artifactId>
-        <version>2017.8.0-SNAPSHOT</version>
+        <version>2017.9.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 


### PR DESCRIPTION
This resolves the test failure on https://ci.wildfly-swarm.io/job/scottdockertest/22/console :)

I'll push on adding the other NoSQL databases to Jenkins via Docker, so we can include nosql when testing pull requests (if that works for the team :)