### PR TITLE
SWARM-1480: Don't use Arquillian test classes in client mode to detect fractions

### DIFF
--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
@@ -250,6 +250,10 @@ public class UberjarSimpleContainer implements SimpleContainer {
             tool.mainClass(mainClassName.orElse(Swarm.class.getName()));
         }
 
+        if (this.testClass != null) {
+            tool.testClass(this.testClass.getName());
+        }
+
         Archive<?> wrapped = null;
         try {
             wrapped = tool.build();

--- a/meta/fraction-metadata/src/main/java/org/wildfly/swarm/fractions/ArquillianClientAnnotationSeekingClassVisitor.java
+++ b/meta/fraction-metadata/src/main/java/org/wildfly/swarm/fractions/ArquillianClientAnnotationSeekingClassVisitor.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.fractions;
+
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+/**
+ * @author Juan Gonzalez
+ */
+public class ArquillianClientAnnotationSeekingClassVisitor extends ClassVisitor {
+
+    static final String DEPLOYMENT_ANNOTATION = "org/jboss/arquillian/container/test/api/Deployment";
+    static final String RUN_AS_CLIENT_ANNOTATION = "org/jboss/arquillian/container/test/api/RunAsClient";
+
+    private int clientCounter;
+    private int containerCounter;
+
+    public ArquillianClientAnnotationSeekingClassVisitor() {
+        super(Opcodes.ASM5);
+    }
+
+    public boolean isClient() {
+        return this.clientCounter > 0 && this.containerCounter == 0;
+    }
+
+    @Override
+    public MethodVisitor visitMethod(final int __,
+                                     final String ___,
+                                     final String desc,
+                                     final String signature,
+                                     final String[] exceptions) {
+
+        return new MethodVisitor(Opcodes.ASM5) {
+            @Override
+            public AnnotationVisitor visitAnnotation(final String desc,
+                                                     final boolean __) {
+
+                Type type = Type.getType(desc);
+                String className = type.getInternalName();
+
+                if (className.equals(DEPLOYMENT_ANNOTATION)) {
+                    containerCounter++;
+                    return new ArquillianAnnotationVisitor();
+                }
+
+                if (className.equals(RUN_AS_CLIENT_ANNOTATION)) {
+                    clientCounter++;
+                }
+
+                return null;
+            }
+       };
+    }
+
+    private final class ArquillianAnnotationVisitor extends AnnotationVisitor {
+
+            public ArquillianAnnotationVisitor() {
+                super(Opcodes.ASM5);
+            }
+
+            @Override
+            public void visit(final String name, final Object value) {
+
+                if (name.equals("testable") && value.equals(Boolean.FALSE)) {
+                    clientCounter++;
+                    containerCounter--;
+                }
+            }
+    };
+}

--- a/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
@@ -92,6 +92,11 @@ public class BuildTool {
         return this;
     }
 
+    public BuildTool testClass(String testClass) {
+        this.testClass = testClass;
+        return this;
+    }
+
     public BuildTool properties(Properties properties) {
         this.properties.putAll(properties);
         return this;
@@ -314,6 +319,10 @@ public class BuildTool {
         final FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer()
                 .logger(log)
                 .source(tmpFile);
+
+        if (testClass != null && !"".equals(testClass)) {
+            analyzer.testClass(testClass);
+        }
 
         final Collection<FractionDescriptor> detectedFractions = analyzer.detectNeededFractions();
 
@@ -578,6 +587,8 @@ public class BuildTool {
     private Path uberjarResourcesDirectory = null;
 
     private String mainClass;
+
+    private String testClass;
 
     private boolean bundleDependencies = true;
 


### PR DESCRIPTION
Motivation
----------
There are cases when test classes want to use some client tools that could cause some additional fraction to be detected. These client tools are usually used in Arquillian client mode tests (@RunAsClient or testable="false"). These fractions aren't needed and can cause some unexpected errors.

Modifications
-------------
Added a ClassReader annotation visitor to check if a test class is an Arquillian client mode one. In that case, test class will not count on fraction detection.

Result
------
Arquillian test classes in client mode won't affect fraction detection, avoiding unexpected results due to unwanted fractions being added in these cases.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----

Sorry for not adding a test. Tried but unsucessfully. I may try on 14th with the help of @bobmcwhirter or @Ladicek if needed