### PR TITLE
SWARM-1472: Arquillian fraction has test scope in all boms.

### DIFF
--- a/arquillian/arquillian/pom.xml
+++ b/arquillian/arquillian/pom.xml
@@ -24,6 +24,7 @@
 
   <properties>
     <swarm.fraction.stability>stable</swarm.fraction.stability>
+    <swarm.fraction.scope>test</swarm.fraction.scope>
   </properties>
 
   <build>

--- a/boms/bom-certified/pom.xml
+++ b/boms/bom-certified/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>boms</artifactId>
-    <version>2017.8.0-SNAPSHOT</version>
+    <version>2017.9.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 


### PR DESCRIPTION
Motivation
----------
Arquillian fraction should have "test" scope in all boms so that its
dependencies are not added to the resulting artifact during compilation.

Modifications
-------------
Added <swarm.fraction.scope>test</swarm.fraction.scope> to the
arquillian fraction. The property will be currently ignored (arquillian
fraction is handled in a special way) but it's good to be consistent.

Result
------
Nothing changes.
