### PR TITLE
SWARM-1494: add FileSystemLayout for Gradle 4

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/internal/FileSystemLayout.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/FileSystemLayout.java
@@ -42,7 +42,7 @@ public abstract class FileSystemLayout {
             // Maven
             return path.subpath(path.getNameCount() - 3, path.getNameCount() - 2).toString() + JAR;
         } else if (path.endsWith(BUILD_CLASSES_MAIN) || path.endsWith(BUILD_RESOURCES_MAIN)) {
-            // Gradle
+            // Gradle + Gradle 4+
             return path.subpath(path.getNameCount() - 4, path.getNameCount() - 3).toString() + JAR;
         } else {
             return UUID.randomUUID().toString() + JAR;
@@ -75,7 +75,13 @@ public abstract class FileSystemLayout {
         if (Files.exists(Paths.get(root, POM_XML))) {
             return new MavenFileSystemLayout(root);
         } else if (Files.exists(Paths.get(root, BUILD_GRADLE))) {
-            return new GradleFileSystemLayout(root);
+            // from version 4 gradle uses separate output directories for each jvm language
+
+            if (Files.exists(Paths.get(root, BUILD_CLASSES_JAVA_MAIN))) {
+                return new Gradle4FileSystemLayout(root);
+            } else if (Files.exists(Paths.get(root, BUILD_CLASSES_MAIN))) {
+                return new GradleFileSystemLayout(root);
+            }
         }
 
         throw SwarmMessages.MESSAGES.cannotIdentifyFileSystemLayout(root);
@@ -94,6 +100,8 @@ public abstract class FileSystemLayout {
     private static final String TARGET_CLASSES = "target/classes";
 
     private static final String BUILD_CLASSES_MAIN = "build/classes/main";
+
+    private static final String BUILD_CLASSES_JAVA_MAIN = "build/classes/java/main";
 
     private static final String BUILD_RESOURCES_MAIN = "build/resources/main";
 

--- a/core/container/src/main/java/org/wildfly/swarm/internal/Gradle4FileSystemLayout.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/Gradle4FileSystemLayout.java
@@ -16,7 +16,6 @@
 package org.wildfly.swarm.internal;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * @author Maximilian Zellhofer

--- a/core/container/src/main/java/org/wildfly/swarm/internal/Gradle4FileSystemLayout.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/Gradle4FileSystemLayout.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.internal;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * @author Maximilian Zellhofer
+ * @since 10/08/17
+ */
+public class Gradle4FileSystemLayout extends GradleFileSystemLayout {
+
+    Gradle4FileSystemLayout(String root) {
+        super(root);
+    }
+
+    @Override
+    public Path resolveBuildClassesDir() {
+        return getRootPath().resolve(BUILD).resolve(CLASSES).resolve(JAVA).resolve(MAIN);
+    }
+
+    private static final String JAVA = "java";
+}

--- a/core/container/src/main/java/org/wildfly/swarm/internal/GradleFileSystemLayout.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/GradleFileSystemLayout.java
@@ -57,17 +57,17 @@ public class GradleFileSystemLayout extends FileSystemLayout {
         return rootPath;
     }
 
-    private static final String BUILD = "build";
+    protected static final String BUILD = "build";
 
-    private static final String CLASSES = "classes";
+    protected static final String CLASSES = "classes";
 
-    private static final String MAIN = "main";
+    protected static final String MAIN = "main";
 
-    private static final String RESOURCES = "resources";
+    protected static final String RESOURCES = "resources";
 
-    private static final String SRC = "src";
+    protected static final String SRC = "src";
 
-    private static final String WEBAPP = "webapp";
+    protected static final String WEBAPP = "webapp";
 
     private final Path rootPath;
 }


### PR DESCRIPTION
- [ x ] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [ x ] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [ x ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ x ] Have you built the project locally prior to submission with `mvn clean install`?

-----

Gradle introduced seperate output directories for each jvm language in version 4. Therefore, when running Swarm from the IDE, resolving the build classes directory fails because the path now looks like `build/classes/java/main
`