### PR TITLE
SWARM-1427: Swarm hangs on shutdown with Consul Topology

### DIFF
--- a/fractions/topology-consul/src/main/java/org/wildfly/swarm/topology/consul/runtime/Advertiser.java
+++ b/fractions/topology-consul/src/main/java/org/wildfly/swarm/topology/consul/runtime/Advertiser.java
@@ -72,19 +72,17 @@ public class Advertiser implements Service<Advertiser>, Runnable {
     public void unadvertise(String name, String address, int port) {
 
         AgentClient client = this.agentClientInjector.getValue();
+        Registration r = new Registration("consul", name, address, port, "");
 
         this.advertisements
                 .stream()
+                .filter(e -> e.equals(r))
                 .forEach(e -> {
                     String serviceId = serviceId(e);
                     log.info("Deregister service " + serviceId);
                     client.deregister(serviceId);
                 });
-
-
-        this.advertisements.removeIf(e -> e.getName().equals(name) && e.getAddress().equals(address) && e.getPort() == port);
-
-
+        this.advertisements.removeIf(e -> e.equals(r));
     }
 
     @Override


### PR DESCRIPTION
Motivation
----------
Topology consul unadvertise always sends a deregister to consul for every registered service, totally ignoring the provided name adress and port. This results in unwanted behaviour and leads to errors and deadlock on shutdown

Modifications
-------------
added a filter before the foreach to filter out only those registrations that match the provided data and only deregister those.

Result
------
only matching services are deregistered from consul

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
