### PR TITLE
SWARM-1519: GradleResolver is ignoring the classifier for artifact do…

### DIFF
--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/GradleResolver.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/GradleResolver.java
@@ -97,7 +97,7 @@ public class GradleResolver implements MavenResolver {
      * @return
      */
     File downloadFromRemoteRepository(ArtifactCoordinates artifactCoordinates, String packaging, Path artifactDirectory) {
-        String artifactRelativeHttpPath = artifactCoordinates.relativeArtifactPath('/');
+        String artifactRelativeHttpPath = toGradleArtifactPath(artifactCoordinates);
         String artifactRelativeMetadataHttpPath = artifactCoordinates.relativeMetadataPath('/');
         for (String remoteRepos : remoteRepositories) {
             String artifactAbsoluteHttpPath = remoteRepos + artifactRelativeHttpPath + ".";
@@ -193,6 +193,26 @@ public class GradleResolver implements MavenResolver {
         return sbFileFilter.toString();
     }
 
+    /**
+     * Build the artifact path including the classifier.
+     *
+     * @param artifactCoordinates
+     * @return
+     */
+    String toGradleArtifactPath(ArtifactCoordinates artifactCoordinates) {
+        // e.g.: org/jboss/ws/cxf/jbossws-cxf-resources/5.1.5.Final/jbossws-cxf-resources-5.1.5.Final
+        String pathWithMissingClassifier = artifactCoordinates.relativeArtifactPath('/');
+        StringBuilder sb = new StringBuilder(pathWithMissingClassifier);
+
+        if (artifactCoordinates.getClassifier() != null && artifactCoordinates.getClassifier().length() > 0) {
+            // org/jboss/ws/cxf/jbossws-cxf-resources/5.1.5.Final/jbossws-cxf-resources-5.1.5.Final-wildfly1000
+            sb
+                    .append("-")
+                    .append(artifactCoordinates.getClassifier());
+        }
+
+        return sb.toString();
+    }
 
     /**
      * Compute gradle uuid for artifacts.

--- a/core/bootstrap/src/test/java/org/wildfly/swarm/bootstrap/modules/GradleResolverTest.java
+++ b/core/bootstrap/src/test/java/org/wildfly/swarm/bootstrap/modules/GradleResolverTest.java
@@ -105,6 +105,43 @@ public class GradleResolverTest {
     }
 
     @Test
+    public void testToGradleArtifactPath(){
+        //GIVEN
+        String group = "org.jboss.ws.cxf";
+        String artifact = "jbossws-cxf-resources";
+        String version = "5.1.5.Final";
+        ArtifactCoordinates artifactCoordinates = new ArtifactCoordinates(group, artifact, version);
+
+        //WHEN
+        GradleResolver resolver = new GradleResolver(null);
+        String artifactPath = resolver.toGradleArtifactPath(artifactCoordinates);
+
+        //THEN
+        assertEquals(
+                "org/jboss/ws/cxf/jbossws-cxf-resources/5.1.5.Final/jbossws-cxf-resources-5.1.5.Final",
+                artifactPath);
+    }
+
+    @Test
+    public void testToGradleArtifactPath_withClassifier(){
+        //GIVEN
+        String group = "org.jboss.ws.cxf";
+        String artifact = "jbossws-cxf-resources";
+        String version = "5.1.5.Final";
+        String classifier = "wildfly1000";
+        ArtifactCoordinates artifactCoordinates = new ArtifactCoordinates(group, artifact, version, classifier);
+
+        //WHEN
+        GradleResolver resolver = new GradleResolver(null);
+        String artifactPath = resolver.toGradleArtifactPath(artifactCoordinates);
+
+        //THEN
+        assertEquals(
+                "org/jboss/ws/cxf/jbossws-cxf-resources/5.1.5.Final/jbossws-cxf-resources-5.1.5.Final-wildfly1000",
+                artifactPath);
+    }
+
+    @Test
     public void testResolveArtifact() throws IOException {
         //GIVEN
         File dirFile = TempFileManager.INSTANCE.newTempDirectory("gradle", null);


### PR DESCRIPTION
…wnloads

Motivation
----------
The GradleResolver is using a wrong download url for artifacts with a
classifier. If an artifact has a classifier, it is downloading an
artifact without classifier and storing it in the Gradle cache with the
classifier added to the name. This leads to artifact a to be stored as
aritfact b.
The problem arose with jbossws-cxf-resources-5.1.5.Final-wildfly1000.

The management console was another place where this problem arose. There
was the problem that an artifact was not found as the was no artifact
without classifier existent.

Modifications
-------------
The classifier is added to the download url.

Result
------
Artifacts are found and downloaded correctly.
How does this commit affect the product in behavior or usage.

- [ ] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
