### PR TITLE
SWARM-1518: Should interpolate ${property} names in settings.xml

### DIFF
--- a/core/bootstrap/pom.xml
+++ b/core/bootstrap/pom.xml
@@ -59,7 +59,7 @@
               <excludeTransitive>true</excludeTransitive>
               <includeGroupIds>org.jboss.modules,org.yaml</includeGroupIds>
               <includeScope>compile</includeScope>
-              <excludes>**\/MavenArtifactUtil.class,**\/ArtifactCoordinates.class</excludes>
+              <excludes>**\/MavenArtifactUtil.class,**\/ArtifactCoordinates.class,**\/MavenSettings.class</excludes>
               <outputDirectory>${project.build.directory}/classes</outputDirectory>
             </configuration>
           </execution>

--- a/core/bootstrap/src/main/java/org/jboss/modules/maven/MavenSettings.java
+++ b/core/bootstrap/src/main/java/org/jboss/modules/maven/MavenSettings.java
@@ -1,0 +1,381 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.modules.maven;
+
+import static org.jboss.modules.maven.MavenArtifactUtil.doIo;
+import static org.jboss.modules.xml.ModuleXmlParser.endOfDocument;
+import static org.jboss.modules.xml.ModuleXmlParser.unexpectedContent;
+import static org.jboss.modules.xml.XmlPullParser.END_DOCUMENT;
+import static org.jboss.modules.xml.XmlPullParser.END_TAG;
+import static org.jboss.modules.xml.XmlPullParser.FEATURE_PROCESS_NAMESPACES;
+import static org.jboss.modules.xml.XmlPullParser.START_TAG;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.modules.xml.MXParser;
+import org.jboss.modules.xml.XmlPullParser;
+import org.jboss.modules.xml.XmlPullParserException;
+
+/**
+ * @author Tomaz Cerar (c) 2014 Red Hat Inc.
+ */
+final class MavenSettings {
+    private static final Object settingLoaderMutex = new Object();
+
+    private static volatile MavenSettings mavenSettings;
+
+    private Path localRepository = null;
+
+    private final List<String> remoteRepositories = new LinkedList<>();
+
+    private final Map<String, Profile> profiles = new HashMap<>();
+
+    private final List<String> activeProfileNames = new LinkedList<>();
+
+    MavenSettings() {
+        configureDefaults();
+    }
+
+    static MavenSettings getSettings() throws IOException {
+        if (mavenSettings != null) {
+            return mavenSettings;
+        }
+        synchronized (settingLoaderMutex) {
+            if (mavenSettings != null) {
+                return mavenSettings;
+            }
+            return mavenSettings = doIo(() -> {
+                MavenSettings settings = new MavenSettings();
+
+                Path m2 = Paths.get(System.getProperty("user.home"), ".m2");
+                Path settingsPath = m2.resolve("settings.xml");
+
+                if (Files.notExists(settingsPath)) {
+                    String mavenHome = System.getenv("M2_HOME");
+                    if (mavenHome != null) {
+                        settingsPath = Paths.get(mavenHome, "conf", "settings.xml");
+                    }
+                }
+                if (Files.exists(settingsPath)) {
+                    parseSettingsXml(settingsPath, settings);
+                }
+                if (settings.getLocalRepository() == null) {
+                    Path repository = m2.resolve("repository");
+                    settings.setLocalRepository(repository);
+                }
+                settings.resolveActiveSettings();
+                return settings;
+            });
+        }
+    }
+
+    static MavenSettings parseSettingsXml(Path settings, MavenSettings mavenSettings) throws IOException {
+        try {
+            final MXParser reader = new MXParser();
+            reader.setFeature(FEATURE_PROCESS_NAMESPACES, false);
+            InputStream source = Files.newInputStream(settings, StandardOpenOption.READ);
+            reader.setInput(source, null);
+            int eventType;
+            while ((eventType = reader.next()) != END_DOCUMENT) {
+                switch (eventType) {
+                    case START_TAG: {
+                        switch (reader.getName()) {
+                            case "settings": {
+                                parseSettings(reader, mavenSettings);
+                                break;
+                            }
+                        }
+                    }
+                    default: {
+                        break;
+                    }
+                }
+            }
+            return mavenSettings;
+        } catch (XmlPullParserException e) {
+            throw new IOException("Could not parse maven settings.xml");
+        }
+
+    }
+
+    static void parseSettings(final XmlPullParser reader, MavenSettings mavenSettings) throws XmlPullParserException, IOException {
+        int eventType;
+        while ((eventType = reader.nextTag()) != END_DOCUMENT) {
+            switch (eventType) {
+                case END_TAG: {
+                    return;
+                }
+                case START_TAG: {
+
+                    switch (reader.getName()) {
+                        case "localRepository": {
+                            String localRepository = reader.nextText();
+                            if (localRepository != null && !localRepository.trim().isEmpty()) {
+                                mavenSettings.setLocalRepository(Paths.get(interpolateVariables(localRepository)));
+                            }
+                            break;
+                        }
+                        case "profiles": {
+                            while ((eventType = reader.nextTag()) != END_DOCUMENT) {
+                                if (eventType == START_TAG) {
+                                    switch (reader.getName()) {
+                                        case "profile": {
+                                            parseProfile(reader, mavenSettings);
+                                            break;
+                                        }
+                                    }
+                                } else {
+                                    break;
+                                }
+                            }
+                            break;
+                        }
+                        case "activeProfiles": {
+                            while ((eventType = reader.nextTag()) != END_DOCUMENT) {
+                                if (eventType == START_TAG) {
+                                    switch (reader.getName()) {
+                                        case "activeProfile": {
+                                            mavenSettings.addActiveProfile(reader.nextText());
+                                            break;
+                                        }
+                                    }
+                                } else {
+                                    break;
+                                }
+
+                            }
+                            break;
+                        }
+                        default: {
+                            skip(reader);
+
+                        }
+                    }
+                    break;
+                }
+                default: {
+                    throw unexpectedContent(reader);
+                }
+            }
+        }
+        throw endOfDocument(reader);
+    }
+
+    static void parseProfile(final XmlPullParser reader, MavenSettings mavenSettings) throws XmlPullParserException, IOException {
+        int eventType;
+        Profile profile = new Profile();
+        while ((eventType = reader.nextTag()) != END_DOCUMENT) {
+            if (eventType == START_TAG) {
+                switch (reader.getName()) {
+                    case "id": {
+                        profile.setId(reader.nextText());
+                        break;
+                    }
+                    case "repositories": {
+                        while ((eventType = reader.nextTag()) != END_DOCUMENT) {
+                            if (eventType == START_TAG) {
+                                switch (reader.getName()) {
+                                    case "repository": {
+                                        parseRepository(reader, profile);
+                                        break;
+                                    }
+                                }
+                            } else {
+                                break;
+                            }
+
+                        }
+                        break;
+                    }
+                    default: {
+                        skip(reader);
+                    }
+                }
+            } else {
+                break;
+            }
+        }
+        mavenSettings.addProfile(profile);
+    }
+
+    static void parseRepository(final XmlPullParser reader, Profile profile) throws XmlPullParserException, IOException {
+        int eventType;
+        while ((eventType = reader.nextTag()) != END_DOCUMENT) {
+            if (eventType == START_TAG) {
+                switch (reader.getName()) {
+                    case "url": {
+                        profile.addRepository(reader.nextText());
+                        break;
+                    }
+                    default: {
+                        skip(reader);
+                    }
+                }
+            } else {
+                break;
+            }
+
+        }
+    }
+
+    static void skip(XmlPullParser parser) throws XmlPullParserException, IOException {
+        if (parser.getEventType() != XmlPullParser.START_TAG) {
+            throw new IllegalStateException();
+        }
+        int depth = 1;
+        while (depth != 0) {
+            switch (parser.next()) {
+                case XmlPullParser.END_TAG:
+                    depth--;
+                    break;
+                case XmlPullParser.START_TAG:
+                    depth++;
+                    break;
+            }
+        }
+    }
+
+    void configureDefaults() {
+        //always add maven central
+        remoteRepositories.add("https://repo1.maven.org/maven2/");
+        String localRepositoryPath = System.getProperty("local.maven.repo.path");
+        if (localRepositoryPath != null && !localRepositoryPath.trim().isEmpty()) {
+            System.out.println("Please use 'maven.repo.local' instead of 'local.maven.repo.path'");
+            localRepository = java.nio.file.Paths.get(localRepositoryPath.split(File.pathSeparator)[0]);
+        }
+
+        localRepositoryPath = System.getProperty("maven.repo.local");
+        if (localRepositoryPath != null && !localRepositoryPath.trim().isEmpty()) {
+            localRepository = java.nio.file.Paths.get(localRepositoryPath);
+        }
+        String remoteRepository = System.getProperty("remote.maven.repo");
+        if (remoteRepository != null) {
+            for (String repo : remoteRepository.split(",")) {
+                if (!repo.endsWith("/")) {
+                    repo += "/";
+                }
+                remoteRepositories.add(repo);
+            }
+        }
+    }
+
+    public void setLocalRepository(Path localRepository) {
+        this.localRepository = localRepository;
+    }
+
+    public Path getLocalRepository() {
+        return localRepository;
+    }
+
+    public List<String> getRemoteRepositories() {
+        return remoteRepositories;
+    }
+
+    public void addProfile(Profile profile) {
+        this.profiles.put(profile.getId(), profile);
+    }
+
+    public void addActiveProfile(String profileName) {
+        activeProfileNames.add(profileName);
+    }
+
+    void resolveActiveSettings() {
+        for (String name : activeProfileNames) {
+            Profile p = profiles.get(name);
+            if (p != null) {
+                remoteRepositories.addAll(p.getRepositories());
+            }
+        }
+    }
+
+    static String interpolateVariables(String in) {
+        StringBuilder out = new StringBuilder();
+
+        int cur = 0;
+        int startLoc = -1;
+
+        while ((startLoc = in.indexOf("${", cur)) >= 0) {
+            out.append(in.substring(cur, startLoc));
+            int endLoc = in.indexOf("}", startLoc);
+            if (endLoc > 0) {
+                String name = in.substring(startLoc + 2, endLoc);
+                String value = null;
+                if (name.startsWith("env.")) {
+                    value = System.getenv(name.substring(4));
+                } else {
+                    value = System.getProperty(name);
+                }
+                if (value == null) {
+                    value = "";
+                }
+                out.append(value);
+            } else {
+                out.append(in.substring(startLoc));
+                cur = in.length();
+                break;
+            }
+            cur = endLoc + 1;
+        }
+
+        out.append(in.substring(cur));
+
+        return out.toString();
+    }
+
+
+    static final class Profile {
+        private String id;
+
+        final List<String> repositories = new LinkedList<>();
+
+        Profile() {
+
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public void addRepository(String url) {
+            if (!url.endsWith("/")) {
+                url += "/";
+            }
+            repositories.add(url);
+        }
+
+        public List<String> getRepositories() {
+            return repositories;
+        }
+    }
+}
+

--- a/core/bootstrap/src/test/java/org/jboss/modules/maven/MavenSettingsTest.java
+++ b/core/bootstrap/src/test/java/org/jboss/modules/maven/MavenSettingsTest.java
@@ -1,0 +1,143 @@
+package org.jboss.modules.maven;
+
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * @author Tomaz Cerar (c) 2015 Red Hat Inc.
+ */
+public class MavenSettingsTest {
+
+    void clearCachedSettings() throws Exception {
+        Field mavenSettings = MavenSettings.class.getDeclaredField("mavenSettings");
+        mavenSettings.setAccessible(true);
+        mavenSettings.set(null, null);
+    }
+
+    @Rule
+    public TemporaryFolder tmpdir = new TemporaryFolder();
+
+    @Test
+    public void testWithPassedRepository() throws Exception {
+        System.setProperty("maven.repo.local", tmpdir.newFolder("repository").getAbsolutePath());
+        System.setProperty("remote.maven.repo", "http://repository.jboss.org/nexus/content/groups/public/,https://maven-central.storage.googleapis.com/");
+
+        try {
+            clearCachedSettings();
+            MavenSettings settings = MavenSettings.getSettings();
+            List<String> remoteRepos = settings.getRemoteRepositories();
+            Assert.assertTrue(remoteRepos.size() >= 3); //at least 3 must be present, other can come from settings.xml
+            Assert.assertTrue(remoteRepos.contains("https://repo1.maven.org/maven2/"));
+            Assert.assertTrue(remoteRepos.contains("http://repository.jboss.org/nexus/content/groups/public/"));
+            Assert.assertTrue(remoteRepos.contains("https://maven-central.storage.googleapis.com/"));
+
+        } finally {
+            System.clearProperty("maven.repo.local");
+            System.clearProperty("remote.repository");
+        }
+    }
+
+    @Test
+    public void testWithEmptyPassedRepository() throws Exception {
+        Path userRepo = tmpdir.newFolder(".m2", "repository").toPath();
+        String userHome = System.getProperty("user.home");
+        System.setProperty("user.home", tmpdir.getRoot().getAbsolutePath());
+        System.setProperty("maven.repo.local", "");
+
+        try {
+            clearCachedSettings();
+            MavenSettings settings = MavenSettings.getSettings();
+            Assert.assertEquals(userRepo, settings.getLocalRepository());
+        } finally {
+            System.setProperty("user.home", userHome);
+            System.clearProperty("maven.repo.local");
+        }
+    }
+
+    @Test
+    public void testEmptyLocalRepo() throws Exception {
+        MavenSettings settings = new MavenSettings();
+
+        MavenSettings.parseSettingsXml(Paths.get(MavenSettingsTest.class.getResource("settings-empty-local-repo.xml").toURI()), settings);
+        Assert.assertNull(settings.getLocalRepository());//local repo shouldn't be set
+    }
+
+    @Test
+    public void testInterpolatedLocalRepo() throws Exception {
+        try {
+            System.setProperty("test.user.home", "/home/bobmcw");
+            MavenSettings settings = new MavenSettings();
+
+            MavenSettings.parseSettingsXml(Paths.get(MavenSettingsTest.class.getResource("settings-interpolated-local-repo.xml").toURI()), settings);
+            Assert.assertEquals(Paths.get("/home/bobmcw/.mvnrepository"), settings.getLocalRepository());
+        } finally {
+            System.clearProperty("test.user.home");
+        }
+    }
+
+    /**
+     * testing is snapshot resolving works properly, as in case of snapshot version, we need to use different path than exact version.
+     * @throws Exception
+     */
+    @Test
+    public void testSnapshotResolving()throws Exception{
+        ArtifactCoordinates coordinates = ArtifactCoordinates.fromString("org.wildfly.core:wildfly-version:2.0.5.Final-20151222.144931-1");
+        String path = coordinates.relativeArtifactPath('/');
+        Assert.assertEquals("org/wildfly/core/wildfly-version/2.0.5.Final-SNAPSHOT/wildfly-version-2.0.5.Final-20151222.144931-1", path);
+    }
+
+    @Test
+    public void testInterpolateVariablesNoVariables() throws Exception {
+        Assert.assertEquals("/home/bob/.m2/repository", MavenSettings.interpolateVariables( "/home/bob/.m2/repository" ) );
+    }
+
+    @Test
+    public void testInterpolateVariablesOneVariable() throws Exception {
+        try {
+            System.setProperty( "test.user.home", "/home/bob" );
+            Assert.assertEquals("/home/bob/.m2/repository", MavenSettings.interpolateVariables("${test.user.home}/.m2/repository"));
+        } finally {
+            System.clearProperty("test.user.home");
+        }
+    }
+
+    @Test
+    public void testInterpolateVariablesTwoVariables() throws Exception {
+        try {
+            System.setProperty( "test.user.home", "/home/bob" );
+            System.setProperty( "test.repo.dir", "repository" );
+            Assert.assertEquals("/home/bob/.m2/repository", MavenSettings.interpolateVariables("${test.user.home}/.m2/${test.repo.dir}"));
+        } finally {
+            System.clearProperty("test.user.home");
+        }
+    }
+
+    @Test
+    public void testInterpolateVariablesInvalidExpression() throws Exception {
+        try {
+            System.setProperty( "test.user.home", "/home/bob" );
+            Assert.assertEquals("${test.user.home/.m2/repository", MavenSettings.interpolateVariables("${test.user.home/.m2/repository"));
+        } finally {
+            System.clearProperty("test.user.home");
+        }
+    }
+
+    @Test
+    public void testInterpolateVariablesInvalidExpression2() throws Exception {
+        try {
+            System.setProperty( "test.user.home", "/home/bob" );
+            Assert.assertEquals("/home/bob/.m2/${repoName", MavenSettings.interpolateVariables("${test.user.home}/.m2/${repoName"));
+        } finally {
+            System.clearProperty("test.user.home");
+        }
+    }
+
+}
+

--- a/core/bootstrap/src/test/resources/org/jboss/modules/maven/settings-empty-local-repo.xml
+++ b/core/bootstrap/src/test/resources/org/jboss/modules/maven/settings-empty-local-repo.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/settings/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+>
+
+  <localRepository/>
+  <profiles>
+    <profile>
+      <id>jboss-public-repository</id>
+      <repositories>
+
+
+        <repository>
+          <id>jboss-public-repository-group</id>
+          <name>JBoss Public Maven Repository Group</name>
+          <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </repository>
+
+        <repository>
+          <id>jboss-developer-repository-group</id>
+          <name>JBoss Developer Maven Repository Group</name>
+          <url>https://repository.jboss.org/nexus/content/groups/developer/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+
+
+    </profile>
+    <profile>
+      <id>eap-repo</id>
+      <repositories>
+        <repository>
+          <id>brew-maven-repo</id>
+          <name>Red Hat Brew repo</name>
+          <url>http://download.lab.bos.redhat.com/brewroot/repos/jb-eap-6-rhel-6-build/latest/maven/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>brew-maven-repo</id>
+          <name>Red Hat Brew repo</name>
+          <url>http://download.lab.bos.redhat.com/brewroot/repos/jb-eap-6-rhel-6-build/latest/maven/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+
+
+  </profiles>
+
+  <activeProfiles>
+    <activeProfile>jboss-public-repository</activeProfile>
+  </activeProfiles>
+</settings>

--- a/core/bootstrap/src/test/resources/org/jboss/modules/maven/settings-interpolated-local-repo.xml
+++ b/core/bootstrap/src/test/resources/org/jboss/modules/maven/settings-interpolated-local-repo.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/settings/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+>
+
+  <localRepository>${test.user.home}/.mvnrepository</localRepository>
+  <profiles>
+    <profile>
+      <id>jboss-public-repository</id>
+      <repositories>
+
+
+        <repository>
+          <id>jboss-public-repository-group</id>
+          <name>JBoss Public Maven Repository Group</name>
+          <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </repository>
+
+        <repository>
+          <id>jboss-developer-repository-group</id>
+          <name>JBoss Developer Maven Repository Group</name>
+          <url>https://repository.jboss.org/nexus/content/groups/developer/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+
+
+    </profile>
+    <profile>
+      <id>eap-repo</id>
+      <repositories>
+        <repository>
+          <id>brew-maven-repo</id>
+          <name>Red Hat Brew repo</name>
+          <url>http://download.lab.bos.redhat.com/brewroot/repos/jb-eap-6-rhel-6-build/latest/maven/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>brew-maven-repo</id>
+          <name>Red Hat Brew repo</name>
+          <url>http://download.lab.bos.redhat.com/brewroot/repos/jb-eap-6-rhel-6-build/latest/maven/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+
+
+  </profiles>
+
+  <activeProfiles>
+    <activeProfile>jboss-public-repository</activeProfile>
+  </activeProfiles>
+</settings>


### PR DESCRIPTION
Motivation
----------
Since JBoss-Modules reads settings.xml, it should support the same
${property.notation} for <localRepository> that Maven itself supports.

Modifications
-------------
Brought MavenSettings.java into our codebase to monkey patch interpolation
of the localRepository value, iff present.

Result
------
${user.home} and other variables now work.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
