### PR TITLE
Update Keycloak from 2.5.5. to 3.2.1

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -30,7 +30,7 @@
 
     <version.keycloak.config-api>1.1.0.Final</version.keycloak.config-api>
     <version.teiid.config-api>1.0.2</version.teiid.config-api>
-    <version.keycloak>2.5.5.Final</version.keycloak>
+    <version.keycloak>3.2.1.Final</version.keycloak>
     <version.mongo.config-api>1.2.0</version.mongo.config-api>
     <version.cassandra.config-api>1.2.0</version.cassandra.config-api>
     <version.neo4j.config-api>1.2.0</version.neo4j.config-api>


### PR DESCRIPTION
Motivation
----------
Keycloak version is really outdated.

Modifications
-------------
Update Keycloak verstion from 2.5.5 to 3.2.1

Result
------
New version has fixed a bunch issues so this should imporve security.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
