### PR TITLE
SWARM-1522: Consul TTL service check not recovering from errors

### DIFF
--- a/fractions/topology-consul/src/main/java/org/wildfly/swarm/topology/consul/runtime/Advertiser.java
+++ b/fractions/topology-consul/src/main/java/org/wildfly/swarm/topology/consul/runtime/Advertiser.java
@@ -113,6 +113,8 @@ public class Advertiser implements Service<Advertiser>, Runnable {
                             client.pass(serviceId(e));
                         } catch (NotRegisteredException ex) {
                             TopologyMessages.MESSAGES.notRegistered(e.toString(), ex);
+                        } catch (Exception ex) {
+                            TopologyMessages.MESSAGES.errorOnCheck(e.toString(), ex);
                         }
                     });
             try {

--- a/fractions/topology/src/main/java/org/wildfly/swarm/topology/TopologyMessages.java
+++ b/fractions/topology/src/main/java/org/wildfly/swarm/topology/TopologyMessages.java
@@ -50,4 +50,7 @@ public interface TopologyMessages extends BasicLogger {
     @Message(id = 4, value = "Error stopping advertisement.")
     void errorStoppingAdvertisement(@Cause Throwable cause);
 
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 5, value = "Error sending check for %s.")
+    void errorOnCheck(String clientId, @Cause Throwable cause);
 }


### PR DESCRIPTION
Motivation
----------
If any error occurs while sending ttl check (network error, consul unreachable..) the thread will silently die. All other consul components are resilient and will continue working once consul is reachable again.
But the check will then never be called again.

Modifications
-------------
Simply catch and log any exception in the thread so it keeps on trying.

Result
------
makes this part more resilient

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
