### PR TITLE
SWARM-1524: Make Consul CatalogWatcher more robust

### DIFF
--- a/fractions/topology-consul/src/main/java/org/wildfly/swarm/topology/consul/ConsulTopologyMessages.java
+++ b/fractions/topology-consul/src/main/java/org/wildfly/swarm/topology/consul/ConsulTopologyMessages.java
@@ -42,4 +42,8 @@ public interface ConsulTopologyMessages extends BasicLogger {
     @Message(id = 2, value = "Error stopping catalog watcher for: %s.")
     void errorSettingUpCatalogWatcher(String key, @Cause Throwable t);
 
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 3, value = "Error while querying service data from consul.")
+    void errorOnCatalogUpdate(@Cause Throwable t);
+
 }


### PR DESCRIPTION
Motivation
----------
CatalogWatcher starts a Thread that does not catch exceptions. So if any error occurs while querying consul the thread dies..

Modifications
-------------
Added a try catch around the critical part.

Result
------
code is more resilient

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
