### PR TITLE
SWARM-1525: Leverage maven args to determine build file

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/internal/FileSystemLayout.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/FileSystemLayout.java
@@ -18,6 +18,7 @@ package org.wildfly.swarm.internal;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -27,6 +28,8 @@ import java.util.UUID;
  * @since 02/08/16
  */
 public abstract class FileSystemLayout {
+
+    public static final String MAVEN_CMD_LINE_ARGS = "MAVEN_CMD_LINE_ARGS";
 
     public abstract String determinePackagingType();
 
@@ -56,6 +59,7 @@ public abstract class FileSystemLayout {
      * @return a FileSystemLayout instance
      */
     public static FileSystemLayout create() {
+
         String userDir = System.getProperty(USER_DIR);
         if (null == userDir) {
             throw SwarmMessages.MESSAGES.systemPropertyNotFound(USER_DIR);
@@ -72,7 +76,9 @@ public abstract class FileSystemLayout {
      */
     public static FileSystemLayout create(String root) {
 
-        if (Files.exists(Paths.get(root, POM_XML))) {
+        String mavenBuildFile = resolveMavenBuildFileName();
+
+        if (Files.exists(Paths.get(root, mavenBuildFile))) {
             return new MavenFileSystemLayout(root);
         } else if (Files.exists(Paths.get(root, BUILD_GRADLE))) {
             // from version 4 gradle uses separate output directories for each jvm language
@@ -85,6 +91,20 @@ public abstract class FileSystemLayout {
         }
 
         throw SwarmMessages.MESSAGES.cannotIdentifyFileSystemLayout(root);
+    }
+
+    public static String resolveMavenBuildFileName() {
+        String cmdLine = System.getenv(MAVEN_CMD_LINE_ARGS);
+        String buildFileName = POM_XML;
+
+        if (cmdLine != null) {
+            MavenArgsParser args = MavenArgsParser.parse(cmdLine);
+            Optional<String> f_arg = args.get(MavenArgsParser.ARG.F);
+            if (f_arg.isPresent()) {
+                buildFileName = f_arg.get();
+            }
+        }
+        return buildFileName;
     }
 
     public abstract Path getRootPath();

--- a/core/container/src/main/java/org/wildfly/swarm/internal/MavenArgsParser.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/MavenArgsParser.java
@@ -1,0 +1,89 @@
+package org.wildfly.swarm.internal;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.StringTokenizer;
+
+/**
+ * Created by hbraun on 22.08.17.
+ */
+public class MavenArgsParser {
+
+    public enum ARG {
+            F("-f", "--file"),
+            P("-P", "--activate-profiles");
+
+        // the flag is the short form
+        private final String flag;
+
+        // the alt flag is the long form (different syntax applies)
+        private final String altFlag;
+
+        ARG(String flag, String altFlag) {
+            this.flag = flag;
+            this.altFlag = altFlag;
+        }
+
+        public String getFlag() {
+            return flag;
+        }
+        public String getAltFlag() {
+            return altFlag;
+        }
+    }
+
+    private Map<ARG, String> argValues = new HashMap<>();
+
+    private MavenArgsParser(String commandLine) {
+
+        StringTokenizer tok = new StringTokenizer(commandLine, " ");
+        while (tok.hasMoreTokens()) {
+            String token = tok.nextToken();
+            ARG[] args = ARG.values();
+            for (ARG arg : args) {
+
+                // irregular values, without whitespace between flag and value
+                Optional<String> irregularValue = parseIrregularSyntax(arg, token);
+                if (irregularValue.isPresent()) {
+                    argValues.put(arg, irregularValue.get());
+                    continue;
+                }
+
+                // regular syntax with whitespace between flag and value
+                if (token.equals(arg.flag) && tok.hasMoreTokens()) {
+                    argValues.put(arg, tok.nextToken());
+                } else if (token.equals(arg.altFlag) && tok.hasMoreTokens()) {
+                    argValues.put(arg, tok.nextToken());
+                }
+            }
+        }
+    }
+
+    private Optional<String> parseIrregularSyntax(ARG arg, String token) {
+        return extract(arg.flag, token); // irregular syntax only applies to the short form of flags
+    }
+
+    private static Optional<String> extract(String flag, String token) {
+
+        Optional<String> result = Optional.empty();
+
+        if (token.startsWith(flag) && token.length() > flag.length()) {
+            result = Optional.of(token.substring(token.indexOf(flag) + flag.length()));
+        }
+
+        return result;
+    }
+
+    public Optional<String> get(ARG arg) {
+        return argValues.containsKey(arg) ? Optional.of(argValues.get(arg)) : Optional.empty();
+    }
+
+    public static MavenArgsParser parse(String commandLine) {
+        if (null == commandLine) {
+            throw new IllegalArgumentException("commandLine cannot be null");
+        }
+
+        return new MavenArgsParser(commandLine);
+    }
+}

--- a/core/container/src/test/java/org/wildfly/swarm/internal/FileSystemUtilsTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/internal/FileSystemUtilsTest.java
@@ -1,0 +1,62 @@
+package org.wildfly.swarm.internal;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Optional;
+
+/**
+ * Created by hbraun on 22.08.17.
+ */
+public class FileSystemUtilsTest {
+
+    @Test
+    public void testMavenArgsPresent() {
+        String cmd = "clean -f pom-other.xml install";
+        MavenArgsParser args = MavenArgsParser.parse(cmd);
+        Optional<String> f_arg = args.get(MavenArgsParser.ARG.F);
+        Assert.assertTrue(f_arg.isPresent());
+        Assert.assertEquals("pom-other.xml", f_arg.get());
+    }
+
+    @Test
+    public void testMavenArgsMissing() {
+        String cmd = "clean install";
+        MavenArgsParser args = MavenArgsParser.parse(cmd);
+        Optional<String> f_arg = args.get(MavenArgsParser.ARG.F);
+        Assert.assertFalse(f_arg.isPresent());
+    }
+
+    @Test
+    public void testAlternativeFlags() {
+        String cmd = "clean --file pom-other.xml install";
+        MavenArgsParser args = MavenArgsParser.parse(cmd);
+        Optional<String> f_arg = args.get(MavenArgsParser.ARG.F);
+        Assert.assertTrue(f_arg.isPresent());
+        Assert.assertEquals("pom-other.xml", f_arg.get());
+    }
+
+    @Test
+    public void testLackOfWhitespaces() {
+        String cmd = "clean -fpom-other.xml install";
+        MavenArgsParser args = MavenArgsParser.parse(cmd);
+        Optional<String> f_arg = args.get(MavenArgsParser.ARG.F);
+        Assert.assertTrue(f_arg.isPresent());
+        Assert.assertEquals("pom-other.xml", f_arg.get());
+    }
+
+    @Test
+    public void testMultiArgCommand() {
+        String cmd = "clean -fpom-other.xml -PmyProfile install";
+        MavenArgsParser args = MavenArgsParser.parse(cmd);
+
+        Optional<String> f_arg = args.get(MavenArgsParser.ARG.F);
+        Assert.assertTrue(f_arg.isPresent());
+        Assert.assertEquals("pom-other.xml", f_arg.get());
+
+        Optional<String> p_arg = args.get(MavenArgsParser.ARG.P);
+        Assert.assertTrue(p_arg.isPresent());
+        Assert.assertEquals("myProfile", p_arg.get());
+    }
+
+}


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

With these changes in place, any codepath that previously did assume `pom.xm`, scans for `env.MAVEN_CMD_LINE_ARGS` and leverage the argument to `mvn -f <BUILD_FILE_NAME>` to determine which build file should be used. 
