### PR TITLE
SWARM-1328 - Ensure classifier is not lost.

### DIFF
--- a/tools/src/main/java/org/wildfly/swarm/tools/DeclaredDependencies.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/DeclaredDependencies.java
@@ -78,7 +78,7 @@ public class DeclaredDependencies extends DependencyTree<ArtifactSpec> {
                     maven.artifactId(),
                     maven.version(),
                     maven.type(),
-                    null,
+                    maven.classifier(),
                     null
             );
         } catch (IOException e) {


### PR DESCRIPTION
Motivation
----------
We were losing information in DeclaredDependencies
when converting between two of our multiple types of
Maven artifact descriptors.

Modifications
-------------
Don't discard the classifier during conversion.

Result
------
Information is retained.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
