### PR TITLE
SWARM-1033 -- Support usage.txt

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/core/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -640,6 +640,8 @@ public class Swarm {
             tryToStopAfterStartupError(t, swarm);
             throw t;
         }
+
+        displayUsage();
     }
 
     public static void stopMain() throws Exception {
@@ -666,6 +668,10 @@ public class Swarm {
                 System.exit(1);
             }
         }
+    }
+
+    private static void displayUsage() throws Exception {
+        swarm.server.displayUsage();
     }
 
     private static ArtifactLookup artifactLookup() {

--- a/core/container/src/main/java/org/wildfly/swarm/container/internal/Server.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/internal/Server.java
@@ -24,4 +24,5 @@ public interface Server {
 
     Deployer deployer();
 
+    void displayUsage() throws Exception;
 }

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
@@ -54,6 +54,7 @@ import org.wildfly.swarm.container.internal.Deployer;
 import org.wildfly.swarm.container.internal.Server;
 import org.wildfly.swarm.container.runtime.deployments.DefaultDeploymentCreator;
 import org.wildfly.swarm.container.runtime.marshal.DMRMarshaller;
+import org.wildfly.swarm.container.runtime.usage.UsageCreator;
 import org.wildfly.swarm.container.runtime.wildfly.ContentRepositoryServiceActivator;
 import org.wildfly.swarm.container.runtime.wildfly.SwarmContentRepository;
 import org.wildfly.swarm.container.runtime.wildfly.UUIDFactory;
@@ -106,6 +107,9 @@ public class RuntimeServer implements Server {
 
     @Inject
     private ConfigurableManager configurableManager;
+
+    @Inject
+    private UsageCreator usageCreator;
 
     public RuntimeServer() {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
@@ -177,7 +181,6 @@ public class RuntimeServer implements Server {
         try (AutoCloseable handle = Performance.time("configurable-manager rescan")) {
             this.configurableManager.rescan();
             this.configurableManager.log();
-            this.configurableManager.close();
         }
 
         try (AutoCloseable handle = Performance.time("marshall DMR")) {
@@ -278,6 +281,16 @@ public class RuntimeServer implements Server {
     @Override
     public Deployer deployer() {
         return this.deployer.get();
+    }
+
+    @Override
+    public void displayUsage() throws Exception {
+        String message = this.usageCreator.getUsageMessage();
+        if (message != null) {
+            SwarmMessages.MESSAGES.usage(message);
+        }
+
+        this.configurableManager.close();
     }
 
     private SelfContainedContainer container;

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/usage/ConfigurableManagerUsageVariableSupplier.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/usage/ConfigurableManagerUsageVariableSupplier.java
@@ -1,0 +1,36 @@
+package org.wildfly.swarm.container.runtime.usage;
+
+import java.util.Optional;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.wildfly.swarm.container.runtime.ConfigurableHandle;
+import org.wildfly.swarm.container.runtime.ConfigurableManager;
+
+/**
+ * Created by bob on 8/30/17.
+ */
+@ApplicationScoped
+public class ConfigurableManagerUsageVariableSupplier implements UsageVariableSupplier {
+
+    @Inject
+    public ConfigurableManagerUsageVariableSupplier(ConfigurableManager manager) {
+        this.manager = manager;
+    }
+
+    @Override
+    public Object valueOf(String name) throws Exception {
+        Optional<ConfigurableHandle> configurable = this.manager.configurables().stream()
+                .filter(e -> e.key().toString().equals(name))
+                .findFirst();
+
+        if (configurable.isPresent()) {
+            return configurable.get().currentValue();
+        }
+
+        return null;
+    }
+
+    private final ConfigurableManager manager;
+}

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/usage/ModuleUsageProvider.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/usage/ModuleUsageProvider.java
@@ -1,0 +1,50 @@
+package org.wildfly.swarm.container.runtime.usage;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.stream.Collectors;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.jboss.modules.Module;
+import org.jboss.modules.ModuleIdentifier;
+
+/**
+ * Created by bob on 8/30/17.
+ */
+@ApplicationScoped
+public class ModuleUsageProvider implements UsageProvider {
+
+    String USAGE_TXT = "usage.txt";
+
+    String META_INF_USAGE_TXT = "META-INF/" + USAGE_TXT;
+
+    String WEB_INF_USAGE_TXT = "WEB-INF/" + USAGE_TXT;
+
+    @Override
+    public String getRawUsageText() throws Exception {
+        Module module = Module.getBootModuleLoader().loadModule(ModuleIdentifier.create("swarm.application"));
+        ClassLoader cl = module.getClassLoader();
+
+        InputStream in = cl.getResourceAsStream(META_INF_USAGE_TXT);
+
+        if (in == null) {
+            in = cl.getResourceAsStream(WEB_INF_USAGE_TXT);
+        }
+
+        if (in == null) {
+            in = cl.getResourceAsStream(USAGE_TXT);
+        }
+
+        if (in != null) {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
+                return reader
+                        .lines()
+                        .collect(Collectors.joining("\n"));
+            }
+        }
+
+        return null;
+    }
+}

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/usage/UsageCreator.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/usage/UsageCreator.java
@@ -1,0 +1,66 @@
+package org.wildfly.swarm.container.runtime.usage;
+
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+/**
+ * Created by bob on 8/30/17.
+ */
+@ApplicationScoped
+public class UsageCreator {
+
+    @Inject
+    public UsageCreator(UsageProvider provider, UsageVariableSupplier supplier) {
+        this.provider = provider;
+        this.supplier = supplier;
+    }
+
+    public String getUsageMessage() throws Exception {
+        return replaceVariables(readRawUsage());
+    }
+
+    public String readRawUsage() throws Exception {
+        return this.provider.getRawUsageText();
+    }
+
+    public String replaceVariables(String raw) throws Exception {
+        if (raw == null) {
+            return null;
+        }
+
+        Matcher matcher = PATTERN.matcher(raw);
+        StringBuilder replaced = new StringBuilder();
+
+        int cur = 0;
+
+        while (matcher.find()) {
+            MatchResult result = matcher.toMatchResult();
+
+            replaced.append(raw.substring(cur, result.start(1)));
+
+            String name = result.group(2);
+            Object value = this.supplier.valueOf(name);
+            if (value == null) {
+                value = "${" + name + "}";
+            }
+            replaced.append(value);
+
+            cur = result.end();
+        }
+
+        replaced.append(raw.substring(cur));
+
+        return replaced.toString();
+    }
+
+    private static final Pattern PATTERN = Pattern.compile("[^\\\\]?(\\$\\{([^}]+)\\})");
+
+    private final UsageProvider provider;
+
+    private final UsageVariableSupplier supplier;
+
+}

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/usage/UsageProvider.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/usage/UsageProvider.java
@@ -1,0 +1,32 @@
+package org.wildfly.swarm.container.runtime.usage;
+
+/**
+ * Created by bob on 8/30/17.
+ */
+public interface UsageProvider {
+
+    static UsageProvider ofString(String str) {
+        return new StringUsageProvider(str);
+    }
+
+    static UsageProvider byModule() {
+        return new ModuleUsageProvider();
+    }
+
+    default String getRawUsageText() throws Exception {
+        return null;
+    }
+
+    class StringUsageProvider implements UsageProvider {
+        public StringUsageProvider(String str) {
+            this.str = str;
+        }
+
+        @Override
+        public String getRawUsageText() throws Exception {
+            return this.str;
+        }
+
+        private final String str;
+    }
+}

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/usage/UsageVariableSupplier.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/usage/UsageVariableSupplier.java
@@ -1,0 +1,28 @@
+package org.wildfly.swarm.container.runtime.usage;
+
+import java.util.Properties;
+
+/**
+ * Created by bob on 8/30/17.
+ */
+public interface UsageVariableSupplier {
+    Object valueOf(String name) throws Exception;
+
+    static UsageVariableSupplier ofProperties(Properties props) {
+        return new PropertiesUsageVariableSupplier(props);
+    }
+
+    class PropertiesUsageVariableSupplier implements UsageVariableSupplier {
+
+        PropertiesUsageVariableSupplier(Properties props) {
+            this.props = props;
+        }
+
+        @Override
+        public Object valueOf(String name) throws Exception {
+            return this.props.getProperty(name);
+        }
+
+        private final Properties props;
+    }
+}

--- a/core/container/src/main/java/org/wildfly/swarm/internal/SwarmMessages.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/SwarmMessages.java
@@ -162,6 +162,11 @@ public interface SwarmMessages extends BasicLogger {
     // ------------------------------------------------------------------------
 
     @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 88888, value = "%n%n========================================================================%n%n%s%n%n========================================================================%n")
+    void usage(String message);
+
+
+    @LogMessage(level = Logger.Level.INFO)
     @Message(id = 99999, value = "WildFly Swarm is Ready")
     void wildflySwarmIsReady();
 

--- a/core/container/src/test/java/org/wildfly/swarm/container/runtime/usage/UsageCreatorTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/container/runtime/usage/UsageCreatorTest.java
@@ -1,0 +1,48 @@
+package org.wildfly.swarm.container.runtime.usage;
+
+import java.util.Properties;
+
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * Created by bob on 8/30/17.
+ */
+public class UsageCreatorTest {
+
+    @Test
+    public void testNoUsage() throws Exception {
+        UsageCreator creator = new UsageCreator(UsageProvider.ofString(null), null);
+        assertThat(creator.getUsageMessage()).isNull();
+    }
+
+    @Test
+    public void testUsageWithNoVariableReplacement() throws Exception {
+        UsageCreator creator = new UsageCreator(UsageProvider.ofString("I LIKE TACOS"), null);
+        assertThat(creator.getUsageMessage()).isEqualTo("I LIKE TACOS");
+    }
+
+    @Test
+    public void testUsageWithVariableReplacement() throws Exception {
+        Properties props = new Properties();
+        props.setProperty("swarm.http.port", "8080");
+        props.setProperty("swarm.app.thingy", "TACOS");
+        UsageVariableSupplier supplier = UsageVariableSupplier.ofProperties(props);
+
+        UsageCreator creator = new UsageCreator(UsageProvider.ofString("I LIKE ${swarm.app.thingy}\nOn port ${swarm.http.port}.\nTry it now!"), supplier);
+        String message = creator.getUsageMessage();
+        assertThat(message).isEqualTo("I LIKE TACOS\nOn port 8080.\nTry it now!");
+    }
+
+    @Test
+    public void testUsageWithVariableReplacementSomeUnknown() throws Exception {
+        Properties props = new Properties();
+        props.setProperty("swarm.http.port", "8080");
+        UsageVariableSupplier supplier = UsageVariableSupplier.ofProperties(props);
+
+        UsageCreator creator = new UsageCreator(UsageProvider.ofString("I LIKE ${swarm.app.thingy}\nOn port ${swarm.http.port}.\nTry it now!"), supplier);
+        String message = creator.getUsageMessage();
+        assertThat(message).isEqualTo("I LIKE ${swarm.app.thingy}\nOn port 8080.\nTry it now!");
+    }
+}


### PR DESCRIPTION
Motivation
----------
Some -swarm.jar apps might enjoy being able to display some
usage information after booting.

Modifications
-------------

If a user's application has one of:

* `usage.txt`
* `META-INF/usage.txt`
* `WEB-INF/usage.txt`

it will be displayed immediately prior to the message that
states "WildFly Swarm is Ready".

Variables within this file, in the form of ${foo} will be interpolated
if the associated configurable is available.  This is useful for
pointing out which port or URL might be available, such as by using
${swarm.http.port} within the file.

If the configurable is un-set, then the variable will *not* be
interpolated, and you will see a literal `${whatever}` in the
output.  `usage.txt` is *not* intended to be a fancy scripting
language. The variables *are* exposed from defaults after all
configurables have been processed from the fraction configurations,
so they do not need to be explicitly set.

Result
------
Ability to display customized usage information at boot.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
