### PR TITLE
SWARM-1355 -- Support configuration value filtering.

### DIFF
--- a/boms/src/main/resources/bom-template.xml
+++ b/boms/src/main/resources/bom-template.xml
@@ -55,6 +55,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>spi</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.jboss.shrinkwrap</groupId>
         <artifactId>shrinkwrap-bom</artifactId>
         <version>${version.shrinkwrap}</version>

--- a/core/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/core/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -15,6 +15,7 @@
  */
 package org.wildfly.swarm;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Method;
@@ -27,6 +28,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -40,13 +42,21 @@ import java.util.zip.ZipEntry;
 
 import javax.enterprise.inject.Vetoed;
 
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.Indexer;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoadException;
 import org.jboss.modules.ModuleLoader;
+import org.jboss.modules.Resource;
+import org.jboss.modules.filter.PathFilters;
 import org.jboss.modules.log.StreamModuleLogger;
 import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePath;
 import org.jboss.shrinkwrap.api.Domain;
+import org.jboss.shrinkwrap.api.Node;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.exporter.ExplodedExporter;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
@@ -76,6 +86,7 @@ import org.wildfly.swarm.internal.OutboundSocketBindingRequest;
 import org.wildfly.swarm.internal.SocketBindingRequest;
 import org.wildfly.swarm.internal.SwarmMessages;
 import org.wildfly.swarm.spi.api.ArtifactLookup;
+import org.wildfly.swarm.spi.api.ConfigurationFilter;
 import org.wildfly.swarm.spi.api.Fraction;
 import org.wildfly.swarm.spi.api.OutboundSocketBinding;
 import org.wildfly.swarm.spi.api.SocketBinding;
@@ -606,8 +617,86 @@ public class Swarm {
 
             this.configView.load("defaults");
 
+            initializeConfigFilters();
+
         } catch (Exception e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    private void initializeConfigFilters() throws ModuleLoadException, IOException, ClassNotFoundException {
+        if (isFatJar()) {
+            initializeConfigFiltersFatJar();
+        } else {
+            initializeConfigFiltersClassPath();
+        }
+    }
+
+    private void initializeConfigFiltersFatJar() throws ModuleLoadException, IOException, ClassNotFoundException {
+        Indexer indexer = new Indexer();
+
+        Module appModule = Module.getBootModuleLoader().loadModule(ModuleIdentifier.create(APPLICATION_MODULE_NAME));
+        Iterator<Resource> iter = appModule.iterateResources(PathFilters.acceptAll());
+        while (iter.hasNext()) {
+            Resource each = iter.next();
+            if (each.getName().endsWith(".class")) {
+                indexer.index(each.openStream());
+            }
+        }
+
+        Index index = indexer.complete();
+        Set<ClassInfo> impls = index.getAllKnownImplementors(DotName.createSimple(ConfigurationFilter.class.getName()));
+
+        for (ClassInfo each : impls) {
+            String name = each.name().toString();
+            Class<? extends ConfigurationFilter> cls = (Class<? extends ConfigurationFilter>) appModule.getClassLoader().loadClass(name);
+            try {
+                ConfigurationFilter filter = cls.newInstance();
+                this.configView.withFilter(filter);
+            } catch (InstantiationException | IllegalAccessException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private void initializeConfigFiltersClassPath() throws IOException, ClassNotFoundException {
+        String classpath = System.getProperty("java.class.path");
+        String[] locations = classpath.split(System.getProperty("path.separator"));
+
+        Indexer indexer = new Indexer();
+
+        for (String location : locations) {
+            File file = new File(location);
+            JavaArchive archive = null;
+            if (file.exists()) {
+                if (file.isDirectory()) {
+                    archive = ShrinkWrap.create(ExplodedImporter.class).importDirectory(file).as(JavaArchive.class);
+                } else {
+                    archive = ShrinkWrap.create(ZipImporter.class).importFrom(file).as(JavaArchive.class);
+                }
+
+                Map<ArchivePath, Node> content = archive.getContent();
+                for (ArchivePath path : content.keySet()) {
+                    if (path.get().endsWith(".class")) {
+                        Node node = content.get(path);
+                        indexer.index(node.getAsset().openStream());
+                    }
+                }
+            }
+        }
+
+        Index index = indexer.complete();
+        Set<ClassInfo> impls = index.getAllKnownImplementors(DotName.createSimple(ConfigurationFilter.class.getName()));
+
+        for (ClassInfo each : impls) {
+            String name = each.name().toString();
+            Class<? extends ConfigurationFilter> cls = (Class<? extends ConfigurationFilter>) Class.forName(name);
+            try {
+                ConfigurationFilter filter = cls.newInstance();
+                this.configView.withFilter(filter);
+            } catch (InstantiationException | IllegalAccessException e) {
+                e.printStackTrace();
+            }
         }
     }
 

--- a/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewFactory.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewFactory.java
@@ -27,6 +27,7 @@ import java.util.Properties;
 import javax.enterprise.inject.Vetoed;
 
 import org.jboss.modules.ModuleLoadException;
+import org.wildfly.swarm.spi.api.ConfigurationFilter;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
@@ -212,6 +213,11 @@ public class ConfigViewFactory {
     public void withProperty(String name, String value) {
         this.configView.withProperty(name, value);
     }
+
+    public void withFilter(ConfigurationFilter filter) {
+        this.configView.withFilter(filter);
+    }
+
 
     private List<ConfigLocator> locators = new ArrayList<>();
 

--- a/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewImpl.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigViewImpl.java
@@ -25,6 +25,7 @@ import java.util.stream.Stream;
 
 import javax.enterprise.inject.Vetoed;
 
+import org.wildfly.swarm.spi.api.ConfigurationFilter;
 import org.wildfly.swarm.spi.api.config.Builder;
 import org.wildfly.swarm.spi.api.config.ConfigKey;
 import org.wildfly.swarm.spi.api.config.ConfigView;
@@ -125,6 +126,10 @@ public class ConfigViewImpl implements ConfigView {
      */
     public Object valueOf(ConfigKey key) {
         return this.strategy.valueOf(key);
+    }
+
+    public void withFilter(ConfigurationFilter filter) {
+        this.strategy.withFilter(filter);
     }
 
     void withProfile(String... names) {

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/ConfigurableManager.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/ConfigurableManager.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -765,7 +766,7 @@ public class ConfigurableManager implements AutoCloseable {
 
         List<ConfigurableHandle> sorted = this.configurables
                 .stream()
-                .sorted((l, r) -> l.key().name().compareTo(r.key().name()))
+                .sorted(Comparator.comparing(l -> l.key().name()))
                 .collect(Collectors.toList());
 
         boolean first = true;

--- a/core/container/src/main/resources/modules/org/wildfly/swarm/container/api/module.xml
+++ b/core/container/src/main/resources/modules/org/wildfly/swarm/container/api/module.xml
@@ -47,6 +47,7 @@
     <module name="org.jboss.weld.se"/>
     <module name="javax.enterprise.api"/>
     <module name="javax.inject.api"/>
+    <module name="org.jboss.jandex"/>
     <module name="javax.annotation.api" export="true"/>
 
     <!-- the following have been added to support xml parsing -->

--- a/core/spi/pom.xml
+++ b/core/spi/pom.xml
@@ -27,11 +27,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.wildfly.swarm</groupId>
-      <artifactId>bootstrap</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.jboss.shrinkwrap</groupId>
       <artifactId>shrinkwrap-api</artifactId>
     </dependency>

--- a/core/spi/src/main/java/org/wildfly/swarm/spi/api/ConfigurationFilter.java
+++ b/core/spi/src/main/java/org/wildfly/swarm/spi/api/ConfigurationFilter.java
@@ -1,0 +1,28 @@
+package org.wildfly.swarm.spi.api;
+
+/**
+ * SPI for user-provided configuration value filtering.
+ *
+ * <p>Implementations will be discovered within the user's classpath
+ * and given an opportunity to filter any user-provided configuration
+ * values.</p>
+ *
+ * Created by bob on 8/31/17.
+ */
+public interface ConfigurationFilter {
+
+    /**
+     * Filter the provided configuration key and value.
+     *
+     * <p>Each filter will be given an opportunity to filter
+     * each user-provided value. If the filter chooses to
+     * perform no filtering, it should simply return the
+     * original value.</p>
+     *
+     * @param key   The key of the configuration item to filter.
+     * @param value The value to filter.
+     * @param <T>   The type of the filtered value.
+     * @return The filtered value.
+     */
+    <T> T filter(String key, T value);
+}

--- a/testsuite/testsuite-project-stages/pom.xml
+++ b/testsuite/testsuite-project-stages/pom.xml
@@ -26,6 +26,11 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>container</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+
 
   </dependencies>
 


### PR DESCRIPTION
Motivation
----------
Some people may encrypt or otherwise obscure configuration
values and desire a generic way to filter the values from
the YAML files (or properties) through a decryption service.

Modifications
-------------
* Added `spi` to the BOM
* Added `ConfigurationFilter` class to the SPI
* Scan applications for implementations of aforementioned class
* Provide all implementations an opportunity to filter configuration values.

Result
------
Users can ROT13 or otherwise mutate configuration values specified
in YAML or as properties.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
