### PR TITLE
SWARM-1203: Fix SQLServerDriverInfo module dependencies.

### DIFF
--- a/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/DriverInfo.java
+++ b/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/DriverInfo.java
@@ -82,6 +82,10 @@ public abstract class DriverInfo {
         // no-op, but overridable
     }
 
+    protected void addModuleDependencies(ModuleSpec.Builder builder) {
+        // no-op, but overridable
+    }
+
     protected abstract void configureDefaultDS(DataSource datasource);
 
     public boolean detect(DatasourcesFraction fraction) {
@@ -124,6 +128,7 @@ public abstract class DriverInfo {
                 builder.addDependency(DependencySpec.createModuleDependencySpec(ModuleIdentifier.create("javax.api")));
                 builder.addDependency(DependencySpec.createModuleDependencySpec(ModuleIdentifier.create("javax.transactions.api"), false, true));
                 builder.addDependency(DependencySpec.createLocalDependencySpec());
+                addModuleDependencies(builder);
 
                 return builder.create();
             });

--- a/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/drivers/SQLServerDriverInfo.java
+++ b/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/drivers/SQLServerDriverInfo.java
@@ -17,7 +17,9 @@ package org.wildfly.swarm.datasources.runtime.drivers;
 
 import javax.enterprise.context.ApplicationScoped;
 
+import org.jboss.modules.DependencySpec;
 import org.jboss.modules.ModuleIdentifier;
+import org.jboss.modules.ModuleSpec.Builder;
 import org.wildfly.swarm.config.datasources.DataSource;
 import org.wildfly.swarm.config.datasources.JDBCDriver;
 import org.wildfly.swarm.datasources.runtime.DriverInfo;
@@ -50,4 +52,11 @@ public class SQLServerDriverInfo extends DriverInfo {
         datasource.userName(DEFAULT_USER_NAME);
         datasource.password(DEFAULT_PASSWORD);
     }
+
+    @Override
+    protected void addModuleDependencies(Builder builder) {
+        // JDBC driver for SQL Server 6.0 - 6.2 is using javax.xml.bind.DatatypeConverter
+        builder.addDependency(DependencySpec.createModuleDependencySpec(ModuleIdentifier.create("javax.xml.bind.api")));
+    }
+
 }


### PR DESCRIPTION
Motivation
----------
JDBC driver for SQL Server 6.0 - 6.2 is using
javax.xml.bind.DatatypeConverter.

Modifications
-------------
Added "javax.xml.bind.api" dependency to "com.microsoft" module.

Result
------
Autodetection should not fail anymore.