### PR TITLE
ENTSWM-156: Use explicit versions for licenses-related maven plugins.

### DIFF
--- a/boms/src/main/resources/licenses-project-template.xml
+++ b/boms/src/main/resources/licenses-project-template.xml
@@ -23,6 +23,7 @@
          <plugin>
             <groupId>org.wildfly.maven.plugins</groupId>
             <artifactId>licenses-plugin</artifactId>
+            <version>${version.wildfly-licenses-plugin}</version>
             <inherited>false</inherited>
             <executions>
                <execution>
@@ -99,6 +100,7 @@
          <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>license-maven-plugin</artifactId>
+            <version>${version.license-maven-plugin}</version>
             <inherited>false</inherited>
             <executions>
                <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,8 @@
     <version.keytool-maven-plugin>1.5</version.keytool-maven-plugin>
     <version.maven.plugin.api>3.2.5</version.maven.plugin.api>
     <version.xml-maven-plugin>1.0.1</version.xml-maven-plugin>
+    <version.license-maven-plugin>1.13</version.license-maven-plugin>
+    <version.wildfly-licenses-plugin>1.0.1</version.wildfly-licenses-plugin>
 
     <version.checkstyle>7.4</version.checkstyle>
 


### PR DESCRIPTION
According to PNC the latest release of
org.codehaus.mojo:license-maven-plugin is 1.0-alpha-1-2-jbossorg (very
outdated, more than six years old).