### PR TITLE
SWARM-1539 - Accomodate port offset.

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
@@ -142,6 +142,8 @@ public class RuntimeServer implements Server {
             throw new RuntimeException(e);
         }
 
+        this.networkConfigurer.configure();
+
         List<ModelNode> bootstrapOperations = new ArrayList<>();
         BootstrapConfiguration bootstrapConfiguration = () -> bootstrapOperations;
 
@@ -166,7 +168,7 @@ public class RuntimeServer implements Server {
             }
         }
 
-        this.socketBindingGroupConfigurer.configure();
+        this.networkConfigurer.configure();
 
         /*
         this.archivePreparers.forEach(e -> {
@@ -302,7 +304,7 @@ public class RuntimeServer implements Server {
     private ArtifactDeployer artifactDeployer;
 
     @Inject
-    private SocketBindingGroupConfigurer socketBindingGroupConfigurer;
+    private NetworkConfigurer networkConfigurer;
 
     private ModelControllerClient client;
 }

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/config/DefaultSocketBindingGroupProducer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/config/DefaultSocketBindingGroupProducer.java
@@ -21,7 +21,6 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.wildfly.swarm.spi.api.SocketBindingGroup;
-import org.wildfly.swarm.spi.api.SwarmProperties;
 
 /**
  * @author Bob McWhirter
@@ -38,7 +37,7 @@ public class DefaultSocketBindingGroupProducer {
         return new SocketBindingGroup(
                 STANDARD_SOCKETS,
                 "public",
-                SwarmProperties.propertyVar(SwarmProperties.PORT_OFFSET, "0"));
+                "0");
     }
 
 }

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/config/PublicInterfaceProducer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/config/PublicInterfaceProducer.java
@@ -18,9 +18,9 @@ package org.wildfly.swarm.container.runtime.config;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import org.wildfly.swarm.container.Interface;
-import org.wildfly.swarm.spi.api.SwarmProperties;
 
 /**
  * @author Bob McWhirter
@@ -30,7 +30,8 @@ public class PublicInterfaceProducer {
 
     @Produces
     @Named(Interface.PUBLIC)
-    public Interface publicInterace() {
-        return new Interface("public", SwarmProperties.propertyVar(SwarmProperties.BIND_ADDRESS, "0.0.0.0"));
+    @Singleton
+    public Interface publicInterface() {
+        return new Interface("public", "0.0.0.0");
     }
 }

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/usage/NetworkVariableSupplier.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/usage/NetworkVariableSupplier.java
@@ -1,0 +1,94 @@
+package org.wildfly.swarm.container.runtime.usage;
+
+import org.wildfly.swarm.container.Interface;
+import org.wildfly.swarm.spi.api.SocketBinding;
+import org.wildfly.swarm.spi.api.SocketBindingGroup;
+
+/**
+ * Created by bob on 9/7/17.
+ */
+public class NetworkVariableSupplier implements UsageVariableSupplier {
+
+    public NetworkVariableSupplier(Iterable<Interface> interfaces, Iterable<SocketBindingGroup> socketBindings, UsageVariableSupplier delegate) {
+        this.interfaces = interfaces;
+        this.socketBindings = socketBindings;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Object valueOf(String name) throws Exception {
+        // very special case
+        if (name.equals("swarm.public.url.base")) {
+            return "http://" + valueOf("swarm.public.host") + ":" + valueOf("swarm.http.port") + "/";
+        }
+
+        String[] parts = name.split("\\.");
+        if (parts.length > 0 && parts[0].equals("swarm")) {
+            if (parts.length == 3) {
+                for (Interface each : this.interfaces) {
+                    if (parts[1].equals(each.getName())) {
+                        if (parts[2].equals("host")) {
+                            return each.getExpression();
+                        }
+                    }
+                }
+            }
+
+            Object value = null;
+            for (SocketBindingGroup each : this.socketBindings) {
+                value = valueOf(each, name);
+                if (value != null) {
+                    break;
+                }
+            }
+
+            if (value != null) {
+                return value;
+            }
+        }
+
+        return this.delegate.valueOf(name);
+    }
+
+    protected Object valueOf(SocketBindingGroup group, String name) throws Exception {
+        String[] parts = name.split("\\.");
+
+        String bindingName = null;
+        String which = "port";
+
+        if (parts.length == 3) {
+            bindingName = parts[1];
+        } else if (parts.length == 4) {
+            bindingName = parts[1];
+            which = parts[2];
+        }
+
+        int offset = Integer.parseInt(group.portOffsetExpression());
+
+        for (SocketBinding socketBinding : group.socketBindings()) {
+            if (socketBinding.name().equals(bindingName)) {
+                if (which.equals("port")) {
+                    int port = Integer.parseInt(socketBinding.portExpression());
+                    return "" + (port + offset);
+                } else if (which.equals("multicast-port")) {
+                    int port = Integer.parseInt(socketBinding.multicastPortExpression());
+                    return "" + (port + offset);
+                } else if (which.equals("multicast-address")) {
+                    String addr = socketBinding.multicastAddress();
+                    return addr;
+                } else if (which.equals("host")) {
+                    return valueOf("swarm." + socketBinding.iface() + ".host");
+                }
+            }
+        }
+
+        return null;
+    }
+
+
+    private final UsageVariableSupplier delegate;
+
+    private final Iterable<SocketBindingGroup> socketBindings;
+
+    private final Iterable<Interface> interfaces;
+}

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/usage/UsageCreator.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/usage/UsageCreator.java
@@ -19,8 +19,14 @@ import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
+
+import org.wildfly.swarm.container.Interface;
+import org.wildfly.swarm.spi.api.SocketBindingGroup;
 
 /**
  * Created by bob on 8/30/17.
@@ -28,7 +34,14 @@ import javax.inject.Inject;
 @ApplicationScoped
 public class UsageCreator {
 
-    @Inject
+    public UsageCreator() {
+    }
+
+    @PostConstruct
+    public void setupDelegateSupplier() {
+        this.supplier = new NetworkVariableSupplier(this.interfaces, this.socketBindingGroups, this.supplier);
+    }
+
     public UsageCreator(UsageProvider provider, UsageVariableSupplier supplier) {
         this.provider = provider;
         this.supplier = supplier;
@@ -74,8 +87,19 @@ public class UsageCreator {
 
     private static final Pattern PATTERN = Pattern.compile("[^\\\\]?(\\$\\{([^}]+)\\})");
 
-    private final UsageProvider provider;
+    @Inject
+    private UsageProvider provider;
 
-    private final UsageVariableSupplier supplier;
+    @Inject
+    private UsageVariableSupplier supplier;
+
+    @Inject
+    @Any
+    private Instance<SocketBindingGroup> socketBindingGroups;
+
+    @Inject
+    @Any
+    private Instance<Interface> interfaces;
+
 
 }

--- a/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/runtime/ManagementInterfaceProducer.java
+++ b/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/runtime/ManagementInterfaceProducer.java
@@ -18,10 +18,9 @@ package org.wildfly.swarm.management.runtime;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import org.wildfly.swarm.container.Interface;
-import org.wildfly.swarm.management.ManagementProperties;
-import org.wildfly.swarm.spi.api.SwarmProperties;
 
 /**
  * @author Bob McWhirter
@@ -31,7 +30,8 @@ public class ManagementInterfaceProducer {
 
     @Produces
     @Named(Interface.MANAGEMENT)
+    @Singleton
     public Interface publicInterace() {
-        return new Interface("management", SwarmProperties.propertyVar(ManagementProperties.MANAGEMENT_BIND_ADDRESS, "127.0.0.1"));
+        return new Interface("management", "127.0.0.1");
     }
 }


### PR DESCRIPTION
Motivation
----------
usage.txt needs to be able to display the actual port in use,
not just bare swarm.http.port.

Modifications
-------------
In general move away from ${swarm.port.offset:0} format for expressions
resolved by WF into forcing our own YAML/configurable to handle it prior
because we need it resolved earlier for usage.txt.

Now support:

${swarm.INTERFACE_NAME.host} such as ${swarm.public.host} for learning
of hostnames for interfaces.

${swarm.BINDING.port}, ${swarm.BINDING.multicast-port} and ${swarm.BINDING.multicast-address}
for general socket-bindings etc, taking into account the port-offset.

Just so happens that makes ${swarm.http.port} tell you the correctly-offsetted
port.

Additionally, for ease of use, ${swarm.public.url.base} will resolve the same
as:

    http://${swarm.public.host}:${swarm.http.port}/

It's the only friendly short-hand we've got.

Result
------
See above.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
