### PR TITLE
SWARM-1535 - Handle deployment exceptions via Arquilian.

### DIFF
--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
@@ -185,6 +185,8 @@ public class UberjarSimpleContainer implements SimpleContainer {
             executor.withProperty(SwarmProperties.CONTEXT_PATH, contextRoot.context());
         }
 
+        executor.withProperty("swarm.inhibit.auto-stop", "true");
+
         String additionalRepos = System.getProperty(SwarmInternalProperties.BUILD_REPOS);
         if (additionalRepos != null) {
             additionalRepos = additionalRepos + ",";
@@ -204,7 +206,7 @@ public class UberjarSimpleContainer implements SimpleContainer {
         // check for "org.wildfly.swarm.allDependencies" flag
         // see DependenciesContainer#addAllDependencies()
         if (archive instanceof DependenciesContainer) {
-            DependenciesContainer<?> depContainer =  (DependenciesContainer<?>) archive;
+            DependenciesContainer<?> depContainer = (DependenciesContainer<?>) archive;
             if (depContainer.hasMarker(DependenciesContainer.ALL_DEPENDENCIES_MARKER)) {
                 munge(depContainer, declaredDependencies);
             }

--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/WildFlySwarmContainer.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/WildFlySwarmContainer.java
@@ -64,7 +64,7 @@ public class WildFlySwarmContainer extends DaemonDeployableContainerBase<DaemonC
     }
 
     @Override
-    public ProtocolMetaData deploy(Archive<?> archive) throws DeploymentException {
+    public synchronized ProtocolMetaData deploy(Archive<?> archive) throws DeploymentException {
         StartupTimeout startupTimeout = this.testClass.getAnnotation(StartupTimeout.class);
         if (startupTimeout != null) {
             setTimeout(startupTimeout.value());
@@ -85,13 +85,16 @@ public class WildFlySwarmContainer extends DaemonDeployableContainerBase<DaemonC
             metaData.addContext(createDeploymentContext(archive.getId()));
 
             return metaData;
-        } catch (Exception e) {
+        } catch (Throwable e) {
+            if (e instanceof LifecycleException) {
+                e = e.getCause();
+            }
             throw new DeploymentException(e.getMessage(), e);
         }
     }
 
     @Override
-    public void undeploy(Archive<?> archive) throws DeploymentException {
+    public synchronized void undeploy(Archive<?> archive) throws DeploymentException {
         try {
             this.delegateContainer.stop();
         } catch (Exception e) {

--- a/arquillian/arquillian/src/main/java/org/wildfly/swarm/arquillian/deployment/TestableArchiveService.java
+++ b/arquillian/arquillian/src/main/java/org/wildfly/swarm/arquillian/deployment/TestableArchiveService.java
@@ -39,6 +39,10 @@ public class TestableArchiveService implements Service<Void> {
         return null;
     }
 
+    public void setError(Throwable cause) {
+        this.serverInjector.getValue().setError(cause);
+    }
+
     private String archiveName;
 
     public final InjectedValue<Server> serverInjector = new InjectedValue<>();

--- a/arquillian/daemon/src/main/java/org/wildfly/swarm/arquillian/daemon/protocol/WireProtocol.java
+++ b/arquillian/daemon/src/main/java/org/wildfly/swarm/arquillian/daemon/protocol/WireProtocol.java
@@ -35,6 +35,8 @@ public interface WireProtocol {
 
     String PREFIX_STRING_COMMAND = "CMD ";
 
+    String COMMAND_CHECK_DEPLOYMENT = PREFIX_STRING_COMMAND + "checkdeployment";
+
     String COMMAND_STOP = PREFIX_STRING_COMMAND + "stop";
 
     /**

--- a/core/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/core/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -726,7 +726,10 @@ public class Swarm {
             vme.printStackTrace();
             System.exit(1);
         } catch (final Throwable t) {
-            tryToStopAfterStartupError(t, swarm);
+            if (System.getProperty("swarm.inhibit.auto-stop") == null) {
+                t.printStackTrace();
+                tryToStopAfterStartupError(t, swarm);
+            }
             throw t;
         }
 

--- a/tools/src/main/java/org/wildfly/swarm/tools/exec/IOBridge.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/exec/IOBridge.java
@@ -84,6 +84,9 @@ public class IOBridge implements Runnable, Closeable {
         if (line.contains("WFSWARM99999")) {
             this.latch.countDown();
         }
+        if (line.contains("MSC000001: Failed to start service jboss.deployment.unit.")) {
+            this.latch.countDown();
+        }
     }
 
     private final InputStream in;


### PR DESCRIPTION
Motivation
----------
Apparently a @Deployment can @ShouldThrowException, and we
gleefully ignored that fact, and never transmitted deployment
exceptions across to the client side.

Modifications
-------------
Capture deployment exceptions (via Service<T> start failures)
to the Daemon and thence to the client.  Have the client check
on the deployment during the deploy() phase once the Uberjar
container has decided that deployment is complete in one form
or another.

Result
------
Exceptions from @Deployment are serialized back to the test.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
