### PR TITLE
SWARM-1497 - Avoid removing non-temporal jar files

### DIFF
--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/NestedJarResourceLoader.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/NestedJarResourceLoader.java
@@ -154,7 +154,6 @@ public class NestedJarResourceLoader {
                     BootstrapUtil.explodeJar(jarFile, tmpDir.getAbsolutePath());
 
                     jarFile.close();
-                    file.delete();
 
                     return ResourceLoaders.createFileResourceLoader(loaderName, tmpDir);
                 } else {
@@ -171,7 +170,6 @@ public class NestedJarResourceLoader {
                 BootstrapUtil.explodeJar(jarFile, tmpDir.getAbsolutePath());
 
                 jarFile.close();
-                file.delete();
 
                 return ResourceLoaders.createFileResourceLoader(loaderName, tmpDir);
             }


### PR DESCRIPTION
Motivation
----------
As part of the fix for SWARM-1327, some non temporal jar files that are being exploded are being removed, which is wrong. Only exploded jar files should be removed.

Modifications
-------------
Fix code in order to not remove original unexploded jar files that are going to be exploded later.

Result
------
User jar files aren't being removed.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
