### PR TITLE
SWARM-1549: enable PermitAll semantics.

### DIFF
--- a/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/descriptors/SecurityConstraint.java
+++ b/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/descriptors/SecurityConstraint.java
@@ -60,6 +60,14 @@ public class SecurityConstraint {
         return this;
     }
 
+    public SecurityConstraint permitAll() {
+        this.permitAll = true;
+        return this;
+    }
+    public boolean isPermitAll() {
+        return permitAll;
+    }
+
     public List<String> roles() {
         return this.roles;
     }
@@ -69,4 +77,6 @@ public class SecurityConstraint {
     private List<String> methods = new ArrayList<>();
 
     private List<String> roles = new ArrayList<>();
+
+    private boolean permitAll;
 }

--- a/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/descriptors/WebXmlAsset.java
+++ b/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/descriptors/WebXmlAsset.java
@@ -32,6 +32,7 @@ import org.jboss.shrinkwrap.descriptor.api.javaee7.ListenerType;
 import org.jboss.shrinkwrap.descriptor.api.javaee7.ParamValueType;
 import org.jboss.shrinkwrap.descriptor.api.webapp31.WebAppDescriptor;
 import org.jboss.shrinkwrap.descriptor.api.webcommon31.LoginConfigType;
+import org.jboss.shrinkwrap.descriptor.api.webcommon31.SecurityConstraintType;
 import org.jboss.shrinkwrap.descriptor.api.webcommon31.ServletType;
 
 import static org.wildfly.swarm.spi.api.ClassLoading.withTCCL;
@@ -133,6 +134,10 @@ public class WebXmlAsset implements NamedAsset {
         return constraint;
     }
 
+    public List<SecurityConstraint> allConstraints() {
+        return constraints;
+    }
+
     /**
      *
      * @param servletName
@@ -149,14 +154,16 @@ public class WebXmlAsset implements NamedAsset {
         Set<String> allRoles = new HashSet<>();
 
         for (SecurityConstraint each : this.constraints) {
-            this.descriptor.createSecurityConstraint()
+            SecurityConstraintType<WebAppDescriptor> sc = this.descriptor.createSecurityConstraint()
                     .createWebResourceCollection()
                     .urlPattern(each.urlPattern())
                     .httpMethod(each.methods().toArray(new String[each.methods().size()]))
-                    .up()
-                    .getOrCreateAuthConstraint()
-                    .roleName(each.roles().toArray(new String[each.roles().size()]))
                     .up();
+            if (!each.isPermitAll()) {
+                sc.getOrCreateAuthConstraint()
+                        .roleName(each.roles().toArray(new String[each.roles().size()]))
+                        .up();
+            }
 
             allRoles.addAll(each.roles());
         }


### PR DESCRIPTION
Motivation
----------
The current SecurityConstraint/WebXmlAsset does not carry enough information
to allow one to configure a @PermitAll semantics.

Modifications
-------------
A permitAll flag has been added to SecurityConstraint and WebXmlAsset openStream
will not call getOrCreateAuthConstraint() for a SecurityConstraint that has
permitAll true as this is what indicates uncontrained access to the given
web resources.

Result
------
This change allows one to configure unrestricted access for a collection of
url patterns, something that was not possible previously.

Signed-off-by: Scott Stark <starksm64@gmail.com>

- [x ] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
