### PR TITLE
SWARM-1468 - Mark additional modules as "private"

### DIFF
--- a/core/bootstrap/src/main/resources/modules/org/jboss/shrinkwrap/descriptors/impl/module.xml
+++ b/core/bootstrap/src/main/resources/modules/org/jboss/shrinkwrap/descriptors/impl/module.xml
@@ -6,6 +6,9 @@
   -->
 
 <module xmlns="urn:jboss:module:1.3" name="org.jboss.shrinkwrap.descriptors" slot="impl">
+  <properties>
+    <property name="jboss.api" value="private"/>
+  </properties>
   <resources>
     <artifact name="org.jboss.shrinkwrap.descriptors:shrinkwrap-descriptors-api-base:${version.org.jboss.shrinkwrap.descriptors}"/>
     <artifact name="org.jboss.shrinkwrap.descriptors:shrinkwrap-descriptors-api-javaee:${version.org.jboss.shrinkwrap.descriptors}"/>

--- a/core/bootstrap/src/main/resources/modules/org/jboss/shrinkwrap/descriptors/main/module.xml
+++ b/core/bootstrap/src/main/resources/modules/org/jboss/shrinkwrap/descriptors/main/module.xml
@@ -7,6 +7,10 @@
 
 <module xmlns="urn:jboss:module:1.3" name="org.jboss.shrinkwrap.descriptors">
 
+  <properties>
+    <property name="jboss.api" value="private"/>
+  </properties>
+
   <dependencies>
     <system export="true">
       <paths>

--- a/core/bootstrap/src/main/resources/modules/org/jboss/shrinkwrap/impl/module.xml
+++ b/core/bootstrap/src/main/resources/modules/org/jboss/shrinkwrap/impl/module.xml
@@ -6,6 +6,10 @@
   -->
 
 <module xmlns="urn:jboss:module:1.3" name="org.jboss.shrinkwrap" slot="impl">
+  <properties>
+    <property name="jboss.api" value="private"/>
+  </properties>
+
   <resources>
     <artifact name="org.jboss.shrinkwrap:shrinkwrap-api:${version.org.jboss.shrinkwrap}"/>
     <artifact name="org.jboss.shrinkwrap:shrinkwrap-spi:${version.org.jboss.shrinkwrap}"/>

--- a/core/bootstrap/src/main/resources/modules/org/jboss/shrinkwrap/main/module.xml
+++ b/core/bootstrap/src/main/resources/modules/org/jboss/shrinkwrap/main/module.xml
@@ -7,6 +7,10 @@
 
 <module xmlns="urn:jboss:module:1.3" name="org.jboss.shrinkwrap">
 
+  <properties>
+    <property name="jboss.api" value="private"/>
+  </properties>
+
   <dependencies>
     <system export="true">
       <paths>

--- a/core/bootstrap/src/main/resources/modules/org/yaml/snakeyaml/main/module.xml
+++ b/core/bootstrap/src/main/resources/modules/org/yaml/snakeyaml/main/module.xml
@@ -6,6 +6,9 @@
   -->
 
 <module xmlns="urn:jboss:module:1.3" name="org.yaml.snakeyaml">
+  <properties>
+    <property name="jboss.api" value="private"/>
+  </properties>
   <dependencies>
     <system export="true">
       <paths>

--- a/core/container/src/main/resources/modules/org/jboss/weld/se/main/module.xml
+++ b/core/container/src/main/resources/modules/org/jboss/weld/se/main/module.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module xmlns="urn:jboss:module:1.5" name="org.jboss.weld.se">
+  <properties>
+    <property name="jboss.api" value="private"/>
+  </properties>
   <resources>
     <artifact name="org.jboss.weld.environment:weld-environment-common:${version.weld-se}"/>
     <artifact name="org.jboss.weld:weld-api:${org.jboss.weld:weld-api:jar.version}"/>

--- a/core/container/src/main/resources/modules/org/ow2/asm/impl/module.xml
+++ b/core/container/src/main/resources/modules/org/ow2/asm/impl/module.xml
@@ -6,6 +6,9 @@
   -->
 
 <module xmlns="urn:jboss:module:1.3" name="org.ow2.asm" slot="impl">
+  <properties>
+    <property name="jboss.api" value="private"/>
+  </properties>
   <resources>
     <artifact name="org.ow2.asm:asm-all:${version.org.objectweb.asm}"/>
   </resources>

--- a/core/container/src/main/resources/modules/org/ow2/asm/main/module.xml
+++ b/core/container/src/main/resources/modules/org/ow2/asm/main/module.xml
@@ -6,6 +6,9 @@
   -->
 
 <module xmlns="urn:jboss:module:1.3" name="org.ow2.asm">
+  <properties>
+    <property name="jboss.api" value="private"/>
+  </properties>
 
   <dependencies>
     <system export="true">

--- a/core/container/src/main/resources/modules/org/wildfly/swarm/container/runtime/module.xml
+++ b/core/container/src/main/resources/modules/org/wildfly/swarm/container/runtime/module.xml
@@ -6,6 +6,9 @@
   -->
 
 <module xmlns="urn:jboss:module:1.5" name="org.wildfly.swarm.container" slot="runtime">
+  <properties>
+    <property name="jboss.api" value="private"/>
+  </properties>
   <resources>
     <artifact name="org.wildfly.swarm:container:${project.version}">
       <filter>

--- a/core/container/src/main/resources/modules/org/wildfly/swarm/spi/runtime/module.xml
+++ b/core/container/src/main/resources/modules/org/wildfly/swarm/spi/runtime/module.xml
@@ -6,6 +6,9 @@
   -->
 
 <module xmlns="urn:jboss:module:1.5" name="org.wildfly.swarm.spi" slot="runtime">
+  <properties>
+    <property name="jboss.api" value="private"/>
+  </properties>
   <resources>
     <artifact name="org.wildfly.swarm:spi:${project.version}">
       <filter>

--- a/fractions/netflix/ribbon-secured/src/main/resources/modules/org/wildfly/swarm/netflix/ribbon/secured/runtime/module.xml
+++ b/fractions/netflix/ribbon-secured/src/main/resources/modules/org/wildfly/swarm/netflix/ribbon/secured/runtime/module.xml
@@ -1,4 +1,7 @@
 <module xmlns="urn:jboss:module:1.3" name="org.wildfly.swarm.netflix.ribbon.secured" slot="runtime">
+  <properties>
+    <property name="jboss.api" value="private"/>
+  </properties>
   <resources>
     <artifact name="org.wildfly.swarm:ribbon-secured-runtime:${project.version}"/>
   </resources>


### PR DESCRIPTION
Motivation
----------
They're not user-facing, warn people if they are used wrongly.

Modifications
-------------
Added the private marker to more modules.

Result
------
If a user uses them, they get a warning.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
