### PR TITLE
SWARM-1556: Certified fractions missing

### DIFF
--- a/boms/bom-certified/pom.xml
+++ b/boms/bom-certified/pom.xml
@@ -41,7 +41,7 @@
         </dependencies>
         <executions>
           <execution>
-            <id>generate-bom</id>
+            <id>generate-certified-bom</id>
             <phase>prepare-package</phase>
             <goals>
               <goal>generate-certified-bom</goal>
@@ -49,6 +49,13 @@
             <configuration>
               <template>${project.basedir}/../target/bom-template.xml</template>
             </configuration>
+          </execution>
+          <execution>
+            <id>generate-bom</id>
+            <phase>none</phase>
+            <goals>
+              <goal>generate-bom</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
Certified fractions present in certified.conf are not present in the generated bom.pom.

Modifications
-------------
Need to prevent generate-bom mojo from running after generate-certified-bom.

Result
------
No change to product behavior, fixes build issue.
