### PR TITLE
SWARM-1535: Make sure Arq exception handling doesn't break stuff.

### DIFF
--- a/arquillian/arquillian/module-rewrite.conf
+++ b/arquillian/arquillian/module-rewrite.conf
@@ -1,0 +1,3 @@
+
+module: org.jboss.as.host-controller
+  optional: org.jboss.as.jmx


### PR DESCRIPTION
Motivation
----------
Somehow the previous change caused Arq to bring in org.jboss.as.jmx
from the community feature-pack.

Modifications
-------------
Mark the dependency between host-controller and jmx as optional=true.

Result
------
Prod build doesn't not build.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
