### PR TITLE
[SWARM-1597] Topology OpenShift: advertise cluster IP

### DIFF
--- a/fractions/topology-openshift/src/main/java/org/wildfly/swarm/topology/openshift/runtime/ServiceWatcher.java
+++ b/fractions/topology-openshift/src/main/java/org/wildfly/swarm/topology/openshift/runtime/ServiceWatcher.java
@@ -156,7 +156,7 @@ public class ServiceWatcher implements Service<ServiceWatcher>, IOpenShiftWatchL
                 .forEach(servicePort -> {
                     Registration registration = new Registration(TOPOLOGY_SOURCE_KEY,
                                                                  service.getName(),
-                                                                 service.getName(),
+                                                                 service.getClusterIP(),
                                                                  servicePort.getPort());
                     if (servicePort.getPort() == DEFAULT_HTTPS_PORT) {
                         registration.addTags(Collections.singletonList("https"));


### PR DESCRIPTION
Shouldn't OpenShift Topology plugin advertise clusterIP? Using currently advertised data listeners are unable to talk to the service that is being discovered.
