### PR TITLE
SWARM-1599: `fraction-metadata` in BOM

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -22,7 +22,7 @@
   <description>Build Parent to bring in required dependencies</description>
 
   <properties>
-    <version.wildfly.swarm.fraction.plugin>63</version.wildfly.swarm.fraction.plugin>
+    <version.wildfly.swarm.fraction.plugin>66</version.wildfly.swarm.fraction.plugin>
 
     <version.org.snakeyaml>1.17</version.org.snakeyaml>
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
Update to latest fraction-plugin so that `fraction-metadata` is always added to every BOM.

Modifications
-------------
Update fraction-plugin version.

Result
------
BOMs contain `fraction-metadata`.
