### PR TITLE
Bring ref-guide generation into the primary docs build.

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -22,7 +22,7 @@
   <description>Build Parent to bring in required dependencies</description>
 
   <properties>
-    <version.wildfly.swarm.fraction.plugin>66</version.wildfly.swarm.fraction.plugin>
+    <version.wildfly.swarm.fraction.plugin>67</version.wildfly.swarm.fraction.plugin>
 
     <version.org.snakeyaml>1.17</version.org.snakeyaml>
 

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -24,3 +24,6 @@ ifndef::product[]
 include::howto/create-a-fraction/index.adoc[leveloffset=+2]
 
 endif::product[]
+
+## Reference
+include::reference/index.adoc[leveloffset=+2]

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -95,6 +95,7 @@
   </profiles>
 
   <modules>
+    <module>reference</module>
     <module>howto/use-a-bom</module>
     <module>howto/create-an-uberjar</module>
     <module>howto/create-a-hollow-jar</module>

--- a/docs/reference/.gitignore
+++ b/docs/reference/.gitignore
@@ -1,0 +1,3 @@
+index.adoc
+fractions/*
+*.adoc

--- a/docs/reference/pom.xml
+++ b/docs/reference/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.wildfly.swarm.docs</groupId>
+  <artifactId>reference</artifactId>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>build-parent</artifactId>
+    <version>2017.11.0-SNAPSHOT</version>
+    <relativePath>../../build-parent/pom.xml</relativePath>
+  </parent>
+
+  <name>WildFly Swarm Reference Documentation</name>
+  <description>WildFly Swarm Reference Documentation</description>
+
+  <packaging>pom</packaging>
+
+  <properties>
+    <maven.min.version>3.3.3</maven.min.version>
+
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <swarm.product.build>false</swarm.product.build>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>wildfly-swarm-fraction-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>fraction-reference</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>.</directory>
+              <includes>
+                <include>index.adoc</include>
+                <include>fractions/**</include>
+              </includes>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>


### PR DESCRIPTION
- Respected -Dswarm.product.build to build product-only
  ref-guide.



-----
