### PR TITLE
Further improvements:

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -22,7 +22,7 @@
   <description>Build Parent to bring in required dependencies</description>
 
   <properties>
-    <version.wildfly.swarm.fraction.plugin>69</version.wildfly.swarm.fraction.plugin>
+    <version.wildfly.swarm.fraction.plugin>72</version.wildfly.swarm.fraction.plugin>
 
     <version.org.snakeyaml>1.17</version.org.snakeyaml>
 

--- a/docs/docinfo.html
+++ b/docs/docinfo.html
@@ -1,0 +1,76 @@
+<!-- Generate a nice TOC -->
+<script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
+<script src="https://code.jquery.com/ui/1.11.4/jquery-ui.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.tocify/1.9.0/javascripts/jquery.tocify.min.js"></script>
+<!-- We do not need the tocify CSS because the asciidoc CSS already provides most of what we neeed -->
+
+<style>
+.tocify-header {
+    font-style: italic;
+}
+
+.tocify-subheader {
+    font-style: normal;
+    font-size: 90%;
+}
+
+.tocify ul {
+    margin: 0;
+ }
+
+.tocify-focus {
+    color: #7a2518; 
+    background-color: rgba(0, 0, 0, 0.1);
+}
+
+.tocify-focus > a {
+    color: #7a2518; 
+}
+</style>
+
+<script type="text/javascript">
+    $(function () {
+        // Add a new container for the tocify toc into the existing toc so we can re-use its
+        // styling
+        $("#toc").append("<div id='generated-toc'></div>");
+        $("#generated-toc").tocify({
+            extendPage: true,
+            context: "#content",
+            highlightOnScroll: true,
+            hideEffect: "slideUp",
+            // Use the IDs that asciidoc already provides so that TOC links and intra-document
+            // links are the same. Anything else might confuse users when they create bookmarks.
+            hashGenerator: function(text, element) {
+                return $(element).attr("id");
+            },
+            // Smooth scrolling doesn't work properly if we use the asciidoc IDs
+            smoothScroll: false,
+            // Set to 'none' to use the tocify classes
+            theme: "none",
+            // Handle book (may contain h1) and article (only h2 deeper)
+            selectors: $( "#content" ).has( "h1" ).size() > 0 ? "h1,h2,h3,h4,h5" : "h2,h3,h4,h5",
+            ignoreSelector: ".discrete"
+        });
+
+        // Switch between static asciidoc toc and dynamic tocify toc based on browser size
+        // This is set to match the media selectors in the asciidoc CSS
+        // Without this, we keep the dynamic toc even if it is moved from the side to preamble
+        // position which will cause odd scrolling behavior
+        var handleTocOnResize = function() {
+            if ($(document).width() < 768) {
+                $("#generated-toc").hide();
+                $(".sectlevel0").show();
+                $(".sectlevel1").show();
+            }
+            else {
+                $("#generated-toc").show();
+                $(".sectlevel0").hide();
+                $(".sectlevel1").hide();
+            }
+        }
+
+        $(window).resize(handleTocOnResize);
+        handleTocOnResize();
+    });
+</script>
+

--- a/docs/howto/autodetect-fractions/index.adoc
+++ b/docs/howto/autodetect-fractions/index.adoc
@@ -6,7 +6,7 @@ If you enable the WildFly Swarm Maven plugin in your application, WildFly Swarm 
 
 For example, consider your `pom.xml` already specifies the API `.jar` file for a specification such as JAX-RS:
 
-[source,java]
+[source,xml]
 ----
 <dependencies>
 include::pom.xml[tag=jaxrs,index=2]

--- a/docs/howto/create-a-fraction/index.adoc
+++ b/docs/howto/create-a-fraction/index.adoc
@@ -11,7 +11,7 @@ in others.
 It is useful to set at least a pair of properties, specifying the version
 of the WildFly Swarm SPI and fraction-plugin being used:
 
-[source,xml,,subs=+attributes]
+[source,xml,subs=+attributes]
 ----
 <properties>
   <version.swarm>{version}</version.swarm.spi>

--- a/docs/howto/create-an-uberjar/index.adoc
+++ b/docs/howto/create-an-uberjar/index.adoc
@@ -12,7 +12,7 @@ with WildFly Swarm is as an _uberjar_.
 
 . Add the `wildfly-swarm-maven-plugin` to your `pom.xml` in a `<plugin>` block,
   with an `<execution>` specifying the `package` goal.
-
++
 [source,xml]
 ----
 <plugins>
@@ -20,16 +20,15 @@ include::pom.xml[tag=plugin,indent=2]
 </plugins>
 ----
 
-[start=2]
 . Perform a normal Maven build:
-
++
 [source]
 ----
 $ mvn package
 ----
 
 . Execute the resulting uberjar:
-
++
 [source]
 ----
 $ java -jar ./target/myapp-swarm.jar

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1,5 +1,15 @@
 :toc: left
-= WildFly Swarm Documentation: {version}
+:toclevels: 3
+:sectnums:
+:sectanchors:
+:source-highlighter: coderay
+
+
+= WildFly Swarm Documentation
+The WildFly Swarm Team
+v{version}
+
+include::introduction.adoc[]
 
 # Concepts
 
@@ -25,5 +35,14 @@ include::howto/create-a-fraction/index.adoc[leveloffset=+2]
 
 endif::product[]
 
-## Reference
+# Reference
+
+## General
+
+include::reference/configuration.adoc[leveloffset=+2]
+include::reference/network.adoc[leveloffset=+2]
+include::reference/usage.adoc[leveloffset=+2]
+
+## Fractions
+
 include::reference/index.adoc[leveloffset=+2]

--- a/docs/introduction.adoc
+++ b/docs/introduction.adoc
@@ -1,0 +1,7 @@
+
+WildFly Swarm is a framework based upon the popular WildFly Java application server to enable the creation of small, standalone microservice-based applications.
+WildFly Swarm is capable of producing _just enough app-server_ to support each component of your system.
+
+For more information, please see the WildFly Swarm website at http://wildfly-swarm.io/.
+
+

--- a/docs/introduction.adoc
+++ b/docs/introduction.adoc
@@ -1,7 +1,6 @@
 
-WildFly Swarm is a framework based upon the popular WildFly Java application server to enable the creation of small, standalone microservice-based applications.
-WildFly Swarm is capable of producing _just enough app-server_ to support each component of your system.
+WildFly Swarm is a framework based on the popular WildFly Java application server to enable the creation of small, standalone microservice-based applications.
+WildFly Swarm is capable of producing so-called _just enough app-server_ to support each component of your system.
 
-For more information, please see the WildFly Swarm website at http://wildfly-swarm.io/.
-
+For more information, see the WildFly Swarm link:http://wildfly-swarm.io/[home page].
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -58,7 +58,7 @@
       <plugin>
         <groupId>org.asciidoctor</groupId>
         <artifactId>asciidoctor-maven-plugin</artifactId>
-        <version>1.5.5</version>
+        <version>1.5.6</version>
         <inherited>false</inherited>
         <configuration>
           <attributes>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -37,20 +37,37 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/generated-docs</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/main/resources</directory>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.asciidoctor</groupId>
         <artifactId>asciidoctor-maven-plugin</artifactId>
         <version>1.5.5</version>
         <inherited>false</inherited>
         <configuration>
           <attributes>
+            <docinfo>shared</docinfo>
             <version>${project.version}</version>
             <product>${swarm.product.build}</product>
           </attributes>
-          <sourceDirectory>.</sourceDirectory>
-          <sourceDocumentName>index.adoc</sourceDocumentName>
           <doctype>book</doctype>
-          <backend>html</backend>
-          <preserveDirectories>true</preserveDirectories>
+          <backend>html5</backend>
           <resources>
             <resource>
               <directory>.</directory>
@@ -67,6 +84,28 @@
             <goals>
               <goal>process-asciidoc</goal>
             </goals>
+            <configuration>
+              <sourceDirectory>.</sourceDirectory>
+              <sourceDocumentName>index.adoc</sourceDocumentName>
+              <outputDirectory>${project.build.directory}/generated-docs/${project.version}</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-scm-publish-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>publish-scm</goal>
+            </goals>
+            <phase>deploy</phase>
+            <configuration>
+              <pubScmUrl>scm:git:git@github.com:wildfly-swarm/docs.wildfly-swarm.io.git</pubScmUrl>
+              <dryRun>false</dryRun>
+              <skipDeletedFiles>true</skipDeletedFiles>
+              <content>${project.build.directory}/generated-docs/</content>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/docs/reference/.gitignore
+++ b/docs/reference/.gitignore
@@ -1,3 +1,2 @@
 index.adoc
 fractions/*
-*.adoc

--- a/docs/reference/configuration.adoc
+++ b/docs/reference/configuration.adoc
@@ -1,0 +1,137 @@
+= Configuration of a WildFly Swarm Application
+
+Every application built with WildFly Swarm has a vast variety of configurable options.  
+In all cases, reasonable defaults are already applied, and you only need concern yourself with those particular items you wish to explicitly change from their default values.
+
+This _Reference_ serves as a complete index of all configurable items, separated by the fraction which introduces them.  
+Only items related to the fractions involved in your application are pertinent to your application.
+
+== Using Properties
+
+Within this document, the configuration items are presented using dotted notation, and are suitable for use as Java property names, provided to your application through explicit setting via the Maven plugin or through the command-line when executing your application.
+
+Any property that has _KEY_ listed in its name indicates that a user-supplied key or identifier should be used in that segment of the name.
+
+For instance, the configuration item documented as `swarm.undertow.servers.KEY.default-host` indicates that the configuration applies to a particular named server.  
+In actual usage, the property would be something such as `swarm.undertow.servers.default.default-host`, applying to the server known as `default`.
+
+.Properties via Maven Plugin
+
+If you wish to set explicit configuration values to be baked in as defaults through the Maven plugin, in your `pom.xml` you would add a `<properties>` section to the plugin's `<configuration>`.
+
+For instance, the configuration item of `swarm.bind.address` is set through the plugin.
+
+[source,xml,subs=+attributes]
+----
+<build>
+  <plugins>
+    <plugin>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>wildfly-swarm-plugin</artifactId>
+      <version>{version}</version>
+      <configuration>
+        <properties>
+          <swarm.bind.address>127.0.0.1</swarm.bind.address>
+          <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
+        </properties>
+      </configuration>
+    </plugin>
+  </plugins>
+</build>
+----
+
+NOTE: We generally recommend not using the Maven plugin to explicitly set properties to control configuration. 
+The YAML method, described further below, is the preferred method.
+
+.Properties via the Command-Line
+
+While setting properties via the Maven plugin is not recommended, it is often useful to temporarily change a configuration item for a given launching of your application. 
+This may be to customize some environment-specific setting, or to experiment with some configuration items before committing them to YAML.
+
+To use a property via the command-line, you simply pass them as you would any other Java process:
+
+[source,shell]
+----
+$ java -Dswarm.bind.address=127.0.0.1 -jar myapp-swarm.jar
+----
+
+## Using YAML
+
+YAML is the preferred method for long-term configuration of an application. 
+Additionally, the YAML strategy provides for grouping together of environment-specific configurations which can be selectively enabled when launching the application.
+
+.General format
+
+In the configuration names within this document, a YAML structure can be derrived.  
+
+For instance, the item described `swarm.undertow.servers.KEY.default-host` would translate to the following YAML, substituting the identifier of `default` for the `KEY` segment:
+
+[source,yaml]
+----
+swarm:
+  undertow:
+    servers:
+      default:
+        default-host: <myhost>
+----
+
+.Default YAML Files
+
+If your application's original `.war` contains a file named `project-defaults.yml`, that file represents the defaults applied overtop the absolute defaults that WildFly Swarm provides to your application.
+
+Additionally, if specific configurations are selected, using the `-S <name>` commandline option, those associated files will be loaded, in order, prior to the `project-defaults.yml` file. 
+The names provided to the `-S <name>` argument relates to a file named `project-<name>.yml` within your classpath.
+ 
+If you were to invoke your application with the following:
+
+[source,shell]
+----
+$ java -jar myapp-swarm.jar -Stesting -Scloud
+----
+
+Then the relevant YAML files would be loaded in the following preference order, where the first one containing a given configuration item wins:
+
+. `project-testing.yml`
+. `project-cloud.yml`
+. `project-defaults.yml`
+
+.Non-default YAML Files
+
+In some events, you may wish to reference a YAML file of configuration values that it _outside_ of your application.  
+In that case, the `-s <path>` command-line option may be used.
+
+Files loaded by the `-s <path>` option take precedent over any default YAML file contained within your application.  
+Both `-s <path>` and `-S <name>` may be freely used concurrently, but be aware that all `-s <path>` options are considered to have higher precedent over `-S <name>` options.
+
+For instance, if you were to invoke your application with the following:
+
+[source,shell]
+----
+$ java -jar myapp-swarm -s/home/app/openshift.yml -Scloud -Stesting
+----
+
+Then the relevant YAML files would be loaded in the following order:
+
+. `/home/app/openshift.yml`
+. `project-cloud.yml`
+. `project-testing.yml`
+. `project-defaults.yml`
+
+The same preference would be applied even if the application was invoked using:
+
+[source,shell]
+----
+$ java -jar myapp-swarmm -Scloud -Stesting -s/home/app/openshift.yml
+----
+
+
+
+
+
+
+
+
+
+
+
+

--- a/docs/reference/configuration.adoc
+++ b/docs/reference/configuration.adoc
@@ -1,25 +1,34 @@
 = Configuration of a WildFly Swarm Application
 
-Every application built with WildFly Swarm has a vast variety of configurable options.  
-In all cases, reasonable defaults are already applied, and you only need concern yourself with those particular items you wish to explicitly change from their default values.
+Every application built with WildFly Swarm has a many configurable options.
+In all cases, reasonable defaults are already applied, therefore you do not have to change any options unless you explicitly want to.
 
-This _Reference_ serves as a complete index of all configurable items, separated by the fraction which introduces them.  
-Only items related to the fractions involved in your application are pertinent to your application.
+This reference is a complete list of all configurable items, grouped by the fraction that introduces them.
+Only the items related to the fractions that your application uses are relevant to you.
 
-== Using Properties
+[#configure-your-application-using-properties]
+== Configure your application using properties
 
-Within this document, the configuration items are presented using dotted notation, and are suitable for use as Java property names, provided to your application through explicit setting via the Maven plugin or through the command-line when executing your application.
+In this document, configuration items are presented using dotted notation, and are suitable for use as Java property names, which your application consumes through explicit setting in the Maven plugin configuration, or through the command line when executing your application.
 
-Any property that has _KEY_ listed in its name indicates that a user-supplied key or identifier should be used in that segment of the name.
+Any property that has the _KEY_ parameter in its name indicates that you must supply a key or identifier in that segment of the name.
 
-For instance, the configuration item documented as `swarm.undertow.servers.KEY.default-host` indicates that the configuration applies to a particular named server.  
-In actual usage, the property would be something such as `swarm.undertow.servers.default.default-host`, applying to the server known as `default`.
+.Using configuration items with the KEY parameter
+====
+The configuration item documented as `swarm.undertow.servers.KEY.default-host` indicates that the configuration applies to a particular named server.
 
-.Properties via Maven Plugin
+In practical usage, the property would be, for example, `swarm.undertow.servers.default.default-host`, for a server known as `default`.
+====
 
-If you wish to set explicit configuration values to be baked in as defaults through the Maven plugin, in your `pom.xml` you would add a `<properties>` section to the plugin's `<configuration>`.
+[discrete]
+=== Maven plugin properties
 
-For instance, the configuration item of `swarm.bind.address` is set through the plugin.
+If you want to set explicit configuration values as defaults through the Maven plugin, add a `<properties>` section to the `<configuration>` block of the plugin in the `pom.xml` file in your application.
+
+.Setting a configuration item through the Maven Plugin
+====
+
+An example Maven plugin configuration for the `swarm.bind.address` item:
 
 [source,xml,subs=+attributes]
 ----
@@ -39,32 +48,36 @@ For instance, the configuration item of `swarm.bind.address` is set through the 
   </plugins>
 </build>
 ----
+====
 
-NOTE: We generally recommend not using the Maven plugin to explicitly set properties to control configuration. 
-The YAML method, described further below, is the preferred method.
+NOTE: It is not recommended to use the Maven plugin to explicitly set properties to control the configuration.
+Instead, using the xref:configure-your-application-using-yaml[YAML method] is recommended.
 
-.Properties via the Command-Line
+[discrete]
+=== Setting properties using the Command Line
 
-While setting properties via the Maven plugin is not recommended, it is often useful to temporarily change a configuration item for a given launching of your application. 
-This may be to customize some environment-specific setting, or to experiment with some configuration items before committing them to YAML.
+Even hough setting properties using the Maven plugin is not recommended, it is useful for temporarily changing a configuration item for a single launch of your application.
+You can customize an environment-specific setting or experiment with configuration items before committing them to YAML.
 
-To use a property via the command-line, you simply pass them as you would any other Java process:
+To use a property on the command line, pass them as a command-line parameter to the Java binary:
 
 [source,shell]
 ----
 $ java -Dswarm.bind.address=127.0.0.1 -jar myapp-swarm.jar
 ----
 
-## Using YAML
+[#configure-your-application-using-yaml]
+== Configure your application using YAML
 
-YAML is the preferred method for long-term configuration of an application. 
-Additionally, the YAML strategy provides for grouping together of environment-specific configurations which can be selectively enabled when launching the application.
+YAML is the preferred method for long-term configuration of your application.
+In addition to that, the YAML strategy provides grouping of environment-specific configurations, which can be selectively enabled when launching the application.
 
-.General format
+[discrete]
+=== General YAML format
 
-In the configuration names within this document, a YAML structure can be derrived.  
+The configuration names correspond to the YAML configuration structure.
 
-For instance, the item described `swarm.undertow.servers.KEY.default-host` would translate to the following YAML, substituting the identifier of `default` for the `KEY` segment:
+For example, the item documented as `swarm.undertow.servers.KEY.default-host` translates to the following YAML, substituting the `KEY` segment with the `default` identifier:
 
 [source,yaml]
 ----
@@ -75,63 +88,60 @@ swarm:
         default-host: <myhost>
 ----
 
-.Default YAML Files
+[discrete]
+=== Default YAML Files
 
-If your application's original `.war` contains a file named `project-defaults.yml`, that file represents the defaults applied overtop the absolute defaults that WildFly Swarm provides to your application.
+If the original `.war` file with your application contains a file named `project-defaults.yml`, that file represents the defaults applied over the absolute defaults that WildFly Swarm provides to your application.
 
-Additionally, if specific configurations are selected, using the `-S <name>` commandline option, those associated files will be loaded, in order, prior to the `project-defaults.yml` file. 
-The names provided to the `-S <name>` argument relates to a file named `project-<name>.yml` within your classpath.
- 
-If you were to invoke your application with the following:
+Additionally, if you provide specific configuration files using the `-S <name>` command-line option, those files are loaded, in that order, before `project-defaults.yml`.
+A name provided in the `-S <name>` argument specifies the `project-<name>.yml` file on your classpath.
 
-[source,shell]
+.Specifying configuration files on the command line
+====
+
+Consider the following application execution:
+
+[source,bash]
 ----
 $ java -jar myapp-swarm.jar -Stesting -Scloud
 ----
 
-Then the relevant YAML files would be loaded in the following preference order, where the first one containing a given configuration item wins:
+In this example, the following YAML files are loaded in this order. The first file containing a given configuration item takes precedence over others:
 
 . `project-testing.yml`
 . `project-cloud.yml`
 . `project-defaults.yml`
+====
 
-.Non-default YAML Files
+[discrete]
+=== Non-default YAML Files
 
-In some events, you may wish to reference a YAML file of configuration values that it _outside_ of your application.  
-In that case, the `-s <path>` command-line option may be used.
+If you want to reference a YAML file that exists outside of your application, use the `-s <path>` command-line option.
 
-Files loaded by the `-s <path>` option take precedent over any default YAML file contained within your application.  
-Both `-s <path>` and `-S <name>` may be freely used concurrently, but be aware that all `-s <path>` options are considered to have higher precedent over `-S <name>` options.
+Both the `-s <path>` and `-S <name>` command-line options can be used at the same time, but files specified using the `-s <path>` option take precedence over YAML files contained in your application.
 
-For instance, if you were to invoke your application with the following:
+.Specifying configuration files inside and outside of the application
+====
 
-[source,shell]
+Consider the following application execution:
+
+[source,bash]
 ----
 $ java -jar myapp-swarm -s/home/app/openshift.yml -Scloud -Stesting
 ----
 
-Then the relevant YAML files would be loaded in the following order:
+In this example, the following YAML files are loaded in this order:
 
 . `/home/app/openshift.yml`
 . `project-cloud.yml`
 . `project-testing.yml`
 . `project-defaults.yml`
 
-The same preference would be applied even if the application was invoked using:
+The same order of preference is applied even when the application is invoked as follows:
 
-[source,shell]
+[source,bash]
 ----
 $ java -jar myapp-swarmm -Scloud -Stesting -s/home/app/openshift.yml
 ----
-
-
-
-
-
-
-
-
-
-
-
+====
 

--- a/docs/reference/network.adoc
+++ b/docs/reference/network.adoc
@@ -1,0 +1,80 @@
+= Network 
+
+For network configuration, *interfaces*, *socket-bindings* and *outbound-socket-bindings* may be created or adjusted. 
+The networking configuration is under the `network` key underneath the core `swarm` key.
+
+== Interfaces
+
+An interface represents a known ethernet interface. 
+By default the interface named `public` is bound to the IP address of `0.0.0.0` which represents all known interfaces of the underlying machine. 
+This includes publicly-routed interfaces and the localhost `127.0.0.1` interface.
+
+Additionally, when the `management` fraction is included in an application, an interface named `management` is also provisioned, which is bound to only the localhost `127.0.0.1` address.
+
+To configuration an additional interface, bound to `192.168.4.5` for instance:
+
+[source,yaml]
+----
+swarm:
+  network:
+    interfaces:
+      backnet:
+        bind: 192.168.4.5
+----
+
+
+If you wish to change the bind address for the public or management interfaces, special, easier-to-use properties are defined for those two cases:
+
+By setting `swarm.bind.address` or `swarm.management.bind.address` (or their related YAML values), the underlying address used by each can be changed.
+
+== Sockets
+
+_Socket-bindings_ and _outbound-socket-bindings_ allow for externalized configuration of sockets (and ports) bound to a particular interface. 
+Regular socket-bindings are for inbound connections, while outbound-socket-bindings denote connections capable of being made to remote locations.
+
+### Socket-Binding Groups
+
+Groups of bindings occur within _socket-binding-groups_, with the default group being named `standard-sockets`. 
+An entire group's sockets can be bound to a given default interface, or all members of the group may be offset by a particular number of ports.
+
+[source,yaml]
+----
+swarm:
+  network:
+    socket-binding-groups:
+      standard-sockets:
+        port-offset: 10
+        default-interface: public
+----
+
+.Socket- Bindings
+
+Socket-bindings may be created or adjusted within a `socket-binding-group`:
+
+[source,yaml]
+----
+swarm:
+  network:
+    socket-binding-groups:
+      standard-sockets:
+        http:
+          port: 8081
+----
+
+.Outbound Socket-Bindings
+
+To create a named outbound socket-binding for connection to remote endpoints, `outbound-socket-bindings` may be defined within a `socket-binding-group`:
+
+[source,yaml]
+----
+swarm:
+  network:
+    socket-binding-groups:
+      standard-sockets:
+        outbound-socket-bindings:
+              neo4jtesthost:
+                remote-host: localhost
+                remote-port: 7687
+----
+
+

--- a/docs/reference/network.adoc
+++ b/docs/reference/network.adoc
@@ -1,17 +1,20 @@
-= Network 
+= Network
 
-For network configuration, *interfaces*, *socket-bindings* and *outbound-socket-bindings* may be created or adjusted. 
-The networking configuration is under the `network` key underneath the core `swarm` key.
+For network configuration, create or adjust _interfaces,_ _socket-bindings,_ and _outbound-socket-bindings._
+The networking configuration is stored under the `network` -> `swarm` key.
 
 == Interfaces
 
-An interface represents a known ethernet interface. 
-By default the interface named `public` is bound to the IP address of `0.0.0.0` which represents all known interfaces of the underlying machine. 
-This includes publicly-routed interfaces and the localhost `127.0.0.1` interface.
+An interface represents a known ethernet interface.
+By default, the interface named `public` is bound to the `0.0.0.0` IP address, which represents all known interfaces of the underlying machine.
+This includes both publicly-routed interfaces, and the localhost (`127.0.0.1`) interface.
 
-Additionally, when the `management` fraction is included in an application, an interface named `management` is also provisioned, which is bound to only the localhost `127.0.0.1` address.
+In addition to that, when you include the `management` fraction in an application, an interface named `management` is also provisioned, and it is bound only to localhost.
 
-To configuration an additional interface, bound to `192.168.4.5` for instance:
+.Additional interface configuration
+====
+
+The following interface is called `backnet`, and is bound to the `192.168.4.5` address.
 
 [source,yaml]
 ----
@@ -21,21 +24,29 @@ swarm:
       backnet:
         bind: 192.168.4.5
 ----
+====
 
+If you want to change the bind address for the `public` or `management` interfaces, use special properties, which are defined for these two cases in particular:
 
-If you wish to change the bind address for the public or management interfaces, special, easier-to-use properties are defined for those two cases:
+* `swarm.bind.address`
+* `swarm.management.bind.address`
 
-By setting `swarm.bind.address` or `swarm.management.bind.address` (or their related YAML values), the underlying address used by each can be changed.
+Change the underlying addresses by changing the above properties or their related YAML values.
 
 == Sockets
 
-_Socket-bindings_ and _outbound-socket-bindings_ allow for externalized configuration of sockets (and ports) bound to a particular interface. 
-Regular socket-bindings are for inbound connections, while outbound-socket-bindings denote connections capable of being made to remote locations.
+_Socket bindings_ and _outbound socket bindings_ allow externalized configuration of sockets and ports bound to a particular interface.
+Use regular socket-bindings for inbound connections, while outbound-socket-bindings denote connections capable of changing to remote locations.
 
-### Socket-Binding Groups
+=== Socket-binding groups
 
-Groups of bindings occur within _socket-binding-groups_, with the default group being named `standard-sockets`. 
-An entire group's sockets can be bound to a given default interface, or all members of the group may be offset by a particular number of ports.
+Groups of bindings occur within _socket binding groups,_ where `standard-sockets` is the default group.
+You can bind the sockets of an entire group to a given default interface, or you can offset all members of the group by a particular number of ports.
+
+.Socket-binding group
+====
+
+The ports of the `standard-sockets` default group are offset by 10:
 
 [source,yaml]
 ----
@@ -46,8 +57,10 @@ swarm:
         port-offset: 10
         default-interface: public
 ----
+====
 
-.Socket- Bindings
+.Socket binding
+====
 
 Socket-bindings may be created or adjusted within a `socket-binding-group`:
 
@@ -60,10 +73,12 @@ swarm:
         http:
           port: 8081
 ----
+====
 
-.Outbound Socket-Bindings
+.Outbound socket binding
+====
 
-To create a named outbound socket-binding for connection to remote endpoints, `outbound-socket-bindings` may be defined within a `socket-binding-group`:
+To create a named outbound socket binding for connection to remote endpoints, define `outbound-socket-bindings` in a `socket-binding-group`:
 
 [source,yaml]
 ----
@@ -76,5 +91,5 @@ swarm:
                 remote-host: localhost
                 remote-port: 7687
 ----
-
+====
 

--- a/docs/reference/usage.adoc
+++ b/docs/reference/usage.adoc
@@ -1,21 +1,18 @@
-= `usage.txt`
+= The `usage.txt` file
 
-Each WildFly Swarm application may contain a text file at one of the following locations:
+Each WildFly Swarm application can contain a text file with usage instructions at one of the following locations:
 
 * `/usage.txt`
 * `/META-INF/usage.txt`
 * `/WEB-INF/usage.txt`
 
-If found, once the application has fully started, then the file will be logged with variable substitution from the configuration properties.
+When the application has fully started, the contents of the file are be logged to the logging output, with variables substituted according to the configuration properties.
+This is useful for displaying the currently active port used by the application, for example.
 
-== Variable substitution
-
-Variables within the `usage.txt` file of the format `${swarm.thing}` will be replaced with their current value.  
-This may be useful for display the currently active port used by the application, for instance by having content such as:
+Reference the configuration variables in the `${swarm.thing}` format:
 
 [source,text]
 ----
 The application is now ready on ${swarm.http.port}!
 ----
-
 

--- a/docs/reference/usage.adoc
+++ b/docs/reference/usage.adoc
@@ -1,0 +1,21 @@
+= `usage.txt`
+
+Each WildFly Swarm application may contain a text file at one of the following locations:
+
+* `/usage.txt`
+* `/META-INF/usage.txt`
+* `/WEB-INF/usage.txt`
+
+If found, once the application has fully started, then the file will be logged with variable substitution from the configuration properties.
+
+== Variable substitution
+
+Variables within the `usage.txt` file of the format `${swarm.thing}` will be replaced with their current value.  
+This may be useful for display the currently active port used by the application, for instance by having content such as:
+
+[source,text]
+----
+The application is now ready on ${swarm.http.port}!
+----
+
+

--- a/docs/src/main/resources/CNAME
+++ b/docs/src/main/resources/CNAME
@@ -1,0 +1,1 @@
+docs.wildfly-swarm.io

--- a/fractions/javaee/batch-jberet/README.adoc
+++ b/fractions/javaee/batch-jberet/README.adoc
@@ -1,4 +1,4 @@
-# Batch (JBeret)
+= Batch (JBeret)
 
 The Batch fraction provides support for scheduled job execution,
 through JSR-352.

--- a/fractions/javaee/bean-validation/README.adoc
+++ b/fractions/javaee/bean-validation/README.adoc
@@ -1,3 +1,3 @@
-# Bean Validation
+= Bean Validation
 
 Provides class-level constraint and validation according to JSR 303.

--- a/fractions/javaee/cdi/README.adoc
+++ b/fractions/javaee/cdi/README.adoc
@@ -1,3 +1,3 @@
-# CDI
+= CDI
 
 Provides context and dependency-injection support according to JSR-299.

--- a/fractions/javaee/connector/README.adoc
+++ b/fractions/javaee/connector/README.adoc
@@ -1,4 +1,4 @@
-# Connector
+= Connector
 
 Primarily an internal fraction used to provide support for 
 higher-level fractions such as JCA (JSR-322).

--- a/fractions/javaee/datasources/README.adoc
+++ b/fractions/javaee/datasources/README.adoc
@@ -1,4 +1,4 @@
-= Datasources Fraction
+= Datasources
 
 Provides support for container-managed database connections.
 

--- a/fractions/javaee/datasources/README.adoc
+++ b/fractions/javaee/datasources/README.adoc
@@ -1,8 +1,8 @@
-# Datasources Fraction
+= Datasources Fraction
 
 Provides support for container-managed database connections.
 
-## Autodetectable drivers
+== Autodetectable drivers
 
 If your application includes the appropriate vendor JDBC
 library in its normal dependencies, these drivers will be detected

--- a/fractions/javaee/ee/README.adoc
+++ b/fractions/javaee/ee/README.adoc
@@ -1,4 +1,4 @@
-# EE
+= EE
 
 An internal fraction used to support other higher-level fractions. 
 

--- a/fractions/javaee/jaxrs-cdi/README.adoc
+++ b/fractions/javaee/jaxrs-cdi/README.adoc
@@ -1,4 +1,4 @@
-# JAX-RS + CDI
+= JAX-RS + CDI
 
 An internal fraction providing integration between JAX-RS
 and CDI.

--- a/fractions/javaee/jaxrs-jaxb/README.adoc
+++ b/fractions/javaee/jaxrs-jaxb/README.adoc
@@ -1,4 +1,4 @@
-# JAX-RS + JAXB
+= JAX-RS + JAXB
 
 Provides support within JAX-RS applications for the XML binding
 framework according to JSR-31 and JSR-222.

--- a/fractions/javaee/jaxrs-jsonp/README.adoc
+++ b/fractions/javaee/jaxrs-jsonp/README.adoc
@@ -1,4 +1,4 @@
-# JAX-RS + JSON-P
+= JAX-RS + JSON-P
 
 Provides support within JAX-RS application for JSON processing
 according to JSR-374.

--- a/fractions/javaee/jaxrs-multipart/README.adoc
+++ b/fractions/javaee/jaxrs-multipart/README.adoc
@@ -1,4 +1,4 @@
-# JAX-RS + Multipart
+= JAX-RS + Multipart
 
 Provides support within JAX-RS application for MIME multipart
 form processing. 

--- a/fractions/javaee/jaxrs-validator/README.adoc
+++ b/fractions/javaee/jaxrs-validator/README.adoc
@@ -1,4 +1,4 @@
-# JAX-RS + Validator
+= JAX-RS + Validator
 
 Provides integration and support between JAX-RS applications and
 Hibernate Validator.

--- a/fractions/javaee/jaxrs/README.adoc
+++ b/fractions/javaee/jaxrs/README.adoc
@@ -1,3 +1,3 @@
-# JAX-RS
+= JAX-RS
 
 Provides support for building RESTful web services according to JSR-311.

--- a/fractions/javaee/jca/README.adoc
+++ b/fractions/javaee/jca/README.adoc
@@ -1,4 +1,4 @@
-# JCA
+= JCA
 
 Provides support for the Java Connector Architecture (JCA)
 according to JSR 322.

--- a/fractions/javaee/jmx/README.adoc
+++ b/fractions/javaee/jmx/README.adoc
@@ -1,4 +1,4 @@
-# JMX
+= JMX
 
 Provides support for Java Management Extensions (JMX)
 according to JSR-3.

--- a/fractions/javaee/jpa/README.adoc
+++ b/fractions/javaee/jpa/README.adoc
@@ -1,4 +1,4 @@
-# JPA
+= JPA
 
 Provides support for the Java Persistence API according
 to JSR-220.

--- a/fractions/javaee/jsf/README.adoc
+++ b/fractions/javaee/jsf/README.adoc
@@ -1,3 +1,3 @@
-# JSF
+= JSF
 
 Provides support for JavaServer Faces according to JSR-344.

--- a/fractions/javaee/jsonp/README.adoc
+++ b/fractions/javaee/jsonp/README.adoc
@@ -1,3 +1,3 @@
-# JSON-P
+= JSON-P
 
 Provides support for JSON Processing according to JSR-353.

--- a/fractions/javaee/naming/README.adoc
+++ b/fractions/javaee/naming/README.adoc
@@ -1,3 +1,3 @@
-# Naming
+= Naming
 
 Provides support for JNDI.

--- a/fractions/javaee/remoting/README.adoc
+++ b/fractions/javaee/remoting/README.adoc
@@ -1,4 +1,4 @@
-# Remoting
+= Remoting
 
 Primarily an internal fraction providing remote invocation
 support for higher-level fractions such as EJB.

--- a/fractions/javaee/transactions/README.adoc
+++ b/fractions/javaee/transactions/README.adoc
@@ -1,4 +1,4 @@
-# Transactions
+= Transactions
 
 Provides support for the Java Transaction API (JTA) according to 
 JSR-907.

--- a/fractions/javaee/undertow/README.adoc
+++ b/fractions/javaee/undertow/README.adoc
@@ -1,4 +1,4 @@
-# Undertow
+= Undertow
 
 Provides basic HTTP support, including Java Servlets, JavaServer Pages (JSP),
 and JavaServer Pages Standard Tag Library (JSTL) according to JSR-340, JSR-245

--- a/fractions/javaee/web/README.adoc
+++ b/fractions/javaee/web/README.adoc
@@ -1,4 +1,4 @@
-# Web
+= Web
 
 Provides a collection of fractions equivalent to the _Web Profile_:
 

--- a/fractions/netflix/hystrix/src/main/java/org/wildfly/swarm/netflix/hystrix/HystrixFraction.java
+++ b/fractions/netflix/hystrix/src/main/java/org/wildfly/swarm/netflix/hystrix/HystrixFraction.java
@@ -162,7 +162,7 @@ public class HystrixFraction implements Fraction<HystrixFraction> {
     @Configurable("swarm.hystrix.threadpool.default.maxQueueSize")
     private Defaultable<Integer> threadpoolMaxQueueSize = integer(-1);
 
-    @AttributeDocumentation("The queue size rejection threshold — an artificial maximum queue size at which rejections will occur even if maxQueueSize has not been reached")
+    @AttributeDocumentation("The queue size rejection threshold - an artificial maximum queue size at which rejections will occur even if maxQueueSize has not been reached")
     @Configurable("swarm.hystrix.threadpool.default.queueSizeRejectionThreshold")
     private Defaultable<Integer> threadpoolQueueSizeRejectionThreshold = integer(5);
 

--- a/fractions/wildfly/hibernate-validator/README.adoc
+++ b/fractions/wildfly/hibernate-validator/README.adoc
@@ -1,3 +1,3 @@
-# Hibernate Validator
+= Hibernate Validator
 
 Provides support and integration for applications using Hibernate Validator.

--- a/fractions/wildfly/io/README.adoc
+++ b/fractions/wildfly/io/README.adoc
@@ -1,4 +1,4 @@
-# IO
+= IO
 
 Primarily an internal fraction supporting I/O activities
 for higher-level fractions.

--- a/fractions/wildfly/logging/README.adoc
+++ b/fractions/wildfly/logging/README.adoc
@@ -1,4 +1,4 @@
-# Logging
+= Logging
 
 Provides facilities to configure logging categories, levels and handlers.
 

--- a/fractions/wildfly/management/README.adoc
+++ b/fractions/wildfly/management/README.adoc
@@ -1,3 +1,3 @@
-# Management
+= Management
 
 Provides the WildFly management API.

--- a/fractions/wildfly/msc/README.adoc
+++ b/fractions/wildfly/msc/README.adoc
@@ -1,4 +1,4 @@
-# MSC
+= MSC
 
 Primarily an internal fraction providing support for the 
 JBoss Modular Container (MSC). JBoss MSC provides the underpinning

--- a/fractions/wildfly/request-controller/README.adoc
+++ b/fractions/wildfly/request-controller/README.adoc
@@ -1,4 +1,4 @@
-# Request Controller
+= Request Controller
 
 Provides support for the WildFly request-controller, allowing
 for graceful pause/resume/shutdown of the container.

--- a/fractions/wildfly/security/README.adoc
+++ b/fractions/wildfly/security/README.adoc
@@ -1,4 +1,4 @@
-# Security
+= Security
 
 Provides underlying security infrastructure to support JAAS
 and other security APIs.


### PR DESCRIPTION
- Removed the need for start=2 on numbered lists
- Replace # with = in all of the READMEs
- Added syntax-highlighting via coderay
- Added collapsible TOC via jquery
- Rev to latest fraction-plugin to get better hierarchic TOC.
- Added scm-publish to publish to docs.wildfly-swarm.io
  (hopefully works during `mvn deploy`)


