### PR TITLE
SWARM-1108 Keycloak Server Customization fix

### DIFF
--- a/fractions/keycloak-server/module.conf
+++ b/fractions/keycloak-server/module.conf
@@ -3,7 +3,7 @@
 org.wildfly.swarm.infinispan
 org.wildfly.swarm.datasources
 
-org.wildfly.swarm.configuration.keycloak.server
+org.wildfly.swarm.configuration.keycloak.server export=true
 
 io.undertow.servlet
 io.undertow.core


### PR DESCRIPTION
SWARM-1108: Modified keycloak-server fraction for the theme customization functionality to work

Motivation- The keycloak theme customization while using Wildfly Swarm option is completely broken now and throws a NoClassDefFoundError

Modifications
Changed the module.conf of the keycloak-server fraction to include export=true

Result
The NoClassDefFoundError is no longer thrown and it's possible to use custom themes now using the parameters given in the reference

For more details on my attempts at getting it to work completely for my use case, please refer to [https://groups.google.com/forum/#!topic/wildfly-swarm/0hsNdFF2a3M](https://groups.google.com/forum/#!topic/wildfly-swarm/0hsNdFF2a3M)