### PR TITLE
Use `bom` in HOWTOs instead of `bom-all`

### DIFF
--- a/docs/howto/autodetect-fractions/pom.xml
+++ b/docs/howto/autodetect-fractions/pom.xml
@@ -160,7 +160,6 @@
         <executions>
           <execution>
             <goals>
-              <goal>integration-test</goal>
               <goal>verify</goal>
             </goals>
           </execution>
@@ -187,7 +186,7 @@
     <dependencies>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
-        <artifactId>bom-all</artifactId>
+        <artifactId>bom</artifactId>
         <version>${project.version}</version>
         <type>pom</type>
         <scope>import</scope>

--- a/docs/howto/create-a-datasource/pom.xml
+++ b/docs/howto/create-a-datasource/pom.xml
@@ -161,7 +161,6 @@
         <executions>
           <execution>
             <goals>
-              <goal>integration-test</goal>
               <goal>verify</goal>
             </goals>
           </execution>
@@ -188,7 +187,7 @@
     <dependencies>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
-        <artifactId>bom-all</artifactId>
+        <artifactId>bom</artifactId>
         <version>${version.wildfly-swarm}</version>
         <type>pom</type>
         <scope>import</scope>

--- a/docs/howto/create-a-hollow-jar/pom.xml
+++ b/docs/howto/create-a-hollow-jar/pom.xml
@@ -163,7 +163,6 @@
         <executions>
           <execution>
             <goals>
-              <goal>integration-test</goal>
               <goal>verify</goal>
             </goals>
           </execution>
@@ -190,7 +189,7 @@
     <dependencies>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
-        <artifactId>bom-all</artifactId>
+        <artifactId>bom</artifactId>
         <version>${project.version}</version>
         <type>pom</type>
         <scope>import</scope>

--- a/docs/howto/create-an-uberjar/pom.xml
+++ b/docs/howto/create-an-uberjar/pom.xml
@@ -160,7 +160,6 @@
         <executions>
           <execution>
             <goals>
-              <goal>integration-test</goal>
               <goal>verify</goal>
             </goals>
           </execution>
@@ -187,7 +186,7 @@
     <dependencies>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
-        <artifactId>bom-all</artifactId>
+        <artifactId>bom</artifactId>
         <version>${project.version}</version>
         <type>pom</type>
         <scope>import</scope>

--- a/docs/howto/explicit-fractions/pom.xml
+++ b/docs/howto/explicit-fractions/pom.xml
@@ -159,7 +159,6 @@
         <executions>
           <execution>
             <goals>
-              <goal>integration-test</goal>
               <goal>verify</goal>
             </goals>
           </execution>
@@ -186,7 +185,7 @@
     <dependencies>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
-        <artifactId>bom-all</artifactId>
+        <artifactId>bom</artifactId>
         <version>${project.version}</version>
         <type>pom</type>
         <scope>import</scope>

--- a/docs/howto/test-in-container/pom.xml
+++ b/docs/howto/test-in-container/pom.xml
@@ -115,7 +115,7 @@
       <!-- tag::bom[] -->
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
-        <artifactId>bom-all</artifactId>
+        <artifactId>bom</artifactId>
         <version>${version.wildfly-swarm}</version>
         <type>pom</type>
         <scope>import</scope>

--- a/docs/howto/use-a-bom/pom.xml
+++ b/docs/howto/use-a-bom/pom.xml
@@ -161,7 +161,6 @@
         <executions>
           <execution>
             <goals>
-              <goal>integration-test</goal>
               <goal>verify</goal>
             </goals>
           </execution>


### PR DESCRIPTION
Provides the capability for them to work indentically in
both upstream and downstream, all with normal `bom`.

- [ ] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
