### PR TITLE
SWARM-1561 - Configurable keys incorrect

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -22,7 +22,7 @@
   <description>Build Parent to bring in required dependencies</description>
 
   <properties>
-    <version.wildfly.swarm.fraction.plugin>72</version.wildfly.swarm.fraction.plugin>
+    <version.wildfly.swarm.fraction.plugin>74</version.wildfly.swarm.fraction.plugin>
 
     <version.org.snakeyaml>1.17</version.org.snakeyaml>
 


### PR DESCRIPTION
Motivation
----------
KeycloakServerFraction was erroneously translated to
swarm.keycloakserver instead of swarm.keycloak-server.

Modifications
-------------
Newer fraction plugin with better name conversion.

Result
------
Correct documentation.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
