### PR TITLE
SWARM-1612 - Setting Long integer values fails

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/config/MapConfigNodeFactory.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/MapConfigNodeFactory.java
@@ -80,6 +80,8 @@ public class MapConfigNodeFactory {
             load(child, (List<?>) value);
         } else if (value instanceof String) {
             child = new ConfigNode("" + value);
+        } else if (value instanceof Long) {
+            child = new ConfigNode("" + value);
         } else if (value instanceof Integer) {
             child = new ConfigNode("" + value);
         } else if (value instanceof Boolean) {

--- a/testsuite/testsuite-undertow-context/src/main/webapp/project-defaults.yaml
+++ b/testsuite/testsuite-undertow-context/src/main/webapp/project-defaults.yaml
@@ -1,0 +1,7 @@
+swarm:
+  undertow:
+    servers:
+      default-server:
+        http-listeners:
+          default:
+            max-post-size: 2147483648


### PR DESCRIPTION
Motivation
----------
For setting Long-centric values, such as max-post-size for undertow,
we were losing the value.

Modifications
-------------
Accomodate more scalar types (Long).

Result
------
max-post-size can be set effectively via YAML.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
