### PR TITLE
SWARM-1590 - Support project-*.yaml within hollow-jars.

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/core/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
@@ -78,6 +79,7 @@ import org.wildfly.swarm.bootstrap.performance.Performance;
 import org.wildfly.swarm.bootstrap.util.BootstrapProperties;
 import org.wildfly.swarm.cli.CommandLine;
 import org.wildfly.swarm.container.DeploymentException;
+import org.wildfly.swarm.container.config.ClassLoaderConfigLocator;
 import org.wildfly.swarm.container.config.ConfigViewFactory;
 import org.wildfly.swarm.container.internal.Server;
 import org.wildfly.swarm.container.internal.ServerBootstrap;
@@ -236,9 +238,20 @@ public class Swarm {
         installModuleMBeanServer();
         createShrinkWrapDomain();
 
-        this.configView = ConfigViewFactory.defaultFactory(properties, environment);
         this.commandLine = CommandLine.parse(args);
+        this.configView = ConfigViewFactory.defaultFactory(properties, environment);
+
+        if (ApplicationEnvironment.get().isHollow()) {
+            if (!this.commandLine.extraArguments().isEmpty()) {
+                URLClassLoader firstDeploymentCL = new URLClassLoader(new URL[]{
+                        new File(this.commandLine.extraArguments().get(0)).toURI().toURL()
+                });
+                this.configView.addLocator(new ClassLoaderConfigLocator(firstDeploymentCL));
+            }
+        }
+
         this.commandLine.apply(this);
+
         initializeConfigView(properties);
 
         this.isConstructing = false;
@@ -715,6 +728,7 @@ public class Swarm {
         }
 
         swarm = new Swarm(args);
+
 
         try {
             swarm.start();

--- a/core/container/src/main/java/org/wildfly/swarm/container/config/ClassLoaderConfigLocator.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/ClassLoaderConfigLocator.java
@@ -41,7 +41,7 @@ public class ClassLoaderConfigLocator extends ConfigLocator {
         return new ClassLoaderConfigLocator(appModule.getClassLoader());
     }
 
-    private ClassLoaderConfigLocator(ClassLoader classLoader) {
+    public ClassLoaderConfigLocator(ClassLoader classLoader) {
         this.classLoader = classLoader;
     }
 

--- a/docs/howto/create-a-hollow-jar/src/main/webapp/project-defaults.yaml
+++ b/docs/howto/create-a-hollow-jar/src/main/webapp/project-defaults.yaml
@@ -1,0 +1,3 @@
+swarm:
+  http:
+    port: 9191


### PR DESCRIPTION
Motivation
----------
If a project-defaults.yaml is used with a deployment and a hollow
jar, it was not recognized.

Modifications
-------------
If running as a hollow jar, support locating project-*.yaml configuration
within the _first_ deployment passed.

Result
------
The first (typically only) deployment may contain YAML to configure the
runtime of a hollow jar.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
