### PR TITLE
SWARM-1650: documentation of datasources should include validation settings

### DIFF
--- a/fractions/javaee/datasources/README.adoc
+++ b/fractions/javaee/datasources/README.adoc
@@ -56,3 +56,66 @@ may be used when defining a datasource is as follows:
 |`prestodb`
 |===
 
+== Example datasource definitions
+
+=== MySQL
+
+An example of a MySQL datasource configuration with connection information, basic security, and validation options:
+
+[source,yaml,options="nowrap"]
+----
+swarm:
+  datasources:
+    data-sources:
+      MyDS:
+        driver-name: mysql
+        connection-url: jdbc:mysql://localhost:3306/jbossdb
+        user-name: admin
+        password: admin
+        valid-connection-checker-class-name: org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLValidConnectionChecker
+        validate-on-match: true
+        background-validation: false
+        exception-sorter-class-name: org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLExceptionSorter
+----
+
+=== PostgreSQL
+
+An example of a PostgreSQL datasource configuration with connection information, basic security, and validation options:
+
+[source,yaml,options="nowrap"]
+----
+swarm:
+  datasources:
+    data-sources:
+      MyDS:
+        driver-name: postgresql
+        connection-url: jdbc:postgresql://localhost:5432/postgresdb
+        user-name: admin
+        password: admin
+        valid-connection-checker-class-name: org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLValidConnectionChecker
+        validate-on-match: true
+        background-validation: false
+        exception-sorter-class-name: org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLExceptionSorter
+----
+
+=== Oracle
+
+An example of an Oracle datasource configuration with connection information, basic security, and validation options:
+
+[source,yaml,options="nowrap"]
+----
+swarm:
+  datasources:
+    data-sources:
+      MyDS:
+        driver-name: oracle
+        connection-url: jdbc:oracle:thin:@localhost:1521:XE
+        user-name: admin
+        password: admin
+        valid-connection-checker-class-name: org.jboss.jca.adapters.jdbc.extensions.oracle.OracleValidConnectionChecker
+        validate-on-match: true
+        background-validation: false
+        stale-connection-checker-class-name: org.jboss.jca.adapters.jdbc.extensions.oracle.OracleStaleConnectionChecker
+        exception-sorter-class-name: org.jboss.jca.adapters.jdbc.extensions.oracle.OracleExceptionSorter
+----
+


### PR DESCRIPTION
Motivation
----------
The `datasources` fraction documentation should include full examples
of datasource configuration as shown in EAP documentation:
https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.0/html/configuration_guide/datasource_management#example_datasource_configurations

This mainly includes connection validation settings, which is
important in case a DB temporarily goes away and then returns back.

Modifications
-------------
Added examples of MySQL, PostgreSQL and Oracle datasources, showing
all the configuration options included in the EAP documentation.

Result
------
More complete documentation for datasources.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
