### PR TITLE
SWARM-1654: Terminate on deployment errors that happen before swarm.s…

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/core/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -773,6 +773,10 @@ public class Swarm {
                 t.printStackTrace();
                 System.exit(1);
             }
+        } else {
+            // errors can be thrown before swarm.server is created
+            errorCause.printStackTrace();
+            System.exit(1);
         }
     }
 


### PR DESCRIPTION
SWARM-1654: Terminate on deployment errors that happen before swarm.server is initialized.

Motivation
----------
When certain deployment errors are thrown, the server is stuck in an inconsistent state but the JVM does not terminate.

Modifications
-------------
Changed Swarm.main to call System.exit() after deployment errors even if swarm.server is null.

Result
------
JVM terminates after deployment errors that happen before swarm.server is initialized.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
