### PR TITLE
Replaced string "WildFly" (not Swarm) with an attribute

### DIFF
--- a/docs/howto/create-a-datasource/configuring-the-jdbc-driver-manually.adoc
+++ b/docs/howto/create-a-datasource/configuring-the-jdbc-driver-manually.adoc
@@ -4,7 +4,7 @@
 .Prerequisites
 
 * A Maven-based application.
-* The `module.xml` file created according to relevant WildFly instructions.
+* The `module.xml` file created according to relevant {WildFly} instructions.
   This file is necessary to expose the driver through JBoss Modules.
 
 .Procedure

--- a/docs/introduction.adoc
+++ b/docs/introduction.adoc
@@ -1,5 +1,5 @@
 
-WildFly Swarm is a framework based on the popular WildFly Java application server to enable the creation of small, standalone microservice-based applications.
+WildFly Swarm is a framework based on the popular {WildFly} Java application server to enable the creation of small, standalone microservice-based applications.
 WildFly Swarm is capable of producing so-called _just enough app-server_ to support each component of your system.
 
 For more information, see the WildFly Swarm link:http://wildfly-swarm.io/[home page].

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -80,6 +80,7 @@
             <docinfo>shared</docinfo>
             <version>${project.version}</version>
             <product>${swarm.product.build}</product>
+            <WildFly>WildFly</WildFly>
           </attributes>
           <doctype>book</doctype>
           <backend>html5</backend>

--- a/fractions/wildfly/management/README.adoc
+++ b/fractions/wildfly/management/README.adoc
@@ -1,3 +1,3 @@
 = Management
 
-Provides the WildFly management API.
+Provides the {WildFly} management API.

--- a/fractions/wildfly/request-controller/README.adoc
+++ b/fractions/wildfly/request-controller/README.adoc
@@ -1,4 +1,4 @@
 = Request Controller
 
-Provides support for the WildFly request-controller, allowing
+Provides support for the {WildFly} request-controller, allowing
 for graceful pause/resume/shutdown of the container.


### PR DESCRIPTION
This is useful for replacing WildFly with EAP when needed.

The attribute is called `WildFly`, referenced `{WildFly}` in the source files. It is set to "WildFly" in the community build, so it does not affect the current community docs in any way.