### PR TITLE
Fix and enable Microprofile TCKS within testsuite

### DIFF
--- a/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/mpjwtauth/runtime/MPJWTAuthExtensionArchivePreparer.java
+++ b/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/mpjwtauth/runtime/MPJWTAuthExtensionArchivePreparer.java
@@ -146,9 +146,9 @@ public class MPJWTAuthExtensionArchivePreparer implements DeploymentProcessor {
             log.debugf("PublicKey: %s", fraction.getPublicKey());
             war.addAsManifestResource(new StringAsset(fraction.getPublicKey()), "MP-JWT-SIGNER");
         }
-        if (log.isInfoEnabled()) {
-            log.info("jar: " + jwtAuthJar.toString(true));
-            log.info("war: " + war.toString(true));
+        if (log.isTraceEnabled()) {
+            log.trace("jar: " + jwtAuthJar.toString(true));
+            log.trace("war: " + war.toString(true));
         }
     }
 

--- a/testsuite/microprofile-tcks/pom.xml
+++ b/testsuite/microprofile-tcks/pom.xml
@@ -24,7 +24,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.wildfly.swarm</groupId>
+        <groupId>org.wildfly.swarm.testsuite</groupId>
         <artifactId>testsuite-parent</artifactId>
         <version>2017.12.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
@@ -61,6 +61,7 @@
             </plugin>
         </plugins>
     </build>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -131,11 +132,11 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-        <dependency>
+      <!--  <dependency>
             <groupId>org.wildfly.swarm</groupId>
             <artifactId>jwt-auth-tck</artifactId>
             <version>1.0-MP_12-RC4</version>
-        </dependency>
+        </dependency>-->
         <!-- The JAX-RS client implemention -->
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
@@ -222,5 +223,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
 </project>
 

--- a/testsuite/microprofile-tcks/pom.xml
+++ b/testsuite/microprofile-tcks/pom.xml
@@ -52,7 +52,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.20</version>
                 <configuration>
-                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <redirectTestOutputToFile>false</redirectTestOutputToFile>
                     <suiteXmlFiles>
                         <suiteXmlFile>tck-suite.xml</suiteXmlFile>
                     </suiteXmlFiles>
@@ -176,7 +176,7 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.swarm</groupId>
-            <artifactId>monitor</artifactId>
+            <artifactId>microprofile-health</artifactId>
             <scope>test</scope>
         </dependency>
         <!--


### PR DESCRIPTION
This fixes assorted minor problems and allows to run the microprofile TCK's from the main testsuite 