### PR TITLE
Workaround for https://issues.jboss.org/browse/SWARM-1689

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/core/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -690,7 +690,7 @@ public class Swarm {
 
                 Map<ArchivePath, Node> content = archive.getContent();
                 for (ArchivePath path : content.keySet()) {
-                    if (path.get().endsWith(".class")) {
+                    if (path.get().endsWith(".class") && !path.get().equals("module-info.class")) {
                         Node node = content.get(path);
                         indexer.index(node.getAsset().openStream());
                     }


### PR DESCRIPTION
This is a workaround to solve https://issues.jboss.org/browse/SWARM-1689 until Jandex is upgraded to 2.0.4

A similar patch was applied to the fraction plugin, but this issue is different: https://github.com/wildfly-swarm/wildfly-swarm-fraction-plugin/pull/43/files

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
