### PR TITLE
SWARM-1692: upgrade wildfly-nosql + nosql config-api variants and add test case.

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -31,11 +31,11 @@
     <version.keycloak.config-api>1.1.0.Final</version.keycloak.config-api>
     <version.teiid.config-api>1.0.3.Final</version.teiid.config-api>
     <version.keycloak>2.5.5.Final</version.keycloak>
-    <version.mongo.config-api>1.2.0</version.mongo.config-api>
-    <version.cassandra.config-api>1.2.0</version.cassandra.config-api>
-    <version.neo4j.config-api>1.2.0</version.neo4j.config-api>
-    <version.orientdb.config-api>1.2.0</version.orientdb.config-api>
-    <version.wildfly.nosql.feature-pack>1.0.0.Alpha4</version.wildfly.nosql.feature-pack>
+    <version.mongo.config-api>1.2.1</version.mongo.config-api>
+    <version.cassandra.config-api>1.2.1</version.cassandra.config-api>
+    <version.neo4j.config-api>1.2.1</version.neo4j.config-api>
+    <version.orientdb.config-api>1.2.1</version.orientdb.config-api>
+    <version.wildfly.nosql.feature-pack>1.0.0.Alpha5</version.wildfly.nosql.feature-pack>
 
     <version.wildfly>10.1.0.Final</version.wildfly>
     <version.org.wildfly.core>2.2.1.Final</version.org.wildfly.core>

--- a/testsuite/testsuite-mongodb/src/test/java/org/wildfly/swarm/mongodb/test/StatefulTestBean.java
+++ b/testsuite/testsuite-mongodb/src/test/java/org/wildfly/swarm/mongodb/test/StatefulTestBean.java
@@ -17,8 +17,8 @@
 package org.wildfly.swarm.mongodb.test;
 
 import javax.inject.Inject;
+import javax.enterprise.context.Dependent;
 import javax.inject.Named;
-import javax.annotation.Resource;
 import javax.ejb.Stateful;
 import javax.json.Json;
 import javax.json.JsonObject;
@@ -38,11 +38,20 @@ import org.bson.Document;
 public class StatefulTestBean {
 
     //@Resource(lookup = "java:jboss/mongodb/test")
-    @Inject @Named("mongodbtestprofile")
+    //@Inject @Named("mongodbtestprofile")
     MongoDatabase database;
 
-    @Resource(lookup = "java:jboss/mongodb/test")
-    MongoDatabase databaseJNDI;
+    // recreate https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/wildfly-nosql/8IIuxR30xAc/RxAEWs4fAAAJ
+    // ensure that @Inject without a @Named, doesn't cause a deployment failure
+    @Inject
+    public StatefulTestBean(MongoDatabase mongoDatabase) {
+        this.database = mongoDatabase;
+        // System.out.println("xxx parameter " + mongoDatabase + " ctor called");
+    }
+
+    public StatefulTestBean() {
+        // System.out.println("xxx no parameter ctor called");
+    }
 
     public String addUserComment() {
         MongoCollection collection = null;
@@ -96,4 +105,14 @@ public class StatefulTestBean {
             }
         }
     }
+
+    @Dependent @Named
+    static class CauseFailure {
+        private String ignore="ignore";
+
+        public String getIgnore() {
+            return ignore;
+        }
+    }
+
 }


### PR DESCRIPTION
 Resolves WFNOSQL-21 'IllegalArgumentException: WFLYNOSQL0003: @Named annotations must provide a value' deployment failure and also brings in an OrientDB subsystem configuration improvement.