### PR TITLE
SWARM-1619: BOM should not include internal fractions

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -22,7 +22,7 @@
   <description>Build Parent to bring in required dependencies</description>
 
   <properties>
-    <version.wildfly.swarm.fraction.plugin>76</version.wildfly.swarm.fraction.plugin>
+    <version.wildfly.swarm.fraction.plugin>77</version.wildfly.swarm.fraction.plugin>
 
     <version.org.snakeyaml>1.17</version.org.snakeyaml>
 

--- a/testsuite/testsuite-maven-plugin/src/test/java/org/wildfly/swarm/maven/plugin/TestingProject.java
+++ b/testsuite/testsuite-maven-plugin/src/test/java/org/wildfly/swarm/maven/plugin/TestingProject.java
@@ -84,7 +84,7 @@ public final class TestingProject {
         String pomXmlContent = new String(Files.readAllBytes(pomXml), StandardCharsets.UTF_8)
                 .replace("<!--PLACEHOLDER:swarm-version-->", swarmVersion)
                 .replace("<!--PLACEHOLDER:packaging-->", packaging.packagingType())
-                .replace("<!--PLACEHOLDER:dependencies-->", dependenciesSnippet())
+                .replace("<!--PLACEHOLDER:dependencies-->", dependenciesSnippet(swarmVersion))
                 .replace("<!--PLACEHOLDER:configuration-->", swarmPluginConfigurationSnippet());
         Files.write(pomXml, pomXmlContent.getBytes(StandardCharsets.UTF_8));
 
@@ -143,13 +143,14 @@ public final class TestingProject {
         }
     }
 
-    private String dependenciesSnippet() {
+    private String dependenciesSnippet(String swarmVersion) {
         StringBuilder result = new StringBuilder();
 
         if (packaging.hasCustomMain()) {
             result.append("<dependency>\n" +
                           "  <groupId>org.wildfly.swarm</groupId>\n" +
                           "  <artifactId>container</artifactId>\n" +
+                          "  <version>" + swarmVersion + "</version>\n" +
                           "</dependency>\n");
         }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
BOM currently includes fractions that are marked internal.

Users should not be adding internal fractions as dependencies to their applications.

Modifications
-------------
Update fraction-plugin to version that filters out internal fractions from BOM creation.

Result
------
BOM no longer includes internal fractions
