### PR TITLE
SWARM-1643: MP Metrics API appears twice

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1124,7 +1124,6 @@
 
       <modules>
         <module>client-apis/jaxrs-client-api</module>
-        <module>client-apis/metrics-api</module>
 
         <module>swarmtool</module>
         <module>cli</module>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
Maven module is in two different profiles, only needs to be in one.

Modifications
-------------
Remove MP Metrics API from one of the profiles.

Result
------
No impact to product, just build.
