### PR TITLE
SWARM-1707: Actual fix for module-info.class files

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/core/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -690,7 +690,7 @@ public class Swarm {
 
                 Map<ArchivePath, Node> content = archive.getContent();
                 for (ArchivePath path : content.keySet()) {
-                    if (path.get().endsWith(".class") && !path.get().equals("module-info.class")) {
+                    if (path.get().endsWith(".class") && !path.get().endsWith("module-info.class")) {
                         Node node = content.get(path);
                         indexer.index(node.getAsset().openStream());
                     }


### PR DESCRIPTION
Motivation
----------
SWARM-1650 tried to fix module-info.class existence problem when starting up Wildfly Swarm. Unfortunately, this didn't actually fix the problem

Modifications
-------------
Minor change to take into account it's a path, and not a file name when doing the comparison.

Result
------
Fix module-info.class issue.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
