### PR TITLE
[SWARM-1710] Fix test-jar

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/internal/ArtifactManager.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/ArtifactManager.java
@@ -47,6 +47,9 @@ public class ArtifactManager implements ArtifactLookup {
 
     private static final String COLON = ":";
 
+    private static final String JAR = "jar";
+    private static final String TEST_JAR = "test-jar";
+
     public ArtifactManager() {
     }
 
@@ -122,7 +125,7 @@ public class ArtifactManager implements ArtifactLookup {
 
         String groupId = parts[0];
         String artifactId = parts[1];
-        String packaging = "jar";
+        String packaging = JAR;
         String version = null;
         String classifier = "";
 
@@ -131,12 +134,13 @@ public class ArtifactManager implements ArtifactLookup {
         }
 
         if (parts.length == 4) {
-            packaging = parts[2];
+            // the type "test-jar" is packaged as a .jar file more info: https://maven.apache.org/plugins/maven-jar-plugin/examples/create-test-jar.html
+            packaging = TEST_JAR.equals(parts[2]) ? JAR : TEST_JAR;
             version = parts[3];
         }
 
         if (parts.length == 5) {
-            packaging = parts[2];
+            packaging = TEST_JAR.equals(parts[2]) ? JAR : TEST_JAR;
             classifier = parts[3];
             version = parts[4];
         }

--- a/core/container/src/main/java/org/wildfly/swarm/internal/ArtifactManager.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/ArtifactManager.java
@@ -135,12 +135,12 @@ public class ArtifactManager implements ArtifactLookup {
 
         if (parts.length == 4) {
             // the type "test-jar" is packaged as a .jar file more info: https://maven.apache.org/plugins/maven-jar-plugin/examples/create-test-jar.html
-            packaging = TEST_JAR.equals(parts[2]) ? JAR : TEST_JAR;
+            packaging = TEST_JAR.equals(parts[2]) ? JAR : parts[2];
             version = parts[3];
         }
 
         if (parts.length == 5) {
-            packaging = TEST_JAR.equals(parts[2]) ? JAR : TEST_JAR;
+            packaging = TEST_JAR.equals(parts[2]) ? JAR : parts[2];
             classifier = parts[3];
             version = parts[4];
         }


### PR DESCRIPTION
Found a problem when using wildfly swarm with arquilian and I want to use one or more classes of a dependecy's test source code. This scenario I can just import the dependency in maven specifying the type as test-jar. This will make the test source code of that depdency available to me. The problem fixed was that it was using the type to get the specific file extension but in this scenario is not the case

- [ ] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
