### PR TITLE
SWARM-1712: Upgrade wildfly-microprofile-config to 1.1.5

### DIFF
--- a/fractions/microprofile/microprofile-config/pom.xml
+++ b/fractions/microprofile/microprofile-config/pom.xml
@@ -28,7 +28,7 @@
         <!-- The MicroProfile Config API version -->
         <mpconfig.api.version>1.1</mpconfig.api.version>
         <!-- The Wildfly Extras Version -->
-        <mpconfig.wildfly.version>1.1.2</mpconfig.wildfly.version>
+        <mpconfig.wildfly.version>1.1.5</mpconfig.wildfly.version>
     </properties>
 
     <build>

--- a/testsuite/microprofile-tcks/config/src/test/tck-suite.xml
+++ b/testsuite/microprofile-tcks/config/src/test/tck-suite.xml
@@ -26,15 +26,6 @@
       <packages>
          <package name="org.eclipse.microprofile.config.tck.*" />
       </packages>
-
-      <classes>
-        <!-- https://github.com/wildfly-extras/wildfly-microprofile-config/issues/26 -->
-        <class name="org.eclipse.microprofile.config.tck.ConverterTest">
-            <methods>
-                <exclude name=".*"/>
-            </methods>
-        </class>
-      </classes>
    </test>
 
 </suite>


### PR DESCRIPTION
- also remove ConverterTest from exclude list
(https://github.com/wildfly-extras/wildfly-microprofile-config/issues/26)

NOTE: `wildfly-microprofile-config` 1.1.5 is not in maven central yet.