### PR TITLE
SWARM-1713: upgrade Arquillian to 1.1.15.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <version.certified-community>2017.10.1</version.certified-community>
     <version.wildfly.swarm>${project.version}</version.wildfly.swarm>
 
-    <version.org.arquillian>1.1.12.Final</version.org.arquillian>
+    <version.org.arquillian>1.1.15.Final</version.org.arquillian>
     <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>
     <version.org.jboss.shrinkwrap.descriptors>2.0.0</version.org.jboss.shrinkwrap.descriptors>
     <version.fest-assert>1.4</version.fest-assert>
@@ -1074,6 +1074,7 @@
       <modules>
         <module>testsuite</module>
         <module>testsuite/testsuite-ajp</module>
+        <module>testsuite/testsuite-arquillian-without-cdi</module>
         <module>testsuite/testsuite-buildtool</module>
         <module>testsuite/testsuite-cdi</module>
         <module>testsuite/testsuite-cdi-bean-validation</module>

--- a/testsuite/testsuite-arquillian-without-cdi/pom.xml
+++ b/testsuite/testsuite-arquillian-without-cdi/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm.testsuite</groupId>
+    <artifactId>testsuite-parent</artifactId>
+    <version>2017.12.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <artifactId>testsuite-arquillian-without-cdi</artifactId>
+
+  <name>Test Suite: Arquillian Without CDI</name>
+  <description>Test Suite: Arquillian Without CDI</description>
+
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <!-- the entire point of this test is that the CDI fraction is NOT present -->
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>ejb</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>undertow</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>arquillian</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/testsuite/testsuite-arquillian-without-cdi/src/main/java/org/wildfly/swarm/arquillian/test/MyBean.java
+++ b/testsuite/testsuite-arquillian-without-cdi/src/main/java/org/wildfly/swarm/arquillian/test/MyBean.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.arquillian.test;
+
+import javax.ejb.Stateless;
+
+@Stateless
+public class MyBean {
+    public String hello() {
+        return "Hello, world!";
+    }
+}

--- a/testsuite/testsuite-arquillian-without-cdi/src/test/java/org/wildfly/swarm/arquillian/test/ArquillianEnrichersWithoutCdiTest.java
+++ b/testsuite/testsuite-arquillian-without-cdi/src/test/java/org/wildfly/swarm/arquillian/test/ArquillianEnrichersWithoutCdiTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.arquillian.test;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.undertow.WARArchive;
+
+import javax.annotation.Resource;
+import javax.ejb.EJB;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(Arquillian.class)
+public class ArquillianEnrichersWithoutCdiTest {
+    @Deployment
+    public static Archive<?> deployment() throws Exception {
+        return ShrinkWrap.create(WARArchive.class)
+                .addClass(MyBean.class)
+                .addAllDependencies();
+    }
+
+    @EJB
+    private MyBean myBeanFromEjb;
+
+    @Resource(lookup = "java:module/MyBean")
+    private MyBean myBeanFromResource;
+
+    @Test
+    public void ejbEnricher() throws IOException {
+        assertNotNull(myBeanFromEjb);
+        assertEquals("Hello, world!", myBeanFromEjb.hello());
+    }
+
+    @Test
+    public void resourceEnricher() {
+        assertNotNull(myBeanFromResource);
+        assertEquals("Hello, world!", myBeanFromResource.hello());
+    }
+}


### PR DESCRIPTION
Motivation
----------
Arquillian 1.1.15.Final contains two bugfixes for situations
where CDI isn't present: ARQ-2107 and ARQ-2109. These are
unlikely to affect usage e.g. with WildFly, but they are pretty
likely to affect usage with Swarm (the issues actually affected
Java EE 7 Samples tests).

Modifications
-------------
Arquillian upgraded to 1.1.15.Final. Added tests for injecting
an EJB via @EJB and @Resource without CDI being present.

Result
------
More up-to-date version of Arquillian. Shouldn't affect behavior.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
