### PR TITLE
Re-arrange BOMs in build order

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -142,7 +142,7 @@
 
   <profiles>
     <profile>
-      <id>boms-unsupported</id>
+      <id>unsupported</id>
       <dependencies>
         <dependency>
           <groupId>org.wildfly.swarm</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1041,29 +1041,6 @@
     </profile>
 
     <profile>
-      <id>boms-unsupported</id>
-      <activation>
-        <property>
-          <name>!swarm.product.build</name>
-        </property>
-      </activation>
-      <properties>
-        <testCategory.excluded>category.ProductOnly</testCategory.excluded>
-      </properties>
-      <modules>
-        <module>boms</module>
-        <module>boms/bom</module>
-        <module>boms/bom-deprecated</module>
-        <module>boms/bom-experimental</module>
-        <module>boms/bom-unstable</module>
-        <module>boms/bom-stable</module>
-        <module>boms/bom-frozen</module>
-        <module>boms/bom-locked</module>
-        <module>boms/bom-all</module>
-      </modules>
-    </profile>
-
-    <profile>
       <id>core-testsuite</id>
       <activation>
         <property>
@@ -1211,6 +1188,16 @@
         <module>standalone-servers/management-console</module>
         <module>standalone-servers/microprofile</module>
         <module>standalone-servers/swagger-ui</module>
+
+        <module>boms</module>
+        <module>boms/bom</module>
+        <module>boms/bom-deprecated</module>
+        <module>boms/bom-experimental</module>
+        <module>boms/bom-unstable</module>
+        <module>boms/bom-stable</module>
+        <module>boms/bom-frozen</module>
+        <module>boms/bom-locked</module>
+        <module>boms/bom-all</module>
 
         <module>testsuite/testsuite-asciidoctorj</module>
         <module>testsuite/testsuite-batch-jberet</module>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Re-arrange where BOMs are in the module order to ensure that a BOM has all local artifacts present before its creation, to prevent remote downloads.

Should result in faster local build time.
