### PR TITLE
Fixing dependency in MP health TCK runner

### DIFF
--- a/testsuite/microprofile-tcks/health/pom.xml
+++ b/testsuite/microprofile-tcks/health/pom.xml
@@ -49,6 +49,11 @@
       </dependency>
 
       <dependency>
+         <groupId>commons-logging</groupId>
+         <artifactId>commons-logging</artifactId>
+      </dependency>
+
+      <dependency>
          <groupId>org.wildfly.swarm</groupId>
          <artifactId>microprofile-health</artifactId>
          <scope>test</scope>


### PR DESCRIPTION
Signed-off-by: Antoine Sabot-Durand <antoine@sabot-durand.net>

Fixing dependency in MP Health TCK runner to solve a ClassNotFound Exception