### PR TITLE
SWARM-1711: Fix MP FT fraction to pass TCK.

### DIFF
--- a/client-apis/mp_fault_tolerance_cdi_extension/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/config/GenericConfig.java
+++ b/client-apis/mp_fault_tolerance_cdi_extension/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/config/GenericConfig.java
@@ -54,7 +54,7 @@ public abstract class GenericConfig<X extends Annotation> {
     }
 
     private GenericConfig(Method method, AnnotatedMethod<?> annotatedMethod, X annotation, ElementType annotationSource) {
-        this.method = annotatedMethod.getJavaMember();
+        this.method = method;
         this.annotatedMethod = annotatedMethod;
         this.annotation = annotation;
         this.annotationSource = annotationSource;

--- a/fractions/microprofile/microprofile-fault-tolerance/pom.xml
+++ b/fractions/microprofile/microprofile-fault-tolerance/pom.xml
@@ -25,7 +25,6 @@
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.wildfly.swarm</groupId>
   <artifactId>microprofile-fault-tolerance</artifactId>
   <name>Eclipse MicroProfile Fault Tolerance</name>
   <description>WildFly: Swarm Fraction for Eclipse MicroProfile Fault Tolerance</description>
@@ -36,13 +35,7 @@
     <swarm.fraction.internal>false</swarm.fraction.internal>
     <swarm.fraction.stability>experimental</swarm.fraction.stability>
     <swarm.fraction.tags>EclipseMicroProfile,MicroServices,FaultTolerance</swarm.fraction.tags>
-    <!-- The MicroProfile Config API version -->
-    <mpconfig.api.version>1.1</mpconfig.api.version>
-    <!-- The Wildfly Extras Version -->
-    <mpconfig.wildfly.version>1.1.2</mpconfig.wildfly.version>
-    <mpft-api.version>1.0</mpft-api.version>
-    <hystrix.version>1.5.12</hystrix.version>
-    <javax-annotation-api.version>1.3.1</javax-annotation-api.version>
+    <version.microprofile.fault-tolerance.api>1.0</version.microprofile.fault-tolerance.api>
   </properties>
 
   <build>
@@ -71,25 +64,22 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>cdi</artifactId>
     </dependency>
-
-
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>hystrix</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>microprofile-config</artifactId>
-      <version>${mpconfig.wildfly.version}</version>
     </dependency>
-
-    <!-- Provided APIs -->
     <dependency>
       <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
       <artifactId>microprofile-fault-tolerance-api</artifactId>
-      <version>${mpft-api.version}</version>
+      <version>${version.microprofile.fault-tolerance.api}</version>
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>mp_fault_tolerance_cdi_extension</artifactId>
-      <version>${project.version}</version>
     </dependency>
-
   </dependencies>
 </project>

--- a/fractions/microprofile/microprofile-fault-tolerance/src/main/resources/modules/org/eclipse/microprofile/faulttolerance/main/module.xml
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/main/resources/modules/org/eclipse/microprofile/faulttolerance/main/module.xml
@@ -13,7 +13,12 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-
 <module xmlns="urn:jboss:module:1.3" name="org.eclipse.microprofile.faulttolerance">
-
+   <resources>
+      <artifact
+         name="org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:${version.microprofile.fault-tolerance.api}" />
+   </resources>
+   <dependencies>
+      <module name="javax.enterprise.api" />
+   </dependencies>
 </module>

--- a/fractions/microprofile/microprofile-fault-tolerance/src/main/resources/modules/org/wildfly/swarm/microprofile/faulttolerance/cdi/main/module.xml
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/main/resources/modules/org/wildfly/swarm/microprofile/faulttolerance/cdi/main/module.xml
@@ -1,0 +1,33 @@
+<!--
+  ~ /*
+  ~   Copyright 2017 Red Hat, Inc, and individual contributors.
+  ~
+  ~   Licensed under the Apache License, Version 2.0 (the "License");
+  ~   you may not use this file except in compliance with the License.
+  ~   You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~   Unless required by applicable law or agreed to in writing, software
+  ~   distributed under the License is distributed on an "AS IS" BASIS,
+  ~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~   See the License for the specific language governing permissions and
+  ~   limitations under the License.
+  ~ */
+  -->
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.swarm.microprofile.faulttolerance.cdi">
+   <resources>
+      <artifact
+         name="org.wildfly.swarm:mp_fault_tolerance_cdi_extension:${project.version}" />
+   </resources>
+   <dependencies>
+      <module name="javax.enterprise.api" />
+      <module name="javax.annotation.api" />
+      <module name="javax.api" />
+      <module name="org.eclipse.microprofile.faulttolerance" />
+      <module name="org.eclipse.microprofile.config.api" />
+      <module name="org.wildfly.extension.microprofile.config" />
+      <module name="com.netflix.hystrix" />
+      <module name="org.jboss.logging" />
+   </dependencies>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -1325,6 +1325,7 @@
         <module>testsuite/microprofile-tcks/config</module>
         <module>testsuite/microprofile-tcks/jwt-auth</module>
         <module>testsuite/microprofile-tcks/metrics</module>
+        <module>testsuite/microprofile-tcks/fault-tolerance</module>
       </modules>
     </profile>
 

--- a/testsuite/microprofile-tcks/fault-tolerance/pom.xml
+++ b/testsuite/microprofile-tcks/fault-tolerance/pom.xml
@@ -77,6 +77,14 @@
          </exclusions>
       </dependency>
 
+      <!-- This is needed for tests with @ShouldThrowException - the real
+         exception is org.jboss.weld.exceptions.DeploymentException -->
+      <dependency>
+         <groupId>org.jboss.weld</groupId>
+         <artifactId>weld-core-impl</artifactId>
+         <scope>test</scope>
+      </dependency>
+
    </dependencies>
 
    <build>
@@ -94,6 +102,12 @@
                <dependenciesToScan>
                   <dependency>org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-tck</dependency>
                </dependenciesToScan>
+               <systemProperties>
+                  <property>
+                     <name>java.util.logging.config.file</name>
+                     <value>${project.build.testOutputDirectory}/logging.properties</value>
+                  </property>
+               </systemProperties>
             </configuration>
          </plugin>
       </plugins>

--- a/testsuite/microprofile-tcks/fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/tck/FaultToleranceApplicationArchiveProcessor.java
+++ b/testsuite/microprofile-tcks/fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/tck/FaultToleranceApplicationArchiveProcessor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.faulttolerance.tck;
+
+import java.util.logging.Logger;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.container.ResourceContainer;
+
+/**
+ *
+ * @author Martin Kouba
+ */
+public class FaultToleranceApplicationArchiveProcessor implements ApplicationArchiveProcessor {
+
+    private static final Logger LOGGER = Logger.getLogger(FaultToleranceApplicationArchiveProcessor.class.getName());
+
+    @Override
+    public void process(Archive<?> applicationArchive, TestClass testClass) {
+        if (!(applicationArchive instanceof ResourceContainer)) {
+            LOGGER.warning("Unable to add Hystrix config.properties - not a resource container: " + applicationArchive);
+            return;
+        }
+        LOGGER.info("Adding customized Hystrix config.properties to " + applicationArchive);
+        ResourceContainer<?> resourceContainer = (ResourceContainer<?>) applicationArchive;
+        resourceContainer.addAsResource(buildProperties(), "config.properties");
+    }
+
+    private StringAsset buildProperties() {
+        StringBuilder builder = new StringBuilder();
+        // Do not interrupt command execution when a timeout occurs - needed for bulkhead tests
+        builder.append("hystrix.command.default.execution.isolation.thread.interruptOnTimeout=false");
+        return new StringAsset(builder.toString());
+    }
+
+}

--- a/testsuite/microprofile-tcks/fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/tck/FaultToleranceExtension.java
+++ b/testsuite/microprofile-tcks/fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/tck/FaultToleranceExtension.java
@@ -13,19 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.wildfly.swarm.microprofile.faulttolerance.tck;
 
-package org.wildfly.swarm.microprofile.faulttolerance;
-
-import org.wildfly.swarm.spi.api.Fraction;
-import org.wildfly.swarm.spi.api.annotations.DeploymentModule;
-import org.wildfly.swarm.spi.api.annotations.DeploymentModule.MetaInfDisposition;
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.core.spi.LoadableExtension;
 
 /**
- * @author Antoine Sabot-Durand
+ *
+ * @author Martin Kouba
  */
-@DeploymentModule(name = "org.wildfly.swarm.microprofile.faulttolerance.cdi", metaInf = MetaInfDisposition.IMPORT)
-public class MicroProfileFaultToleranceFraction implements Fraction<MicroProfileFaultToleranceFraction> {
+public class FaultToleranceExtension implements LoadableExtension {
 
-    public MicroProfileFaultToleranceFraction() {
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.service(ApplicationArchiveProcessor.class, FaultToleranceApplicationArchiveProcessor.class);
     }
+
 }

--- a/testsuite/microprofile-tcks/fault-tolerance/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/testsuite/microprofile-tcks/fault-tolerance/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+org.wildfly.swarm.microprofile.faulttolerance.tck.FaultToleranceExtension

--- a/testsuite/microprofile-tcks/fault-tolerance/src/test/resources/logging.properties
+++ b/testsuite/microprofile-tcks/fault-tolerance/src/test/resources/logging.properties
@@ -1,0 +1,2 @@
+handlers = java.util.logging.ConsoleHandler
+org.wildfly.swarm.microprofile.level = DEBUG


### PR DESCRIPTION
Motivation
----------
We need to fix MP FT fraction to pass the TCK.

Modifications
-------------
MP FT fraction put into operation. Note that we need customized hystrix
properties to pass the bulkhead tests (see also arquillian FaultToleranceExtension).

Result
------
MP FT TCK should pass.