### PR TITLE
SWARM-1627: Consolidate MP versions in build-parent.

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -94,6 +94,17 @@
     <version.jaeger.gson>2.8.0</version.jaeger.gson>
 
     <version.maven.aether>3.2.5</version.maven.aether>
+
+    <!-- MicroProfile APIs -->
+    <!-- NOTE: we cannot use MP BOM as it does not define dependencyManagement -->
+    <version.microprofile-config>1.1</version.microprofile-config>
+    <version.microprofile-health>1.0</version.microprofile-health>
+    <version.microprofile-fault-tolerance>1.0</version.microprofile-fault-tolerance>
+    <version.microprofile-jwt-auth>1.0</version.microprofile-jwt-auth>
+    <version.microprofile-metrics>1.0.1</version.microprofile-metrics>
+    <!-- MP Config implementation -->
+    <version.wildfly-microprofile-config>1.1.5</version.wildfly-microprofile-config>
+
   </properties>
 
   <build>
@@ -584,6 +595,50 @@
             <artifactId>consul-client</artifactId>
             <version>${version.com.orbitz.consul}</version>
           </dependency>
+
+          <!-- MicroProfile -->
+          <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+            <version>${version.microprofile-config}</version>
+          </dependency>
+
+          <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-microprofile-config-implementation</artifactId>
+            <version>${version.wildfly-microprofile-config}</version>
+          </dependency>
+
+          <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+            <version>${version.wildfly-microprofile-config}</version>
+          </dependency>
+
+          <dependency>
+            <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
+            <artifactId>microprofile-fault-tolerance-api</artifactId>
+            <version>${version.microprofile-fault-tolerance}</version>
+          </dependency>
+
+          <dependency>
+            <groupId>org.eclipse.microprofile.health</groupId>
+            <artifactId>microprofile-health-api</artifactId>
+            <version>${version.microprofile-health}</version>
+          </dependency>
+
+          <dependency>
+            <groupId>org.eclipse.microprofile.metrics</groupId>
+            <artifactId>microprofile-metrics-api</artifactId>
+            <version>${version.microprofile-metrics}</version>
+          </dependency>
+
+          <dependency>
+            <groupId>org.eclipse.microprofile.jwt</groupId>
+            <artifactId>microprofile-jwt-auth-api</artifactId>
+            <version>${version.microprofile-jwt-auth}</version>
+         </dependency>
+
         </dependencies>
       </dependencyManagement>
 

--- a/client-apis/health-api/pom.xml
+++ b/client-apis/health-api/pom.xml
@@ -21,9 +21,6 @@
   <description>Health API</description>
 
   <packaging>jar</packaging>
-  <properties>
-    <version.mp.health>1.0</version.mp.health>
-  </properties>
 
   <build>
     <resources>
@@ -35,7 +32,7 @@
   </build>
 
   <dependencies>
-    
+
     <dependency>
       <groupId>org.jboss.spec.javax.ws.rs</groupId>
       <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
@@ -45,7 +42,6 @@
     <dependency>
        <groupId>org.eclipse.microprofile.health</groupId>
        <artifactId>microprofile-health-api</artifactId>
-       <version>${version.mp.health}</version>
       <scope>provided</scope>
      </dependency>
 

--- a/client-apis/mp_fault_tolerance_cdi_extension/pom.xml
+++ b/client-apis/mp_fault_tolerance_cdi_extension/pom.xml
@@ -34,11 +34,6 @@
   <packaging>jar</packaging>
 
   <properties>
-    <!-- The MicroProfile Config API version -->
-    <mpconfig.api.version>1.1</mpconfig.api.version>
-    <!-- The Wildfly Extras Version -->
-    <mpconfig.wildfly.version>1.1.2</mpconfig.wildfly.version>
-    <mpft-api.version>1.0</mpft-api.version>
     <hystrix.version>1.5.12</hystrix.version>
     <version.arquillian-weld-embedded>2.0.0.Beta5</version.arquillian-weld-embedded>
     <version.wildfly-microprofile-config>1.1.1</version.wildfly-microprofile-config>
@@ -72,7 +67,6 @@
     <dependency>
       <groupId>org.eclipse.microprofile.config</groupId>
       <artifactId>microprofile-config-api</artifactId>
-      <version>${mpconfig.api.version}</version>
     </dependency>
     <dependency>
       <groupId>com.netflix.hystrix</groupId>
@@ -82,35 +76,27 @@
     <dependency>
       <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
       <artifactId>microprofile-fault-tolerance-api</artifactId>
-      <version>${mpft-api.version}</version>
     </dependency>
-
     <dependency>
       <groupId>org.jboss.arquillian.junit</groupId>
       <artifactId>arquillian-junit-container</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.wildfly</groupId>
       <artifactId>wildfly-weld</artifactId>
       <scope>provided</scope>
     </dependency>
-
-
     <dependency>
       <groupId>org.jboss.arquillian.container</groupId>
       <artifactId>arquillian-weld-embedded</artifactId>
       <version>${version.arquillian-weld-embedded}</version>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.wildfly</groupId>
       <artifactId>wildfly-microprofile-config-implementation</artifactId>
-      <version>${version.wildfly-microprofile-config}</version>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 </project>

--- a/fractions/microprofile/microprofile-config/pom.xml
+++ b/fractions/microprofile/microprofile-config/pom.xml
@@ -25,10 +25,6 @@
         <swarm.fraction.internal>false</swarm.fraction.internal>
         <swarm.fraction.stability>experimental</swarm.fraction.stability>
         <swarm.fraction.tags>EclipseMicroProfile,MicroServices,Config</swarm.fraction.tags>
-        <!-- The MicroProfile Config API version -->
-        <mpconfig.api.version>1.1</mpconfig.api.version>
-        <!-- The Wildfly Extras Version -->
-        <mpconfig.wildfly.version>1.1.5</mpconfig.wildfly.version>
     </properties>
 
     <build>
@@ -80,12 +76,10 @@
         <dependency>
             <groupId>org.wildfly.swarm</groupId>
             <artifactId>microprofile-config-api</artifactId>
-            <version>${mpconfig.wildfly.version}</version>
         </dependency>
         <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-microprofile-config-implementation</artifactId>
-            <version>${mpconfig.wildfly.version}</version>
         </dependency>
         <!-- CDI fraction is required to be able to inject Config -->
         <dependency>
@@ -96,12 +90,11 @@
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
-            <version>${mpconfig.api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-microprofile-config-feature-pack</artifactId>
-            <version>${mpconfig.wildfly.version}</version>
+            <version>${version.wildfly-microprofile-config}</version>
             <type>zip</type>
             <scope>provided</scope>
             <exclusions>

--- a/fractions/microprofile/microprofile-fault-tolerance/pom.xml
+++ b/fractions/microprofile/microprofile-fault-tolerance/pom.xml
@@ -35,7 +35,6 @@
     <swarm.fraction.internal>false</swarm.fraction.internal>
     <swarm.fraction.stability>experimental</swarm.fraction.stability>
     <swarm.fraction.tags>EclipseMicroProfile,MicroServices,FaultTolerance</swarm.fraction.tags>
-    <version.microprofile.fault-tolerance.api>1.0</version.microprofile.fault-tolerance.api>
   </properties>
 
   <build>
@@ -75,7 +74,6 @@
     <dependency>
       <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
       <artifactId>microprofile-fault-tolerance-api</artifactId>
-      <version>${version.microprofile.fault-tolerance.api}</version>
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>

--- a/fractions/microprofile/microprofile-fault-tolerance/src/main/resources/modules/org/eclipse/microprofile/faulttolerance/main/module.xml
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/main/resources/modules/org/eclipse/microprofile/faulttolerance/main/module.xml
@@ -16,7 +16,7 @@
 <module xmlns="urn:jboss:module:1.3" name="org.eclipse.microprofile.faulttolerance">
    <resources>
       <artifact
-         name="org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:${version.microprofile.fault-tolerance.api}" />
+         name="org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-api:${version.microprofile-fault-tolerance}" />
    </resources>
    <dependencies>
       <module name="javax.enterprise.api" />

--- a/fractions/microprofile/microprofile-health/pom.xml
+++ b/fractions/microprofile/microprofile-health/pom.xml
@@ -25,7 +25,6 @@
   <properties>
     <swarm.fraction.stability>stable</swarm.fraction.stability>
     <swarm.fraction.tags>Management</swarm.fraction.tags>
-    <version.mp.health>1.0</version.mp.health>
   </properties>
 
   <build>
@@ -68,7 +67,6 @@
     <dependency>
       <groupId>org.eclipse.microprofile.health</groupId>
       <artifactId>microprofile-health-api</artifactId>
-      <version>${version.mp.health}</version>
     </dependency>
 
     <dependency>

--- a/fractions/microprofile/microprofile-health/src/main/resources/modules/org/eclipse/microprofile/health/main/module.xml
+++ b/fractions/microprofile/microprofile-health/src/main/resources/modules/org/eclipse/microprofile/health/main/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module xmlns="urn:jboss:module:1.3" name="org.eclipse.microprofile.health">
     <resources>
-        <artifact name="org.eclipse.microprofile.health:microprofile-health-api:${version.mp.health}"/>
+        <artifact name="org.eclipse.microprofile.health:microprofile-health-api:${version.microprofile-health}"/>
         <artifact name="org.wildfly.swarm:health-api:${project.version}"/>
     </resources>
 

--- a/fractions/microprofile/microprofile-jwt/pom.xml
+++ b/fractions/microprofile/microprofile-jwt/pom.xml
@@ -26,9 +26,6 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <swarm.fraction.stability>experimental</swarm.fraction.stability>
     <swarm.fraction.tags>MicroProfile,JWT,Security,Web</swarm.fraction.tags>
-    <arquillian.version>1.1.13.Final</arquillian.version>
-    <!-- The MicroProfile JWT Auth API version -->
-    <mpjwt.auth.version>1.0</mpjwt.auth.version>
   </properties>
 
   <build>
@@ -40,23 +37,10 @@
     </resources>
   </build>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.jboss.arquillian</groupId>
-        <artifactId>arquillian-bom</artifactId>
-        <version>${arquillian.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>org.eclipse.microprofile.jwt</groupId>
       <artifactId>microprofile-jwt-auth-api</artifactId>
-      <version>${mpjwt.auth.version}</version>
     </dependency>
     <dependency>
       <groupId>org.bitbucket.b_c</groupId>

--- a/fractions/microprofile/microprofile-jwt/src/main/resources/modules/org/eclipse/microprofile/jwt/main/module.xml
+++ b/fractions/microprofile/microprofile-jwt/src/main/resources/modules/org/eclipse/microprofile/jwt/main/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module xmlns="urn:jboss:module:1.5" name="org.eclipse.microprofile.jwt">
   <resources>
-    <artifact name="org.eclipse.microprofile.jwt:microprofile-jwt-auth-api:${mpjwt.auth.version}" />
+    <artifact name="org.eclipse.microprofile.jwt:microprofile-jwt-auth-api:${version.microprofile-jwt-auth}" />
     <artifact name="org.jboss.resteasy:resteasy-json-p-provider:3.0.6.Final" />
     <artifact name="org.bitbucket.b_c:jose4j:0.6.0" />
     <artifact name="org.slf4j:slf4j-api:1.7.21" />

--- a/fractions/microprofile/microprofile-metrics/pom.xml
+++ b/fractions/microprofile/microprofile-metrics/pom.xml
@@ -25,7 +25,6 @@
   <properties>
     <swarm.fraction.stability>experimental</swarm.fraction.stability>
     <swarm.fraction.tags>Microprofile, Metrics, Monitoring</swarm.fraction.tags>
-    <version.microprofile.metrics.api>1.0</version.microprofile.metrics.api>
   </properties>
 
   <build>
@@ -92,7 +91,6 @@
     <dependency>
       <groupId>org.eclipse.microprofile.metrics</groupId>
       <artifactId>microprofile-metrics-api</artifactId>
-      <version>1.0</version>
     </dependency>
 
     <dependency>

--- a/fractions/microprofile/microprofile-metrics/src/main/resources/modules/org/eclipse/microprofile/metrics/main/module.xml
+++ b/fractions/microprofile/microprofile-metrics/src/main/resources/modules/org/eclipse/microprofile/metrics/main/module.xml
@@ -1,5 +1,5 @@
 <module xmlns="urn:jboss:module:1.3" name="org.eclipse.microprofile.metrics">
   <resources>
-    <artifact name="org.eclipse.microprofile.metrics:microprofile-metrics-api:${version.microprofile.metrics.api}"/>
+    <artifact name="org.eclipse.microprofile.metrics:microprofile-metrics-api:${version.microprofile-metrics}"/>
   </resources>
 </module>

--- a/testsuite/microprofile-tcks/config/pom.xml
+++ b/testsuite/microprofile-tcks/config/pom.xml
@@ -33,18 +33,11 @@
    <artifactId>wildlfy-swarm-microprofile-tck-config</artifactId>
    <name>MicroProfile TCK: Config</name>
 
-   <properties>
-      <!-- The version should be located in build-parent -->
-      <version.mp-config>1.1</version.mp-config>
-   </properties>
-
    <dependencies>
 
       <dependency>
          <groupId>org.eclipse.microprofile.config</groupId>
          <artifactId>microprofile-config-tck</artifactId>
-         <version>${version.mp-config}</version>
-         <scope>test</scope>
       </dependency>
 
       <dependency>

--- a/testsuite/microprofile-tcks/fault-tolerance/pom.xml
+++ b/testsuite/microprofile-tcks/fault-tolerance/pom.xml
@@ -33,18 +33,11 @@
    <artifactId>wildlfy-swarm-microprofile-tck-fault-tolerance</artifactId>
    <name>MicroProfile TCK: Fault Tolerance</name>
 
-   <properties>
-      <!-- The version should be located in build-parent -->
-      <version.mp-ft>1.0</version.mp-ft>
-   </properties>
-
    <dependencies>
 
       <dependency>
          <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
          <artifactId>microprofile-fault-tolerance-tck</artifactId>
-         <version>${version.mp-ft}</version>
-         <scope>test</scope>
       </dependency>
 
       <dependency>

--- a/testsuite/microprofile-tcks/health/pom.xml
+++ b/testsuite/microprofile-tcks/health/pom.xml
@@ -34,18 +34,11 @@
    <artifactId>wildlfy-swarm-microprofile-tck-health</artifactId>
    <name>MicroProfile TCK: Health</name>
 
-   <properties>
-      <!-- The version should be located in build-parent -->
-      <version.mp-health>1.0</version.mp-health>
-   </properties>
-
    <dependencies>
 
       <dependency>
          <groupId>org.eclipse.microprofile.health</groupId>
          <artifactId>microprofile-health-tck</artifactId>
-         <version>${version.mp-health}</version>
-         <scope>test</scope>
       </dependency>
 
       <dependency>

--- a/testsuite/microprofile-tcks/jwt-auth/pom.xml
+++ b/testsuite/microprofile-tcks/jwt-auth/pom.xml
@@ -35,8 +35,6 @@
    <name>MicroProfile TCK: JWT</name>
 
    <properties>
-      <!-- The version should be located in build-parent -->
-      <version.mp-jwt>1.0</version.mp-jwt>
       <!-- TCK needs a JAX-RS Client -->
       <!-- Override 3.0.19 due to some odd dependency problems -->
       <version.resteasy>3.1.4.Final</version.resteasy>
@@ -47,14 +45,12 @@
       <dependency>
          <groupId>org.eclipse.microprofile.jwt</groupId>
          <artifactId>microprofile-jwt-auth-tck</artifactId>
-         <version>${version.mp-jwt}</version>
-         <scope>test</scope>
       </dependency>
 
       <dependency>
          <groupId>org.eclipse.microprofile.jwt</groupId>
          <artifactId>microprofile-jwt-auth-tck</artifactId>
-         <version>${version.mp-jwt}</version>
+         <version>${version.microprofile-jwt-auth}</version>
          <type>test-jar</type>
          <scope>test</scope>
       </dependency>

--- a/testsuite/microprofile-tcks/metrics/pom.xml
+++ b/testsuite/microprofile-tcks/metrics/pom.xml
@@ -34,37 +34,21 @@
    <artifactId>wildlfy-swarm-microprofile-tck-metrics</artifactId>
    <name>MicroProfile TCK: Metrics</name>
 
-   <properties>
-      <!-- The version should be located in build-parent -->
-      <version.mp-metrics>1.0.1</version.mp-metrics>
-      <mp.test.engine>junit</mp.test.engine>
-   </properties>
-
    <dependencies>
 
       <dependency>
          <groupId>org.eclipse.microprofile.metrics</groupId>
          <artifactId>microprofile-metrics-api</artifactId>
-         <version>${version.mp-metrics}</version>
       </dependency>
 
       <dependency>
          <groupId>org.eclipse.microprofile.metrics</groupId>
          <artifactId>microprofile-metrics-rest-tck</artifactId>
-         <version>${version.mp-metrics}</version>
       </dependency>
 
       <dependency>
          <groupId>org.eclipse.microprofile.metrics</groupId>
          <artifactId>microprofile-metrics-api-tck</artifactId>
-         <version>${version.mp-metrics}</version>
-         <!-- https://github.com/eclipse/microprofile-metrics/issues/185 -->
-         <exclusions>
-            <exclusion>
-               <groupId>org.jboss.arquillian.container</groupId>
-               <artifactId>arquillian-wlp-managed-8.5</artifactId>
-            </exclusion>
-         </exclusions>
       </dependency>
 
       <dependency>

--- a/testsuite/microprofile-tcks/pom.xml
+++ b/testsuite/microprofile-tcks/pom.xml
@@ -90,6 +90,56 @@
             <scope>test</scope>
          </dependency>
 
+         <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-tck</artifactId>
+            <version>${version.microprofile-config}</version>
+            <scope>test</scope>
+         </dependency>
+
+         <dependency>
+            <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
+            <artifactId>microprofile-fault-tolerance-tck</artifactId>
+            <version>${version.microprofile-fault-tolerance}</version>
+            <scope>test</scope>
+         </dependency>
+
+         <dependency>
+            <groupId>org.eclipse.microprofile.health</groupId>
+            <artifactId>microprofile-health-tck</artifactId>
+            <version>${version.microprofile-health}</version>
+            <scope>test</scope>
+         </dependency>
+
+
+         <dependency>
+            <groupId>org.eclipse.microprofile.metrics</groupId>
+            <artifactId>microprofile-metrics-rest-tck</artifactId>
+            <version>${version.microprofile-metrics}</version>
+            <scope>test</scope>
+         </dependency>
+
+         <dependency>
+            <groupId>org.eclipse.microprofile.metrics</groupId>
+            <artifactId>microprofile-metrics-api-tck</artifactId>
+            <version>${version.microprofile-metrics}</version>
+            <scope>test</scope>
+            <!-- https://github.com/eclipse/microprofile-metrics/issues/185 -->
+            <exclusions>
+               <exclusion>
+                  <groupId>org.jboss.arquillian.container</groupId>
+                  <artifactId>arquillian-wlp-managed-8.5</artifactId>
+               </exclusion>
+            </exclusions>
+         </dependency>
+
+         <dependency>
+            <groupId>org.eclipse.microprofile.jwt</groupId>
+            <artifactId>microprofile-jwt-auth-tck</artifactId>
+            <version>${version.microprofile-jwt-auth}</version>
+            <scope>test</scope>
+         </dependency>
+
       </dependencies>
    </dependencyManagement>
 


### PR DESCRIPTION
Motivation
----------
Currently each MP fraction and TCK has versions for the particular spec
within its pom.xml.

Modifications
-------------
Move the versions inside build-parent. Added dependencies into
dependencyManagement section.

Result
------
MP versions are defined in one place.