### PR TITLE
SWARM-1642: Update MP overall fraction to 1.2.

### DIFF
--- a/fractions/microprofile/microprofile-jwt/pom.xml
+++ b/fractions/microprofile/microprofile-jwt/pom.xml
@@ -49,10 +49,6 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
-      <artifactId>microprofile</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.wildfly.swarm</groupId>
       <artifactId>microprofile-config</artifactId>
     </dependency>
     <dependency>
@@ -62,6 +58,14 @@
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>security</artifactId>
+    </dependency>
+      <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>cdi</artifactId>
     </dependency>
 
     <!-- Provided APIs -->

--- a/fractions/microprofile/microprofile/pom.xml
+++ b/fractions/microprofile/microprofile/pom.xml
@@ -14,7 +14,6 @@
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.wildfly.swarm</groupId>
   <artifactId>microprofile</artifactId>
 
   <name>MicroProfile</name>
@@ -37,7 +36,7 @@
   </build>
 
   <dependencies>
-    <!-- Fraction Dependencies -->
+    <!-- Fractions introduced by MicroProfile 1.0 -->
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>jaxrs</artifactId>
@@ -54,12 +53,26 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>jaxrs-jaxb</artifactId>
     </dependency>
+    <!-- Fractions introduced by MicroProfile 1.2 -->
     <dependency>
-      <groupId>org.eclipse.microprofile</groupId>
-      <artifactId>microprofile</artifactId>
-      <version>1.2</version>
-      <type>pom</type>
-      <scope>provided</scope>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>microprofile-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>microprofile-health</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>microprofile-fault-tolerance</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>microprofile-jwt</artifactId>
+    </dependency>
+     <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>microprofile-metrics</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Motivation
----------
The fraction should be MP 1.2 compliant.

Modifications
-------------
Added dependencies for all new MP 1.2 fractions. Also removed circular
dependency from jwt fraction.

Result
------
Overall fraction is MP 1.2.