### PR TITLE
SWARM-1720: Update MicroProfile fraction stability

### DIFF
--- a/fractions/microprofile/microprofile-config/pom.xml
+++ b/fractions/microprofile/microprofile-config/pom.xml
@@ -22,9 +22,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <swarm.fraction.internal>false</swarm.fraction.internal>
-        <swarm.fraction.stability>experimental</swarm.fraction.stability>
-        <swarm.fraction.tags>EclipseMicroProfile,MicroServices,Config</swarm.fraction.tags>
+        <swarm.fraction.stability>stable</swarm.fraction.stability>
+        <swarm.fraction.tags>Eclipse MicroProfile,MicroServices,Config</swarm.fraction.tags>
     </properties>
 
     <build>

--- a/fractions/microprofile/microprofile-fault-tolerance/pom.xml
+++ b/fractions/microprofile/microprofile-fault-tolerance/pom.xml
@@ -32,9 +32,8 @@
   <packaging>jar</packaging>
 
   <properties>
-    <swarm.fraction.internal>false</swarm.fraction.internal>
-    <swarm.fraction.stability>experimental</swarm.fraction.stability>
-    <swarm.fraction.tags>EclipseMicroProfile,MicroServices,FaultTolerance</swarm.fraction.tags>
+    <swarm.fraction.stability>stable</swarm.fraction.stability>
+    <swarm.fraction.tags>Eclipse MicroProfile,MicroServices,Fault Tolerance</swarm.fraction.tags>
     <version.arquillian-weld-embedded>2.0.0.Beta5</version.arquillian-weld-embedded>
   </properties>
 

--- a/fractions/microprofile/microprofile-health/pom.xml
+++ b/fractions/microprofile/microprofile-health/pom.xml
@@ -24,7 +24,7 @@
 
   <properties>
     <swarm.fraction.stability>stable</swarm.fraction.stability>
-    <swarm.fraction.tags>Management</swarm.fraction.tags>
+    <swarm.fraction.tags>Management,Eclipse MicroProfile</swarm.fraction.tags>
   </properties>
 
   <build>

--- a/fractions/microprofile/microprofile-jwt/pom.xml
+++ b/fractions/microprofile/microprofile-jwt/pom.xml
@@ -22,8 +22,8 @@
   <packaging>jar</packaging>
 
   <properties>
-    <swarm.fraction.stability>experimental</swarm.fraction.stability>
-    <swarm.fraction.tags>MicroProfile,JWT,Security,Web</swarm.fraction.tags>
+    <swarm.fraction.stability>stable</swarm.fraction.stability>
+    <swarm.fraction.tags>Eclipse MicroProfile,JWT,Security,Web</swarm.fraction.tags>
   </properties>
 
   <build>

--- a/fractions/microprofile/microprofile-metrics/pom.xml
+++ b/fractions/microprofile/microprofile-metrics/pom.xml
@@ -23,8 +23,8 @@
   <packaging>jar</packaging>
 
   <properties>
-    <swarm.fraction.stability>experimental</swarm.fraction.stability>
-    <swarm.fraction.tags>Microprofile, Metrics, Monitoring</swarm.fraction.tags>
+    <swarm.fraction.stability>stable</swarm.fraction.stability>
+    <swarm.fraction.tags>Eclipse Microprofile,Metrics,Monitoring</swarm.fraction.tags>
   </properties>
 
   <build>

--- a/fractions/microprofile/microprofile/pom.xml
+++ b/fractions/microprofile/microprofile/pom.xml
@@ -23,7 +23,7 @@
 
   <properties>
     <swarm.fraction.stability>stable</swarm.fraction.stability>
-    <swarm.fraction.tags>JavaEE,Web,MicroProfile</swarm.fraction.tags>
+    <swarm.fraction.tags>JavaEE,Web,Eclipse MicroProfile</swarm.fraction.tags>
   </properties>
 
   <build>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
MicroProfile fractions should be stable to make it easier for users to use them in the regular BOM.

Modifications
-------------
Updated stability index in fractions that weren't already stable, and cleaned up the tags for the generator site.

Result
------
All MicroProfile fractions will now appear in the stable BOM.
