### PR TITLE
ENTSWM-244: Fix prod doc build.

### DIFF
--- a/docs/howto/autodetect-fractions/pom.xml
+++ b/docs/howto/autodetect-fractions/pom.xml
@@ -9,80 +9,20 @@
 
   <groupId>org.wildfly.swarm.howto</groupId>
   <artifactId>howto-autodetect-fractions</artifactId>
-  <version>2018.1.0-SNAPSHOT</version>
+
+  <parent>
+    <groupId>org.wildfly.swarm.howto</groupId>
+    <artifactId>howto-parent</artifactId>
+    <version>2018.1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
 
   <name>WildFly Swarm HOWTO: Auto-detecting Fractions</name>
   <description>WildFly Swarm HOWTO: Auto-detecting Fractions</description>
-
   <packaging>war</packaging>
 
-  <properties>
-    <version.wildfly-swarm>2018.1.0-SNAPSHOT</version.wildfly-swarm>
-    <version.maven-war-plugin>2.2</version.maven-war-plugin>
-    <version.maven-failsafe-plugin>2.19.1</version.maven-failsafe-plugin>
-    <version.build-helper-maven-plugin>1.9.1</version.build-helper-maven-plugin>
-    <version.arquillian>1.1.12.Final</version.arquillian>
-    <version.arquillian-drone>2.0.1.Final</version.arquillian-drone>
-    <version.arquillian-graphene>2.1.0.Alpha2</version.arquillian-graphene>
-    <version.junit>4.11</version.junit>
-   
-    <version.jaxrs-api>1.0.0.Final</version.jaxrs-api>
-  </properties>
-
-  <repositories>
-    <repository>
-      <id>sonatype-nexus-snapshots</id>
-      <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <name>JBoss Public Repository Group</name>
-      <url>http://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>sonatype-nexus-snapshots</id>
-      <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
-
   <build>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-war-plugin</artifactId>
-        <version>${version.maven-war-plugin}</version>
-        <configuration>
-          <failOnMissingWebXml>false</failOnMissingWebXml>
-        </configuration>
-      </plugin>
       <!-- tag::plugin[] -->
       <plugin>
         <groupId>org.wildfly.swarm</groupId>
@@ -167,20 +107,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-install-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 
@@ -190,20 +116,6 @@
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>bom</artifactId>
         <version>${version.wildfly-swarm}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.arquillian</groupId>
-        <artifactId>arquillian-bom</artifactId>
-        <version>${version.arquillian}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.arquillian.extension</groupId>
-        <artifactId>arquillian-drone-bom</artifactId>
-        <version>${version.arquillian-drone}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -223,20 +135,15 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${version.junit}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.arquillian.junit</groupId>
       <artifactId>arquillian-junit-container</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.arquillian.graphene</groupId>
       <artifactId>graphene-webdriver</artifactId>
-      <version>${version.arquillian-graphene}</version>
       <type>pom</type>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/docs/howto/create-a-datasource/pom.xml
+++ b/docs/howto/create-a-datasource/pom.xml
@@ -9,84 +9,20 @@
 
   <groupId>org.wildfly.swarm.howto</groupId>
   <artifactId>howto-datasources</artifactId>
-  <version>2018.1.0-SNAPSHOT</version>
+
+  <parent>
+    <groupId>org.wildfly.swarm.howto</groupId>
+    <artifactId>howto-parent</artifactId>
+    <version>2018.1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
 
   <name>WildFly Swarm HOWTO: Create a Datasource</name>
   <description>WildFly Swarm HOWTO: Create a Datasource</description>
-
   <packaging>war</packaging>
 
-  <properties>
-    <version.wildfly-swarm>2018.1.0-SNAPSHOT</version.wildfly-swarm>
-    <version.maven-war-plugin>2.2</version.maven-war-plugin>
-    <version.maven-failsafe-plugin>2.19.1</version.maven-failsafe-plugin>
-    <version.build-helper-maven-plugin>1.9.1</version.build-helper-maven-plugin>
-    <version.arquillian>1.1.12.Final</version.arquillian>
-    <version.arquillian-drone>2.0.1.Final</version.arquillian-drone>
-    <version.arquillian-graphene>2.1.0.Alpha2</version.arquillian-graphene>
-    <version.junit>4.11</version.junit>
-
-    <version.jaxrs-api>1.0.0.Final</version.jaxrs-api>
-
-    <version.h2>1.4.187</version.h2>
-    <version.postgresql>9.4.1207</version.postgresql>
-    <version.mysql>5.1.38</version.mysql>
-  </properties>
-
-  <repositories>
-    <repository>
-      <id>sonatype-nexus-snapshots</id>
-      <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <name>JBoss Public Repository Group</name>
-      <url>http://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>sonatype-nexus-snapshots</id>
-      <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
-
   <build>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-war-plugin</artifactId>
-        <version>${version.maven-war-plugin}</version>
-        <configuration>
-          <failOnMissingWebXml>false</failOnMissingWebXml>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>wildfly-swarm-plugin</artifactId>
@@ -167,20 +103,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-install-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 
@@ -190,20 +112,6 @@
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>bom</artifactId>
         <version>${version.wildfly-swarm}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.arquillian</groupId>
-        <artifactId>arquillian-bom</artifactId>
-        <version>${version.arquillian}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.arquillian.extension</groupId>
-        <artifactId>arquillian-drone-bom</artifactId>
-        <version>${version.arquillian-drone}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -239,20 +147,15 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${version.junit}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.arquillian.junit</groupId>
       <artifactId>arquillian-junit-container</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.arquillian.graphene</groupId>
       <artifactId>graphene-webdriver</artifactId>
-      <version>${version.arquillian-graphene}</version>
       <type>pom</type>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/docs/howto/create-a-fraction/pom.xml
+++ b/docs/howto/create-a-fraction/pom.xml
@@ -9,40 +9,16 @@
 
   <groupId>org.wildfly.swarm.howto</groupId>
   <artifactId>howto-fractions</artifactId>
-  <version>2018.1.0-SNAPSHOT</version>
+
+  <parent>
+    <groupId>org.wildfly.swarm.howto</groupId>
+    <artifactId>howto-parent</artifactId>
+    <version>2018.1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
 
   <name>WildFly Swarm HOWTO: Create a Fraction</name>
   <description>WildFly Swarm HOWTO: Create a Fraction</description>
-
   <packaging>pom</packaging>
 
-  <properties>
-    <version.wildfly-swarm>2017.12.0-SNAPSHOT</version.wildfly-swarm>
-    <version.build-helper-maven-plugin>1.9.1</version.build-helper-maven-plugin>
-  </properties>
-
-  <build>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-install-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/docs/howto/create-a-hollow-jar/pom.xml
+++ b/docs/howto/create-a-hollow-jar/pom.xml
@@ -9,80 +9,20 @@
 
   <groupId>org.wildfly.swarm.howto</groupId>
   <artifactId>howto-create-a-hollow-jar</artifactId>
-  <version>2018.1.0-SNAPSHOT</version>
+
+  <parent>
+    <groupId>org.wildfly.swarm.howto</groupId>
+    <artifactId>howto-parent</artifactId>
+    <version>2018.1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
 
   <name>WildFly Swarm HOWTO: Create a Hollow Jar</name>
   <description>WildFly Swarm HOWTO: Create a Hollow Jar</description>
-
   <packaging>war</packaging>
 
-  <properties>
-    <version.wildfly-swarm>2018.1.0-SNAPSHOT</version.wildfly-swarm>
-    <version.maven-war-plugin>2.2</version.maven-war-plugin>
-    <version.maven-failsafe-plugin>2.19.1</version.maven-failsafe-plugin>
-    <version.build-helper-maven-plugin>1.9.1</version.build-helper-maven-plugin>
-    <version.arquillian>1.1.12.Final</version.arquillian>
-    <version.arquillian-drone>2.0.1.Final</version.arquillian-drone>
-    <version.arquillian-graphene>2.1.0.Alpha2</version.arquillian-graphene>
-    <version.junit>4.11</version.junit>
-
-    <version.jaxrs-api>1.0.0.Final</version.jaxrs-api>
-  </properties>
-
-  <repositories>
-    <repository>
-      <id>sonatype-nexus-snapshots</id>
-      <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <name>JBoss Public Repository Group</name>
-      <url>http://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>sonatype-nexus-snapshots</id>
-      <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
-
   <build>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-war-plugin</artifactId>
-        <version>${version.maven-war-plugin}</version>
-        <configuration>
-          <failOnMissingWebXml>false</failOnMissingWebXml>
-        </configuration>
-      </plugin>
       <!-- tag::plugin[] -->
       <plugin>
         <groupId>org.wildfly.swarm</groupId>
@@ -170,20 +110,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-install-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 
@@ -193,20 +119,6 @@
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>bom</artifactId>
         <version>${version.wildfly-swarm}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.arquillian</groupId>
-        <artifactId>arquillian-bom</artifactId>
-        <version>${version.arquillian}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.arquillian.extension</groupId>
-        <artifactId>arquillian-drone-bom</artifactId>
-        <version>${version.arquillian-drone}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -224,20 +136,15 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${version.junit}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.arquillian.junit</groupId>
       <artifactId>arquillian-junit-container</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.arquillian.graphene</groupId>
       <artifactId>graphene-webdriver</artifactId>
-      <version>${version.arquillian-graphene}</version>
       <type>pom</type>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/docs/howto/create-an-uberjar/pom.xml
+++ b/docs/howto/create-an-uberjar/pom.xml
@@ -9,80 +9,20 @@
 
   <groupId>org.wildfly.swarm.howto</groupId>
   <artifactId>howto-create-an-uberjar</artifactId>
-  <version>2018.1.0-SNAPSHOT</version>
+
+  <parent>
+    <groupId>org.wildfly.swarm.howto</groupId>
+    <artifactId>howto-parent</artifactId>
+    <version>2018.1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
 
   <name>WildFly Swarm HOWTO: Create an Uberjar</name>
   <description>WildFly Swarm HOWTO: Create an Uberjar</description>
-
   <packaging>war</packaging>
 
-  <properties>
-    <version.wildfly-swarm>2018.1.0-SNAPSHOT</version.wildfly-swarm>
-    <version.maven-war-plugin>2.2</version.maven-war-plugin>
-    <version.maven-failsafe-plugin>2.19.1</version.maven-failsafe-plugin>
-    <version.build-helper-maven-plugin>1.9.1</version.build-helper-maven-plugin>
-    <version.arquillian>1.1.12.Final</version.arquillian>
-    <version.arquillian-drone>2.0.1.Final</version.arquillian-drone>
-    <version.arquillian-graphene>2.1.0.Alpha2</version.arquillian-graphene>
-    <version.junit>4.11</version.junit>
-
-    <version.jaxrs-api>1.0.0.Final</version.jaxrs-api>
-  </properties>
-
-  <repositories>
-    <repository>
-      <id>sonatype-nexus-snapshots</id>
-      <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <name>JBoss Public Repository Group</name>
-      <url>http://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>sonatype-nexus-snapshots</id>
-      <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
-
   <build>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-war-plugin</artifactId>
-        <version>${version.maven-war-plugin}</version>
-        <configuration>
-          <failOnMissingWebXml>false</failOnMissingWebXml>
-        </configuration>
-      </plugin>
       <!-- tag::plugin[] -->
       <plugin>
         <groupId>org.wildfly.swarm</groupId>
@@ -167,20 +107,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-install-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 
@@ -190,20 +116,6 @@
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>bom</artifactId>
         <version>${version.wildfly-swarm}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.arquillian</groupId>
-        <artifactId>arquillian-bom</artifactId>
-        <version>${version.arquillian}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.arquillian.extension</groupId>
-        <artifactId>arquillian-drone-bom</artifactId>
-        <version>${version.arquillian-drone}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -221,20 +133,15 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${version.junit}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.arquillian.junit</groupId>
       <artifactId>arquillian-junit-container</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.arquillian.graphene</groupId>
       <artifactId>graphene-webdriver</artifactId>
-      <version>${version.arquillian-graphene}</version>
       <type>pom</type>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/docs/howto/explicit-fractions/pom.xml
+++ b/docs/howto/explicit-fractions/pom.xml
@@ -9,79 +9,20 @@
 
   <groupId>org.wildfly.swarm.howto</groupId>
   <artifactId>howto-explicit-fractions</artifactId>
-  <version>2018.1.0-SNAPSHOT</version>
+
+  <parent>
+    <groupId>org.wildfly.swarm.howto</groupId>
+    <artifactId>howto-parent</artifactId>
+    <version>2018.1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
 
   <name>WildFly Swarm HOWTO: Use Explicit Fractions</name>
   <description>WildFly Swarm HOWTO: Use Explicit Fractions</description>
-
   <packaging>war</packaging>
 
-  <properties>
-    <version.wildfly-swarm>2018.1.0-SNAPSHOT</version.wildfly-swarm>
-    <version.maven-war-plugin>2.2</version.maven-war-plugin>
-    <version.maven-failsafe-plugin>2.19.1</version.maven-failsafe-plugin>
-    <version.build-helper-maven-plugin>1.9.1</version.build-helper-maven-plugin>
-    <version.arquillian>1.1.12.Final</version.arquillian>
-    <version.arquillian-drone>2.0.1.Final</version.arquillian-drone>
-    <version.arquillian-graphene>2.1.0.Alpha2</version.arquillian-graphene>
-    <version.junit>4.11</version.junit>
-
-  </properties>
-
-  <repositories>
-    <repository>
-      <id>sonatype-nexus-snapshots</id>
-      <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <name>JBoss Public Repository Group</name>
-      <url>http://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>sonatype-nexus-snapshots</id>
-      <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
-
   <build>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-war-plugin</artifactId>
-        <version>${version.maven-war-plugin}</version>
-        <configuration>
-          <failOnMissingWebXml>false</failOnMissingWebXml>
-        </configuration>
-      </plugin>
       <!-- tag::plugin[] -->
       <plugin>
         <groupId>org.wildfly.swarm</groupId>
@@ -166,20 +107,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-install-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 
@@ -189,20 +116,6 @@
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>bom</artifactId>
         <version>${version.wildfly-swarm}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.arquillian</groupId>
-        <artifactId>arquillian-bom</artifactId>
-        <version>${version.arquillian}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.arquillian.extension</groupId>
-        <artifactId>arquillian-drone-bom</artifactId>
-        <version>${version.arquillian-drone}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -220,20 +133,15 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${version.junit}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.arquillian.junit</groupId>
       <artifactId>arquillian-junit-container</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.arquillian.graphene</groupId>
       <artifactId>graphene-webdriver</artifactId>
-      <version>${version.arquillian-graphene}</version>
       <type>pom</type>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/docs/howto/pom.xml
+++ b/docs/howto/pom.xml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.wildfly.swarm.howto</groupId>
+  <artifactId>howto-parent</artifactId>
+  <version>2018.1.0-SNAPSHOT</version>
+
+  <name>WildFly Swarm HOWTO: Parent</name>
+  <packaging>pom</packaging>
+
+  <properties>
+    <version.wildfly-swarm>${project.version}</version.wildfly-swarm>
+    <version.maven-war-plugin>2.2</version.maven-war-plugin>
+    <version.maven-failsafe-plugin>2.19.1</version.maven-failsafe-plugin>
+    <version.build-helper-maven-plugin>1.9.1</version.build-helper-maven-plugin>
+    <version.arquillian>1.1.12.Final</version.arquillian>
+    <version.arquillian-drone>2.0.1.Final</version.arquillian-drone>
+    <version.arquillian-graphene>2.1.0.Alpha2</version.arquillian-graphene>
+    <version.junit>4.11</version.junit>
+    <version.h2>1.4.187</version.h2>
+    <version.jaxrs-api>1.0.0.Final</version.jaxrs-api>
+    <version.postgresql>9.4.1207</version.postgresql>
+    <version.mysql>5.1.38</version.mysql>
+  </properties>
+
+   <modules>
+      <module>use-a-bom</module>
+      <module>create-an-uberjar</module>
+      <module>create-a-hollow-jar</module>
+      <module>autodetect-fractions</module>
+      <module>explicit-fractions</module>
+      <module>create-a-datasource</module>
+      <module>create-a-fraction</module>
+      <module>test-in-container</module>
+   </modules>
+
+  <repositories>
+    <repository>
+      <id>sonatype-nexus-snapshots</id>
+      <name>Sonatype Nexus Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+    <repository>
+      <id>jboss-public-repository-group</id>
+      <name>JBoss Public Repository Group</name>
+      <url>http://repository.jboss.org/nexus/content/groups/public/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>sonatype-nexus-snapshots</id>
+      <name>Sonatype Nexus Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>wildfly-swarm-plugin</artifactId>
+        <version>${version.wildfly-swarm}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>package</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>${version.maven-war-plugin}</version>
+        <configuration>
+          <failOnMissingWebXml>false</failOnMissingWebXml>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencyManagement>
+    <dependencies>
+
+      <dependency>
+        <groupId>org.jboss.arquillian</groupId>
+        <artifactId>arquillian-bom</artifactId>
+        <version>${version.arquillian}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.arquillian.extension</groupId>
+        <artifactId>arquillian-drone-bom</artifactId>
+        <version>${version.arquillian-drone}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>${version.junit}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.arquillian.junit</groupId>
+        <artifactId>arquillian-junit-container</artifactId>
+        <version>${version.arquillian}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.arquillian.graphene</groupId>
+        <artifactId>graphene-webdriver</artifactId>
+        <version>${version.arquillian-graphene}</version>
+        <type>pom</type>
+        <scope>test</scope>
+      </dependency>
+
+    </dependencies>
+  </dependencyManagement>
+
+</project>

--- a/docs/howto/test-in-container/index.adoc
+++ b/docs/howto/test-in-container/index.adoc
@@ -12,8 +12,7 @@ testing work well with WildFly Swarm&ndash;based applications.
 
 .Procedure
 
-. Include the WildFly Swarm BOM as described in xref:using-a-bom[]. For
-example, `bom-all`:
+. Include the WildFly Swarm BOM as described in xref:using-a-bom[]:
 +
 [source,xml]
 ----

--- a/docs/howto/test-in-container/pom.xml
+++ b/docs/howto/test-in-container/pom.xml
@@ -9,106 +9,40 @@
 
   <groupId>org.wildfly.swarm.howto</groupId>
   <artifactId>howto-test-in-container</artifactId>
-  <version>2018.1.0-SNAPSHOT</version>
+
+  <parent>
+    <groupId>org.wildfly.swarm.howto</groupId>
+    <artifactId>howto-parent</artifactId>
+    <version>2018.1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
 
   <name>WildFly Swarm HOWTO: Test in Container</name>
   <description>WildFly Swarm HOWTO: Test in Container</description>
-
   <packaging>war</packaging>
 
-  <properties>
-    <version.wildfly-swarm>2018.1.0-SNAPSHOT</version.wildfly-swarm>
-    <version.maven-war-plugin>3.0.0</version.maven-war-plugin>
-    <version.maven-failsafe-plugin>2.19.1</version.maven-failsafe-plugin>
-    <version.build-helper-maven-plugin>3.0.0</version.build-helper-maven-plugin>
-    <version.arquillian>1.1.12.Final</version.arquillian>
-    <version.junit>4.12</version.junit>
-
-    <version.h2>1.4.187</version.h2>
-  </properties>
-
-  <repositories>
-    <repository>
-      <id>sonatype-nexus-snapshots</id>
-      <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <name>JBoss Public Repository Group</name>
-      <url>http://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>sonatype-nexus-snapshots</id>
-      <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
-
-  <build>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
-    <plugins>
-      <plugin>
-        <groupId>org.wildfly.swarm</groupId>
-        <artifactId>wildfly-swarm-plugin</artifactId>
-        <version>${version.wildfly-swarm}</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>package</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-war-plugin</artifactId>
-        <version>${version.maven-war-plugin}</version>
-        <configuration>
-          <failOnMissingWebXml>false</failOnMissingWebXml>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-install-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
+  <profiles>
+    <!-- Arquillian fraction is not productized -->
+    <profile>
+      <id>boms-product</id>
+      <activation>
+        <property>
+          <name>swarm.product.build</name>
+        </property>
+      </activation>
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>bom-certified</artifactId>
+            <version>${version.wildfly-swarm}</version>
+            <type>pom</type>
+            <scope>import</scope>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+    </profile>
+  </profiles>
 
   <dependencyManagement>
     <dependencies>
@@ -121,14 +55,6 @@
         <scope>import</scope>
       </dependency>
       <!-- end::bom[] -->
-
-      <dependency>
-        <groupId>org.jboss.arquillian</groupId>
-        <artifactId>arquillian-bom</artifactId>
-        <version>${version.arquillian}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -161,14 +87,11 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${version.junit}</version>
-      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.jboss.arquillian.junit</groupId>
       <artifactId>arquillian-junit-container</artifactId>
-      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/docs/howto/use-a-bom/pom.xml
+++ b/docs/howto/use-a-bom/pom.xml
@@ -9,82 +9,26 @@
 
   <groupId>org.wildfly.swarm.howto</groupId>
   <artifactId>howto-use-a-bom</artifactId>
-  <version>2018.1.0-SNAPSHOT</version>
+
+   <parent>
+    <groupId>org.wildfly.swarm.howto</groupId>
+    <artifactId>howto-parent</artifactId>
+    <version>2018.1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
 
   <name>WildFly Swarm HOWTO: Use a BOM</name>
   <description>WildFly Swarm HOWTO: Use a BOM</description>
-
   <packaging>war</packaging>
 
   <properties>
     <!-- tag::property[] -->
     <version.wildfly-swarm>2018.1.0-SNAPSHOT</version.wildfly-swarm>
     <!-- end::property[] -->
-    <version.maven-war-plugin>2.2</version.maven-war-plugin>
-    <version.maven-failsafe-plugin>2.19.1</version.maven-failsafe-plugin>
-    <version.build-helper-maven-plugin>1.9.1</version.build-helper-maven-plugin>
-    <version.arquillian>1.1.12.Final</version.arquillian>
-    <version.arquillian-drone>2.0.1.Final</version.arquillian-drone>
-    <version.arquillian-graphene>2.1.0.Alpha2</version.arquillian-graphene>
-    <version.junit>4.11</version.junit>
-
-    <version.h2>1.4.187</version.h2>
   </properties>
 
-  <repositories>
-    <repository>
-      <id>sonatype-nexus-snapshots</id>
-      <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <name>JBoss Public Repository Group</name>
-      <url>http://repository.jboss.org/nexus/content/groups/public/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>sonatype-nexus-snapshots</id>
-      <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
-
   <build>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-war-plugin</artifactId>
-        <version>${version.maven-war-plugin}</version>
-        <configuration>
-          <failOnMissingWebXml>false</failOnMissingWebXml>
-        </configuration>
-      </plugin>
       <plugin>
         <!-- tag::plugin[] -->
         <groupId>org.wildfly.swarm</groupId>
@@ -167,20 +111,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-install-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 
@@ -207,20 +137,6 @@
       </dependency>
       -->
       <!-- end::bom-unstable-dependency[] -->
-      <dependency>
-        <groupId>org.jboss.arquillian</groupId>
-        <artifactId>arquillian-bom</artifactId>
-        <version>${version.arquillian}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.arquillian.extension</groupId>
-        <artifactId>arquillian-drone-bom</artifactId>
-        <version>${version.arquillian-drone}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -245,20 +161,15 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${version.junit}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.arquillian.junit</groupId>
       <artifactId>arquillian-junit-container</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.arquillian.graphene</groupId>
       <artifactId>graphene-webdriver</artifactId>
-      <version>${version.arquillian-graphene}</version>
       <type>pom</type>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -163,14 +163,7 @@
 
   <modules>
     <module>reference</module>
-    <module>howto/use-a-bom</module>
-    <module>howto/create-an-uberjar</module>
-    <module>howto/create-a-hollow-jar</module>
-    <module>howto/autodetect-fractions</module>
-    <module>howto/explicit-fractions</module>
-    <module>howto/create-a-datasource</module>
-    <module>howto/create-a-fraction</module>
-    <module>howto/test-in-container</module>
+    <module>howto</module>
   </modules>
 
 </project>


### PR DESCRIPTION
Motivation
----------
Building of the docs from the prod repo fails because some howto modules
depend on org.wildfly.swarm:bom-all which is not available in product.
Make sure bom-all is not used in any module (org.wildfly.swarm:bom
should work).

Modifications
-------------
Introduced a minimal howto parent pom (versions, repos, etc.). Added
prod profile in test-in-container to add bom-certified (arquillian
fraction is not productized).

Result
------
Docs build should not fail in prod repo. Howto modules management should
be easier.