### PR TITLE
SWARM-1737: Keycloak Server fails to start

### DIFF
--- a/fractions/keycloak-server/pom.xml
+++ b/fractions/keycloak-server/pom.xml
@@ -14,7 +14,6 @@
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.wildfly.swarm</groupId>
   <artifactId>keycloak-server</artifactId>
 
   <name>Keycloak Server</name>
@@ -23,6 +22,7 @@
   <packaging>jar</packaging>
 
   <properties>
+    <swarm.fraction.stability>stable</swarm.fraction.stability>
     <swarm.fraction.tags>Security</swarm.fraction.tags>
   </properties>
 

--- a/fractions/keycloak-server/src/main/java/org/wildfly/swarm/keycloak/server/runtime/KeycloakCacheCustomizer.java
+++ b/fractions/keycloak-server/src/main/java/org/wildfly/swarm/keycloak/server/runtime/KeycloakCacheCustomizer.java
@@ -56,6 +56,7 @@ public class KeycloakCacheCustomizer implements Customizer {
                         });
                     })
                     .localCache("sessions")
+                    .localCache("authenticationSessions")
                     .localCache("offlineSessions")
                     .localCache("loginFailures")
                     .localCache("work")
@@ -73,6 +74,16 @@ public class KeycloakCacheCustomizer implements Customizer {
                         });
                         localCache.expirationComponent((expire) -> {
                             expire.maxIdle(3600000L);
+                        });
+                    })
+                    .localCache("actionTokens", (localCache) -> {
+                        localCache.evictionComponent((evict) -> {
+                            evict.strategy(EvictionComponent.Strategy.NONE);
+                            evict.maxEntries((long) -1);
+                        });
+                        localCache.expirationComponent((expire) -> {
+                            expire.maxIdle((long) -1);
+                            expire.interval((long) 300000);
                         });
                     })
             );

--- a/fractions/keycloak-server/src/main/resources/modules/org/antlr/3-5/module.xml
+++ b/fractions/keycloak-server/src/main/resources/modules/org/antlr/3-5/module.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<module xmlns="urn:jboss:module:1.3" name="org.antlr" slot="3-5">
+<properties>
+    <property name="jboss.api" value="private"/>
+  </properties>
+  <resources>
+    <artifact name="org.antlr:antlr-runtime:3.5"/>
+  </resources>
+  <dependencies>
+    <module name="javax.api"/>
+  </dependencies>
+</module>

--- a/fractions/keycloak-server/src/main/resources/modules/org/drools/main/module.xml
+++ b/fractions/keycloak-server/src/main/resources/modules/org/drools/main/module.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<module xmlns="urn:jboss:module:1.3" name="org.drools" slot="main">
+<properties>
+    <property name="jboss.api" value="private"/>
+  </properties>
+  <resources>
+    <artifact name="org.drools:drools-core:6.4.0.Final"/>
+    <artifact name="org.drools:drools-compiler:6.4.0.Final"/>
+  </resources>
+  <dependencies>
+    <module name="javax.activation.api"/>
+    <module name="javax.api"/>
+    <module name="javax.enterprise.api"/>
+    <module name="javax.inject.api"/>
+    <module name="org.keycloak.keycloak-core"/>
+    <module name="org.keycloak.keycloak-common"/>
+    <module name="org.keycloak.keycloak-server-spi"/>
+    <module name="org.keycloak.keycloak-server-spi-private"/>
+    <module name="com.thoughtworks.xstream"/>
+    <module name="org.antlr" slot="3-5"/>
+    <module name="org.kie"/>
+    <module name="org.mvel"/>
+    <module name="org.slf4j"/>
+    <module name="org.eclipse.jdt.ecj"/>
+  </dependencies>
+</module>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
Keycloak Server fails to start due to errors of missing services.

Modifications
-------------
Added missing infinispan cache's that was preventing server start.

Then encountered an issue with WF 11 module.xml handling that breaks with a slot="3.5" within Keycloak server modules.
Added overridden module.xml's for these references to provide temporary work around for them.

Result
------
Keycloak Server starts and it's possible to open the administration console.
