### PR TITLE
SWARM-1677 -- Too much disk-space consumed.

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeDeployer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeDeployer.java
@@ -261,7 +261,7 @@ public class RuntimeDeployer implements Deployer {
                 }
             }
 
-            byte[] hash = this.contentRepository.addContent(deployment.as(ZipExporter.class).exportAsInputStream());
+            byte[] hash = this.contentRepository.addContent(deployment);
 
             final ModelNode deploymentAdd = new ModelNode();
 

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/wildfly/ShrinkWrapFileSystem.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/wildfly/ShrinkWrapFileSystem.java
@@ -1,0 +1,187 @@
+package org.wildfly.swarm.container.runtime.wildfly;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.CodeSigner;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.vfs.TempDir;
+import org.jboss.vfs.TempFileProvider;
+import org.jboss.vfs.VirtualFile;
+import org.jboss.vfs.spi.FileSystem;
+
+/**
+ * Created by bob on 1/3/18.
+ */
+@ApplicationScoped
+public class ShrinkWrapFileSystem implements FileSystem {
+
+    public ShrinkWrapFileSystem() {
+
+    }
+
+    @PostConstruct
+    public void postConstruct() throws IOException {
+        this.tempDir = this.tempFileProvider.createTempDir("wildfly-swarm-deployments.tmp");
+    }
+
+    public void addArchive(String name, Archive<?> archive) {
+        this.archives.put(name, new Entry(archive));
+    }
+
+    @Override
+    public File getFile(VirtualFile mountPoint, VirtualFile target) throws IOException {
+        return getEntry(mountPoint, target)
+                .map(e -> getFile(e))
+                .orElse(null);
+    }
+
+    File getFile(Entry entry) {
+        if (entry.file == null) {
+            try {
+                entry.file = this.tempDir.createFile(entry.archive.getName(), entry.archive.as(ZipExporter.class).exportAsInputStream());
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        return entry.file;
+    }
+
+    @Override
+    public InputStream openInputStream(VirtualFile mountPoint, VirtualFile target) throws IOException {
+        return getEntry(mountPoint, target)
+                .map(e -> e.archive.as(ZipExporter.class).exportAsInputStream()).orElse(null);
+    }
+
+    Optional<Entry> getEntry(VirtualFile mountPoint, VirtualFile target) {
+        String name = target.getPathNameRelativeTo(mountPoint);
+        Entry entry = this.archives.get(name);
+        return Optional.ofNullable(entry);
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
+
+    @Override
+    public boolean delete(VirtualFile mountPoint, VirtualFile target) {
+        getEntry(mountPoint, target)
+                .ifPresent(e -> {
+                    try {
+                        e.close();
+                    } catch (IOException e1) {
+                        e1.printStackTrace();
+                    }
+                });
+        return true;
+    }
+
+    @Override
+    public long getSize(VirtualFile mountPoint, VirtualFile target) {
+        return getEntry(mountPoint, target)
+                .map(e -> sizeof(e))
+                .orElse(0L);
+    }
+
+    long sizeof(Entry entry) {
+        if (entry.size == null) {
+            SizingOutputStream sizingOutputStream = new SizingOutputStream();
+            entry.archive.as(ZipExporter.class).exportTo(sizingOutputStream);
+            entry.size = sizingOutputStream.getSize();
+        }
+        return entry.size;
+    }
+
+    @Override
+    public long getLastModified(VirtualFile mountPoint, VirtualFile target) {
+        return 0;
+    }
+
+    @Override
+    public boolean exists(VirtualFile mountPoint, VirtualFile target) {
+        return getEntry(mountPoint, target)
+                .isPresent();
+    }
+
+    @Override
+    public boolean isFile(VirtualFile mountPoint, VirtualFile target) {
+        return exists(mountPoint, target);
+    }
+
+    @Override
+    public boolean isDirectory(VirtualFile mountPoint, VirtualFile target) {
+        return false;
+    }
+
+    @Override
+    public List<String> getDirectoryEntries(VirtualFile mountPoint, VirtualFile target) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public CodeSigner[] getCodeSigners(VirtualFile mountPoint, VirtualFile target) {
+        return new CodeSigner[0];
+    }
+
+    @Override
+    public void close() throws IOException {
+        for (Entry each : this.archives.values()) {
+            each.close();
+        }
+        this.tempDir.close();
+    }
+
+    @Override
+    public File getMountSource() {
+        return null;
+    }
+
+    @Override
+    public URI getRootURI() throws URISyntaxException {
+        return null;
+    }
+
+    private Map<String, Entry> archives = new HashMap<>();
+
+    private TempDir tempDir;
+
+    @Inject
+    private TempFileProvider tempFileProvider;
+
+    private static class Entry implements Closeable {
+        Entry(Archive<?> archive) {
+            this.archive = archive;
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (this.file != null) {
+                this.file.delete();
+            }
+        }
+
+        final Archive<?> archive;
+
+        Long size;
+
+        File file;
+    }
+
+
+}

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/wildfly/SizingOutputStream.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/wildfly/SizingOutputStream.java
@@ -1,0 +1,25 @@
+package org.wildfly.swarm.container.runtime.wildfly;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Created by bob on 1/3/18.
+ */
+public class SizingOutputStream extends OutputStream {
+
+    public SizingOutputStream() {
+
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        ++this.size;
+    }
+
+    public long getSize() {
+        return this.size;
+    }
+
+    private long size;
+}

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/wildfly/SwarmContentRepository.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/wildfly/SwarmContentRepository.java
@@ -38,10 +38,13 @@ package org.wildfly.swarm.container.runtime.wildfly;
  */
 
 import java.io.BufferedInputStream;
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.DigestOutputStream;
@@ -53,6 +56,7 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 
 import org.jboss.as.repository.ContentReference;
 import org.jboss.as.repository.ContentRepository;
@@ -62,6 +66,8 @@ import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.vfs.VFS;
 import org.jboss.vfs.VirtualFile;
 
@@ -73,7 +79,6 @@ import org.jboss.vfs.VirtualFile;
 @ApplicationScoped
 public class SwarmContentRepository implements ContentRepository, Service<ContentRepository> {
 
-    private Map<String, Path> index = new HashMap<>();
 
     /**
      * Install the service.
@@ -103,7 +108,28 @@ public class SwarmContentRepository implements ContentRepository, Service<Conten
                 sha1Bytes = messageDigest.digest();
             }
             String key = toKey(sha1Bytes);
-            this.index.put(key, tmp);
+            this.index.put(key, tmp.toUri());
+            return sha1Bytes;
+        } catch (NoSuchAlgorithmException e) {
+            throw new IOException(e);
+        }
+    }
+
+    public byte[] addContent(Archive<?> archive) throws IOException, URISyntaxException {
+        try {
+            MessageDigest messageDigest = MessageDigest.getInstance("SHA-1");
+            byte[] sha1Bytes;
+            messageDigest.reset();
+            BufferedInputStream bis = new BufferedInputStream(archive.as(ZipExporter.class).exportAsInputStream());
+            byte[] bytes = new byte[8192];
+            int read;
+            while ((read = bis.read(bytes)) > -1) {
+                messageDigest.update(bytes, 0, read);
+            }
+            sha1Bytes = messageDigest.digest();
+            String key = toKey(sha1Bytes);
+            this.fs.addArchive(archive.getName(), archive);
+            this.index.put(key, this.fsMount.getChild(archive.getName()).toURI());
             return sha1Bytes;
         } catch (NoSuchAlgorithmException e) {
             throw new IOException(e);
@@ -117,7 +143,7 @@ public class SwarmContentRepository implements ContentRepository, Service<Conten
     @Override
     public VirtualFile getContent(byte[] sha1Bytes) {
         String key = toKey(sha1Bytes);
-        VirtualFile result = VFS.getChild(this.index.get(key).toUri());
+        VirtualFile result = VFS.getChild(this.index.get(key));
         return result;
     }
 
@@ -149,16 +175,9 @@ public class SwarmContentRepository implements ContentRepository, Service<Conten
 
     public void removeAllContent() throws IOException {
         IOException exception = null;
-        for (Path path: this.index.values()) {
-            try {
-                Files.delete(path);
-            } catch (IOException e) {
-                exception = e;
-            }
-        }
-
-        if (exception != null) {
-            throw exception;
+        for (URI uri : this.index.values()) {
+            VirtualFile file = VFS.getChild(uri);
+            file.delete();
         }
     }
 
@@ -172,15 +191,36 @@ public class SwarmContentRepository implements ContentRepository, Service<Conten
 
     @Override
     public void start(StartContext startContext) throws StartException {
+        this.fsMount = VFS.getChild("wildfly-swarm-deployments");
+        try {
+            this.fsCloseable = VFS.mount(this.fsMount, this.fs);
+        } catch (IOException e) {
+            throw new StartException(e);
+        }
     }
 
     @Override
     public void stop(StopContext stopContext) {
+        try {
+            this.fsCloseable.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 
     @Override
     public ContentRepository getValue() throws IllegalStateException, IllegalArgumentException {
         return this;
     }
+
+    private Map<String, URI> index = new HashMap<>();
+
+    private VirtualFile fsMount;
+
+
+    @Inject
+    private ShrinkWrapFileSystem fs;
+
+    private Closeable fsCloseable;
 
 }


### PR DESCRIPTION
Motivation
----------
We copy the deployment, a lot, between ourselves and
VFS within WildFly-Core. We don't need to do that.

Modifications
-------------
Invent a ShrinkWrap-based VFS filesystem capable of providing
the deployment to WildFly-Core without scribbling it to disk
until/unless something (like undertow) desires to explode the
deployment for whatever reason.

Result
------
Hopefully less diskspace usage.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
