### PR TITLE
SWARM-1765: Transitive dependencies not present in Arquillian test.

### DIFF
--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
@@ -312,7 +312,7 @@ public class UberjarSimpleContainer implements SimpleContainer {
 
     private <C extends LibraryContainer<?> & ManifestContainer<?>> void munge(C container, DeclaredDependencies declaredDependencies) {
 
-        for (ArtifactSpec artifact : declaredDependencies.getExplicitDependencies()) { // [hb] TODO: this should actually be transient deps
+        for (ArtifactSpec artifact : declaredDependencies.getRuntimeExplicitAndTransientDependencies()) {
             assert artifact.file != null : "artifact.file cannot be null at this point: " + artifact;
             container.addAsLibrary(artifact.file);
         }

--- a/arquillian/test/pom.xml
+++ b/arquillian/test/pom.xml
@@ -59,21 +59,6 @@
       <artifactId>jgroups</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.wildfly.swarm</groupId>
-      <artifactId>spi</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.wildfly.swarm</groupId>
-      <artifactId>msc</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.wildfly.swarm</groupId>
-      <artifactId>naming</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jboss.arquillian.junit</groupId>
       <artifactId>arquillian-junit-container</artifactId>
       <scope>test</scope>

--- a/core/spi/src/main/java/org/wildfly/swarm/spi/api/DependenciesContainer.java
+++ b/core/spi/src/main/java/org/wildfly/swarm/spi/api/DependenciesContainer.java
@@ -15,11 +15,8 @@
  */
 package org.wildfly.swarm.spi.api;
 
-import java.util.List;
-
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.container.LibraryContainer;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 
 /**
  * Archive mix-in capable of supporting {@code addAllDependencies}
@@ -51,25 +48,6 @@ public interface DependenciesContainer<T extends Archive<T>> extends LibraryCont
         // flag to instruct the container to add the missing deps upon deploy time
         addMarker(ALL_DEPENDENCIES_MARKER);
         return (T) this;
-    }
-
-
-    @SuppressWarnings("unchecked")
-    // [hb] TODO: is this actually needed anymore? looks brittle to add swarm deps tp the deployment ...
-    default T addAllDependencies(boolean includingWildFlySwarm) throws Exception {
-        if (!includingWildFlySwarm) {
-            return addAllDependencies();
-        }
-
-        if (!hasMarker(ALL_DEPENDENCIES_MARKER)) {
-            List<JavaArchive> artifacts = ArtifactLookup.get().allArtifacts();
-            addAsLibraries(artifacts);
-            addMarker(ALL_DEPENDENCIES_MARKER);
-        }
-
-        return (T) this;
-
-
     }
 
     /**

--- a/tools/src/main/java/org/wildfly/swarm/tools/DeclaredDependencies.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/DeclaredDependencies.java
@@ -50,6 +50,20 @@ public class DeclaredDependencies extends DependencyTree<ArtifactSpec> {
         return allTransient;
     }
 
+    public Collection<ArtifactSpec> getRuntimeExplicitAndTransientDependencies() {
+        Collection<ArtifactSpec> allDeps = new HashSet<>();
+
+        getDirectDeps()
+                .stream()
+                .filter(spec -> !spec.scope.equals("test"))
+                .forEach(spec -> {
+                    allDeps.add(spec);
+                    allDeps.addAll(getTransientDependencies(spec));
+                });
+
+        return allDeps;
+    }
+
     public Collection<ArtifactSpec> getTransientDependencies(ArtifactSpec artifact) {
         return getTransientDeps(artifact);
     }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
When a project's dependency has transitives, those transitives are not included in WEB-INF/lib of the test deployment.

Modifications
-------------
Ensure that transitives of direct dependencies, not in test scope,
are included as dependencies to the deployment.

Result
------
No impact to product, but improves Arquillian support.
