### PR TITLE
SWARM-1457: Swarmtool unable to resolve undertow artifacts

### DIFF
--- a/plugins/gradle/src/main/java/org/wildfly/swarm/plugin/gradle/GradleArtifactResolvingHelper.java
+++ b/plugins/gradle/src/main/java/org/wildfly/swarm/plugin/gradle/GradleArtifactResolvingHelper.java
@@ -93,14 +93,6 @@ public class GradleArtifactResolvingHelper implements ArtifactResolvingHelper {
         final Configuration config = this.project.getConfigurations().detachedConfiguration().setTransitive(transitive);
         final DependencySet dependencySet = config.getDependencies();
 
-        if (transitive) {
-            // if transitive, then dependency-manage everything,
-            // if non-transitive, we want exactly what we've asked for, and don't force
-            // to the project's dependencies.
-            config.getResolutionStrategy().setForcedModules(
-                    this.project.getConfigurations().getByName("compile").getResolutionStrategy().getForcedModules());
-        }
-
         deps.forEach(spec -> {
             if (projects.containsKey(spec.groupId() + ":" + spec.artifactId() + ":" + spec.version())) {
                 dependencySet.add(new DefaultProjectDependency((ProjectInternal) projects.get(spec.groupId() + ":" + spec.artifactId() + ":" + spec.version()), new DefaultProjectAccessListener(), false));

--- a/plugins/gradle/src/main/java/org/wildfly/swarm/plugin/gradle/PackageTask.java
+++ b/plugins/gradle/src/main/java/org/wildfly/swarm/plugin/gradle/PackageTask.java
@@ -91,7 +91,7 @@ public class PackageTask extends DefaultTask {
 
         this.tool = new BuildTool(resolvingHelper)
                 .projectArtifact(project.getGroup().toString(), project.getName(), project.getVersion().toString(),
-                    getPackaging(), getProjectArtifactFile())
+                                 getPackaging(), getProjectArtifactFile())
                 .mainClass(getMainClassName())
                 .bundleDependencies(getBundleDependencies())
                 .executable(getExecutable())
@@ -101,9 +101,9 @@ public class PackageTask extends DefaultTask {
                 .properties(PropertiesUtil.filteredSystemProperties(propertiesFromExtension, false))
                 .fractionDetectionMode(getSwarmExtension().getFractionDetectMode())
                 .additionalModules(moduleDirs.stream()
-                        .filter(File::exists)
-                        .map(File::getAbsolutePath)
-                        .collect(Collectors.toList()))
+                                           .filter(File::exists)
+                                           .map(File::getAbsolutePath)
+                                           .collect(Collectors.toList()))
                 .logger(new SimpleLogger() {
                     @Override
                     public void debug(String msg) {
@@ -145,7 +145,7 @@ public class PackageTask extends DefaultTask {
                 .forEach(e -> addDependency(declaredDependencies, explicitDependencies, e));*/
 
         ResolvedConfiguration resolvedConfiguration = project.getConfigurations()
-                .getByName("compile")
+                .getByName("default")
                 .getResolvedConfiguration();
 
         Set<ResolvedDependency> directDeps = resolvedConfiguration
@@ -203,9 +203,9 @@ public class PackageTask extends DefaultTask {
         if (mainClassName != null && !mainClassName.equals("")) {
             getLogger().warn(
                     "\n------\n" +
-                    "Custom main() usage is intended to be deprecated in a future release and is no longer supported, \n" +
-                    "please refer to http://reference.wildfly-swarm.io for YAML configuration that replaces it." +
-                    "\n------"
+                            "Custom main() usage is intended to be deprecated in a future release and is no longer supported, \n" +
+                            "please refer to http://reference.wildfly-swarm.io for YAML configuration that replaces it." +
+                            "\n------"
             );
         }
 


### PR DESCRIPTION
Motivation
----------
In certain circumstances, Wildfly Swarm Dependency Management may define an artifact version while while a dependency may require some specific different version of that same artifact. If using Gradle, the current code would only add the defined dependency management version inside the m2repo of the uberjar. Furthermore Gradle only considers compile dependencies and would not include dependencies in the runtime configurations.

Modifications
-------------
org.wildfly.swarm.plugin.gradle.GradleArtifactResolvingHelper:doResolve no longer tries to dependency managed everything by forcing modules.
org.wildfly.swarm.plugin.gradle.PackageTask:packageForSwarm resolves all artifacts in the default configurations-all runtime and compile dependencies.

Result
------
The m2repo of an uberjar will now contain all runtime and compile artifacts required by all modules. This may cause the uberjar to be bigger in size.

- [X ] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
