### PR TITLE
SWARM-1677 - Too many temp files.

### DIFF
--- a/core/bootstrap/src/main/java/org/jboss/modules/maven/MavenSettings.java
+++ b/core/bootstrap/src/main/java/org/jboss/modules/maven/MavenSettings.java
@@ -15,14 +15,6 @@
  */
 package org.jboss.modules.maven;
 
-import static org.jboss.modules.maven.MavenArtifactUtil.doIo;
-import static org.jboss.modules.xml.ModuleXmlParser.endOfDocument;
-import static org.jboss.modules.xml.ModuleXmlParser.unexpectedContent;
-import static org.jboss.modules.xml.XmlPullParser.END_DOCUMENT;
-import static org.jboss.modules.xml.XmlPullParser.END_TAG;
-import static org.jboss.modules.xml.XmlPullParser.FEATURE_PROCESS_NAMESPACES;
-import static org.jboss.modules.xml.XmlPullParser.START_TAG;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,6 +30,14 @@ import java.util.Map;
 import org.jboss.modules.xml.MXParser;
 import org.jboss.modules.xml.XmlPullParser;
 import org.jboss.modules.xml.XmlPullParserException;
+
+import static org.jboss.modules.maven.MavenArtifactUtil.doIo;
+import static org.jboss.modules.xml.ModuleXmlParser.endOfDocument;
+import static org.jboss.modules.xml.ModuleXmlParser.unexpectedContent;
+import static org.jboss.modules.xml.XmlPullParser.END_DOCUMENT;
+import static org.jboss.modules.xml.XmlPullParser.END_TAG;
+import static org.jboss.modules.xml.XmlPullParser.FEATURE_PROCESS_NAMESPACES;
+import static org.jboss.modules.xml.XmlPullParser.START_TAG;
 
 /**
  * @author Tomaz Cerar (c) 2014 Red Hat Inc.

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/Main.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/Main.java
@@ -15,25 +15,26 @@
  */
 package org.wildfly.swarm.bootstrap;
 
-import static java.nio.file.StandardWatchEventKinds.*;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.WatchEvent;
+import java.nio.file.WatchEvent.Kind;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
-import java.nio.file.WatchEvent.Kind;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import __redirected.__JAXPRedirected;
 import org.jboss.modules.Module;
+import org.jboss.modules.ModuleLoadException;
 import org.wildfly.swarm.bootstrap.env.ApplicationEnvironment;
 import org.wildfly.swarm.bootstrap.modules.BootModuleLoader;
 import org.wildfly.swarm.bootstrap.performance.Performance;
 import org.wildfly.swarm.bootstrap.util.BootstrapProperties;
+
+import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
 
 /**
  * @author Bob McWhirter
@@ -134,6 +135,11 @@ public class Main {
 
     public void setupBootModuleLoader() {
         System.setProperty("boot.module.loader", BootModuleLoader.class.getName());
+        try {
+            Module.registerURLStreamHandlerFactoryModule(Module.getBootModuleLoader().loadModule("org.wildfly.swarm.bootstrap.uberjar"));
+        } catch (ModuleLoadException e) {
+            e.printStackTrace();
+        }
     }
 
     private final String[] args;

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/MainInvoker.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/MainInvoker.java
@@ -89,6 +89,7 @@ public class MainInvoker {
 
     public static void main(String... args) throws Exception {
         System.setProperty(BOOT_MODULE_PROPERTY, BootModuleLoader.class.getName());
+
         List<String> argList = Arrays.asList(args);
 
         if (argList.isEmpty()) {

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/ApplicationEnvironment.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/ApplicationEnvironment.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,7 +15,6 @@
  */
 package org.wildfly.swarm.bootstrap.env;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -36,10 +35,12 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
+import java.util.zip.ZipInputStream;
 
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleLoadException;
 import org.jboss.modules.maven.ArtifactCoordinates;
+import org.wildfly.swarm.bootstrap.modules.ArtifactResolution;
 import org.wildfly.swarm.bootstrap.modules.MavenResolvers;
 import org.wildfly.swarm.bootstrap.performance.Performance;
 import org.wildfly.swarm.bootstrap.util.BootstrapProperties;
@@ -48,11 +49,11 @@ import org.yaml.snakeyaml.Yaml;
 
 /**
  * Entry-point to runtime environment.
- *
+ * <p>
  * <p>This class uses the <code>fraction-manifest.yaml</code> from each fraction,
  * along with the container-wide <code>wildfly-swarm-manifest.yaml</code> if executing
  * in an uberjar mode in order to determine information such as:</p>
- *
+ * <p>
  * <ul>
  * <li>uberjar vs non-uberjar execution mode</li>
  * <li>removable dependencies</li>
@@ -226,7 +227,8 @@ public class ApplicationEnvironment {
 
         bootstrapArtifactsAsCoordinates().forEach((coords) -> {
             try {
-                File artifactFile = MavenResolvers.get().resolveJarArtifact(coords);
+                /*
+                File artifactFile = MavenResolvers.getForJBossModules().resolveJarArtifact(coords);
                 if (artifactFile == null) {
                     throw new RuntimeException("Unable to resolve artifact from coordinates: " + coords);
                 }
@@ -236,6 +238,35 @@ public class ApplicationEnvironment {
                         FractionManifest manifest = new FractionManifest(zip.getInputStream(manifestEntry));
                         if (!modulesManifests.contains(manifest.getGroupId() + manifest.getArtifactId())) {
                             this.manifests.add(manifest);
+                        }
+                    }
+                }
+                */
+
+                ArtifactResolution resolution = MavenResolvers.get().resolveJarArtifact(coords);
+                if (resolution == null) {
+                    throw new RuntimeException("Unable to resolve artifact from coordinates: " + coords);
+                }
+                if (resolution.isFile()) {
+                    try (ZipFile zip = new ZipFile(resolution.getFile())) {
+                        ZipEntry manifestEntry = zip.getEntry(FractionManifest.CLASSPATH_LOCATION);
+                        if (manifestEntry != null) {
+                            FractionManifest manifest = new FractionManifest(zip.getInputStream(manifestEntry));
+                            if (!modulesManifests.contains(manifest.getGroupId() + manifest.getArtifactId())) {
+                                this.manifests.add(manifest);
+                            }
+                        }
+                    }
+                } else {
+                    try (ZipInputStream zip = new ZipInputStream(resolution.openStream())) {
+                        ZipEntry each = null;
+                        while ((each = zip.getNextEntry()) != null) {
+                            if (each.getName().equals(FractionManifest.CLASSPATH_LOCATION)) {
+                                FractionManifest manifest = new FractionManifest(zip);
+                                if (!modulesManifests.contains(manifest.getGroupId() + manifest.getArtifactId())) {
+                                    this.manifests.add(manifest);
+                                }
+                            }
                         }
                     }
                 }
@@ -311,7 +342,7 @@ public class ApplicationEnvironment {
 
     /**
      * List of <i>application-level</i> dependencies.
-     *
+     * <p>
      * <p>Only applicable for uberjar executions.</p>
      *
      * @return The list of Maven GAVs for application dependencies.
@@ -336,9 +367,9 @@ public class ApplicationEnvironment {
 
     /**
      * [hb] TODO: these javadocs are wrong and describe a previous implementation of this method
-     *
+     * <p>
      * Resolve the application's dependencies.
-     *
+     * <p>
      * <p>Using combinations of {@link #getDependencies()}} and {@link #getRemovableDependencies()},
      * depending on execution mode, resolves application dependencies, taking
      * into account any exclusions.</p>

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/MavenDependencyResolution.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/MavenDependencyResolution.java
@@ -52,7 +52,7 @@ public class MavenDependencyResolution implements DependencyResolution {
                     }
 
                     try {
-                        final File artifact = MavenResolvers.get().resolveJarArtifact(coords);
+                        final File artifact = MavenResolvers.getForJBossModules().resolveJarArtifact(coords);
                         if (artifact == null) {
                             LOGGER.error("Unable to resolve artifact: " + coords);
                         } else {

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/ArtifactResolution.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/ArtifactResolution.java
@@ -1,0 +1,119 @@
+package org.wildfly.swarm.bootstrap.modules;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+
+import org.jboss.modules.maven.ArtifactCoordinates;
+import org.wildfly.swarm.bootstrap.util.TempFileManager;
+
+public interface ArtifactResolution {
+
+    enum Type {
+        FILE,
+        STREAM
+    }
+
+    String getName();
+
+    Type getType();
+
+    File getFile() throws IOException;
+
+    default boolean isFile() {
+        return getType() == Type.FILE;
+    }
+
+    InputStream openStream() throws FileNotFoundException;
+
+    class FileArtifactResolution implements ArtifactResolution {
+
+
+        public FileArtifactResolution(ArtifactCoordinates coords, String packaging, File file) {
+            this.coords = coords;
+            this.packaging = packaging;
+            this.file = file;
+            ArtifactResolutionCache.CACHED_FILES.put(coords.toString() + "/" + packaging, file);
+        }
+
+        public String getName() {
+            return this.file.getName();
+        }
+
+        @Override
+        public Type getType() {
+            return Type.FILE;
+        }
+
+        @Override
+        public File getFile() {
+            return this.file;
+        }
+
+        @Override
+        public InputStream openStream() throws FileNotFoundException {
+            return new FileInputStream(this.file);
+        }
+
+        private final ArtifactCoordinates coords;
+        private final String packaging;
+        private final File file;
+
+    }
+
+    class StreamArtifactResolution implements ArtifactResolution {
+
+        public StreamArtifactResolution(ArtifactCoordinates coords, String packaging, String name, InputStream stream) {
+            this.coords = coords;
+            this.packaging = packaging;
+            this.name = name;
+            this.stream = stream;
+        }
+
+        public String getName() {
+            return this.name;
+        }
+
+        @Override
+        public Type getType() {
+            return Type.STREAM;
+        }
+
+        @Override
+        public synchronized File getFile() throws IOException {
+            File file = ArtifactResolutionCache.CACHED_FILES.get(this.coords.toString() + "/" + this.packaging);
+            if (file == null) {
+                file = copyTempJar(name, openStream(), "jar");
+                ArtifactResolutionCache.CACHED_FILES.put(this.coords.toString() + "/" + this.packaging, file);
+            }
+            return file;
+        }
+
+        public static File copyTempJar(String name, InputStream in, String packaging) throws IOException {
+            File tmp = TempFileManager.INSTANCE.newTempFile(name, "." + packaging);
+            Files.copy(in, tmp.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            return tmp;
+        }
+
+        @Override
+        public synchronized InputStream openStream() throws FileNotFoundException {
+            if (this.stream == null) {
+                throw new UnsupportedOperationException("Stream already consumed");
+            }
+            InputStream s = this.stream;
+            this.stream = null;
+            return s;
+        }
+
+        private final ArtifactCoordinates coords;
+        private final String packaging;
+        private InputStream stream;
+        private final String name;
+    }
+
+
+}

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/ArtifactResolutionCache.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/ArtifactResolutionCache.java
@@ -1,0 +1,14 @@
+package org.wildfly.swarm.bootstrap.modules;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ArtifactResolutionCache {
+
+    private ArtifactResolutionCache() {
+
+    }
+
+    public static Map<String,File> CACHED_FILES = new HashMap<>();
+}

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/ArtifactResolver.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/ArtifactResolver.java
@@ -1,0 +1,27 @@
+package org.wildfly.swarm.bootstrap.modules;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.jboss.modules.maven.ArtifactCoordinates;
+import org.jboss.modules.maven.MavenResolver;
+
+public interface ArtifactResolver {
+
+    ArtifactResolution resolveArtifact(ArtifactCoordinates coords, String packaging) throws IOException;
+
+    default ArtifactResolution resolveJarArtifact(ArtifactCoordinates coords) throws IOException {
+        return resolveArtifact(coords, "jar");
+
+    }
+
+    static ArtifactResolver wrapJBossModulesResolver(MavenResolver resolver) {
+        return (coords, packaging) -> {
+            File file = resolver.resolveArtifact(coords, packaging);
+            if (file != null) {
+                return new ArtifactResolution.FileArtifactResolution(coords, packaging, file);
+            }
+            return null;
+        };
+    }
+}

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/BootModuleLoader.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/BootModuleLoader.java
@@ -27,6 +27,7 @@ public class BootModuleLoader extends ModuleLoader {
 
     public BootModuleLoader() throws IOException {
         super(new ModuleFinder[]{
+                new UberjarURLModuleFinder(),
                 new BootstrapClasspathModuleFinder(),
                 new BootstrapModuleFinder(),
                 new ClasspathModuleFinder(),
@@ -34,5 +35,6 @@ public class BootModuleLoader extends ModuleLoader {
                 new ApplicationModuleFinder(),
                 new DynamicModuleFinder(),
         });
+
     }
 }

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/BootstrapClasspathModuleFinder.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/BootstrapClasspathModuleFinder.java
@@ -63,7 +63,7 @@ public class BootstrapClasspathModuleFinder implements ModuleFinder {
                 in = url.openStream();
                 moduleSpec = ModuleXmlParser.parseModuleXml(
                         (rootPath, loaderPath, loaderName) -> NestedJarResourceLoader.loaderFor(base, rootPath, loaderPath, loaderName),
-                        MavenResolvers.get(),
+                        MavenResolvers.getForJBossModules(),
                         "/",
                         in,
                         path.toString(),

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/ClasspathModuleFinder.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/ClasspathModuleFinder.java
@@ -88,7 +88,7 @@ public class ClasspathModuleFinder implements ModuleFinder {
                 try {
                     moduleSpec = ModuleXmlParser.parseModuleXml(
                             (rootPath, loaderPath, loaderName) -> NestedJarResourceLoader.loaderFor(base, rootPath, loaderPath, loaderName),
-                            MavenResolvers.get(),
+                            MavenResolvers.getForJBossModules(),
                             (explodedJar == null ? "/" : explodedJar.toAbsolutePath().toString()),
                             in,
                             path.toString(),

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/GradleResolver.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/GradleResolver.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,12 +15,6 @@
  */
 package org.wildfly.swarm.bootstrap.modules;
 
-import org.jboss.modules.Module;
-import org.jboss.modules.maven.ArtifactCoordinates;
-import org.jboss.modules.maven.MavenArtifactUtil;
-import org.jboss.modules.maven.MavenResolver;
-
-import javax.xml.xpath.XPathExpressionException;
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -34,6 +28,12 @@ import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
 
+import javax.xml.xpath.XPathExpressionException;
+
+import org.jboss.modules.Module;
+import org.jboss.modules.maven.ArtifactCoordinates;
+import org.jboss.modules.maven.MavenArtifactUtil;
+
 /**
  * This resolver try to find the requested artifact in the local gradle cache. If the artifact is missing, it try
  * to download it from a remote repository. Default is the https://repo1.maven.org/maven2/ repository. With the
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
  *
  * @author Michael Fraefel
  */
-public class GradleResolver implements MavenResolver {
+public class GradleResolver implements ArtifactResolver {
     private final String gradleCachePath;
     private final List<String> remoteRepositories = new LinkedList<>();
 
@@ -62,7 +62,7 @@ public class GradleResolver implements MavenResolver {
     }
 
     @Override
-    public File resolveArtifact(ArtifactCoordinates artifactCoordinates, String packaging) throws IOException {
+    public ArtifactResolution resolveArtifact(ArtifactCoordinates artifactCoordinates, String packaging) throws IOException {
         //Search the matching artifact in a gradle cache.
         String filter = toGradleArtifactFileName(artifactCoordinates, packaging);
         Path artifactDirectory = Paths.get(gradleCachePath, artifactCoordinates.getGroupId(), artifactCoordinates.getArtifactId(), artifactCoordinates.getVersion());
@@ -80,12 +80,14 @@ public class GradleResolver implements MavenResolver {
                 }
             }
             if (latestArtifactFile != null) {
-                return latestArtifactFile;
+                return new ArtifactResolution.FileArtifactResolution(artifactCoordinates, packaging, latestArtifactFile);
             }
         }
 
         //Artifact not found in the locale gradle cache. Try to resolve it from the remote respository
-        return downloadFromRemoteRepository(artifactCoordinates, packaging, artifactDirectory);
+        return new ArtifactResolution.FileArtifactResolution(
+                artifactCoordinates, packaging,
+                downloadFromRemoteRepository(artifactCoordinates, packaging, artifactDirectory));
     }
 
     /**

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/InMemoryJarResourceLoader.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/InMemoryJarResourceLoader.java
@@ -1,0 +1,181 @@
+package org.wildfly.swarm.bootstrap.modules;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.security.CodeSource;
+import java.security.cert.Certificate;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarInputStream;
+
+import org.jboss.modules.AbstractResourceLoader;
+import org.jboss.modules.ClassSpec;
+import org.jboss.modules.PackageSpec;
+import org.jboss.modules.Resource;
+import org.jboss.modules.maven.ArtifactCoordinates;
+
+public class InMemoryJarResourceLoader extends AbstractResourceLoader {
+
+    public static final Map<String, InMemoryJarResourceLoader> LOADERS = new HashMap<>();
+
+    public InMemoryJarResourceLoader(ArtifactCoordinates coords, InputStream jarStream) throws IOException {
+        this(coords.getGroupId().replace('.', '-') + "-" + coords.getArtifactId() + "-" + coords.getVersion(), new JarInputStream(jarStream));
+    }
+
+    public InMemoryJarResourceLoader(String rootName, InputStream jarStream) throws IOException {
+        this(rootName, new JarInputStream(jarStream));
+    }
+
+    public InMemoryJarResourceLoader(String rootName, JarInputStream jarStream) throws IOException {
+        this.rootName = rootName;
+        this.paths.add("");
+        initialize(jarStream);
+        synchronized (InMemoryJarResourceLoader.class) {
+            LOADERS.put(rootName, this);
+        }
+    }
+
+    private void initialize(JarInputStream jarStream) throws IOException {
+        JarEntry entry;
+        while ((entry = jarStream.getNextJarEntry()) != null) {
+            if (entry.isDirectory()) {
+                // skip
+            } else {
+                String name = entry.getName();
+                if (name.endsWith(".class")) {
+                    initializeClassSpec(entry, jarStream);
+                } else {
+                    initializeResource(entry, jarStream);
+                }
+            }
+        }
+    }
+
+    private void initializeClassSpec(JarEntry entry, JarInputStream jarStream) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream(1024);
+        byte[] buf = new byte[1024];
+        int len = 0;
+
+        while ((len = jarStream.read(buf)) >= 0) {
+            out.write(buf, 0, len);
+        }
+
+        out.close();
+
+        ClassSpec classSpec = new ClassSpec();
+        classSpec.setBytes(out.toByteArray());
+        classSpec.setCodeSource(new CodeSource(new URL("uberjar://" + this.rootName + "/"), (Certificate[]) null));
+        this.classes.put(entry.getName(), classSpec);
+        index(entry.getName());
+    }
+
+    private void initializeResource(JarEntry entry, JarInputStream jarStream) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream(1024);
+        byte[] buf = new byte[1024];
+        int len = 0;
+
+        while ((len = jarStream.read(buf)) >= 0) {
+            out.write(buf, 0, len);
+        }
+
+        out.close();
+
+        String name = entry.getName();
+        String relativeName = name;
+        int slashLoc = name.lastIndexOf('/');
+        if (slashLoc >= 0) {
+            relativeName = name.substring(slashLoc + 1);
+        }
+
+        InMemoryResource resource = new InMemoryResource(createUrl(this.rootName, name), relativeName, out.toByteArray());
+
+        this.resources.put(name, resource);
+        index(name);
+    }
+
+    private URL createUrl(String rootName, String name) throws MalformedURLException {
+        return new URL("uberjar://" + rootName + "/" + name);
+    }
+
+    private void index(String name) {
+        while (true) {
+            int slashLoc = name.lastIndexOf('/');
+            if (slashLoc < 0) {
+                return;
+            }
+
+            name = name.substring(0, slashLoc);
+            this.paths.add(name);
+        }
+    }
+
+
+    @Override
+    public String getRootName() {
+        return this.rootName;
+    }
+
+    @Override
+    public ClassSpec getClassSpec(String fileName) throws IOException {
+        ClassSpec spec = this.classes.get(fileName);
+        return spec;
+    }
+
+    @Override
+    public PackageSpec getPackageSpec(String name) throws IOException {
+        return super.getPackageSpec(name);
+    }
+
+    @Override
+    public Resource getResource(String name) {
+        Resource resource = this.resources.get(name);
+        if (resource != null) {
+            return resource;
+        }
+
+        ClassSpec classSpec = this.classes.get(name);
+        if (classSpec != null) {
+            try {
+                return new InMemoryResource(createUrl(this.rootName, name), name, classSpec.getBytes());
+            } catch (MalformedURLException e) {
+                e.printStackTrace();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String getLibrary(String name) {
+        return super.getLibrary(name);
+    }
+
+    @Override
+    public Collection<String> getPaths() {
+        return paths;
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public URI getLocation() {
+        return null;
+    }
+
+    private final String rootName;
+    private Map<String, ClassSpec> classes = new HashMap<>();
+    private Map<String, Resource> resources = new HashMap<>();
+    private Set<String> paths = new HashSet<>();
+
+}
+

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/InMemoryResource.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/InMemoryResource.java
@@ -1,0 +1,46 @@
+package org.wildfly.swarm.bootstrap.modules;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+import org.jboss.modules.Resource;
+
+public class InMemoryResource implements Resource {
+
+    private final URL url;
+    private final String name;
+    private final byte[] content;
+
+    public InMemoryResource(URL url, String name, byte[] content) {
+        this.url = url;
+        this.name = name;
+        this.content = content;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public URL getURL() {
+        return this.url;
+    }
+
+    @Override
+    public InputStream openStream() throws IOException {
+        return new ByteArrayInputStream(this.content);
+    }
+
+    @Override
+    public long getSize() {
+        return this.content.length;
+    }
+
+    @Override
+    public String toString() {
+        return "In-memory:\n" + new String(this.content) + "\n";
+    }
+}

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/InstrumentedResourceLoader.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/InstrumentedResourceLoader.java
@@ -1,0 +1,76 @@
+package org.wildfly.swarm.bootstrap.modules;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collection;
+
+import org.jboss.modules.ClassSpec;
+import org.jboss.modules.PackageSpec;
+import org.jboss.modules.Resource;
+import org.jboss.modules.ResourceLoader;
+
+public class InstrumentedResourceLoader implements ResourceLoader {
+
+    public InstrumentedResourceLoader(ResourceLoader delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String getRootName() {
+        return delegate.getRootName();
+    }
+
+    @Override
+    public ClassSpec getClassSpec(String fileName) throws IOException {
+        System.err.println("getClassSpec: " + getRootName() + " // " + fileName);
+        ClassSpec result = delegate.getClassSpec(fileName);
+        System.err.println(" -- " + result);
+        return result;
+    }
+
+    @Override
+    public PackageSpec getPackageSpec(String name) throws IOException {
+        System.err.println("getPackageSpec: " + getRootName() + " // " + name);
+        PackageSpec result = delegate.getPackageSpec(name);
+        System.err.println(" -- " + result);
+        return result;
+    }
+
+    @Override
+    public Resource getResource(String name) {
+        System.err.println("getResource: " + getRootName() + " // " + name);
+        Resource result = delegate.getResource(name);
+        System.err.println(" -- " + result);
+        return result;
+    }
+
+    @Override
+    public String getLibrary(String name) {
+        return delegate.getLibrary(name);
+    }
+
+    @Override
+    public Collection<String> getPaths() {
+        System.err.println("getPaths: " + getRootName());
+        Collection<String> paths = delegate.getPaths();
+        for (String path : paths) {
+            System.err.println(" - " + path);
+        }
+
+        return paths;
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+
+    @Override
+    public URI getLocation() {
+        return delegate.getLocation();
+    }
+
+    private final ResourceLoader delegate;
+
+}
+

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/JBossModulesMavenResolver.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/JBossModulesMavenResolver.java
@@ -1,0 +1,54 @@
+package org.wildfly.swarm.bootstrap.modules;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.jboss.modules.maven.ArtifactCoordinates;
+import org.jboss.modules.maven.MavenResolver;
+import org.wildfly.swarm.bootstrap.util.TempFileManager;
+
+public class JBossModulesMavenResolver implements MavenResolver {
+
+    public JBossModulesMavenResolver(ArtifactResolver delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public File resolveArtifact(ArtifactCoordinates coordinates, String packaging) throws IOException {
+        File file = this.resolutionCache.get(coordinates);
+        if (file != null) {
+            return file;
+        }
+
+        ArtifactResolution resolution = this.delegate.resolveArtifact(coordinates, packaging);
+        if (resolution == null) {
+            return null;
+        }
+        if (resolution.isFile()) {
+            return resolution.getFile();
+        }
+
+
+        file = copyTempJar(coordinates, resolution.openStream(), packaging);
+        this.resolutionCache.put(coordinates, file);
+        return file;
+    }
+
+    private Map<ArtifactCoordinates, File> resolutionCache = new ConcurrentHashMap<>();
+
+    public static File copyTempJar(ArtifactCoordinates coords, InputStream in, String packaging) throws IOException {
+        //String name = coords.getGroupId().replace('.', '-' ) + "@" + coords.getArtifactId();
+        String name = "a";
+        File tmp = TempFileManager.INSTANCE.newTempFile(name, "." + packaging);
+        Files.copy(in, tmp.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        return tmp;
+    }
+
+    private final ArtifactResolver delegate;
+
+}

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/MavenResolvers.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/MavenResolvers.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,8 +30,12 @@ public class MavenResolvers {
 
     private static BootstrapLogger LOGGER = BootstrapLogger.logger("org.wildfly.swarm.bootstrap");
 
-    public static synchronized MavenResolver get() {
+    public static synchronized ArtifactResolver get() {
         return INSTANCE;
+    }
+
+    public static synchronized MavenResolver getForJBossModules() {
+        return new JBossModulesMavenResolver(get());
     }
 
     private static final MultiMavenResolver INSTANCE = new MultiMavenResolver();
@@ -49,7 +53,7 @@ public class MavenResolvers {
                 INSTANCE.addResolver(new GradleResolver(gradleCachePath));
             } else {
                 LOGGER.info("Dependencies not bundled; resolving from M2REPO.");
-                INSTANCE.addResolver(MavenResolver.createDefaultResolver());
+                INSTANCE.addResolver(ArtifactResolver.wrapJBossModulesResolver(MavenResolver.createDefaultResolver()));
             }
         }
     }

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/MultiMavenResolver.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/MultiMavenResolver.java
@@ -15,35 +15,32 @@
  */
 package org.wildfly.swarm.bootstrap.modules;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.jboss.modules.maven.ArtifactCoordinates;
-import org.jboss.modules.maven.MavenResolver;
 import org.wildfly.swarm.bootstrap.performance.Performance;
 
 /**
  * @author Bob McWhirter
  */
-public class MultiMavenResolver implements MavenResolver {
+public class MultiMavenResolver implements ArtifactResolver {
 
 
     public MultiMavenResolver() {
 
     }
 
-    public void addResolver(MavenResolver resolver) {
+    public void addResolver(ArtifactResolver resolver) {
         this.resolvers.add(resolver);
     }
 
-    @Override
-    public File resolveArtifact(ArtifactCoordinates coordinates, String packaging) throws IOException {
+    public ArtifactResolution resolveArtifact(ArtifactCoordinates coordinates, String packaging) throws IOException {
 
         try (AutoCloseable handle = Performance.accumulate("artifact-resolver")) {
-            for (MavenResolver resolver : this.resolvers) {
-                File result = resolver.resolveArtifact(coordinates, packaging);
+            for (ArtifactResolver resolver : this.resolvers) {
+                ArtifactResolution result = resolver.resolveArtifact(coordinates, packaging);
                 if (result != null) {
                     return result;
                 }
@@ -55,5 +52,5 @@ public class MultiMavenResolver implements MavenResolver {
         }
     }
 
-    private List<MavenResolver> resolvers = new ArrayList<>();
+    private List<ArtifactResolver> resolvers = new ArrayList<>();
 }

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/UberJarLocalLoader.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/UberJarLocalLoader.java
@@ -1,0 +1,43 @@
+package org.wildfly.swarm.bootstrap.modules;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.modules.AbstractLocalLoader;
+import org.jboss.modules.Resource;
+
+public class UberJarLocalLoader extends AbstractLocalLoader {
+    @Override
+    public List<Resource> loadResourceLocal(String name) {
+        if (name.equals("META-INF/services/java.net.URLStreamHandlerFactory")) {
+            final URL url = UberJarLocalLoader.class.getClassLoader().getResource("java.net.URLStreamHandlerFactory");
+            return Collections.singletonList(
+                    new Resource() {
+                        @Override
+                        public String getName() {
+                            return url.getPath();
+                        }
+
+                        @Override
+                        public URL getURL() {
+                            return url;
+                        }
+
+                        @Override
+                        public InputStream openStream() throws IOException {
+                            return url.openStream();
+                        }
+
+                        @Override
+                        public long getSize() {
+                            return 0L;
+                        }
+                    }
+            );
+        }
+        return null;
+    }
+}

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/UberJarMavenResolver.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/UberJarMavenResolver.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,18 +21,18 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.jboss.modules.maven.ArtifactCoordinates;
-import org.jboss.modules.maven.MavenResolver;
 import org.wildfly.swarm.bootstrap.util.TempFileManager;
 
 /**
  * @author Bob McWhirter
  */
-public class UberJarMavenResolver implements MavenResolver {
+public class UberJarMavenResolver implements ArtifactResolver {
 
     private static final String HYPHEN = "-";
 
@@ -47,28 +47,26 @@ public class UberJarMavenResolver implements MavenResolver {
     }
 
     @Override
-    public File resolveArtifact(ArtifactCoordinates coordinates, String packaging) throws IOException {
+    public ArtifactResolution resolveArtifact(ArtifactCoordinates coordinates, String packaging) throws IOException {
 
-        File resolved = this.resolutionCache.get(coordinates);
-        if (resolved == null) {
 
-            String artifactRelativePath = "m2repo/" + relativeArtifactPath('/', coordinates.getGroupId(), coordinates.getArtifactId(), coordinates.getVersion());
-            String classifier = "";
-            if (coordinates.getClassifier() != null && !coordinates.getClassifier().trim().isEmpty()) {
-                classifier = HYPHEN + coordinates.getClassifier();
-            }
-
-            String jarPath = artifactRelativePath + classifier + DOT + packaging;
-
-            InputStream stream = UberJarMavenResolver.class.getClassLoader().getResourceAsStream(jarPath);
-
-            if (stream != null) {
-                resolved = copyTempJar(coordinates.getArtifactId() + HYPHEN + coordinates.getVersion(), stream, packaging);
-                this.resolutionCache.put(coordinates, resolved);
-            }
+        String artifactRelativePath = "m2repo/" + relativeArtifactPath('/', coordinates.getGroupId(), coordinates.getArtifactId(), coordinates.getVersion());
+        String classifier = "";
+        if (coordinates.getClassifier() != null && !coordinates.getClassifier().trim().isEmpty()) {
+            classifier = HYPHEN + coordinates.getClassifier();
         }
 
-        return resolved;
+        String jarPath = artifactRelativePath + classifier + DOT + packaging;
+
+        InputStream stream = UberJarMavenResolver.class.getClassLoader().getResourceAsStream(jarPath);
+
+        if (stream != null) {
+            //resolved = copyTempJar(coordinates.getArtifactId() + HYPHEN + coordinates.getVersion(), stream, packaging);
+            //this.resolutionCache.put(coordinates, resolved);
+            return new ArtifactResolution.StreamArtifactResolution(coordinates, packaging,coordinates.getArtifactId() + "-" + UUID.randomUUID().toString() + "." + packaging, stream);
+        }
+
+        return null;
     }
 
     static String relativeArtifactPath(char separator, String groupId, String artifactId, String version) {

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/UberjarURLModuleFinder.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/UberjarURLModuleFinder.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.bootstrap.modules;
+
+import java.util.HashSet;
+
+import org.jboss.modules.DependencySpec;
+import org.jboss.modules.ModuleLoadException;
+import org.jboss.modules.ModuleLoader;
+import org.jboss.modules.ModuleSpec;
+import org.jboss.modules.filter.PathFilters;
+import org.wildfly.swarm.bootstrap.logging.BootstrapLogger;
+import org.wildfly.swarm.bootstrap.performance.Performance;
+
+/**
+ * Module-finder used only for loading the first set of jars when run in an fat-jar scenario.
+ *
+ * @author Bob McWhirter
+ */
+public class UberjarURLModuleFinder extends AbstractSingleModuleFinder {
+
+    public static final String MODULE_NAME = "org.wildfly.swarm.bootstrap.uberjar";
+
+    public UberjarURLModuleFinder() {
+        super(MODULE_NAME);
+    }
+
+    @Override
+    public void buildModule(ModuleSpec.Builder builder, ModuleLoader delegateLoader) throws ModuleLoadException {
+        try (AutoCloseable handle = Performance.accumulate("module: Bootstrap Uberjar Handler")) {
+
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Loading module");
+            }
+
+            HashSet<String> paths = new HashSet<>();
+            paths.add("org/wildfly/swarm/bootstrap/url");
+
+            builder.addDependency(DependencySpec.createSystemDependencySpec(PathFilters.acceptAll(), PathFilters.acceptAll(), paths));
+            builder.setFallbackLoader(new UberJarLocalLoader());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static final BootstrapLogger LOG = BootstrapLogger.logger("org.wildfly.swarm.modules.bootstrap.uberjar");
+}

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/url/UberJarURLStreamHandler.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/url/UberJarURLStreamHandler.java
@@ -1,0 +1,41 @@
+package org.wildfly.swarm.bootstrap.url;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+
+import org.jboss.modules.Resource;
+import org.wildfly.swarm.bootstrap.modules.InMemoryJarResourceLoader;
+
+public class UberJarURLStreamHandler extends URLStreamHandler {
+
+    @Override
+    protected URLConnection openConnection(URL url) throws IOException {
+        String host = url.getHost();
+        String path = url.getPath();
+        if (path.startsWith("/")) {
+            path = path.substring(1);
+        }
+        InMemoryJarResourceLoader loader = InMemoryJarResourceLoader.LOADERS.get(host);
+        if (loader != null) {
+            Resource resource = loader.getResource(path);
+            if (resource != null) {
+                return new URLConnection(resource.getURL()) {
+                    @Override
+                    public void connect() throws IOException {
+                    }
+
+                    @Override
+                    public InputStream getInputStream() throws IOException {
+                        return resource.openStream();
+                    }
+
+                };
+            }
+        }
+        return null;
+    }
+
+}

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/url/UberJarURLStreamHandlerFactory.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/url/UberJarURLStreamHandlerFactory.java
@@ -1,0 +1,14 @@
+package org.wildfly.swarm.bootstrap.url;
+
+import java.net.URLStreamHandler;
+import java.net.URLStreamHandlerFactory;
+
+public class UberJarURLStreamHandlerFactory implements URLStreamHandlerFactory {
+    @Override
+    public URLStreamHandler createURLStreamHandler(String protocol) {
+        if (protocol.equals("uberjar")) {
+            return new UberJarURLStreamHandler();
+        }
+        return null;
+    }
+}

--- a/core/bootstrap/src/main/resources/java.net.URLStreamHandlerFactory
+++ b/core/bootstrap/src/main/resources/java.net.URLStreamHandlerFactory
@@ -1,0 +1,1 @@
+org.wildfly.swarm.bootstrap.url.UberJarURLStreamHandlerFactory

--- a/core/bootstrap/src/test/java/org/wildfly/swarm/bootstrap/env/SystemDependencyResolutionTest.java
+++ b/core/bootstrap/src/test/java/org/wildfly/swarm/bootstrap/env/SystemDependencyResolutionTest.java
@@ -15,12 +15,12 @@
  */
 package org.wildfly.swarm.bootstrap.env;
 
-import org.junit.Test;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Set;
+
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 

--- a/core/bootstrap/src/test/java/org/wildfly/swarm/bootstrap/modules/GradleResolverTest.java
+++ b/core/bootstrap/src/test/java/org/wildfly/swarm/bootstrap/modules/GradleResolverTest.java
@@ -15,20 +15,23 @@
  */
 package org.wildfly.swarm.bootstrap.modules;
 
-import org.jboss.modules.maven.ArtifactCoordinates;
-import org.junit.Test;
-import org.wildfly.swarm.bootstrap.util.TempFileManager;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static org.junit.Assert.*;
+import org.jboss.modules.maven.ArtifactCoordinates;
+import org.junit.Test;
+import org.wildfly.swarm.bootstrap.util.TempFileManager;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 
 /**
  * Test {@link GradleResolver}
@@ -173,7 +176,7 @@ public class GradleResolverTest {
 
         //WHEN
         GradleResolver resolver = new GradleResolver(gradleCachePath.toString());
-        File resolvedArtifactFile = resolver.resolveArtifact(artifactCoordinates, packaging);
+        File resolvedArtifactFile = resolver.resolveArtifact(artifactCoordinates, packaging).getFile();
 
         //THEN
         assertEquals(artifactFile, resolvedArtifactFile);
@@ -199,7 +202,7 @@ public class GradleResolverTest {
 
         //WHEN
         GradleResolver resolver = new GradleResolver(gradleCachePath.toString());
-        File resolvedArtifactFile = resolver.resolveArtifact(artifactCoordinates, packaging);
+        File resolvedArtifactFile = resolver.resolveArtifact(artifactCoordinates, packaging).getFile();
 
         //THEN
         assertEquals(artifactFileLatest, resolvedArtifactFile);
@@ -222,7 +225,7 @@ public class GradleResolverTest {
 
         //WHEN
         GradleResolver resolver = new GradleResolver(gradleCachePath.toString());
-        File resolvedArtifactFile = resolver.resolveArtifact(artifactCoordinates, packaging);
+        File resolvedArtifactFile = resolver.resolveArtifact(artifactCoordinates, packaging).getFile();
 
         //THEN
         assertNull(resolvedArtifactFile);

--- a/core/bootstrap/src/test/resources/org/jboss/modules/maven/settings-empty-local-repo.xml
+++ b/core/bootstrap/src/test/resources/org/jboss/modules/maven/settings-empty-local-repo.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings xmlns="http://maven.apache.org/settings/1.0.0"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 >
 
   <localRepository/>

--- a/core/bootstrap/src/test/resources/org/jboss/modules/maven/settings-interpolated-local-repo.xml
+++ b/core/bootstrap/src/test/resources/org/jboss/modules/maven/settings-interpolated-local-repo.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings xmlns="http://maven.apache.org/settings/1.0.0"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 >
 
   <localRepository>${test.user.home}/.mvnrepository</localRepository>

--- a/core/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/core/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -534,6 +534,8 @@ public class Swarm {
             } catch (URISyntaxException e) {
                 throw new IOException(e);
             }
+        } else if (location.getProtocol().equals("uberjar")) {
+            return true;
         } else if (location.toExternalForm().startsWith("jar:file:")) {
             return true;
         }

--- a/core/container/src/main/java/org/wildfly/swarm/cli/CommandLine.java
+++ b/core/container/src/main/java/org/wildfly/swarm/cli/CommandLine.java
@@ -44,6 +44,7 @@ import org.wildfly.swarm.spi.api.SwarmProperties;
  *
  * @author Bob McWhirter
  */
+@SuppressWarnings("CdiManagedBeanInconsistencyInspection")
 @Vetoed
 public class CommandLine {
 

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/ServerBootstrapImpl.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/ServerBootstrapImpl.java
@@ -137,6 +137,7 @@ public class ServerBootstrapImpl implements ServerBootstrap {
                     weld.addExtension(new DeploymentScopedExtension(deploymentContext));
                     weld.addExtension(new ImplicitArchiveExtension());
 
+
                     for (Class<?> each : this.userComponents) {
                         weld.addBeanClass(each);
                     }

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/ImplicitArchiveExtension.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/ImplicitArchiveExtension.java
@@ -30,8 +30,8 @@ import javax.enterprise.inject.spi.ProcessBeanAttributes;
 import javax.enterprise.inject.spi.ProcessProducer;
 
 import org.jboss.shrinkwrap.api.Archive;
-import org.wildfly.swarm.spi.runtime.annotations.DeploymentScoped;
 import org.wildfly.swarm.container.runtime.ImplicitDeployment;
+import org.wildfly.swarm.spi.runtime.annotations.DeploymentScoped;
 
 /**
  * @author Ken Finnigan

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/marshal/DMRMarshaller.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/marshal/DMRMarshaller.java
@@ -23,7 +23,6 @@ import javax.inject.Inject;
 
 import org.jboss.dmr.ModelNode;
 import org.wildfly.swarm.bootstrap.performance.Performance;
-
 import org.wildfly.swarm.spi.runtime.ConfigurationMarshaller;
 import org.wildfly.swarm.spi.runtime.CustomMarshaller;
 

--- a/core/container/src/main/java/org/wildfly/swarm/container/util/DriverModuleBuilder.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/util/DriverModuleBuilder.java
@@ -41,10 +41,15 @@ import org.wildfly.swarm.bootstrap.modules.DynamicModuleFinder;
 public abstract class DriverModuleBuilder {
 
     private static final String FILE_PREFIX = "file:";
+
     private static final String JAR_FILE_PREFIX = "jar:file:";
+
     private final String name;
+
     private final String detectableClassName;
+
     private final String[] optionalClassNames;
+
     private final String[] driverModuleDependencies;
 
     private boolean installed;

--- a/core/container/src/main/java/org/wildfly/swarm/internal/ArtifactManager.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/ArtifactManager.java
@@ -166,7 +166,7 @@ public class ArtifactManager implements ArtifactLookup {
                 version,
                 classifier == null ? "" : classifier);
 
-        return MavenResolvers.get().resolveArtifact(coords, packaging);
+        return MavenResolvers.get().resolveArtifact(coords, packaging).getFile();
     }
 
 

--- a/core/container/src/test/java/org/wildfly/swarm/cli/ParseStateTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/cli/ParseStateTest.java
@@ -18,7 +18,6 @@ package org.wildfly.swarm.cli;
 import org.junit.Test;
 
 import static org.fest.assertions.Assertions.assertThat;
-import static org.fest.assertions.Fail.fail;
 
 /**
  * @author Bob McWhirter

--- a/core/container/src/test/java/org/wildfly/swarm/container/config/ConfigViewFactoryTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/container/config/ConfigViewFactoryTest.java
@@ -15,12 +15,12 @@
  */
 package org.wildfly.swarm.container.config;
 
-import org.junit.Test;
-
 import java.io.InputStream;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+
+import org.junit.Test;
 
 import static org.fest.assertions.Assertions.assertThat;
 

--- a/core/container/src/test/java/org/wildfly/swarm/container/runtime/ConfigurableManagerTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/container/runtime/ConfigurableManagerTest.java
@@ -30,7 +30,7 @@ import org.wildfly.swarm.spi.api.Defaultable;
 import org.wildfly.swarm.spi.api.annotations.Configurable;
 import org.wildfly.swarm.spi.api.config.ConfigView;
 
-import static org.fest.assertions.Assertions.*;
+import static org.fest.assertions.Assertions.assertThat;
 
 /**
  * Created by bob on 5/19/17.

--- a/core/container/src/test/java/org/wildfly/swarm/container/runtime/deployments/DefaultDeploymentCreatorTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/container/runtime/deployments/DefaultDeploymentCreatorTest.java
@@ -15,7 +15,6 @@
  */
 package org.wildfly.swarm.container.runtime.deployments;
 
-import org.jboss.shrinkwrap.api.Archive;
 import org.junit.Test;
 import org.wildfly.swarm.spi.api.DefaultDeploymentFactory;
 

--- a/core/container/src/test/java/org/wildfly/swarm/internal/ArtifactManagerTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/internal/ArtifactManagerTest.java
@@ -15,27 +15,6 @@
  */
 package org.wildfly.swarm.internal;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.wildfly.swarm.bootstrap.util.MavenArtifactDescriptor;
-
-import static org.fest.assertions.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
-
 /**
  * @author Bob McWhirter
  * @author Ken Finnigan

--- a/core/container/src/test/java/org/wildfly/swarm/internal/FileSystemUtilsTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/internal/FileSystemUtilsTest.java
@@ -15,10 +15,10 @@
  */
 package org.wildfly.swarm.internal;
 
+import java.util.Optional;
+
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.Optional;
 
 /**
  * Created by hbraun on 22.08.17.


### PR DESCRIPTION
Motivation
----------
We explode a lot of temp files from within uberjars. We shouldn't do that
because it wastes space and time.

Modifications
-------------
* Add an uberjar:// URL handler, get it registered with the jboss-modules
  modular URL stream factory.
* Adjust our usage of MavenResolvers to a possibly-stream-based ArtifactResolver
* Still wrap our new ArtifactResolvers into a JBoss-Modules happy file-based
  MavenResolver.
* Monkey-patch the jboss-modules MavenArtifactUtils to not insist on files
  being on disk.
* Iff possible, stream any jars-within-uberjars into JBoss-Module ClassSpec
  byte[] arrays directly in-memory, instead of copying them out of the
  uberjar onto the filesystem.
* But don't do it for org.wildfly.swarm:* artifacts, which are bean archives,
  because uberjar:// annoys the crap out of Weld (Hi Martin).

Result
------
Less disk-space used!

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
