### PR TITLE
SWARM-1775: Fix module id to path resolution in ClassPathModuleFinders

### DIFF
--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/BootstrapClasspathModuleFinder.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/BootstrapClasspathModuleFinder.java
@@ -47,7 +47,8 @@ public class BootstrapClasspathModuleFinder implements ModuleFinder {
         }
 
         try (AutoCloseable handle = Performance.accumulate("module: BootstrapClassPath")) {
-            final String path = "modules/" + identifier.replace('.', MODULE_SEPARATOR).replace(':', MODULE_SEPARATOR) + "/module.xml";
+            final String[] nameAndSlot = identifier.split("\\:", 2);
+            final String path = "modules/" + nameAndSlot[0].replace('.', MODULE_SEPARATOR) + MODULE_SEPARATOR + nameAndSlot[1] + "/module.xml";
 
             ClassLoader cl = BootstrapClasspathModuleFinder.class.getClassLoader();
             URL url = cl.getResource(path);

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/ClasspathModuleFinder.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/ClasspathModuleFinder.java
@@ -47,7 +47,8 @@ public class ClasspathModuleFinder implements ModuleFinder {
             identifier = identifier + ":main";
         }
         try (AutoCloseable handle = Performance.accumulate("module: Classpath")) {
-            final String path = "modules/" + identifier.replace('.', MODULE_SEPARATOR).replace(':', MODULE_SEPARATOR) + "/module.xml";
+            final String[] nameAndSlot = identifier.split("\\:", 2);
+            final String path = "modules/" + nameAndSlot[0].replace('.', MODULE_SEPARATOR) + MODULE_SEPARATOR + nameAndSlot[1] + "/module.xml";
 
 
             if (LOG.isTraceEnabled()) {

--- a/core/bootstrap/src/test/java/org/wildfly/swarm/bootstrap/modules/BootstrapClasspathModuleFinderTest.java
+++ b/core/bootstrap/src/test/java/org/wildfly/swarm/bootstrap/modules/BootstrapClasspathModuleFinderTest.java
@@ -1,0 +1,69 @@
+package org.wildfly.swarm.bootstrap.modules;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import org.jboss.modules.ModuleLoadException;
+import org.jboss.modules.ModuleSpec;
+import org.junit.Test;
+
+/**
+ * @author Benedikt Biallowons <benedikt@biallowons.de>
+ *
+ */
+public class BootstrapClasspathModuleFinderTest {
+
+    @Test
+    public void testMain() {
+        BootstrapClasspathModuleFinder finder = new BootstrapClasspathModuleFinder();
+
+        try {
+            ModuleSpec spec = finder.findModule("classpath.module.load.test", null);
+
+            assertNotNull(spec);
+        } catch (ModuleLoadException e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testMissingMain() {
+        BootstrapClasspathModuleFinder finder = new BootstrapClasspathModuleFinder();
+
+        try {
+            ModuleSpec spec = finder.findModule("classpath.module.load.test.missing", null);
+
+            assertNull(spec);
+        } catch (ModuleLoadException e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testSlot() {
+        BootstrapClasspathModuleFinder finder = new BootstrapClasspathModuleFinder();
+
+        try {
+            ModuleSpec spec = finder.findModule("classpath.module.load.test:1.0.0.Final", null);
+
+            assertNotNull(spec);
+        } catch (ModuleLoadException e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testMissingSlot() {
+        BootstrapClasspathModuleFinder finder = new BootstrapClasspathModuleFinder();
+
+        try {
+            ModuleSpec spec = finder.findModule("classpath.module.load.test:missing", null);
+
+            assertNull(spec);
+        } catch (ModuleLoadException e) {
+            fail();
+        }
+    }
+
+}

--- a/core/bootstrap/src/test/java/org/wildfly/swarm/bootstrap/modules/ClasspathModuleFinderTest.java
+++ b/core/bootstrap/src/test/java/org/wildfly/swarm/bootstrap/modules/ClasspathModuleFinderTest.java
@@ -1,0 +1,68 @@
+package org.wildfly.swarm.bootstrap.modules;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import org.jboss.modules.ModuleLoadException;
+import org.jboss.modules.ModuleSpec;
+import org.junit.Test;
+
+/**
+ * @author Benedikt Biallowons <benedikt@biallowons.de>
+ *
+ */
+public class ClasspathModuleFinderTest {
+    @Test
+    public void testMain() {
+        ClasspathModuleFinder finder = new ClasspathModuleFinder();
+
+        try {
+            ModuleSpec spec = finder.findModule("classpath.module.load.test", null);
+
+            assertNotNull(spec);
+        } catch (ModuleLoadException e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testMissingMain() {
+        ClasspathModuleFinder finder = new ClasspathModuleFinder();
+
+        try {
+            ModuleSpec spec = finder.findModule("classpath.module.load.test.missing", null);
+
+            assertNull(spec);
+        } catch (ModuleLoadException e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testSlot() {
+        ClasspathModuleFinder finder = new ClasspathModuleFinder();
+
+        try {
+            ModuleSpec spec = finder.findModule("classpath.module.load.test:1.0.0.Final", null);
+
+            assertNotNull(spec);
+        } catch (ModuleLoadException e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testMissingSlot() {
+        ClasspathModuleFinder finder = new ClasspathModuleFinder();
+
+        try {
+            ModuleSpec spec = finder.findModule("classpath.module.load.test:missing", null);
+
+            assertNull(spec);
+        } catch (ModuleLoadException e) {
+            fail();
+        }
+    }
+
+}

--- a/core/bootstrap/src/test/resources/modules/classpath/module/load/test/1.0.0.Final/module.xml
+++ b/core/bootstrap/src/test/resources/modules/classpath/module/load/test/1.0.0.Final/module.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.3" name="classpath.module.load.test" slot="1.0.0.Final"></module>

--- a/core/bootstrap/src/test/resources/modules/classpath/module/load/test/main/module.xml
+++ b/core/bootstrap/src/test/resources/modules/classpath/module/load/test/main/module.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.3" name="classpath.module.load.test"></module>


### PR DESCRIPTION
Motivation
----------
Modules with custom (versioned, not main) slots can't be loaded in an
UberJar deployment, the module can't be found.

Modifications
-------------
Change module identifier to path resolution in findModule() of Bootstrap-
& ClasspathModuleFinder. Differentiate between module name and slot. Only
replace dots in module names with path separators.

Result
------
Modules with custom slots can be loaded.

- [*] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [*] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [*] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [*] Have you built the project locally prior to submission with `mvn clean install`?

-----
