### PR TITLE
ENTSWM-255: Turn transformer tests into integration tests 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,13 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <excludedGroups>${testCategory.excluded}</excludedGroups>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <forkCount>1</forkCount>

--- a/testsuite/testsuite-jsp/src/main/java/org/wildfly/swarm/jsp/TransformerServlet.java
+++ b/testsuite/testsuite-jsp/src/main/java/org/wildfly/swarm/jsp/TransformerServlet.java
@@ -1,0 +1,27 @@
+package org.wildfly.swarm.jsp;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.xml.transform.TransformerFactory;
+
+@WebServlet("/transformer")
+public class TransformerServlet extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+
+        TransformerFactory factory = TransformerFactory.newInstance();
+
+        if ("__redirected.__TransformerFactory".equals(factory.getClass().getName())) {
+            response.getWriter().println(factory.toString());
+        } else  {
+            response.setStatus(500);
+            response.getWriter().print(factory.getClass().getName());
+        }
+    }
+}

--- a/testsuite/testsuite-jsp/src/test/java/org/wildfly/swarm/jsp/test/ArquillianTest.java
+++ b/testsuite/testsuite-jsp/src/test/java/org/wildfly/swarm/jsp/test/ArquillianTest.java
@@ -1,7 +1,5 @@
 package org.wildfly.swarm.jsp.test;
 
-import category.CommunityOnly;
-import category.ProductOnly;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.fluent.Request;
 import org.apache.http.util.EntityUtils;
@@ -12,7 +10,6 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.wildfly.swarm.undertow.WARArchive;
 
@@ -37,25 +34,4 @@ public class ArquillianTest {
         Assert.assertTrue(responseBody.startsWith("No TransformerFactory could be found!"));
     }
 
-    @Test
-    @Category(CommunityOnly.class)
-    @RunAsClient
-    public void verifyTransformerFactoryName_Community() throws Exception {
-        HttpResponse response = Request.Get("http://localhost:8080/transformer").execute().returnResponse();
-        String responseBody = EntityUtils.toString(response.getEntity());
-        Assert.assertEquals(200, response.getStatusLine().getStatusCode());
-        Assert.assertTrue("Expected transformer factory class to be org.apache.xalan.xsltc.trax.TransformerFactoryImpl but was " + responseBody,
-                          responseBody.startsWith("org.apache.xalan.xsltc.trax.TransformerFactoryImpl"));
-    }
-
-    @Test
-    @Category(ProductOnly.class)
-    @RunAsClient
-    public void verifyTransformerFactoryName_Product() throws Exception {
-        HttpResponse response = Request.Get("http://localhost:8080/transformer").execute().returnResponse();
-        String responseBody = EntityUtils.toString(response.getEntity());
-        Assert.assertEquals(200, response.getStatusLine().getStatusCode());
-        Assert.assertTrue("Expected transformer factory class to be org.apache.xalan.processor.TransformerFactoryImpl but was " + responseBody,
-                          responseBody.startsWith("org.apache.xalan.processor.TransformerFactoryImpl"));
-    }
 }

--- a/testsuite/testsuite-jsp/src/test/java/org/wildfly/swarm/jsp/test/TransformerIT.java
+++ b/testsuite/testsuite-jsp/src/test/java/org/wildfly/swarm/jsp/test/TransformerIT.java
@@ -1,0 +1,48 @@
+package org.wildfly.swarm.jsp.test;
+
+/**
+ * Copyright 2017 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import category.CommunityOnly;
+import category.ProductOnly;
+import org.apache.http.client.fluent.Request;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * @author Heiko Braun
+ */
+public class TransformerIT {
+
+    @Test
+    @Category(CommunityOnly.class)
+    public void verifyTransformerFactoryName_Community() throws Exception {
+        String result = Request.Get("http://localhost:8080/transformer").execute().returnContent().asString();
+        Assert.assertTrue("Expected transformer factory class to be org.apache.xalan.xsltc.trax.TransformerFactoryImpl but was " + result,
+                          result.startsWith("org.apache.xalan.xsltc.trax.TransformerFactoryImpl"));
+    }
+
+    @Test
+    @Ignore
+    @Category(ProductOnly.class)
+    public void verifyTransformerFactoryName_Product() throws Exception {
+        String result = Request.Get("http://localhost:8080/transformer").execute().returnContent().asString();
+        Assert.assertTrue("Expected transformer factory class to be org.apache.xalan.processor.TransformerFactoryImpl but was " + result,
+                          result.startsWith("org.apache.xalan.processor.TransformerFactoryImpl"));
+    }
+}


### PR DESCRIPTION
Bypass classloading issues the interfere with test execution. The assertions remains the same, but the test have been turned into integration tests (running against the uberJar, predictable classloading isolation) opposed to the former arquillian tests (fishy classloading, unknow error sources)
