### PR TITLE
SWARM-1784: fix ignore datasource jndi name

### DIFF
--- a/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/DatasourceAndDriverCustomizer.java
+++ b/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/DatasourceAndDriverCustomizer.java
@@ -51,6 +51,7 @@ public class DatasourceAndDriverCustomizer implements Customizer {
     DatasourcesFraction fraction;
 
     private String defaultDatasourceName;
+    private String defaultDatasourceJndiName;
 
     @AttributeDocumentation("Name of the default datasource")
     @Configurable("swarm.ds.name")
@@ -89,6 +90,7 @@ public class DatasourceAndDriverCustomizer implements Customizer {
             this.defaultDatasourceName = createDefaultDatasource();
         } else {
             this.defaultDatasourceName = datasources.get(0).getKey();
+            this.defaultDatasourceJndiName = datasources.get(0).jndiName();
         }
     }
 
@@ -148,11 +150,24 @@ public class DatasourceAndDriverCustomizer implements Customizer {
         }
     }
 
-    @Produces
-    @Dependent
-    @DefaultDatasource
     public String getDatasourceName() {
         return this.defaultDatasourceName;
     }
 
+    @Produces
+    @Dependent
+    @DefaultDatasource
+    public String getDatasourceJndiName() {
+        if (this.defaultDatasourceJndiName == null && this.defaultDatasourceName != null) {
+            for (DataSource ds : this.fraction.subresources().dataSources()) {
+                if (this.defaultDatasourceName.equals(ds.getKey())) {
+                    if (ds.jndiName() != null) {
+                        return ds.jndiName();
+                    }
+                    return "java:jboss/datasources/" + this.defaultDatasourceName;
+                }
+            }
+        }
+        return this.defaultDatasourceJndiName;
+    }
 }

--- a/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/DefaultDatasourceCustomizer.java
+++ b/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/DefaultDatasourceCustomizer.java
@@ -32,16 +32,16 @@ public class DefaultDatasourceCustomizer implements Customizer {
 
     @Inject
     @DefaultDatasource
-    String defaultDatasource;
+    String defaultDatasourceJndiName;
 
     @Inject
     Instance<EE> eeInstance;
 
     @Override
     public void customize() {
-        if (!eeInstance.isUnsatisfied() && defaultDatasource != null) {
+        if (!eeInstance.isUnsatisfied() && defaultDatasourceJndiName != null) {
             eeInstance.get().subresources().defaultBindingsService()
-                    .datasource("java:jboss/datasources/" + defaultDatasource);
+                    .datasource(defaultDatasourceJndiName);
         }
     }
 }


### PR DESCRIPTION
SWARM-1784: fix ignore datasource jndi name

Motivation
----------
The purpose of this commit is to make swarm less rigid about JNDI naming
conventions for JPA data sources.

Modifications
-------------
I have modified the producer method for the datasource so that it will
produce a jndi name instead of the name. That way, if the datasource
jndi is specified and is not in the form `java:jboss/datasource/$name`
it will still work.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
