### PR TITLE
Revert "[maven-release-plugin] prepare for next development iteration"

### DIFF
--- a/arquillian/adapter/pom.xml
+++ b/arquillian/adapter/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/arquillian/arquillian/pom.xml
+++ b/arquillian/arquillian/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/arquillian/daemon/pom.xml
+++ b/arquillian/daemon/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/arquillian/gradle-adapter/pom.xml
+++ b/arquillian/gradle-adapter/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/arquillian/resolver/pom.xml
+++ b/arquillian/resolver/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/arquillian/test/pom.xml
+++ b/arquillian/test/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/boms/bom-all/pom.xml
+++ b/boms/bom-all/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>boms</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/boms/bom-deprecated/pom.xml
+++ b/boms/bom-deprecated/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>boms</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/boms/bom-experimental/pom.xml
+++ b/boms/bom-experimental/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>boms</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/boms/bom-frozen/pom.xml
+++ b/boms/bom-frozen/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>boms</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/boms/bom-locked/pom.xml
+++ b/boms/bom-locked/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>boms</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/boms/bom-stable/pom.xml
+++ b/boms/bom-stable/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>boms</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/boms/bom-unstable/pom.xml
+++ b/boms/bom-unstable/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>boms</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/boms/bom/pom.xml
+++ b/boms/bom/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>boms</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/boms/pom.xml
+++ b/boms/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>wildfly-swarm</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/build-resources/pom.xml
+++ b/build-resources/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.wildfly.swarm</groupId>
   <artifactId>build-resources</artifactId>
-  <version>2018.2.0-SNAPSHOT</version>
+  <version>2018.1.0-SNAPSHOT</version>
 
   <name>WildFly Swarm Build Resources</name>
   <description>Resources that are necessary for building WildFly Swarm</description>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/client-apis/health-api/pom.xml
+++ b/client-apis/health-api/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/client-apis/jaxrs-client-api/pom.xml
+++ b/client-apis/jaxrs-client-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/core/bootstrap/pom.xml
+++ b/core/bootstrap/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/core/container/pom.xml
+++ b/core/container/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/core/spi/pom.xml
+++ b/core/spi/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/docs/howto/autodetect-fractions/pom.xml
+++ b/docs/howto/autodetect-fractions/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.wildfly.swarm.howto</groupId>
     <artifactId>howto-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -27,7 +27,7 @@
       <plugin>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>wildfly-swarm-plugin</artifactId>
-        <version>${project.version}</version>
+        <version>${version.wildfly-swarm}</version>
         <executions>
           <execution>
             <id>package</id>
@@ -115,7 +115,7 @@
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>bom</artifactId>
-        <version>${project.version}</version>
+        <version>${version.wildfly-swarm}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/docs/howto/create-a-datasource/pom.xml
+++ b/docs/howto/create-a-datasource/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.wildfly.swarm.howto</groupId>
     <artifactId>howto-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -26,7 +26,7 @@
       <plugin>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>wildfly-swarm-plugin</artifactId>
-        <version>${project.version}</version>
+        <version>${version.wildfly-swarm}</version>
         <executions>
           <execution>
             <id>package</id>
@@ -111,7 +111,7 @@
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>bom</artifactId>
-        <version>${project.version}</version>
+        <version>${version.wildfly-swarm}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/docs/howto/create-a-fraction/pom.xml
+++ b/docs/howto/create-a-fraction/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.wildfly.swarm.howto</groupId>
     <artifactId>howto-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/docs/howto/create-a-hollow-jar/pom.xml
+++ b/docs/howto/create-a-hollow-jar/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.wildfly.swarm.howto</groupId>
     <artifactId>howto-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -27,7 +27,7 @@
       <plugin>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>wildfly-swarm-plugin</artifactId>
-        <version>${project.version}</version>
+        <version>${version.wildfly-swarm}</version>
         <executions>
           <execution>
             <id>package</id>
@@ -118,7 +118,7 @@
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>bom</artifactId>
-        <version>${project.version}</version>
+        <version>${version.wildfly-swarm}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/docs/howto/create-an-uberjar/pom.xml
+++ b/docs/howto/create-an-uberjar/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.wildfly.swarm.howto</groupId>
     <artifactId>howto-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -27,7 +27,7 @@
       <plugin>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>wildfly-swarm-plugin</artifactId>
-        <version>${project.version}</version>
+        <version>${version.wildfly-swarm}</version>
         <executions>
           <execution>
             <id>package</id>
@@ -115,7 +115,7 @@
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>bom</artifactId>
-        <version>${project.version}</version>
+        <version>${version.wildfly-swarm}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/docs/howto/explicit-fractions/pom.xml
+++ b/docs/howto/explicit-fractions/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.wildfly.swarm.howto</groupId>
     <artifactId>howto-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -27,7 +27,7 @@
       <plugin>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>wildfly-swarm-plugin</artifactId>
-        <version>${project.version}</version>
+        <version>${version.wildfly-swarm}</version>
         <executions>
           <execution>
             <id>package</id>
@@ -115,7 +115,7 @@
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>bom</artifactId>
-        <version>${project.version}</version>
+        <version>${version.wildfly-swarm}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/docs/howto/pom.xml
+++ b/docs/howto/pom.xml
@@ -9,12 +9,13 @@
 
   <groupId>org.wildfly.swarm.howto</groupId>
   <artifactId>howto-parent</artifactId>
-  <version>2018.2.0-SNAPSHOT</version>
+  <version>2018.1.0-SNAPSHOT</version>
 
   <name>WildFly Swarm HOWTO: Parent</name>
   <packaging>pom</packaging>
 
   <properties>
+    <version.wildfly-swarm>${project.version}</version.wildfly-swarm>
     <version.maven-war-plugin>2.2</version.maven-war-plugin>
     <version.maven-failsafe-plugin>2.19.1</version.maven-failsafe-plugin>
     <version.build-helper-maven-plugin>1.9.1</version.build-helper-maven-plugin>
@@ -88,7 +89,7 @@
       <plugin>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>wildfly-swarm-plugin</artifactId>
-        <version>${project.version}</version>
+        <version>${version.wildfly-swarm}</version>
         <executions>
           <execution>
             <goals>

--- a/docs/howto/test-in-container/pom.xml
+++ b/docs/howto/test-in-container/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.wildfly.swarm.howto</groupId>
     <artifactId>howto-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -35,7 +35,7 @@
           <dependency>
             <groupId>org.wildfly.swarm</groupId>
             <artifactId>bom-certified</artifactId>
-            <version>${project.version}</version>
+            <version>${version.wildfly-swarm}</version>
             <type>pom</type>
             <scope>import</scope>
           </dependency>
@@ -50,7 +50,7 @@
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>bom</artifactId>
-        <version>${project.version}</version>
+        <version>${version.wildfly-swarm}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/docs/howto/use-a-bom/pom.xml
+++ b/docs/howto/use-a-bom/pom.xml
@@ -13,7 +13,7 @@
    <parent>
     <groupId>org.wildfly.swarm.howto</groupId>
     <artifactId>howto-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -23,6 +23,7 @@
 
   <properties>
     <!-- tag::property[] -->
+    <version.wildfly-swarm>2018.1.0-SNAPSHOT</version.wildfly-swarm>
     <!-- end::property[] -->
   </properties>
 
@@ -32,7 +33,7 @@
         <!-- tag::plugin[] -->
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>wildfly-swarm-plugin</artifactId>
-        <version>${project.version}</version>
+        <version>${version.wildfly-swarm}</version>
         <!-- end::plugin[] -->
         <executions>
           <execution>
@@ -119,7 +120,7 @@
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>bom</artifactId>
-        <version>${project.version}</version>
+        <version>${version.wildfly-swarm}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -130,7 +131,7 @@
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>bom-unstable</artifactId>
-        <version>${project.version}</version>
+        <version>${version.wildfly-swarm}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/docs/reference/pom.xml
+++ b/docs/reference/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/asciidoctorj/pom.xml
+++ b/fractions/asciidoctorj/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>build-parent</artifactId>
-      <version>2018.2.0-SNAPSHOT</version>
+      <version>2018.1.0-SNAPSHOT</version>
       <relativePath>../../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/fractions/camel/components/activemq/pom.xml
+++ b/fractions/camel/components/activemq/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Activemq</name>

--- a/fractions/camel/components/ahc-ws/pom.xml
+++ b/fractions/camel/components/ahc-ws/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Ahc-ws</name>

--- a/fractions/camel/components/ahc/pom.xml
+++ b/fractions/camel/components/ahc/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Ahc</name>

--- a/fractions/camel/components/amqp/pom.xml
+++ b/fractions/camel/components/amqp/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Amqp</name>

--- a/fractions/camel/components/atom/pom.xml
+++ b/fractions/camel/components/atom/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Atom</name>

--- a/fractions/camel/components/avro/pom.xml
+++ b/fractions/camel/components/avro/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Avro</name>

--- a/fractions/camel/components/aws/pom.xml
+++ b/fractions/camel/components/aws/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Aws</name>

--- a/fractions/camel/components/barcode/pom.xml
+++ b/fractions/camel/components/barcode/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Barcode</name>

--- a/fractions/camel/components/base64/pom.xml
+++ b/fractions/camel/components/base64/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Base64</name>

--- a/fractions/camel/components/bean-validator/pom.xml
+++ b/fractions/camel/components/bean-validator/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Bean-validator</name>

--- a/fractions/camel/components/beanio/pom.xml
+++ b/fractions/camel/components/beanio/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Beanio</name>

--- a/fractions/camel/components/bindy/pom.xml
+++ b/fractions/camel/components/bindy/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Bindy</name>

--- a/fractions/camel/components/box/pom.xml
+++ b/fractions/camel/components/box/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Box</name>

--- a/fractions/camel/components/braintree/pom.xml
+++ b/fractions/camel/components/braintree/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Braintree</name>

--- a/fractions/camel/components/cassandraql/pom.xml
+++ b/fractions/camel/components/cassandraql/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Cassandraql</name>

--- a/fractions/camel/components/castor/pom.xml
+++ b/fractions/camel/components/castor/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Castor</name>

--- a/fractions/camel/components/cdi/pom.xml
+++ b/fractions/camel/components/cdi/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Cdi</name>

--- a/fractions/camel/components/coap/pom.xml
+++ b/fractions/camel/components/coap/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Coap</name>

--- a/fractions/camel/components/context/pom.xml
+++ b/fractions/camel/components/context/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Context</name>

--- a/fractions/camel/components/couchdb/pom.xml
+++ b/fractions/camel/components/couchdb/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Couchdb</name>

--- a/fractions/camel/components/crypto/pom.xml
+++ b/fractions/camel/components/crypto/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Crypto</name>

--- a/fractions/camel/components/csv/pom.xml
+++ b/fractions/camel/components/csv/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Csv</name>

--- a/fractions/camel/components/cxf/pom.xml
+++ b/fractions/camel/components/cxf/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Cxf</name>

--- a/fractions/camel/components/dns/pom.xml
+++ b/fractions/camel/components/dns/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Dns</name>

--- a/fractions/camel/components/dozer/pom.xml
+++ b/fractions/camel/components/dozer/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Dozer</name>

--- a/fractions/camel/components/dropbox/pom.xml
+++ b/fractions/camel/components/dropbox/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Dropbox</name>

--- a/fractions/camel/components/ejb/pom.xml
+++ b/fractions/camel/components/ejb/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Ejb</name>

--- a/fractions/camel/components/elasticsearch/pom.xml
+++ b/fractions/camel/components/elasticsearch/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Elasticsearch</name>

--- a/fractions/camel/components/elsql/pom.xml
+++ b/fractions/camel/components/elsql/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Elsql</name>

--- a/fractions/camel/components/exec/pom.xml
+++ b/fractions/camel/components/exec/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Exec</name>

--- a/fractions/camel/components/facebook/pom.xml
+++ b/fractions/camel/components/facebook/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Facebook</name>

--- a/fractions/camel/components/flatpack/pom.xml
+++ b/fractions/camel/components/flatpack/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Flatpack</name>

--- a/fractions/camel/components/freemarker/pom.xml
+++ b/fractions/camel/components/freemarker/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Freemarker</name>

--- a/fractions/camel/components/ftp/pom.xml
+++ b/fractions/camel/components/ftp/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Ftp</name>

--- a/fractions/camel/components/git/pom.xml
+++ b/fractions/camel/components/git/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Git</name>

--- a/fractions/camel/components/github/pom.xml
+++ b/fractions/camel/components/github/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Github</name>

--- a/fractions/camel/components/groovy/pom.xml
+++ b/fractions/camel/components/groovy/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Groovy</name>

--- a/fractions/camel/components/gson/pom.xml
+++ b/fractions/camel/components/gson/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Gson</name>

--- a/fractions/camel/components/hl7/pom.xml
+++ b/fractions/camel/components/hl7/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Hl7</name>

--- a/fractions/camel/components/http4/pom.xml
+++ b/fractions/camel/components/http4/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Http4</name>

--- a/fractions/camel/components/hystrix/pom.xml
+++ b/fractions/camel/components/hystrix/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Hystrix</name>

--- a/fractions/camel/components/infinispan/pom.xml
+++ b/fractions/camel/components/infinispan/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Infinispan</name>

--- a/fractions/camel/components/influxdb/pom.xml
+++ b/fractions/camel/components/influxdb/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Influxdb</name>

--- a/fractions/camel/components/irc/pom.xml
+++ b/fractions/camel/components/irc/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Irc</name>

--- a/fractions/camel/components/jackson/pom.xml
+++ b/fractions/camel/components/jackson/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Jackson</name>

--- a/fractions/camel/components/jacksonxml/pom.xml
+++ b/fractions/camel/components/jacksonxml/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Jacksonxml</name>

--- a/fractions/camel/components/jasypt/pom.xml
+++ b/fractions/camel/components/jasypt/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Jasypt</name>

--- a/fractions/camel/components/jaxb/pom.xml
+++ b/fractions/camel/components/jaxb/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Jaxb</name>

--- a/fractions/camel/components/jbpm/pom.xml
+++ b/fractions/camel/components/jbpm/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Jbpm</name>

--- a/fractions/camel/components/jcache/pom.xml
+++ b/fractions/camel/components/jcache/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Jcache</name>

--- a/fractions/camel/components/jdbc/pom.xml
+++ b/fractions/camel/components/jdbc/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Jdbc</name>

--- a/fractions/camel/components/jgroups/pom.xml
+++ b/fractions/camel/components/jgroups/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Jgroups</name>

--- a/fractions/camel/components/jms/pom.xml
+++ b/fractions/camel/components/jms/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Jms</name>

--- a/fractions/camel/components/jmx/pom.xml
+++ b/fractions/camel/components/jmx/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Jmx</name>

--- a/fractions/camel/components/jpa/pom.xml
+++ b/fractions/camel/components/jpa/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Jpa</name>

--- a/fractions/camel/components/jsch/pom.xml
+++ b/fractions/camel/components/jsch/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Jsch</name>

--- a/fractions/camel/components/jsonpath/pom.xml
+++ b/fractions/camel/components/jsonpath/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Jsonpath</name>

--- a/fractions/camel/components/kafka/pom.xml
+++ b/fractions/camel/components/kafka/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Kafka</name>

--- a/fractions/camel/components/kubernetes/pom.xml
+++ b/fractions/camel/components/kubernetes/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Kubernetes</name>

--- a/fractions/camel/components/ldap/pom.xml
+++ b/fractions/camel/components/ldap/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Ldap</name>

--- a/fractions/camel/components/linkedin/pom.xml
+++ b/fractions/camel/components/linkedin/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Linkedin</name>

--- a/fractions/camel/components/lucene/pom.xml
+++ b/fractions/camel/components/lucene/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Lucene</name>

--- a/fractions/camel/components/mail/pom.xml
+++ b/fractions/camel/components/mail/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Mail</name>

--- a/fractions/camel/components/metrics/pom.xml
+++ b/fractions/camel/components/metrics/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Metrics</name>

--- a/fractions/camel/components/mina2/pom.xml
+++ b/fractions/camel/components/mina2/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Mina2</name>

--- a/fractions/camel/components/mllp/pom.xml
+++ b/fractions/camel/components/mllp/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Mllp</name>

--- a/fractions/camel/components/mongodb/pom.xml
+++ b/fractions/camel/components/mongodb/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Mongodb</name>

--- a/fractions/camel/components/mqtt/pom.xml
+++ b/fractions/camel/components/mqtt/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Mqtt</name>

--- a/fractions/camel/components/mvel/pom.xml
+++ b/fractions/camel/components/mvel/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Mvel</name>

--- a/fractions/camel/components/mybatis/pom.xml
+++ b/fractions/camel/components/mybatis/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Mybatis</name>

--- a/fractions/camel/components/nats/pom.xml
+++ b/fractions/camel/components/nats/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Nats</name>

--- a/fractions/camel/components/netty4/pom.xml
+++ b/fractions/camel/components/netty4/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Netty4</name>

--- a/fractions/camel/components/ognl/pom.xml
+++ b/fractions/camel/components/ognl/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Ognl</name>

--- a/fractions/camel/components/olingo2/pom.xml
+++ b/fractions/camel/components/olingo2/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Olingo2</name>

--- a/fractions/camel/components/optaplanner/pom.xml
+++ b/fractions/camel/components/optaplanner/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Optaplanner</name>

--- a/fractions/camel/components/paho/pom.xml
+++ b/fractions/camel/components/paho/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Paho</name>

--- a/fractions/camel/components/pdf/pom.xml
+++ b/fractions/camel/components/pdf/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Pdf</name>

--- a/fractions/camel/components/pom.xml
+++ b/fractions/camel/components/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>camel</artifactId>
-        <version>2018.2.0-SNAPSHOT</version>
+        <version>2018.1.0-SNAPSHOT</version>
     </parent>
     
     <name>Camel Components</name>

--- a/fractions/camel/components/protobuf/pom.xml
+++ b/fractions/camel/components/protobuf/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Protobuf</name>

--- a/fractions/camel/components/quartz2/pom.xml
+++ b/fractions/camel/components/quartz2/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Quartz2</name>

--- a/fractions/camel/components/rabbitmq/pom.xml
+++ b/fractions/camel/components/rabbitmq/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Rabbitmq</name>

--- a/fractions/camel/components/reactive-streams/pom.xml
+++ b/fractions/camel/components/reactive-streams/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Reactive-streams</name>

--- a/fractions/camel/components/rest-swagger/pom.xml
+++ b/fractions/camel/components/rest-swagger/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Rest-swagger</name>

--- a/fractions/camel/components/rss/pom.xml
+++ b/fractions/camel/components/rss/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Rss</name>

--- a/fractions/camel/components/salesforce/pom.xml
+++ b/fractions/camel/components/salesforce/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Salesforce</name>

--- a/fractions/camel/components/sap-netweaver/pom.xml
+++ b/fractions/camel/components/sap-netweaver/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Sap-netweaver</name>

--- a/fractions/camel/components/saxon/pom.xml
+++ b/fractions/camel/components/saxon/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Saxon</name>

--- a/fractions/camel/components/schematron/pom.xml
+++ b/fractions/camel/components/schematron/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Schematron</name>

--- a/fractions/camel/components/script/pom.xml
+++ b/fractions/camel/components/script/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Script</name>

--- a/fractions/camel/components/servicenow/pom.xml
+++ b/fractions/camel/components/servicenow/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Servicenow</name>

--- a/fractions/camel/components/servlet/pom.xml
+++ b/fractions/camel/components/servlet/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Servlet</name>

--- a/fractions/camel/components/sjms/pom.xml
+++ b/fractions/camel/components/sjms/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Sjms</name>

--- a/fractions/camel/components/sjms2/pom.xml
+++ b/fractions/camel/components/sjms2/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Sjms2</name>

--- a/fractions/camel/components/smpp/pom.xml
+++ b/fractions/camel/components/smpp/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Smpp</name>

--- a/fractions/camel/components/snakeyaml/pom.xml
+++ b/fractions/camel/components/snakeyaml/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Snakeyaml</name>

--- a/fractions/camel/components/snmp/pom.xml
+++ b/fractions/camel/components/snmp/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Snmp</name>

--- a/fractions/camel/components/soap/pom.xml
+++ b/fractions/camel/components/soap/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Soap</name>

--- a/fractions/camel/components/splunk/pom.xml
+++ b/fractions/camel/components/splunk/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Splunk</name>

--- a/fractions/camel/components/spring-batch/pom.xml
+++ b/fractions/camel/components/spring-batch/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Spring-batch</name>

--- a/fractions/camel/components/spring-integration/pom.xml
+++ b/fractions/camel/components/spring-integration/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Spring-integration</name>

--- a/fractions/camel/components/spring-ldap/pom.xml
+++ b/fractions/camel/components/spring-ldap/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Spring-ldap</name>

--- a/fractions/camel/components/spring-redis/pom.xml
+++ b/fractions/camel/components/spring-redis/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Spring-redis</name>

--- a/fractions/camel/components/spring-security/pom.xml
+++ b/fractions/camel/components/spring-security/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Spring-security</name>

--- a/fractions/camel/components/sql/pom.xml
+++ b/fractions/camel/components/sql/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Sql</name>

--- a/fractions/camel/components/ssh/pom.xml
+++ b/fractions/camel/components/ssh/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Ssh</name>

--- a/fractions/camel/components/stax/pom.xml
+++ b/fractions/camel/components/stax/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Stax</name>

--- a/fractions/camel/components/stream/pom.xml
+++ b/fractions/camel/components/stream/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Stream</name>

--- a/fractions/camel/components/swagger/pom.xml
+++ b/fractions/camel/components/swagger/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Swagger</name>

--- a/fractions/camel/components/syslog/pom.xml
+++ b/fractions/camel/components/syslog/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Syslog</name>

--- a/fractions/camel/components/tagsoup/pom.xml
+++ b/fractions/camel/components/tagsoup/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Tagsoup</name>

--- a/fractions/camel/components/tarfile/pom.xml
+++ b/fractions/camel/components/tarfile/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Tarfile</name>

--- a/fractions/camel/components/twitter/pom.xml
+++ b/fractions/camel/components/twitter/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Twitter</name>

--- a/fractions/camel/components/undertow/pom.xml
+++ b/fractions/camel/components/undertow/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Undertow</name>

--- a/fractions/camel/components/velocity/pom.xml
+++ b/fractions/camel/components/velocity/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Velocity</name>

--- a/fractions/camel/components/vertx/pom.xml
+++ b/fractions/camel/components/vertx/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Vertx</name>

--- a/fractions/camel/components/weather/pom.xml
+++ b/fractions/camel/components/weather/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Weather</name>

--- a/fractions/camel/components/xmlbeans/pom.xml
+++ b/fractions/camel/components/xmlbeans/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Xmlbeans</name>

--- a/fractions/camel/components/xmlsecurity/pom.xml
+++ b/fractions/camel/components/xmlsecurity/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Xmlsecurity</name>

--- a/fractions/camel/components/xstream/pom.xml
+++ b/fractions/camel/components/xstream/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Xstream</name>

--- a/fractions/camel/components/zipfile/pom.xml
+++ b/fractions/camel/components/zipfile/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Zipfile</name>

--- a/fractions/camel/components/zipkin/pom.xml
+++ b/fractions/camel/components/zipkin/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Zipkin</name>

--- a/fractions/camel/components/zookeeper/pom.xml
+++ b/fractions/camel/components/zookeeper/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Component :: Zookeeper</name>

--- a/fractions/camel/core/pom.xml
+++ b/fractions/camel/core/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>camel</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Camel Core</name>

--- a/fractions/camel/pom.xml
+++ b/fractions/camel/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/cdi-extensions/cdi-config/pom.xml
+++ b/fractions/cdi-extensions/cdi-config/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/cdi-extensions/cdi-jaxrsapi/pom.xml
+++ b/fractions/cdi-extensions/cdi-jaxrsapi/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/drools-server/pom.xml
+++ b/fractions/drools-server/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/fluentd/pom.xml
+++ b/fractions/fluentd/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/flyway/pom.xml
+++ b/fractions/flyway/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>build-parent</artifactId>
-        <version>2018.2.0-SNAPSHOT</version>
+        <version>2018.1.0-SNAPSHOT</version>
         <relativePath>../../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/fractions/jaeger/pom.xml
+++ b/fractions/jaeger/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/batch-jberet/pom.xml
+++ b/fractions/javaee/batch-jberet/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/bean-validation/pom.xml
+++ b/fractions/javaee/bean-validation/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/cdi/pom.xml
+++ b/fractions/javaee/cdi/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/connector/pom.xml
+++ b/fractions/javaee/connector/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/datasources/pom.xml
+++ b/fractions/javaee/datasources/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/ee/pom.xml
+++ b/fractions/javaee/ee/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/ejb-remote/pom.xml
+++ b/fractions/javaee/ejb-remote/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/ejb/pom.xml
+++ b/fractions/javaee/ejb/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/jaxrs-cdi/pom.xml
+++ b/fractions/javaee/jaxrs-cdi/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/jaxrs-jaxb/pom.xml
+++ b/fractions/javaee/jaxrs-jaxb/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/jaxrs-jsonp/pom.xml
+++ b/fractions/javaee/jaxrs-jsonp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/jaxrs-multipart/pom.xml
+++ b/fractions/javaee/jaxrs-multipart/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/jaxrs-validator/pom.xml
+++ b/fractions/javaee/jaxrs-validator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/jaxrs/pom.xml
+++ b/fractions/javaee/jaxrs/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/jca/pom.xml
+++ b/fractions/javaee/jca/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/jmx/pom.xml
+++ b/fractions/javaee/jmx/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/jpa-eclipselink/pom.xml
+++ b/fractions/javaee/jpa-eclipselink/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/jpa-spatial/pom.xml
+++ b/fractions/javaee/jpa-spatial/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/jpa/pom.xml
+++ b/fractions/javaee/jpa/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/jsf/pom.xml
+++ b/fractions/javaee/jsf/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/jsonp/pom.xml
+++ b/fractions/javaee/jsonp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/mail/pom.xml
+++ b/fractions/javaee/mail/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/messaging/pom.xml
+++ b/fractions/javaee/messaging/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/naming/pom.xml
+++ b/fractions/javaee/naming/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/remoting/pom.xml
+++ b/fractions/javaee/remoting/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/resource-adapters/pom.xml
+++ b/fractions/javaee/resource-adapters/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/transactions/pom.xml
+++ b/fractions/javaee/transactions/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/undertow/pom.xml
+++ b/fractions/javaee/undertow/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/web/pom.xml
+++ b/fractions/javaee/web/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javaee/webservices/pom.xml
+++ b/fractions/javaee/webservices/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/javafx/pom.xml
+++ b/fractions/javafx/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/jolokia/pom.xml
+++ b/fractions/jolokia/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/keycloak-server/pom.xml
+++ b/fractions/keycloak-server/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/keycloak/pom.xml
+++ b/fractions/keycloak/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/logstash/pom.xml
+++ b/fractions/logstash/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/microprofile/microprofile-config/pom.xml
+++ b/fractions/microprofile/microprofile-config/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>build-parent</artifactId>
-        <version>2018.2.0-SNAPSHOT</version>
+        <version>2018.1.0-SNAPSHOT</version>
         <relativePath>../../../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/fractions/microprofile/microprofile-fault-tolerance/pom.xml
+++ b/fractions/microprofile/microprofile-fault-tolerance/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/microprofile/microprofile-health/pom.xml
+++ b/fractions/microprofile/microprofile-health/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/microprofile/microprofile-jwt/pom.xml
+++ b/fractions/microprofile/microprofile-jwt/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/microprofile/microprofile-metrics/pom.xml
+++ b/fractions/microprofile/microprofile-metrics/pom.xml
@@ -4,13 +4,14 @@
 ~
 ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/microprofile/microprofile/pom.xml
+++ b/fractions/microprofile/microprofile/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/monitor/pom.xml
+++ b/fractions/monitor/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/netflix/archaius/pom.xml
+++ b/fractions/netflix/archaius/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>netflix-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/fractions/netflix/guava/pom.xml
+++ b/fractions/netflix/guava/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>netflix-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/fractions/netflix/hystrix/pom.xml
+++ b/fractions/netflix/hystrix/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>netflix-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/fractions/netflix/pom.xml
+++ b/fractions/netflix/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/netflix/ribbon-secured-client/pom.xml
+++ b/fractions/netflix/ribbon-secured-client/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>netflix-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/fractions/netflix/ribbon-secured/pom.xml
+++ b/fractions/netflix/ribbon-secured/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>netflix-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/fractions/netflix/ribbon/pom.xml
+++ b/fractions/netflix/ribbon/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>netflix-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/fractions/netflix/rxjava/pom.xml
+++ b/fractions/netflix/rxjava/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>netflix-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/fractions/netflix/rxnetty/pom.xml
+++ b/fractions/netflix/rxnetty/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>netflix-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/fractions/netflix/servo/pom.xml
+++ b/fractions/netflix/servo/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>netflix-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/fractions/nosql/cassandra/pom.xml
+++ b/fractions/nosql/cassandra/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/nosql/mongodb/pom.xml
+++ b/fractions/nosql/mongodb/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/nosql/neo4j/pom.xml
+++ b/fractions/nosql/neo4j/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/nosql/orientdb/pom.xml
+++ b/fractions/nosql/orientdb/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/opentracing/pom.xml
+++ b/fractions/opentracing/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/spring/pom.xml
+++ b/fractions/spring/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/swagger-webapp/pom.xml
+++ b/fractions/swagger-webapp/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/swagger/pom.xml
+++ b/fractions/swagger/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/teiid/components/accumulo/pom.xml
+++ b/fractions/teiid/components/accumulo/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>teiid-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Teiid Accumulo Translator</name>

--- a/fractions/teiid/components/amazon-s3/pom.xml
+++ b/fractions/teiid/components/amazon-s3/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>teiid-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Teiid Amazon S3 Translator</name>

--- a/fractions/teiid/components/cassandra/pom.xml
+++ b/fractions/teiid/components/cassandra/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>teiid-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Teiid Cassandra Translator</name>

--- a/fractions/teiid/components/couchbase/pom.xml
+++ b/fractions/teiid/components/couchbase/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>teiid-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Teiid Couchbase Translator</name>

--- a/fractions/teiid/components/excel/pom.xml
+++ b/fractions/teiid/components/excel/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>teiid-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Teiid Excel Translator</name>

--- a/fractions/teiid/components/file/pom.xml
+++ b/fractions/teiid/components/file/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>teiid-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Teiid File Translator</name>

--- a/fractions/teiid/components/ftp/pom.xml
+++ b/fractions/teiid/components/ftp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>teiid-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Teiid File Ftp Translator</name>

--- a/fractions/teiid/components/google/pom.xml
+++ b/fractions/teiid/components/google/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>teiid-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Teiid Google Translator</name>

--- a/fractions/teiid/components/infinispan-hotrod/pom.xml
+++ b/fractions/teiid/components/infinispan-hotrod/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>teiid-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Teiid Infinispan Hotrod Translator</name>

--- a/fractions/teiid/components/jdbc/pom.xml
+++ b/fractions/teiid/components/jdbc/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>teiid-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Teiid JDBC Translator</name>

--- a/fractions/teiid/components/ldap/pom.xml
+++ b/fractions/teiid/components/ldap/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>teiid-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Teiid LDAP Translator</name>

--- a/fractions/teiid/components/loopback/pom.xml
+++ b/fractions/teiid/components/loopback/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>teiid-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Teiid Loopback Translator</name>

--- a/fractions/teiid/components/mongodb/pom.xml
+++ b/fractions/teiid/components/mongodb/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>teiid-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Teiid MongoDB Translator</name>

--- a/fractions/teiid/components/odata/pom.xml
+++ b/fractions/teiid/components/odata/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>teiid-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Teiid OData V2 Translator</name>

--- a/fractions/teiid/components/odata4/pom.xml
+++ b/fractions/teiid/components/odata4/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>teiid-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Teiid OData V4 Translator</name>

--- a/fractions/teiid/components/olap/pom.xml
+++ b/fractions/teiid/components/olap/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>teiid-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Teiid OLAP Translator</name>

--- a/fractions/teiid/components/pom.xml
+++ b/fractions/teiid/components/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>teiid-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Teiid Components</name>

--- a/fractions/teiid/components/salesforce-34/pom.xml
+++ b/fractions/teiid/components/salesforce-34/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>teiid-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Teiid Salesforce 34 Translator</name>

--- a/fractions/teiid/components/salesforce-41/pom.xml
+++ b/fractions/teiid/components/salesforce-41/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>teiid-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Teiid Salesforce API Version 41 Translator</name>

--- a/fractions/teiid/components/salesforce/pom.xml
+++ b/fractions/teiid/components/salesforce/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>teiid-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Teiid Salesforce Translator</name>

--- a/fractions/teiid/components/simpledb/pom.xml
+++ b/fractions/teiid/components/simpledb/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>teiid-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Teiid SimpleDB Translator</name>

--- a/fractions/teiid/components/solr/pom.xml
+++ b/fractions/teiid/components/solr/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>teiid-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Teiid SOLR Translator</name>

--- a/fractions/teiid/components/swagger/pom.xml
+++ b/fractions/teiid/components/swagger/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>teiid-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Teiid Swagger Translator</name>

--- a/fractions/teiid/components/ws/pom.xml
+++ b/fractions/teiid/components/ws/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>teiid-components</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Teiid WebService (REST) Translator</name>

--- a/fractions/teiid/core/pom.xml
+++ b/fractions/teiid/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>teiid-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>teiid</artifactId>
   <name>Teiid Fraction</name>

--- a/fractions/teiid/odata/pom.xml
+++ b/fractions/teiid/odata/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>teiid-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>odata</artifactId>
   <name>Teiid OData</name>

--- a/fractions/teiid/pom.xml
+++ b/fractions/teiid/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/topology-consul/pom.xml
+++ b/fractions/topology-consul/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/topology-jgroups/pom.xml
+++ b/fractions/topology-jgroups/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/topology-openshift/pom.xml
+++ b/fractions/topology-openshift/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/topology-webapp/pom.xml
+++ b/fractions/topology-webapp/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/topology/pom.xml
+++ b/fractions/topology/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/vertx/pom.xml
+++ b/fractions/vertx/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/wildfly/cli/pom.xml
+++ b/fractions/wildfly/cli/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/wildfly/elytron/pom.xml
+++ b/fractions/wildfly/elytron/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/wildfly/hibernate-search/pom.xml
+++ b/fractions/wildfly/hibernate-search/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/wildfly/hibernate-validator/pom.xml
+++ b/fractions/wildfly/hibernate-validator/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/wildfly/infinispan/pom.xml
+++ b/fractions/wildfly/infinispan/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/wildfly/io/pom.xml
+++ b/fractions/wildfly/io/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/wildfly/jdr/pom.xml
+++ b/fractions/wildfly/jdr/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/wildfly/jgroups/pom.xml
+++ b/fractions/wildfly/jgroups/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/wildfly/logging/pom.xml
+++ b/fractions/wildfly/logging/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/wildfly/management-console/pom.xml
+++ b/fractions/wildfly/management-console/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/wildfly/management/pom.xml
+++ b/fractions/wildfly/management/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/wildfly/mod_cluster/pom.xml
+++ b/fractions/wildfly/mod_cluster/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/wildfly/msc/pom.xml
+++ b/fractions/wildfly/msc/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/wildfly/request-controller/pom.xml
+++ b/fractions/wildfly/request-controller/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/wildfly/scanner/pom.xml
+++ b/fractions/wildfly/scanner/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/wildfly/security/pom.xml
+++ b/fractions/wildfly/security/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/fractions/zipkin-jaxrs/pom.xml
+++ b/fractions/zipkin-jaxrs/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/maven-enforcer-pattern-size/pom.xml
+++ b/maven-enforcer-pattern-size/pom.xml
@@ -16,7 +16,7 @@
 
   <groupId>org.wildfly.swarm</groupId>
   <artifactId>wildfly-swarm-enforcer-pattern-size</artifactId>
-  <version>2018.2.0-SNAPSHOT</version>
+  <version>2018.1.0-SNAPSHOT</version>
 
   <name>Maven enforcer pattern size rule</name>
   <description>Maven enforcer pattern size rule</description>

--- a/meta/fraction-metadata/pom.xml
+++ b/meta/fraction-metadata/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/meta/meta-spi/pom.xml
+++ b/meta/meta-spi/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/plugins/gradle/pom.xml
+++ b/plugins/gradle/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/plugins/maven/pom.xml
+++ b/plugins/maven/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   </parent>
 
   <artifactId>wildfly-swarm</artifactId>
-  <version>2018.2.0-SNAPSHOT</version>
+  <version>2018.1.0-SNAPSHOT</version>
 
   <name>Root</name>
   <description>Root</description>

--- a/release/pom.xml
+++ b/release/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/standalone-servers/keycloak/pom.xml
+++ b/standalone-servers/keycloak/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.servers</groupId>
     <artifactId>standalone-servers</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/standalone-servers/management-console/pom.xml
+++ b/standalone-servers/management-console/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.servers</groupId>
     <artifactId>standalone-servers</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/standalone-servers/microprofile/pom.xml
+++ b/standalone-servers/microprofile/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.servers</groupId>
     <artifactId>standalone-servers</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/standalone-servers/pom.xml
+++ b/standalone-servers/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/standalone-servers/swagger-ui/pom.xml
+++ b/standalone-servers/swagger-ui/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.servers</groupId>
     <artifactId>standalone-servers</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/swarmtool/pom.xml
+++ b/swarmtool/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 

--- a/testsuite/microprofile-tcks/config/pom.xml
+++ b/testsuite/microprofile-tcks/config/pom.xml
@@ -26,7 +26,7 @@
    <parent>
       <groupId>org.wildfly.swarm.testsuite</groupId>
       <artifactId>wildlfy-swarm-microprofile-tck-parent</artifactId>
-      <version>2018.2.0-SNAPSHOT</version>
+      <version>2018.1.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>wildlfy-swarm-microprofile-tck-config</artifactId>

--- a/testsuite/microprofile-tcks/fault-tolerance/pom.xml
+++ b/testsuite/microprofile-tcks/fault-tolerance/pom.xml
@@ -26,7 +26,7 @@
    <parent>
       <groupId>org.wildfly.swarm.testsuite</groupId>
       <artifactId>wildlfy-swarm-microprofile-tck-parent</artifactId>
-      <version>2018.2.0-SNAPSHOT</version>
+      <version>2018.1.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>wildlfy-swarm-microprofile-tck-fault-tolerance</artifactId>

--- a/testsuite/microprofile-tcks/health/pom.xml
+++ b/testsuite/microprofile-tcks/health/pom.xml
@@ -26,7 +26,7 @@
    <parent>
       <groupId>org.wildfly.swarm.testsuite</groupId>
       <artifactId>wildlfy-swarm-microprofile-tck-parent</artifactId>
-      <version>2018.2.0-SNAPSHOT</version>
+      <version>2018.1.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/testsuite/microprofile-tcks/jwt-auth/pom.xml
+++ b/testsuite/microprofile-tcks/jwt-auth/pom.xml
@@ -26,7 +26,7 @@
    <parent>
       <groupId>org.wildfly.swarm.testsuite</groupId>
       <artifactId>wildlfy-swarm-microprofile-tck-parent</artifactId>
-      <version>2018.2.0-SNAPSHOT</version>
+      <version>2018.1.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/testsuite/microprofile-tcks/metrics/pom.xml
+++ b/testsuite/microprofile-tcks/metrics/pom.xml
@@ -26,7 +26,7 @@
    <parent>
       <groupId>org.wildfly.swarm.testsuite</groupId>
       <artifactId>wildlfy-swarm-microprofile-tck-parent</artifactId>
-      <version>2018.2.0-SNAPSHOT</version>
+      <version>2018.1.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/testsuite/microprofile-tcks/pom.xml
+++ b/testsuite/microprofile-tcks/pom.xml
@@ -26,7 +26,7 @@
    <parent>
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>build-parent</artifactId>
-      <version>2018.2.0-SNAPSHOT</version>
+      <version>2018.1.0-SNAPSHOT</version>
       <relativePath>../../build-parent/pom.xml</relativePath>
    </parent>
 

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>wildfly-swarm</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-ajp/pom.xml
+++ b/testsuite/testsuite-ajp/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-arquillian-without-cdi/pom.xml
+++ b/testsuite/testsuite-arquillian-without-cdi/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-asciidoctorj/pom.xml
+++ b/testsuite/testsuite-asciidoctorj/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-batch-jberet/pom.xml
+++ b/testsuite/testsuite-batch-jberet/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-buildtool/multi-module/api/pom.xml
+++ b/testsuite/testsuite-buildtool/multi-module/api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>multi-module-test</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-buildtool/multi-module/pom.xml
+++ b/testsuite/testsuite-buildtool/multi-module/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-buildtool</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-buildtool/multi-module/view/pom.xml
+++ b/testsuite/testsuite-buildtool/multi-module/view/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>multi-module-test</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-buildtool/pom.xml
+++ b/testsuite/testsuite-buildtool/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-camel-cdi/pom.xml
+++ b/testsuite/testsuite-camel-cdi/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Test Suite: Camel CDI</name>

--- a/testsuite/testsuite-camel-core/pom.xml
+++ b/testsuite/testsuite-camel-core/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Test Suite: Camel Core</name>

--- a/testsuite/testsuite-camel-cxf/pom.xml
+++ b/testsuite/testsuite-camel-cxf/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Test Suite: Camel CXF</name>

--- a/testsuite/testsuite-camel-ejb/pom.xml
+++ b/testsuite/testsuite-camel-ejb/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Test Suite: Camel EJB</name>

--- a/testsuite/testsuite-camel-jms/pom.xml
+++ b/testsuite/testsuite-camel-jms/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Test Suite: Camel JMS</name>

--- a/testsuite/testsuite-camel-jmx/pom.xml
+++ b/testsuite/testsuite-camel-jmx/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Test Suite: Camel JMX</name>

--- a/testsuite/testsuite-camel-jpa/pom.xml
+++ b/testsuite/testsuite-camel-jpa/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Test Suite: Camel JPA</name>

--- a/testsuite/testsuite-camel-ognl/pom.xml
+++ b/testsuite/testsuite-camel-ognl/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Test Suite: Camel Ognl</name>

--- a/testsuite/testsuite-cassandra/pom.xml
+++ b/testsuite/testsuite-cassandra/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-cdi-bean-validation/pom.xml
+++ b/testsuite/testsuite-cdi-bean-validation/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-cdi-ejb/pom.xml
+++ b/testsuite/testsuite-cdi-ejb/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-cdi-jaxrsapi/pom.xml
+++ b/testsuite/testsuite-cdi-jaxrsapi/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-cdi-jaxws/pom.xml
+++ b/testsuite/testsuite-cdi-jaxws/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-cdi-jpa-jta/pom.xml
+++ b/testsuite/testsuite-cdi-jpa-jta/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-cdi/pom.xml
+++ b/testsuite/testsuite-cdi/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-classloader/pom.xml
+++ b/testsuite/testsuite-classloader/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-connector/pom.xml
+++ b/testsuite/testsuite-connector/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-container/pom.xml
+++ b/testsuite/testsuite-container/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-datasources-config/pom.xml
+++ b/testsuite/testsuite-datasources-config/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-datasources-defaultds/pom.xml
+++ b/testsuite/testsuite-datasources-defaultds/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-datasources/pom.xml
+++ b/testsuite/testsuite-datasources/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-default-deployment/pom.xml
+++ b/testsuite/testsuite-default-deployment/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-drools-server/pom.xml
+++ b/testsuite/testsuite-drools-server/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-ee/pom.xml
+++ b/testsuite/testsuite-ee/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-ejb-remote/pom.xml
+++ b/testsuite/testsuite-ejb-remote/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-ejb/pom.xml
+++ b/testsuite/testsuite-ejb/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-flyway/pom.xml
+++ b/testsuite/testsuite-flyway/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-https/pom.xml
+++ b/testsuite/testsuite-https/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-hystrix/pom.xml
+++ b/testsuite/testsuite-hystrix/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-infinispan/pom.xml
+++ b/testsuite/testsuite-infinispan/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-io/pom.xml
+++ b/testsuite/testsuite-io/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-javafx/pom.xml
+++ b/testsuite/testsuite-javafx/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-jaxrs-cdi/pom.xml
+++ b/testsuite/testsuite-jaxrs-cdi/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-jaxrs-client/pom.xml
+++ b/testsuite/testsuite-jaxrs-client/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
 
   <name>Test Suite: JAX-RS Client</name>
   <description>Test Suite: JAX-RS Client</description>
-  <version>2018.2.0-SNAPSHOT</version>
+  <version>2018.1.0-SNAPSHOT</version>
 
   <packaging>war</packaging>
 

--- a/testsuite/testsuite-jaxrs-ejb/pom.xml
+++ b/testsuite/testsuite-jaxrs-ejb/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-jaxrs/pom.xml
+++ b/testsuite/testsuite-jaxrs/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-jca/pom.xml
+++ b/testsuite/testsuite-jca/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-jdr/pom.xml
+++ b/testsuite/testsuite-jdr/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-jgroups/pom.xml
+++ b/testsuite/testsuite-jgroups/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-jmx-remote-management/pom.xml
+++ b/testsuite/testsuite-jmx-remote-management/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-jmx-remote-remoting/pom.xml
+++ b/testsuite/testsuite-jmx-remote-remoting/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-jmx-remote-undertow/pom.xml
+++ b/testsuite/testsuite-jmx-remote-undertow/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-jmx/pom.xml
+++ b/testsuite/testsuite-jmx/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-jolokia-keycloak/pom.xml
+++ b/testsuite/testsuite-jolokia-keycloak/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-jolokia/pom.xml
+++ b/testsuite/testsuite-jolokia/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-jpa-mysql/pom.xml
+++ b/testsuite/testsuite-jpa-mysql/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-jpa-postgresql/pom.xml
+++ b/testsuite/testsuite-jpa-postgresql/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-jpa/pom.xml
+++ b/testsuite/testsuite-jpa/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-jsf/pom.xml
+++ b/testsuite/testsuite-jsf/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-jsp/pom.xml
+++ b/testsuite/testsuite-jsp/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-keycloak-server/pom.xml
+++ b/testsuite/testsuite-keycloak-server/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-keycloak/pom.xml
+++ b/testsuite/testsuite-keycloak/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-local-dependencies/dep/pom.xml
+++ b/testsuite/testsuite-local-dependencies/dep/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-local-dependencies</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-local-dependencies/pom.xml
+++ b/testsuite/testsuite-local-dependencies/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-local-dependencies/test/pom.xml
+++ b/testsuite/testsuite-local-dependencies/test/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-local-dependencies</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-logging/pom.xml
+++ b/testsuite/testsuite-logging/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-logstash/pom.xml
+++ b/testsuite/testsuite-logstash/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-mail-cdi/pom.xml
+++ b/testsuite/testsuite-mail-cdi/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-mail/pom.xml
+++ b/testsuite/testsuite-mail/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-management-console/pom.xml
+++ b/testsuite/testsuite-management-console/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-management/pom.xml
+++ b/testsuite/testsuite-management/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-maven-plugin/pom.xml
+++ b/testsuite/testsuite-maven-plugin/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-messaging-remote/pom.xml
+++ b/testsuite/testsuite-messaging-remote/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-messaging/pom.xml
+++ b/testsuite/testsuite-messaging/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-mod_cluster/pom.xml
+++ b/testsuite/testsuite-mod_cluster/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-modules/pom.xml
+++ b/testsuite/testsuite-modules/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-mongodb/pom.xml
+++ b/testsuite/testsuite-mongodb/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-monitor/pom.xml
+++ b/testsuite/testsuite-monitor/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-msc/pom.xml
+++ b/testsuite/testsuite-msc/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-naming/pom.xml
+++ b/testsuite/testsuite-naming/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-neo4j/pom.xml
+++ b/testsuite/testsuite-neo4j/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-opentracing/pom.xml
+++ b/testsuite/testsuite-opentracing/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-orientdb/pom.xml
+++ b/testsuite/testsuite-orientdb/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wildfly.swarm.testsuite</groupId>
         <artifactId>testsuite-parent</artifactId>
-        <version>2018.2.0-SNAPSHOT</version>
+        <version>2018.1.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/testsuite/testsuite-project-stages/pom.xml
+++ b/testsuite/testsuite-project-stages/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-remoting/pom.xml
+++ b/testsuite/testsuite-remoting/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-request-controller/pom.xml
+++ b/testsuite/testsuite-request-controller/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-resource-adapters/pom.xml
+++ b/testsuite/testsuite-resource-adapters/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-ribbon-secured/pom.xml
+++ b/testsuite/testsuite-ribbon-secured/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-ribbon/pom.xml
+++ b/testsuite/testsuite-ribbon/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-security/pom.xml
+++ b/testsuite/testsuite-security/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-servlet-cdi/pom.xml
+++ b/testsuite/testsuite-servlet-cdi/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-servlet-ejb/pom.xml
+++ b/testsuite/testsuite-servlet-ejb/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-servlet-jpa-jta/pom.xml
+++ b/testsuite/testsuite-servlet-jpa-jta/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-spring/pom.xml
+++ b/testsuite/testsuite-spring/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-swagger-customized/pom.xml
+++ b/testsuite/testsuite-swagger-customized/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-swagger-webapp/pom.xml
+++ b/testsuite/testsuite-swagger-webapp/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-swagger/pom.xml
+++ b/testsuite/testsuite-swagger/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-topology-api/pom.xml
+++ b/testsuite/testsuite-topology-api/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-topology-consul/pom.xml
+++ b/testsuite/testsuite-topology-consul/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-topology-jgroups/pom.xml
+++ b/testsuite/testsuite-topology-jgroups/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-topology-openshift/pom.xml
+++ b/testsuite/testsuite-topology-openshift/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-topology-webapp-no-endpoint/pom.xml
+++ b/testsuite/testsuite-topology-webapp-no-endpoint/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-topology-webapp/pom.xml
+++ b/testsuite/testsuite-topology-webapp/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-topology/pom.xml
+++ b/testsuite/testsuite-topology/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-transactions/pom.xml
+++ b/testsuite/testsuite-transactions/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-undertow-context/pom.xml
+++ b/testsuite/testsuite-undertow-context/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-undertow/pom.xml
+++ b/testsuite/testsuite-undertow/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-vertx/pom.xml
+++ b/testsuite/testsuite-vertx/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-webservices/pom.xml
+++ b/testsuite/testsuite-webservices/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/testsuite/testsuite-zipkin-jaxrs/pom.xml
+++ b/testsuite/testsuite-zipkin-jaxrs/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>build-parent</artifactId>
-    <version>2018.2.0-SNAPSHOT</version>
+    <version>2018.1.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
My local debugging of the release process resulted in an unnecessary commit, this PR is to revert it.

This reverts commit 74aae18c10ac16b9a9379267d4e8dc8ab629bc42.

- [ ] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
