### PR TITLE
SWARM-1530 - Temp files exists after stop an uber jar in Windows

### DIFF
--- a/core/bootstrap/src/main/java/org/jboss/modules/maven/MavenArtifactUtil.java
+++ b/core/bootstrap/src/main/java/org/jboss/modules/maven/MavenArtifactUtil.java
@@ -30,6 +30,8 @@ import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.List;
 import java.util.jar.JarFile;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathExpression;
@@ -40,6 +42,7 @@ import org.jboss.modules.Module;
 import org.jboss.modules.ResourceLoader;
 import org.jboss.modules.ResourceLoaders;
 import org.wildfly.swarm.bootstrap.logging.BootstrapLogger;
+import org.wildfly.swarm.bootstrap.util.JarFileManager;
 import org.xml.sax.InputSource;
 
 /**
@@ -58,6 +61,8 @@ public final class MavenArtifactUtil {
     private static final XPath xpath = XPathFactory.newInstance().newXPath();
 
     private static XPathExpression snapshotVersionXpath;
+
+    private static final Pattern tempFilePattern = Pattern.compile("\\S+[0-9]{5,}.\\S{5,}");
 
     static {
         try {
@@ -265,7 +270,13 @@ public final class MavenArtifactUtil {
     public static ResourceLoader createMavenArtifactLoader(final MavenResolver mavenResolver, final String name) throws IOException {
         File fp = mavenResolver.resolveJarArtifact(ArtifactCoordinates.fromString(name));
         if (fp == null) return null;
-        JarFile jarFile = new JarFile(fp, true);
+        Matcher matcher = tempFilePattern.matcher(fp.getName());
+        JarFile jarFile = null;
+        if (matcher.matches()) {
+            jarFile = JarFileManager.INSTANCE.addJarFile(fp);
+        } else {
+            jarFile = new JarFile(fp, true);
+        }
         return ResourceLoaders.createJarResourceLoader(name, jarFile);
     }
 

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/ApplicationModuleFinder.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/ApplicationModuleFinder.java
@@ -35,6 +35,7 @@ import org.jboss.modules.maven.ArtifactCoordinates;
 import org.wildfly.swarm.bootstrap.env.ApplicationEnvironment;
 import org.wildfly.swarm.bootstrap.logging.BootstrapLogger;
 import org.wildfly.swarm.bootstrap.util.BootstrapUtil;
+import org.wildfly.swarm.bootstrap.util.JarFileManager;
 import org.wildfly.swarm.bootstrap.util.TempFileManager;
 
 /**
@@ -171,7 +172,7 @@ public class ApplicationModuleFinder extends AbstractSingleModuleFinder {
                             LOG.error("Unable to find artifact for " + coords);
                             return;
                         }
-                        JarFile jar = new JarFile(artifact);
+                        JarFile jar = JarFileManager.INSTANCE.addJarFile(artifact);
 
                         builder.addResourceRoot(
                                 ResourceLoaderSpec.createResourceLoaderSpec(

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/BootstrapModuleFinder.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/BootstrapModuleFinder.java
@@ -17,10 +17,7 @@ package org.wildfly.swarm.bootstrap.modules;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Enumeration;
 import java.util.HashSet;
-import java.util.Set;
-import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
 import org.jboss.modules.DependencySpec;
@@ -31,10 +28,10 @@ import org.jboss.modules.ResourceLoader;
 import org.jboss.modules.ResourceLoaderSpec;
 import org.jboss.modules.ResourceLoaders;
 import org.jboss.modules.filter.PathFilter;
-import org.jboss.modules.filter.PathFilters;
 import org.wildfly.swarm.bootstrap.env.ApplicationEnvironment;
 import org.wildfly.swarm.bootstrap.logging.BootstrapLogger;
 import org.wildfly.swarm.bootstrap.performance.Performance;
+import org.wildfly.swarm.bootstrap.util.JarFileManager;
 
 /**
  * Module-finder used only for loading the first set of jars when run in an fat-jar scenario.
@@ -59,6 +56,13 @@ public class BootstrapModuleFinder extends AbstractSingleModuleFinder {
 
             ApplicationEnvironment env = ApplicationEnvironment.get();
 
+            PathFilter filter = new PathFilter() {
+                @Override
+               public boolean accept(String path) {
+                    return path.endsWith("module.xml");
+                }
+            };
+
             env.bootstrapArtifactsAsCoordinates()
                     .forEach((coords) -> {
                         try {
@@ -66,10 +70,9 @@ public class BootstrapModuleFinder extends AbstractSingleModuleFinder {
                             if (artifact == null) {
                                 throw new RuntimeException("Unable to resolve artifact from coordinates: " + coords);
                             }
-                            JarFile jar = new JarFile(artifact);
+                            JarFile jar = JarFileManager.INSTANCE.addJarFile(artifact);
                             ResourceLoader originaloader = ResourceLoaders.createJarResourceLoader(artifact.getName(), jar);
 
-                            PathFilter filter = getModuleFilter(jar);
                             builder.addResourceRoot(
                                     ResourceLoaderSpec.createResourceLoaderSpec(
                                             ResourceLoaders.createFilteredResourceLoader(filter, originaloader)
@@ -96,23 +99,6 @@ public class BootstrapModuleFinder extends AbstractSingleModuleFinder {
             throw new RuntimeException(e);
         }
 
-    }
-
-    private PathFilter getModuleFilter(JarFile jar) {
-        Set<String> paths = new HashSet<>();
-
-        Enumeration<JarEntry> jarEntries = jar.entries();
-
-        while (jarEntries.hasMoreElements()) {
-            JarEntry jarEntry = jarEntries.nextElement();
-            if (!jarEntry.isDirectory()) {
-                String name = jarEntry.getName();
-                if (name.endsWith("/module.xml")) {
-                    paths.add(name);
-                }
-            }
-        }
-        return PathFilters.in(paths);
     }
 
     private static final BootstrapLogger LOG = BootstrapLogger.logger("org.wildfly.swarm.modules.bootstrap");

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/MavenResolvers.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/MavenResolvers.java
@@ -16,6 +16,7 @@
 package org.wildfly.swarm.bootstrap.modules;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Optional;
 
@@ -32,6 +33,10 @@ public class MavenResolvers {
 
     public static synchronized MavenResolver get() {
         return INSTANCE;
+    }
+
+    public static synchronized void close() throws IOException {
+        INSTANCE.close();
     }
 
     private static final MultiMavenResolver INSTANCE = new MultiMavenResolver();

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/MultiMavenResolver.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/MultiMavenResolver.java
@@ -15,6 +15,7 @@
  */
 package org.wildfly.swarm.bootstrap.modules;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -27,7 +28,7 @@ import org.wildfly.swarm.bootstrap.performance.Performance;
 /**
  * @author Bob McWhirter
  */
-public class MultiMavenResolver implements MavenResolver {
+public class MultiMavenResolver implements MavenResolver, Closeable {
 
 
     public MultiMavenResolver() {
@@ -52,6 +53,15 @@ public class MultiMavenResolver implements MavenResolver {
             return null;
         } catch (Exception e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    public void close() throws IOException {
+        for (MavenResolver resolver : this.resolvers) {
+            if (resolver instanceof Closeable) {
+                Closeable closeable = (Closeable) resolver;
+                closeable.close();
+            }
         }
     }
 

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/util/JarFileManager.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/util/JarFileManager.java
@@ -1,0 +1,39 @@
+package org.wildfly.swarm.bootstrap.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.jar.JarFile;
+
+public class JarFileManager {
+
+    public static final JarFileManager INSTANCE = new JarFileManager();
+
+    private JarFileManager() {
+    }
+
+    public JarFile addJarFile(File file) throws IOException {
+
+        JarFile jarFile = jarFileToClose.get(file);
+        if (jarFile == null) {
+             jarFile = new JarFile(file);
+             jarFileToClose.put(file, jarFile);
+        }
+
+        return jarFile;
+    }
+
+    public void close() throws IOException {
+        jarFileToClose.
+                forEach((f, j) -> {
+                        try {
+                            j.close();
+                        } catch (IOException e) {
+                        }
+                    }
+                );
+    }
+
+    private Map<File, JarFile> jarFileToClose = new LinkedHashMap<>();
+}

--- a/core/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/core/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -653,8 +653,8 @@ public class Swarm {
             Resource each = iter.next();
             if (each.getName().endsWith(".class")) {
                 if (!each.getName().equals("module-info.class")) {
-                    try {
-                        indexer.index(each.openStream());
+                    try (InputStream is = each.openStream()) {
+                        indexer.index(is);
                     } catch (IOException e) {
                         // ignore
                     }

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
@@ -47,7 +47,9 @@ import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.ValueService;
 import org.jboss.msc.value.ImmediateValue;
 import org.jboss.shrinkwrap.api.Archive;
+import org.wildfly.swarm.bootstrap.modules.MavenResolvers;
 import org.wildfly.swarm.bootstrap.performance.Performance;
+import org.wildfly.swarm.bootstrap.util.JarFileManager;
 import org.wildfly.swarm.bootstrap.util.TempFileManager;
 import org.wildfly.swarm.container.internal.Deployer;
 import org.wildfly.swarm.container.internal.Server;
@@ -283,6 +285,8 @@ public class RuntimeServer implements Server {
         this.client = null;
         this.deployer.get().removeAllContent();
         this.deployer = null;
+        JarFileManager.INSTANCE.close();
+        MavenResolvers.close();
     }
 
     private void awaitContainerTermination() {

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/wildfly/SwarmContentRepository.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/wildfly/SwarmContentRepository.java
@@ -95,10 +95,10 @@ public class SwarmContentRepository implements ContentRepository, Service<Conten
             MessageDigest messageDigest = MessageDigest.getInstance("SHA-1");
             byte[] sha1Bytes;
             Path tmp = File.createTempFile("content", ".tmp").toPath();
-            try (OutputStream fos = Files.newOutputStream(tmp)) {
+            try (OutputStream fos = Files.newOutputStream(tmp); BufferedInputStream bis = new BufferedInputStream(stream)) {
                 messageDigest.reset();
                 DigestOutputStream dos = new DigestOutputStream(fos, messageDigest);
-                BufferedInputStream bis = new BufferedInputStream(stream);
+
                 byte[] bytes = new byte[8192];
                 int read;
                 while ((read = bis.read(bytes)) > -1) {

--- a/core/container/src/main/java/org/wildfly/swarm/container/util/DriverModuleBuilder.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/util/DriverModuleBuilder.java
@@ -31,6 +31,7 @@ import org.jboss.modules.ModuleSpec;
 import org.jboss.modules.ResourceLoaderSpec;
 import org.jboss.modules.ResourceLoaders;
 import org.wildfly.swarm.bootstrap.modules.DynamicModuleFinder;
+import org.wildfly.swarm.bootstrap.util.JarFileManager;
 
 /**
  * DriverModuleBuilder for applications that bring their own drivers.
@@ -77,9 +78,8 @@ public abstract class DriverModuleBuilder {
                 ModuleSpec.Builder builder = ModuleSpec.build(id);
 
                 for (File eachJar : optionalJars) {
-
                     try {
-                        JarFile jar = new JarFile(eachJar);
+                        JarFile jar = JarFileManager.INSTANCE.addJarFile(eachJar);
                         builder.addResourceRoot(ResourceLoaderSpec.createResourceLoaderSpec(
                                 ResourceLoaders.createIterableJarResourceLoader(jar.getName(), jar)
                         ));

--- a/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/DriverInfo.java
+++ b/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/DriverInfo.java
@@ -32,6 +32,7 @@ import org.jboss.modules.ModuleSpec;
 import org.jboss.modules.ResourceLoaderSpec;
 import org.jboss.modules.ResourceLoaders;
 import org.wildfly.swarm.bootstrap.modules.DynamicModuleFinder;
+import org.wildfly.swarm.bootstrap.util.JarFileManager;
 import org.wildfly.swarm.config.datasources.DataSource;
 import org.wildfly.swarm.config.datasources.DataSourceConsumer;
 import org.wildfly.swarm.config.datasources.JDBCDriver;
@@ -115,9 +116,8 @@ public abstract class DriverInfo {
                 ModuleSpec.Builder builder = ModuleSpec.build(id);
 
                 for (File eachJar : optionalJars) {
-
                     try {
-                        JarFile jar = new JarFile(eachJar);
+                        JarFile jar = JarFileManager.INSTANCE.addJarFile(eachJar);
                         builder.addResourceRoot(ResourceLoaderSpec.createResourceLoaderSpec(
                                 ResourceLoaders.createIterableJarResourceLoader(jar.getName(), jar)
                         ));


### PR DESCRIPTION
Motivation
----------
Windows is more sensitive for used temp files when tried to delete them. This causes temp files not being removed when Swarm applications are shut down.

Modifications
-------------
* All JarFile objects should be closed prior to remove their files. Added a JarFileManager registry to close them properly.
* Removed temp files on shutdown for those being temporary created as needed Maven artifacts.

Result
------
Temp files being removed on shutdown and Windows environments.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
