### PR TITLE
Added note to docs about enabling commons-logging for tests (ENTSWM-220)

### DIFF
--- a/docs/howto/test-in-container/index.adoc
+++ b/docs/howto/test-in-container/index.adoc
@@ -22,6 +22,30 @@ include::pom.xml[tag=bom,indent=4]
   </dependencies>
 </dependencyManagement>
 ----
+
+ifdef::product[]
+. If your test uses the Apache HTTP Client or the JAX-RS Client, add the `commons-logging` artifact to the `test` scope of the project in the `pom.xml` file:
++
+--
+[source,xml]
+----
+<project>
+  <dependencies>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>1.2</version>
+      <scope>test</scope>
+    <dependency>
+  </dependencies>
+</project>
+----
+
+The reason is that the WildFly Swarm productized rutime artifact BOM imports the EAP runtime artifacts BOM (`org.jboss.bom:eap-runtime-artifacts`), which excludes the `commons-logging` artifact from the `org.apache.httpcomponents:httpclient` and `org.apache.james:apache-mime4j` artifacts.
+As a result, when running tests in a Maven project that imports the WildFly Swarm productized rutime artifact BOM, neither the Apache HTTP Client nor any other artifact that depends on it (for example, the JAX-RS Client) work.
+--
+endif::[]
+
 . Reference the `org.wildfly.swarm:arquillian` artifact in your `pom.xml` file
 with the `<scope>` set to `test`:
 +


### PR DESCRIPTION
Resolves ENTSWM-220

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

The `commons-logging` version is taken from https://github.com/jboss-logging/commons-logging-jboss-logmanager/blob/1.0.0.Final/pom.xml#L54, courtesy of @Ladicek. 

Resolves [ENTSWM-220](https://issues.jboss.org/browse/ENTSWM-220).