### PR TITLE
Be more strict when translating to Prometheus names. SWARM-1793

### DIFF
--- a/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/exporters/PrometheusExporter.java
+++ b/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/exporters/PrometheusExporter.java
@@ -115,7 +115,7 @@ public class PrometheusExporter implements Exporter {
                     key = getPrometheusMetricName(md, key);
                     String suffix = null;
                     if (!md.getUnit().equals(MetricUnits.NONE)) {
-                        suffix = "_" + PrometheusUnit.getBaseUnitAsPrometheusString(md.getUnit());
+                        suffix = USCORE + PrometheusUnit.getBaseUnitAsPrometheusString(md.getUnit());
                     }
                     writeTypeLine(sb, scope, key, md, suffix, null);
                     createSimpleValueLine(sb, scope, key, md, metric);
@@ -303,7 +303,7 @@ public class PrometheusExporter implements Exporter {
 
 
     private String getPrometheusMetricName(Metadata entry, String name) {
-        String out = name.replace('-', '_').replace('.', '_').replace(' ', '_');
+        String out = name.replaceAll("[^\\w]+",USCORE);
         out = decamelize(out);
         if (entry == null) {
             throw new IllegalStateException("No entry for " + name + " found");


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----

Prometheus only allows a limited set of characters in metric names. All others are translated to underscore. This is related to https://github.com/eclipse/microprofile-metrics/pull/214