### PR TITLE
SWARM-1819: the warning we print for custom main usage points to an old website

### DIFF
--- a/plugins/gradle/src/main/java/org/wildfly/swarm/plugin/gradle/PackageTask.java
+++ b/plugins/gradle/src/main/java/org/wildfly/swarm/plugin/gradle/PackageTask.java
@@ -204,7 +204,7 @@ public class PackageTask extends DefaultTask {
             getLogger().warn(
                     "\n------\n" +
                             "Custom main() usage is intended to be deprecated in a future release and is no longer supported, \n" +
-                            "please refer to http://reference.wildfly-swarm.io for YAML configuration that replaces it." +
+                            "please refer to http://docs.wildfly-swarm.io for YAML configuration that replaces it." +
                             "\n------"
             );
         }

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/AbstractSwarmMojo.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/AbstractSwarmMojo.java
@@ -105,7 +105,7 @@ public abstract class AbstractSwarmMojo extends AbstractMojo {
             getLog().warn(
                     "\n------\n" +
                     "Custom main() usage is intended to be deprecated in a future release and is no longer supported, \n" +
-                            "please refer to http://reference.wildfly-swarm.io for YAML configuration that replaces it." +
+                            "please refer to http://docs.wildfly-swarm.io for YAML configuration that replaces it." +
                     "\n------"
             );
         }


### PR DESCRIPTION
Motivation
----------
Classes `org.wildfly.swarm.plugin.gradle.PackageTask` and
`org.wildfly.swarm.plugin.maven.AbstractSwarmMojo` print a message
when they detect that user is using custom `main`. The message
refers to old website `reference.wildfly-swarm.io`, which among
others contain wrong fraction names. The message should point
to `docs.wildfly-swarm.io` instead.

Modifications
-------------
Rewrite `reference.wildfly-swarm.io` to `docs.wildfly-swarm.io`.

Result
------
More accurate warning message when user has custom `main`.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
