### PR TITLE
SWARM-1834: Move microprofile dependencies into supported profile

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -341,6 +341,69 @@
         <artifactId>openshift-restclient-java</artifactId>
         <version>${version.openshift.client}</version>
       </dependency>
+
+      <!-- MicroProfile -->
+      <dependency>
+        <groupId>org.eclipse.microprofile.config</groupId>
+        <artifactId>microprofile-config-api</artifactId>
+        <version>${version.microprofile-config}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-microprofile-config-implementation</artifactId>
+        <version>${version.wildfly-microprofile-config}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>microprofile-config-api</artifactId>
+        <version>${version.wildfly-microprofile-config}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
+        <artifactId>microprofile-fault-tolerance-api</artifactId>
+        <version>${version.microprofile-fault-tolerance}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.eclipse.microprofile.health</groupId>
+        <artifactId>microprofile-health-api</artifactId>
+        <version>${version.microprofile-health}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.eclipse.microprofile.metrics</groupId>
+        <artifactId>microprofile-metrics-api</artifactId>
+        <version>${version.microprofile-metrics}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.eclipse.microprofile.jwt</groupId>
+        <artifactId>microprofile-jwt-auth-api</artifactId>
+        <version>${version.microprofile-jwt-auth}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.eclipse.microprofile.rest.client</groupId>
+        <artifactId>microprofile-rest-client-api</artifactId>
+        <version>${version.microprofile.restclient}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-jaxrs</artifactId>
+        <version>${version.resteasy}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-client</artifactId>
+        <version>${version.resteasy}</version>
+      </dependency>
+
+
       <!-- The following are not used, they are here to make PME align proper versions-->
       <dependency>
         <groupId>com.squareup.okhttp3</groupId>
@@ -599,66 +662,6 @@
             <version>${version.com.orbitz.consul}</version>
           </dependency>
 
-          <!-- MicroProfile -->
-          <dependency>
-            <groupId>org.eclipse.microprofile.config</groupId>
-            <artifactId>microprofile-config-api</artifactId>
-            <version>${version.microprofile-config}</version>
-          </dependency>
-
-          <dependency>
-            <groupId>org.wildfly</groupId>
-            <artifactId>wildfly-microprofile-config-implementation</artifactId>
-            <version>${version.wildfly-microprofile-config}</version>
-          </dependency>
-
-          <dependency>
-            <groupId>org.wildfly.swarm</groupId>
-            <artifactId>microprofile-config-api</artifactId>
-            <version>${version.wildfly-microprofile-config}</version>
-          </dependency>
-
-          <dependency>
-            <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
-            <artifactId>microprofile-fault-tolerance-api</artifactId>
-            <version>${version.microprofile-fault-tolerance}</version>
-          </dependency>
-
-          <dependency>
-            <groupId>org.eclipse.microprofile.health</groupId>
-            <artifactId>microprofile-health-api</artifactId>
-            <version>${version.microprofile-health}</version>
-          </dependency>
-
-          <dependency>
-            <groupId>org.eclipse.microprofile.metrics</groupId>
-            <artifactId>microprofile-metrics-api</artifactId>
-            <version>${version.microprofile-metrics}</version>
-          </dependency>
-
-          <dependency>
-            <groupId>org.eclipse.microprofile.jwt</groupId>
-            <artifactId>microprofile-jwt-auth-api</artifactId>
-            <version>${version.microprofile-jwt-auth}</version>
-         </dependency>
-
-          <dependency>
-            <groupId>org.eclipse.microprofile.rest.client</groupId>
-            <artifactId>microprofile-rest-client-api</artifactId>
-            <version>${version.microprofile.restclient}</version>
-          </dependency>
-
-          <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxrs</artifactId>
-            <version>${version.resteasy}</version>
-          </dependency>
-
-          <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-client</artifactId>
-            <version>${version.resteasy}</version>
-          </dependency>
 
         </dependencies>
       </dependencyManagement>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -342,7 +342,7 @@
         <version>${version.openshift.client}</version>
       </dependency>
 
-      <!-- MicroProfile -->
+      <!-- MicroProfile 1.2 -->
       <dependency>
         <groupId>org.eclipse.microprofile.config</groupId>
         <artifactId>microprofile-config-api</artifactId>
@@ -384,25 +384,6 @@
         <artifactId>microprofile-jwt-auth-api</artifactId>
         <version>${version.microprofile-jwt-auth}</version>
       </dependency>
-
-      <dependency>
-        <groupId>org.eclipse.microprofile.rest.client</groupId>
-        <artifactId>microprofile-rest-client-api</artifactId>
-        <version>${version.microprofile.restclient}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-jaxrs</artifactId>
-        <version>${version.resteasy}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-client</artifactId>
-        <version>${version.resteasy}</version>
-      </dependency>
-
 
       <!-- The following are not used, they are here to make PME align proper versions-->
       <dependency>
@@ -632,6 +613,26 @@
           </dependency>
           <!-- NoSQL end -->
 
+          <!-- Microprofile 1.3 -->
+          <dependency>
+            <groupId>org.eclipse.microprofile.rest.client</groupId>
+            <artifactId>microprofile-rest-client-api</artifactId>
+            <version>${version.microprofile.restclient}</version>
+          </dependency>
+
+          <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jaxrs</artifactId>
+            <version>${version.resteasy}</version>
+          </dependency>
+
+          <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+            <version>${version.resteasy}</version>
+          </dependency>
+
+          <!-- Swagger -->
           <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-jaxrs</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -984,7 +984,6 @@
     <module>plugins/maven</module>
 
     <module>client-apis/health-api</module>
-    <module>client-apis/microprofile-restclient</module>
 
     <module>fractions/javaee/bean-validation</module>
     <module>fractions/javaee/cdi</module>
@@ -1024,7 +1023,6 @@
     <module>fractions/microprofile/microprofile-jwt</module>
     <module>fractions/microprofile/microprofile-metrics</module>
     <module>fractions/microprofile/microprofile-fault-tolerance</module>
-    <module>fractions/microprofile/microprofile-restclient</module>
     <module>fractions/microprofile/microprofile</module>
     <module>fractions/monitor</module>
     <module>fractions/topology</module>
@@ -1067,6 +1065,7 @@
       <modules>
         <module>client-apis/jaxrs-client-api</module>
 
+
         <module>swarmtool</module>
         <module>cli</module>
 
@@ -1088,6 +1087,10 @@
         <module>fractions/javaee/messaging</module>
         <module>fractions/javaee/resource-adapters</module>
         <module>fractions/javaee/webservices</module>
+
+        <!-- MP 1.3 -->
+        <module>client-apis/microprofile-restclient</module>
+        <module>fractions/microprofile/microprofile-restclient</module>
 
         <module>fractions/asciidoctorj</module>
         <module>fractions/camel</module>


### PR DESCRIPTION
In order to support a `-Dswarm.product.build` the microprofile deps need to be into the  build profile for supported bits