### PR TITLE
SWARM-1834: Hystrix is a dep of MP FT and needs to be present in supported profile

### DIFF
--- a/fractions/netflix/pom.xml
+++ b/fractions/netflix/pom.xml
@@ -174,15 +174,29 @@
   </dependencyManagement>
 
   <modules>
-    <module>archaius</module>
-    <module>guava</module>
     <module>hystrix</module>
-    <module>ribbon</module>
-    <module>ribbon-secured</module>
-    <module>ribbon-secured-client</module>
-    <module>rxjava</module>
-    <module>rxnetty</module>
-    <module>servo</module>
   </modules>
+
+  <profiles>
+    <profile>
+      <id>unsupported</id>
+      <activation>
+        <property>
+          <name>!swarm.product.build</name>
+        </property>
+      </activation>
+      <modules>
+        <module>archaius</module>
+        <module>guava</module>
+        <module>ribbon</module>
+        <module>ribbon-secured</module>
+        <module>ribbon-secured-client</module>
+        <module>rxjava</module>
+        <module>rxnetty</module>
+        <module>servo</module>
+      </modules>
+
+    </profile>
+  </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1008,6 +1008,9 @@
     <module>fractions/javaee/undertow</module>
     <module>fractions/javaee/web</module>
 
+    <!-- required by MP 1.2 FT, but only hystrix. See the netflix pom.xml for further details -->
+    <module>fractions/netflix</module>
+
     <module>fractions/wildfly/elytron</module>
     <module>fractions/wildfly/hibernate-validator</module>
     <module>fractions/wildfly/io</module>


### PR DESCRIPTION
This is followup commit to SWARM-1834. The hystrix dep was missing.
