### PR TITLE
Further netflix deps are required for MP FT

### DIFF
--- a/fractions/netflix/pom.xml
+++ b/fractions/netflix/pom.xml
@@ -174,7 +174,10 @@
   </dependencyManagement>
 
   <modules>
+    <module>guava</module>
     <module>hystrix</module>
+    <module>archaius</module>
+    <module>rxjava</module>
   </modules>
 
   <profiles>
@@ -186,12 +189,9 @@
         </property>
       </activation>
       <modules>
-        <module>archaius</module>
-        <module>guava</module>
         <module>ribbon</module>
         <module>ribbon-secured</module>
         <module>ribbon-secured-client</module>
-        <module>rxjava</module>
         <module>rxnetty</module>
         <module>servo</module>
       </modules>


### PR DESCRIPTION
All the hystrix deps need to present in supported profile as well.