### PR TITLE
SWARM-1683: `web` hollow jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1033,6 +1033,9 @@
     <module>fractions/topology-webapp</module>
 
     <module>fractions/cdi-extensions/cdi-config</module>
+
+    <module>standalone-servers</module>
+    <module>standalone-servers/web</module>
   </modules>
 
   <profiles>
@@ -1133,7 +1136,6 @@
 
         <module>fractions/cdi-extensions/cdi-jaxrsapi</module>
 
-        <module>standalone-servers</module>
         <module>standalone-servers/keycloak</module>
         <module>standalone-servers/management-console</module>
         <module>standalone-servers/microprofile</module>

--- a/standalone-servers/web/pom.xml
+++ b/standalone-servers/web/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm.servers</groupId>
+    <artifactId>standalone-servers</artifactId>
+    <version>2018.3.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <artifactId>web</artifactId>
+
+  <name>Standalone Server: Web</name>
+  <description>Standalone Server: Web</description>
+
+  <packaging>jar</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>wildfly-swarm-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>package</id>
+            <goals>
+              <goal>package</goal>
+            </goals>
+            <configuration>
+              <hollow>true</hollow>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>web</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
Add a hollow jar for `web` fraction.

Modifications
-------------
Add `web` to standalone-servers.

Result
------
`web` hollow jar available for use.
