### PR TITLE
SWARM-1665: Make it possible to configure Hystrix concurrency strategy.

### DIFF
--- a/fractions/microprofile/microprofile-fault-tolerance/module.conf
+++ b/fractions/microprofile/microprofile-fault-tolerance/module.conf
@@ -1,5 +1,6 @@
 javax.enterprise.api
 javax.annotation.api
+javax.enterprise.concurrent.api
 javax.api
 com.netflix.hystrix
 org.jboss.logging

--- a/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/DefaultHystrixConcurrencyStrategy.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/DefaultHystrixConcurrencyStrategy.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.faulttolerance.deployment;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Resource;
+import javax.enterprise.concurrent.ManagedThreadFactory;
+import javax.enterprise.context.Dependent;
+
+import org.jboss.logging.Logger;
+
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.HystrixThreadPoolProperties;
+import com.netflix.hystrix.strategy.concurrency.HystrixConcurrencyStrategy;
+import com.netflix.hystrix.strategy.properties.HystrixProperty;
+
+/**
+ * The default concurrency strategy using the managed version of {@link ThreadFactory}.
+ *
+ * <p>
+ * A user is allowed to provide a custom implementation of {@link HystrixConcurrencyStrategy}. The bean should be {@link Dependent}, must be marked as
+ * alternative and selected globally for an application.
+ * </p>
+ *
+ * @author Martin Kouba
+ */
+@Dependent
+class DefaultHystrixConcurrencyStrategy extends HystrixConcurrencyStrategy {
+
+    private static final Logger LOGGER = Logger.getLogger(DefaultHystrixConcurrencyStrategy.class);
+
+    @Resource(lookup = "java:comp/DefaultManagedThreadFactory")
+    ManagedThreadFactory threadFactory;
+
+    @Override
+    public ThreadPoolExecutor getThreadPool(HystrixThreadPoolKey threadPoolKey, HystrixProperty<Integer> corePoolSize, HystrixProperty<Integer> maximumPoolSize,
+            HystrixProperty<Integer> keepAliveTime, TimeUnit unit, BlockingQueue<Runnable> workQueue) {
+        int dynamicCoreSize = corePoolSize.get();
+        int dynamicMaximumSize = maximumPoolSize.get();
+
+        LOGGER.debugf("Get thread pool executor [core: %s, max: %s]", dynamicCoreSize, dynamicMaximumSize);
+
+        return new ThreadPoolExecutor(dynamicCoreSize, dynamicCoreSize > dynamicMaximumSize ? dynamicCoreSize : dynamicMaximumSize, keepAliveTime.get(), unit,
+                workQueue, threadFactory);
+    }
+
+    @Override
+    public ThreadPoolExecutor getThreadPool(HystrixThreadPoolKey threadPoolKey, HystrixThreadPoolProperties threadPoolProperties) {
+
+        boolean allowMaximumSizeToDivergeFromCoreSize = threadPoolProperties.getAllowMaximumSizeToDivergeFromCoreSize().get();
+        int dynamicCoreSize = threadPoolProperties.coreSize().get();
+        int dynamicMaximumSize = threadPoolProperties.maximumSize().get();
+        int keepAliveTime = threadPoolProperties.keepAliveTimeMinutes().get();
+        int maxQueueSize = threadPoolProperties.maxQueueSize().get();
+        BlockingQueue<Runnable> workQueue = getBlockingQueue(maxQueueSize);
+
+        LOGGER.debugf("Get thread pool executor [allowMaximumSizeToDivergeFromCoreSize: %s, core: %s, max: %s]", allowMaximumSizeToDivergeFromCoreSize,
+                dynamicCoreSize, dynamicMaximumSize);
+
+        if (allowMaximumSizeToDivergeFromCoreSize) {
+            return new ThreadPoolExecutor(dynamicCoreSize, dynamicCoreSize > dynamicMaximumSize ? dynamicCoreSize : dynamicMaximumSize, keepAliveTime,
+                    TimeUnit.MINUTES, workQueue, threadFactory);
+        } else {
+            return new ThreadPoolExecutor(dynamicCoreSize, dynamicCoreSize, keepAliveTime, TimeUnit.MINUTES, workQueue, threadFactory);
+        }
+    }
+
+}

--- a/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/HystrixExtension.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/HystrixExtension.java
@@ -66,6 +66,8 @@ public class HystrixExtension implements Extension {
         // Add AnnotatedType for HystrixCommandInterceptor
         // It seems that fraction deployment module cannot be picked up as a CDI bean archive - see also SWARM-1725
         bbd.addAnnotatedType(bm.createAnnotatedType(HystrixCommandInterceptor.class), HystrixCommandInterceptor.class.getName());
+        bbd.addAnnotatedType(bm.createAnnotatedType(HystrixInitializer.class), HystrixInitializer.class.getName());
+        bbd.addAnnotatedType(bm.createAnnotatedType(DefaultHystrixConcurrencyStrategy.class), DefaultHystrixConcurrencyStrategy.class.getName());
     }
 
     /**

--- a/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/HystrixInitializer.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/HystrixInitializer.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.faulttolerance.deployment;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Initialized;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.jboss.logging.Logger;
+
+import com.netflix.hystrix.Hystrix;
+import com.netflix.hystrix.strategy.HystrixPlugins;
+import com.netflix.hystrix.strategy.concurrency.HystrixConcurrencyStrategy;
+
+/**
+ * This component configures Hystrix to use a specific {@link HystrixConcurrencyStrategy}.
+ *
+ * @author Martin Kouba
+ */
+@ApplicationScoped
+class HystrixInitializer {
+
+    private static final Logger LOGGER = Logger.getLogger(HystrixInitializer.class);
+
+    @Inject
+    Instance<HystrixConcurrencyStrategy> instance;
+
+    // Initialize eagerly
+    void init(@Observes @Initialized(ApplicationScoped.class) Object event) {
+    }
+
+    @PostConstruct
+    void onStartup() {
+        HystrixConcurrencyStrategy strategy = instance.get();
+        LOGGER.info("Hystrix concurrency strategy used: " + strategy.getClass().getSimpleName());
+        HystrixPlugins.getInstance().registerConcurrencyStrategy(strategy);
+    }
+
+    @PreDestroy
+    void onShutdown() {
+        Hystrix.reset(1, TimeUnit.SECONDS);
+    }
+}

--- a/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/TestHystrixConcurrencyStrategy.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/TestHystrixConcurrencyStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Red Hat, Inc, and individual contributors.
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,20 +15,15 @@
  */
 package org.wildfly.swarm.microprofile.faulttolerance.deployment;
 
-import javax.enterprise.inject.spi.Extension;
+import javax.annotation.Priority;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Alternative;
 
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import com.netflix.hystrix.strategy.concurrency.HystrixConcurrencyStrategy;
 
-public class TestArchive {
-
-    public static JavaArchive createBase(String name) {
-        return ShrinkWrap.create(JavaArchive.class,name)
-                .addClass(TestHystrixConcurrencyStrategy.class)
-                .addAsServiceProvider(Extension.class, HystrixExtension.class)
-                .addAsManifestResource(EmptyAsset.INSTANCE,
-                "beans.xml");
-    }
+@Priority(10)
+@Alternative
+@Dependent
+public class TestHystrixConcurrencyStrategy extends HystrixConcurrencyStrategy {
 
 }


### PR DESCRIPTION
Motivation
----------
By default, ManagedThreadFactory should be used for new threads.

Modifications
-------------
Introduced HystrixInitiator which obtains and registers a bean of type
HystrixConcurrencyStrategy.

Result
------
ManagedThreadFactory is used by default. It is also possible to override
this behavior.