### PR TITLE
SWARM-1844: the Maven plugin reference documentation has some system properties wrong

### DIFF
--- a/docs/reference/maven-plugin.adoc
+++ b/docs/reference/maven-plugin.adoc
@@ -70,7 +70,7 @@ If set, the swarm process will suspend on start and open a debugger on this port
 [cols="1,2a"]
 |===
 |Property
-|_none_
+|`swarm.debug.port`
 
 |Default
 |
@@ -121,7 +121,7 @@ The mode of fraction detection. The available options are:
 [cols="1,2a"]
 |===
 |Property
-|`swarm.fractionDetectMode`
+|`swarm.detect.mode`
 
 |Default
 |`when_missing`
@@ -287,7 +287,7 @@ This JAR is not created automatically, so make sure you execute the `package` go
 [cols="1,2a"]
 |===
 |Property
-|`swarm.useUberJar`
+|`wildfly-swarm.useUberJar`
 
 |Default
 |false


### PR DESCRIPTION
Motivation
----------
The Maven plugin reference documentation has some system properties wrong.
Specifically:
- the debugger port system property is not listed at all
- the fraction detection mode system property is listed as `swarm.fractionDetectMode`
- the "use uberjar" system property is listed as `swarm.useUberJar`

Modifications
-------------
Fix Maven plugin reference documentation to correctly refer to:
- `swarm.debug.port`
- `swarm.detect.mode`
- `wildfly-swarm.useUberJar`

Result
------
More correct Maven plugin reference documentation.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
