### PR TITLE
SWARM-1530 - Temp files exists after stop an uber jar in Windows

### DIFF
--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
@@ -65,6 +65,7 @@ import org.wildfly.swarm.tools.DeclaredDependencies;
 import org.wildfly.swarm.tools.exec.SwarmExecutor;
 import org.wildfly.swarm.tools.exec.SwarmProcess;
 
+
 public class UberjarSimpleContainer implements SimpleContainer {
 
     private final ContainerContext containerContext;
@@ -274,7 +275,7 @@ public class UberjarSimpleContainer implements SimpleContainer {
                 System.err.println("-> " + each.getKey());
             }*/
 
-        File executable = File.createTempFile("arquillian", "-swarm.jar");
+        File executable = File.createTempFile(TempFileManager.WFSWARM_TMP_PREFIX + "arquillian", "-swarm.jar");
         wrapped.as(ZipExporter.class).exportTo(executable, true);
         executable.deleteOnExit();
 
@@ -286,15 +287,14 @@ public class UberjarSimpleContainer implements SimpleContainer {
 
         executor.withProperty("java.net.preferIPv4Stack", "true");
 
-        File processFile = File.createTempFile("mainprocessfile", null);
-        processFile.deleteOnExit();
+        File processFile = File.createTempFile(TempFileManager.WFSWARM_TMP_PREFIX + "mainprocessfile", null);
 
         executor.withProcessFile(processFile);
 
         executor.withJVMArguments(getJavaVmArgumentsList());
         executor.withExecutableJar(executable.toPath());
 
-        File workingDirectory = TempFileManager.INSTANCE.newTempDirectory("arquillian", null);
+        workingDirectory = TempFileManager.INSTANCE.newTempDirectory("arquillian", null);
         executor.withWorkingDirectory(workingDirectory.toPath());
 
         this.process = executor.execute();
@@ -356,6 +356,7 @@ public class UberjarSimpleContainer implements SimpleContainer {
     @Override
     public void stop() throws Exception {
         this.process.stop();
+        TempFileManager.deleteRecursively(workingDirectory);
     }
 
     private String ga(final MavenCoordinate coord) {
@@ -387,6 +388,22 @@ public class UberjarSimpleContainer implements SimpleContainer {
 
     }
 
+    private void deleteRecursively(File file) {
+        if (!file.exists()) {
+            return;
+        }
+        if (file.isDirectory()) {
+            File[] files = file.listFiles();
+            if (files != null) {
+                for (File child : files) {
+                    deleteRecursively(child);
+                }
+            }
+        }
+
+        file.delete();
+    }
+
     private final Class<?> testClass;
 
     private SwarmProcess process;
@@ -394,6 +411,8 @@ public class UberjarSimpleContainer implements SimpleContainer {
     private Set<String> requestedMavenArtifacts = new HashSet<>();
 
     private String javaVmArguments;
+
+    private File workingDirectory;
 
 }
 

--- a/core/bootstrap/src/main/java/org/jboss/modules/maven/MavenArtifactUtil.java
+++ b/core/bootstrap/src/main/java/org/jboss/modules/maven/MavenArtifactUtil.java
@@ -30,6 +30,8 @@ import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.List;
 import java.util.jar.JarFile;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathExpression;
@@ -40,6 +42,7 @@ import org.jboss.modules.Module;
 import org.jboss.modules.ResourceLoader;
 import org.jboss.modules.ResourceLoaders;
 import org.wildfly.swarm.bootstrap.logging.BootstrapLogger;
+import org.wildfly.swarm.bootstrap.util.JarFileManager;
 import org.xml.sax.InputSource;
 
 /**
@@ -58,6 +61,8 @@ public final class MavenArtifactUtil {
     private static final XPath xpath = XPathFactory.newInstance().newXPath();
 
     private static XPathExpression snapshotVersionXpath;
+
+    private static final Pattern tempFilePattern = Pattern.compile("\\S+[0-9]{5,}.\\S{5,}");
 
     static {
         try {
@@ -265,7 +270,13 @@ public final class MavenArtifactUtil {
     public static ResourceLoader createMavenArtifactLoader(final MavenResolver mavenResolver, final String name) throws IOException {
         File fp = mavenResolver.resolveJarArtifact(ArtifactCoordinates.fromString(name));
         if (fp == null) return null;
-        JarFile jarFile = new JarFile(fp, true);
+        Matcher matcher = tempFilePattern.matcher(fp.getName());
+        JarFile jarFile = null;
+        if (matcher.matches()) {
+            jarFile = JarFileManager.INSTANCE.addJarFile(fp);
+        } else {
+            jarFile = new JarFile(fp, true);
+        }
         return ResourceLoaders.createJarResourceLoader(name, jarFile);
     }
 

--- a/core/bootstrap/src/main/java/org/jboss/modules/maven/MavenSettings.java
+++ b/core/bootstrap/src/main/java/org/jboss/modules/maven/MavenSettings.java
@@ -93,10 +93,10 @@ final class MavenSettings {
     }
 
     static MavenSettings parseSettingsXml(Path settings, MavenSettings mavenSettings) throws IOException {
-        try {
-            final MXParser reader = new MXParser();
+        final MXParser reader = new MXParser();
+
+        try (InputStream source = Files.newInputStream(settings, StandardOpenOption.READ)){
             reader.setFeature(FEATURE_PROCESS_NAMESPACES, false);
-            InputStream source = Files.newInputStream(settings, StandardOpenOption.READ);
             reader.setInput(source, null);
             int eventType;
             while ((eventType = reader.next()) != END_DOCUMENT) {

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/ApplicationModuleFinder.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/ApplicationModuleFinder.java
@@ -35,6 +35,7 @@ import org.jboss.modules.maven.ArtifactCoordinates;
 import org.wildfly.swarm.bootstrap.env.ApplicationEnvironment;
 import org.wildfly.swarm.bootstrap.logging.BootstrapLogger;
 import org.wildfly.swarm.bootstrap.util.BootstrapUtil;
+import org.wildfly.swarm.bootstrap.util.JarFileManager;
 import org.wildfly.swarm.bootstrap.util.TempFileManager;
 
 /**
@@ -122,7 +123,7 @@ public class ApplicationModuleFinder extends AbstractSingleModuleFinder {
             name = name.substring(0, dotLoc);
         }
 
-        File tmp = File.createTempFile(name, ext);
+        File tmp = TempFileManager.INSTANCE.newTempFile(name, ext);
 
         try (InputStream artifactIn = getClass().getClassLoader().getResourceAsStream(path)) {
             Files.copy(artifactIn, tmp.toPath(), StandardCopyOption.REPLACE_EXISTING);
@@ -171,7 +172,7 @@ public class ApplicationModuleFinder extends AbstractSingleModuleFinder {
                             LOG.error("Unable to find artifact for " + coords);
                             return;
                         }
-                        JarFile jar = new JarFile(artifact);
+                        JarFile jar = JarFileManager.INSTANCE.addJarFile(artifact);
 
                         builder.addResourceRoot(
                                 ResourceLoaderSpec.createResourceLoaderSpec(

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/BootstrapModuleFinder.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/BootstrapModuleFinder.java
@@ -17,10 +17,7 @@ package org.wildfly.swarm.bootstrap.modules;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Enumeration;
 import java.util.HashSet;
-import java.util.Set;
-import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
 import org.jboss.modules.DependencySpec;
@@ -31,10 +28,10 @@ import org.jboss.modules.ResourceLoader;
 import org.jboss.modules.ResourceLoaderSpec;
 import org.jboss.modules.ResourceLoaders;
 import org.jboss.modules.filter.PathFilter;
-import org.jboss.modules.filter.PathFilters;
 import org.wildfly.swarm.bootstrap.env.ApplicationEnvironment;
 import org.wildfly.swarm.bootstrap.logging.BootstrapLogger;
 import org.wildfly.swarm.bootstrap.performance.Performance;
+import org.wildfly.swarm.bootstrap.util.JarFileManager;
 
 /**
  * Module-finder used only for loading the first set of jars when run in an fat-jar scenario.
@@ -59,6 +56,13 @@ public class BootstrapModuleFinder extends AbstractSingleModuleFinder {
 
             ApplicationEnvironment env = ApplicationEnvironment.get();
 
+            PathFilter filter = new PathFilter() {
+                @Override
+               public boolean accept(String path) {
+                    return path.endsWith("module.xml");
+                }
+            };
+
             env.bootstrapArtifactsAsCoordinates()
                     .forEach((coords) -> {
                         try {
@@ -66,10 +70,9 @@ public class BootstrapModuleFinder extends AbstractSingleModuleFinder {
                             if (artifact == null) {
                                 throw new RuntimeException("Unable to resolve artifact from coordinates: " + coords);
                             }
-                            JarFile jar = new JarFile(artifact);
+                            JarFile jar = JarFileManager.INSTANCE.addJarFile(artifact);
                             ResourceLoader originaloader = ResourceLoaders.createJarResourceLoader(artifact.getName(), jar);
 
-                            PathFilter filter = getModuleFilter(jar);
                             builder.addResourceRoot(
                                     ResourceLoaderSpec.createResourceLoaderSpec(
                                             ResourceLoaders.createFilteredResourceLoader(filter, originaloader)
@@ -96,23 +99,6 @@ public class BootstrapModuleFinder extends AbstractSingleModuleFinder {
             throw new RuntimeException(e);
         }
 
-    }
-
-    private PathFilter getModuleFilter(JarFile jar) {
-        Set<String> paths = new HashSet<>();
-
-        Enumeration<JarEntry> jarEntries = jar.entries();
-
-        while (jarEntries.hasMoreElements()) {
-            JarEntry jarEntry = jarEntries.nextElement();
-            if (!jarEntry.isDirectory()) {
-                String name = jarEntry.getName();
-                if (name.endsWith("/module.xml")) {
-                    paths.add(name);
-                }
-            }
-        }
-        return PathFilters.in(paths);
     }
 
     private static final BootstrapLogger LOG = BootstrapLogger.logger("org.wildfly.swarm.modules.bootstrap");

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/MavenResolvers.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/MavenResolvers.java
@@ -16,6 +16,7 @@
 package org.wildfly.swarm.bootstrap.modules;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Optional;
 
@@ -32,6 +33,10 @@ public class MavenResolvers {
 
     public static synchronized MavenResolver get() {
         return INSTANCE;
+    }
+
+    public static synchronized void close() throws IOException {
+        INSTANCE.close();
     }
 
     private static final MultiMavenResolver INSTANCE = new MultiMavenResolver();

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/MultiMavenResolver.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/MultiMavenResolver.java
@@ -15,6 +15,7 @@
  */
 package org.wildfly.swarm.bootstrap.modules;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -27,7 +28,7 @@ import org.wildfly.swarm.bootstrap.performance.Performance;
 /**
  * @author Bob McWhirter
  */
-public class MultiMavenResolver implements MavenResolver {
+public class MultiMavenResolver implements MavenResolver, Closeable {
 
 
     public MultiMavenResolver() {
@@ -52,6 +53,15 @@ public class MultiMavenResolver implements MavenResolver {
             return null;
         } catch (Exception e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    public void close() throws IOException {
+        for (MavenResolver resolver : this.resolvers) {
+            if (resolver instanceof Closeable) {
+                Closeable closeable = (Closeable) resolver;
+                closeable.close();
+            }
         }
     }
 

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/util/JarFileManager.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/util/JarFileManager.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.bootstrap.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.jar.JarFile;
+
+/**
+ * @author Juan Gonzalez
+ */
+public class JarFileManager {
+
+    public static final JarFileManager INSTANCE = new JarFileManager();
+
+    private JarFileManager() {
+    }
+
+    public JarFile addJarFile(File file) throws IOException {
+
+        JarFile jarFile = jarFileToClose.get(file);
+        if (jarFile == null) {
+             jarFile = new JarFile(file);
+             jarFileToClose.put(file, jarFile);
+        }
+
+        return jarFile;
+    }
+
+    public void close() throws IOException {
+        jarFileToClose.
+                forEach((f, j) -> {
+                        try {
+                            j.close();
+                        } catch (IOException e) {
+                        }
+                    }
+                );
+    }
+
+    private Map<File, JarFile> jarFileToClose = new LinkedHashMap<>();
+}

--- a/core/bootstrap/src/test/java/org/wildfly/swarm/bootstrap/modules/GradleResolverTest.java
+++ b/core/bootstrap/src/test/java/org/wildfly/swarm/bootstrap/modules/GradleResolverTest.java
@@ -16,6 +16,7 @@
 package org.wildfly.swarm.bootstrap.modules;
 
 import org.jboss.modules.maven.ArtifactCoordinates;
+import org.junit.After;
 import org.junit.Test;
 import org.wildfly.swarm.bootstrap.util.TempFileManager;
 
@@ -37,6 +38,10 @@ import static org.mockito.Mockito.*;
  */
 public class GradleResolverTest {
 
+    @After
+    public void tearDown() {
+        TempFileManager.INSTANCE.close();
+    }
 
     @Test
     public void downloadFromRemoteRepository() throws IOException {

--- a/core/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/core/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -653,8 +653,8 @@ public class Swarm {
             Resource each = iter.next();
             if (each.getName().endsWith(".class")) {
                 if (!each.getName().equals("module-info.class")) {
-                    try {
-                        indexer.index(each.openStream());
+                    try (InputStream is = each.openStream()) {
+                        indexer.index(is);
                     } catch (IOException e) {
                         // ignore
                     }

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
@@ -18,8 +18,10 @@ package org.wildfly.swarm.container.runtime;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -47,8 +49,11 @@ import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.ValueService;
 import org.jboss.msc.value.ImmediateValue;
 import org.jboss.shrinkwrap.api.Archive;
+import org.wildfly.swarm.bootstrap.modules.MavenResolvers;
 import org.wildfly.swarm.bootstrap.performance.Performance;
+import org.wildfly.swarm.bootstrap.util.JarFileManager;
 import org.wildfly.swarm.bootstrap.util.TempFileManager;
+
 import org.wildfly.swarm.container.internal.Deployer;
 import org.wildfly.swarm.container.internal.Server;
 import org.wildfly.swarm.container.runtime.deployments.DefaultDeploymentCreator;
@@ -279,10 +284,40 @@ public class RuntimeServer implements Server {
         this.container.stop();
         awaitContainerTermination();
         this.containerStarted = false;
+
+        try {
+            //Clear the container ShutdownHook so it doesn't try to execute after container is stopped
+            Field field = this.container.getClass().getDeclaredField("serviceContainer");
+            field.setAccessible(true);
+            ServiceContainer serviceContainer = (ServiceContainer) field.get(this.container);
+
+            Class<?> shutdownHookHolder = null;
+            Class<?>[] declaredClasses = serviceContainer.getClass().getDeclaredClasses();
+            for (Class<?> clazz : declaredClasses) {
+                if (clazz.getName().contains("ShutdownHookHolder")) {
+                    shutdownHookHolder = clazz;
+                }
+            }
+
+            if (shutdownHookHolder != null) {
+                    Field containersSetField = shutdownHookHolder.getDeclaredField("containers");
+                    containersSetField.setAccessible(true);
+                    Set<?> set = (Set<?>)containersSetField.get(null);
+                    set.clear();
+            }
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
+
         this.container = null;
+
         this.client = null;
         this.deployer.get().removeAllContent();
         this.deployer = null;
+
+        JarFileManager.INSTANCE.close();
+        TempFileManager.INSTANCE.close();
+        MavenResolvers.close();
     }
 
     private void awaitContainerTermination() {
@@ -323,4 +358,5 @@ public class RuntimeServer implements Server {
     private NetworkConfigurer networkConfigurer;
 
     private ModelControllerClient client;
+
 }

--- a/core/container/src/main/java/org/wildfly/swarm/container/util/DriverModuleBuilder.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/util/DriverModuleBuilder.java
@@ -31,6 +31,7 @@ import org.jboss.modules.ModuleSpec;
 import org.jboss.modules.ResourceLoaderSpec;
 import org.jboss.modules.ResourceLoaders;
 import org.wildfly.swarm.bootstrap.modules.DynamicModuleFinder;
+import org.wildfly.swarm.bootstrap.util.JarFileManager;
 
 /**
  * DriverModuleBuilder for applications that bring their own drivers.
@@ -77,9 +78,8 @@ public abstract class DriverModuleBuilder {
                 ModuleSpec.Builder builder = ModuleSpec.build(id);
 
                 for (File eachJar : optionalJars) {
-
                     try {
-                        JarFile jar = new JarFile(eachJar);
+                        JarFile jar = JarFileManager.INSTANCE.addJarFile(eachJar);
                         builder.addResourceRoot(ResourceLoaderSpec.createResourceLoaderSpec(
                                 ResourceLoaders.createIterableJarResourceLoader(jar.getName(), jar)
                         ));

--- a/core/container/src/main/java/org/wildfly/swarm/internal/wildfly/SelfContainedContainer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/wildfly/SelfContainedContainer.java
@@ -51,6 +51,7 @@ import org.jboss.stdio.NullInputStream;
 import org.jboss.stdio.SimpleStdioContextSelector;
 import org.jboss.stdio.StdioContext;
 import org.wildfly.security.manager.WildFlySecurityManager;
+import org.wildfly.swarm.bootstrap.util.TempFileManager;
 
 //import org.jboss.as.selfcontained.ContentProvider;
 //import org.jboss.as.selfcontained.ContentProviderServiceActivator;
@@ -163,7 +164,7 @@ public final class SelfContainedContainer {
         executor.submit(new Runnable() {
             @Override
             public void run() {
-                deleteRecursively(tmpDir);
+                TempFileManager.deleteRecursively(tmpDir);
             }
         });
         executor.shutdown();
@@ -178,11 +179,11 @@ public final class SelfContainedContainer {
 
     private File createTmpDir() {
         try {
-            File tmpDir = File.createTempFile("wildfly-self-contained", ".d");
+            File tmpDir = TempFileManager.INSTANCE.newTempDirectory("wildfly-self-contained", ".d");
             if (tmpDir.exists()) {
                 for (int i = 0; i < 10; ++i) {
                     if (tmpDir.exists()) {
-                        if (deleteRecursively(tmpDir)) {
+                        if (TempFileManager.deleteRecursively(tmpDir)) {
                             break;
                         }
                         try {
@@ -197,8 +198,6 @@ public final class SelfContainedContainer {
                     throw new RuntimeException("Unable to create directory");
                 }
             }
-            tmpDir.mkdirs();
-            tmpDir.deleteOnExit();
             return tmpDir;
 
         } catch (IOException e) {
@@ -206,22 +205,4 @@ public final class SelfContainedContainer {
         }
     }
 
-    private static boolean deleteRecursively(File f) {
-        if (!f.exists()) {
-            return false;
-        }
-        if (f.isDirectory()) {
-            File[] children = f.listFiles();
-            for (int i = 0; i < children.length; ++i) {
-                if (!deleteRecursively(children[i])) {
-                    return false;
-                }
-            }
-        }
-
-        return f.delete();
-    }
-
-
 }
-

--- a/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/DriverInfo.java
+++ b/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/DriverInfo.java
@@ -32,6 +32,7 @@ import org.jboss.modules.ModuleSpec;
 import org.jboss.modules.ResourceLoaderSpec;
 import org.jboss.modules.ResourceLoaders;
 import org.wildfly.swarm.bootstrap.modules.DynamicModuleFinder;
+import org.wildfly.swarm.bootstrap.util.JarFileManager;
 import org.wildfly.swarm.config.datasources.DataSource;
 import org.wildfly.swarm.config.datasources.DataSourceConsumer;
 import org.wildfly.swarm.config.datasources.JDBCDriver;
@@ -115,9 +116,8 @@ public abstract class DriverInfo {
                 ModuleSpec.Builder builder = ModuleSpec.build(id);
 
                 for (File eachJar : optionalJars) {
-
                     try {
-                        JarFile jar = new JarFile(eachJar);
+                        JarFile jar = JarFileManager.INSTANCE.addJarFile(eachJar);
                         builder.addResourceRoot(ResourceLoaderSpec.createResourceLoaderSpec(
                                 ResourceLoaders.createIterableJarResourceLoader(jar.getName(), jar)
                         ));

--- a/fractions/javaee/undertow/src/test/java/org/wildfly/swarm/undertow/runtime/CertInfoProducerTest.java
+++ b/fractions/javaee/undertow/src/test/java/org/wildfly/swarm/undertow/runtime/CertInfoProducerTest.java
@@ -16,17 +16,35 @@
 package org.wildfly.swarm.undertow.runtime;
 
 import category.CommunityOnly;
+
+import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.wildfly.swarm.bootstrap.modules.MavenResolvers;
+import org.wildfly.swarm.bootstrap.util.JarFileManager;
+import org.wildfly.swarm.bootstrap.util.TempFileManager;
 import org.wildfly.swarm.undertow.UndertowFraction;
 import org.wildfly.swarm.undertow.descriptors.CertInfo;
 
 import static org.fest.assertions.Assertions.assertThat;
 
+import java.io.IOException;
+
 /**
  * @author Bob McWhirter
  */
 public class CertInfoProducerTest {
+
+    @After
+    public void tearDown() {
+       try {
+            JarFileManager.INSTANCE.close();
+            MavenResolvers.close();
+            TempFileManager.INSTANCE.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
 
     @Test
     public void testDefaults() {

--- a/maven-enforcer-pattern-size/src/main/java/org/wildfly/swarm/plugin/enforcer/patternsize/RequireFilePatternSize.java
+++ b/maven-enforcer-pattern-size/src/main/java/org/wildfly/swarm/plugin/enforcer/patternsize/RequireFilePatternSize.java
@@ -72,7 +72,7 @@ public class RequireFilePatternSize implements EnforcerRule {
                         new SimpleFileVisitor<Path>() {
                         @Override
                         public FileVisitResult visitFile(Path filePath, BasicFileAttributes attrs) throws IOException {
-                             Matcher matcher = pattern.matcher(filePath.toAbsolutePath().toString());
+                             Matcher matcher = pattern.matcher(filePath.getFileName().toString());
                              if (matcher.matches()) {
                                  File file = filePath.toFile();
                                  matchedFiles.add(file);

--- a/meta/fraction-metadata/src/main/java/org/wildfly/swarm/fractions/scanner/JarScanner.java
+++ b/meta/fraction-metadata/src/main/java/org/wildfly/swarm/fractions/scanner/JarScanner.java
@@ -36,14 +36,18 @@ public class JarScanner implements Scanner<InputStream> {
 
     @Override
     public void scan(PathSource pathSource, Collection<FractionDetector<InputStream>> detectors, Consumer<File> handleFileAsZip) throws IOException {
+
         final File jarFile = File.createTempFile("swarmPackageDetector", ".jar");
-        jarFile.deleteOnExit();
 
-        try (InputStream input = pathSource.getInputStream();
-                FileOutputStream out = new FileOutputStream(jarFile)) {
-            copy(input, out);
+        try {
+            try (InputStream input = pathSource.getInputStream();
+                    FileOutputStream out = new FileOutputStream(jarFile)) {
+                copy(input, out);
+            }
+
+            handleFileAsZip.accept(jarFile);
+        } finally {
+            jarFile.delete();
         }
-
-        handleFileAsZip.accept(jarFile);
-    }
+      }
 }

--- a/meta/fraction-metadata/src/test/java/org/wildfly/swarm/fractions/FractionUsageAnalyzerTest.java
+++ b/meta/fraction-metadata/src/test/java/org/wildfly/swarm/fractions/FractionUsageAnalyzerTest.java
@@ -17,12 +17,14 @@ package org.wildfly.swarm.fractions;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.time.temporal.TemporalField;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.exporter.ExplodedExporter;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.After;
 import org.junit.Test;
 import org.wildfly.swarm.bootstrap.util.TempFileManager;
 import org.wildfly.swarm.jaxrs.JAXRSArchive;
@@ -30,6 +32,11 @@ import org.wildfly.swarm.jaxrs.JAXRSArchive;
 import static org.fest.assertions.Assertions.assertThat;
 
 public class FractionUsageAnalyzerTest {
+
+    @After
+    public void tearDown() {
+        TempFileManager.INSTANCE.close();
+    }
 
     @Test
     public void testFractionMatching() throws Exception {
@@ -39,7 +46,6 @@ public class FractionUsageAnalyzerTest {
 
         final File out = Files.createTempFile(archive.getName(), ".war").toFile();
         archive.as(ZipExporter.class).exportTo(out, true);
-        out.deleteOnExit();
 
         analyzer.source(out);
         assertThat(analyzer.detectNeededFractions()
@@ -47,6 +53,8 @@ public class FractionUsageAnalyzerTest {
                            .filter(fd -> fd.getArtifactId().equals("jaxrs"))
                            .count())
                 .isEqualTo(1);
+
+        out.delete();
     }
 
     @Test
@@ -74,7 +82,6 @@ public class FractionUsageAnalyzerTest {
 
         final File out = Files.createTempFile(archive.getName(), ".war").toFile();
         archive.as(ZipExporter.class).exportTo(out, true);
-        out.deleteOnExit();
 
         analyzer.source(out);
         assertThat(analyzer.detectNeededFractions()
@@ -82,5 +89,7 @@ public class FractionUsageAnalyzerTest {
                            .filter(fd -> fd.getArtifactId().equals("undertow"))
                            .count())
                 .isEqualTo(1);
+
+        out.delete();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -185,9 +185,15 @@
                 <requiredFilePattern>
                   <maxSize>0</maxSize>
                   <recursive>false</recursive>
-            <directory>${project.build.directory}</directory>
-            <pattern>\S+[0-9]{5,}.\S{5,}</pattern>
+	          <directory>${project.build.directory}</directory>
+                  <pattern>wfswarm\S+[0-9]{5,}.\S{5,}</pattern>
                 </requiredFilePattern>
+               <requiredFilePattern>
+                  <maxSize>0</maxSize>
+                  <recursive>false</recursive>
+                  <directory>${java.io.tmpdir}</directory>
+                  <pattern>wfswarm\S+[0-9]{5,}.\S{5,}</pattern>
+               </requiredFilePattern>
             </requiredFilePatterns>
           </patternSizeRule>
               </rules>

--- a/standalone-servers/keycloak/pom.xml
+++ b/standalone-servers/keycloak/pom.xml
@@ -41,6 +41,40 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+       <groupId>org.apache.maven.plugins</groupId>
+       <artifactId>maven-enforcer-plugin</artifactId>
+       <dependencies>
+          <dependency>
+          <groupId>org.wildfly.swarm</groupId>
+          <artifactId>wildfly-swarm-enforcer-pattern-size</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+      <executions>
+        <execution>
+          <id>enforce</id>
+          <phase>verify</phase>
+          <configuration>
+            <rules>
+               <patternSizeRule implementation="org.wildfly.swarm.plugin.enforcer.patternsize.RequireFilePatternSize">
+                  <requiredFilePatterns>
+                    <requiredFilePattern>
+                        <maxSize>0</maxSize>
+                        <recursive>false</recursive>
+                        <directory>${project.build.directory}</directory>
+                        <pattern>wfswarm\S+[0-9]{5,}.\S{5,}</pattern>
+                     </requiredFilePattern>
+                    </requiredFilePatterns>
+             </patternSizeRule>
+                </rules>
+             </configuration>
+             <goals>
+               <goal>enforce</goal>
+             </goals>
+           </execution>
+         </executions>
+       </plugin>
     </plugins>
   </build>
 

--- a/standalone-servers/management-console/pom.xml
+++ b/standalone-servers/management-console/pom.xml
@@ -39,6 +39,40 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+       <groupId>org.apache.maven.plugins</groupId>
+       <artifactId>maven-enforcer-plugin</artifactId>
+       <dependencies>
+          <dependency>
+          <groupId>org.wildfly.swarm</groupId>
+          <artifactId>wildfly-swarm-enforcer-pattern-size</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+      <executions>
+        <execution>
+          <id>enforce</id>
+          <phase>verify</phase>
+          <configuration>
+            <rules>
+               <patternSizeRule implementation="org.wildfly.swarm.plugin.enforcer.patternsize.RequireFilePatternSize">
+                  <requiredFilePatterns>
+                    <requiredFilePattern>
+                        <maxSize>0</maxSize>
+                        <recursive>false</recursive>
+                        <directory>${project.build.directory}</directory>
+                        <pattern>wfswarm\S+[0-9]{5,}.\S{5,}</pattern>
+                     </requiredFilePattern>
+                    </requiredFilePatterns>
+             </patternSizeRule>
+                </rules>
+             </configuration>
+             <goals>
+               <goal>enforce</goal>
+             </goals>
+           </execution>
+         </executions>
+       </plugin>
     </plugins>
   </build>
 

--- a/standalone-servers/web/pom.xml
+++ b/standalone-servers/web/pom.xml
@@ -33,6 +33,40 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+       <artifactId>maven-enforcer-plugin</artifactId>
+           <dependencies>
+              <dependency>
+              <groupId>org.wildfly.swarm</groupId>
+              <artifactId>wildfly-swarm-enforcer-pattern-size</artifactId>
+               <version>${project.version}</version>
+             </dependency>
+           </dependencies>
+           <executions>
+             <execution>
+               <id>enforce</id>
+               <phase>verify</phase>
+               <configuration>
+                 <rules>
+                   <patternSizeRule implementation="org.wildfly.swarm.plugin.enforcer.patternsize.RequireFilePatternSize">
+                      <requiredFilePatterns>
+                        <requiredFilePattern>
+                            <maxSize>0</maxSize>
+                            <recursive>false</recursive>
+                            <directory>${project.build.directory}</directory>
+                            <pattern>wfswarm\S+[0-9]{5,}.\S{5,}</pattern>
+                         </requiredFilePattern>
+                        </requiredFilePatterns>
+                    </patternSizeRule>
+                </rules>
+              </configuration>
+               <goals>
+                <goal>enforce</goal>
+              </goals>
+           </execution>
+         </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/testsuite/testsuite-jpa/src/test/java/org/wildfly/swarm/jpa/JPATest.java
+++ b/testsuite/testsuite-jpa/src/test/java/org/wildfly/swarm/jpa/JPATest.java
@@ -2,7 +2,6 @@ package org.wildfly.swarm.jpa;
 
 import java.io.File;
 import java.nio.file.Files;
-import java.nio.file.Path;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.exporter.ExplodedExporter;
@@ -22,8 +21,7 @@ public class JPATest {
         archive.addAsResource("META-INF/persistence.xml");
         FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer();
 
-        final File out = Files.createTempFile(archive.getName(), ".war").toFile();
-        out.deleteOnExit();
+        File out = Files.createTempFile(archive.getName(), ".war").toFile();
         archive.as(ZipExporter.class).exportTo(out, true);
 
         analyzer.source(out);
@@ -31,6 +29,8 @@ public class JPATest {
                        .stream()
                        .filter(fd -> fd.getArtifactId().equals("jpa"))
                        .count()).isEqualTo(1);
+
+        out.delete();
     }
 
     @Test
@@ -47,5 +47,7 @@ public class JPATest {
                        .stream()
                        .filter(fd -> fd.getArtifactId().equals("jpa"))
                        .count()).isEqualTo(1);
+
+        TempFileManager.deleteRecursively(dirFile);
     }
 }

--- a/testsuite/testsuite-jsf/pom.xml
+++ b/testsuite/testsuite-jsf/pom.xml
@@ -84,6 +84,40 @@
               </execution>
             </executions>
           </plugin>
+          <plugin>
+	       <groupId>org.apache.maven.plugins</groupId>
+	       <artifactId>maven-enforcer-plugin</artifactId>
+	       <dependencies>
+	          <dependency>
+	          <groupId>org.wildfly.swarm</groupId>
+	          <artifactId>wildfly-swarm-enforcer-pattern-size</artifactId>
+	          <version>${project.version}</version>
+	        </dependency>
+	      </dependencies>
+	      <executions>
+	        <execution>
+	          <id>enforce</id>
+	          <phase>verify</phase>
+	          <configuration>
+	            <rules>
+	               <patternSizeRule implementation="org.wildfly.swarm.plugin.enforcer.patternsize.RequireFilePatternSize">
+	                  <requiredFilePatterns>
+	                    <requiredFilePattern>
+	                        <maxSize>0</maxSize>
+	                        <recursive>false</recursive>
+	                        <directory>${project.build.directory}</directory>
+	                        <pattern>wfswarm\S+[0-9]{5,}.\S{5,}</pattern>
+	                     </requiredFilePattern>
+	                    </requiredFilePatterns>
+	             </patternSizeRule>
+	                </rules>
+	             </configuration>
+	             <goals>
+	               <goal>enforce</goal>
+	             </goals>
+	           </execution>
+	         </executions>
+	       </plugin>
         </plugins>
       </build>
     </profile>

--- a/testsuite/testsuite-jsp/pom.xml
+++ b/testsuite/testsuite-jsp/pom.xml
@@ -87,4 +87,43 @@
     </profile>
   </profiles>
 
+  <build>
+    <plugins>
+     <plugin>
+       <groupId>org.apache.maven.plugins</groupId>
+       <artifactId>maven-enforcer-plugin</artifactId>
+       <dependencies>
+          <dependency>
+          <groupId>org.wildfly.swarm</groupId>
+          <artifactId>wildfly-swarm-enforcer-pattern-size</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+      <executions>
+        <execution>
+          <id>enforce</id>
+          <phase>verify</phase>
+          <configuration>
+            <rules>
+               <patternSizeRule implementation="org.wildfly.swarm.plugin.enforcer.patternsize.RequireFilePatternSize">
+                  <requiredFilePatterns>
+                    <requiredFilePattern>
+                        <maxSize>0</maxSize>
+                        <recursive>false</recursive>
+                        <directory>${project.build.directory}</directory>
+                        <pattern>wfswarm\S+[0-9]{5,}.\S{5,}</pattern>
+                     </requiredFilePattern>
+                    </requiredFilePatterns>
+             </patternSizeRule>
+                </rules>
+             </configuration>
+             <goals>
+               <goal>enforce</goal>
+             </goals>
+           </execution>
+         </executions>
+       </plugin>
+     </plugins>
+  </build>
+
 </project>

--- a/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/ProjectStagesTest.java
+++ b/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/ProjectStagesTest.java
@@ -1,11 +1,16 @@
 package org.wildfly.swarm;
 
+import java.io.IOException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import org.junit.After;
 import org.junit.Test;
+import org.wildfly.swarm.bootstrap.modules.MavenResolvers;
+import org.wildfly.swarm.bootstrap.util.JarFileManager;
+import org.wildfly.swarm.bootstrap.util.TempFileManager;
 import org.wildfly.swarm.spi.api.SwarmProperties;
 import org.wildfly.swarm.spi.api.config.ConfigView;
 
@@ -15,6 +20,17 @@ import static org.fest.assertions.Assertions.assertThat;
  * @author Bob McWhirter
  */
 public class ProjectStagesTest {
+
+    @After
+    public void tearDown() {
+        try {
+            JarFileManager.INSTANCE.close();
+            MavenResolvers.close();
+            TempFileManager.INSTANCE.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
 
     @Test
     public void testPropertyBasedConfigStagesFile() throws Exception {

--- a/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/StageConfigTest.java
+++ b/testsuite/testsuite-project-stages/src/test/java/org/wildfly/swarm/StageConfigTest.java
@@ -1,9 +1,14 @@
 package org.wildfly.swarm;
 
+import java.io.IOException;
 import java.net.URL;
 import java.util.Properties;
 
+import org.junit.After;
 import org.junit.Test;
+import org.wildfly.swarm.bootstrap.modules.MavenResolvers;
+import org.wildfly.swarm.bootstrap.util.JarFileManager;
+import org.wildfly.swarm.bootstrap.util.TempFileManager;
 import org.wildfly.swarm.spi.api.StageConfig;
 import org.wildfly.swarm.spi.api.SwarmProperties;
 import org.wildfly.swarm.spi.api.config.ConfigView;
@@ -15,6 +20,17 @@ import static org.fest.assertions.Assertions.assertThat;
  */
 @SuppressWarnings("deprecation")
 public class StageConfigTest {
+
+    @After
+    public void tearDown() {
+        try {
+            JarFileManager.INSTANCE.close();
+            MavenResolvers.close();
+            TempFileManager.INSTANCE.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
 
     @Test
     public void testPropertyBasedConfigStagesFile() throws Exception {


### PR DESCRIPTION
Motivation
----------
Windows is more sensitive for used temp files when tried to delete them. This causes temp files not being removed when Swarm applications are shut down.

Modifications
-------------
* All JarFile objects should be closed prior to remove their files. Added a JarFileManager registry to close them properly.
* Removed temp files on shutdown for those being temporary created as needed Maven artifacts.
* Removed all Shutdownhooks except one, in order to unify and control where those files are being removed for every environment.
* Removed file.deleteOnExit. All files should be deleted under Swarm control in a determined Swarm lifecycle (when server stops).

Result
------
Majority of temp files being removed on shutdown and Windows environments.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [] Have you built the project locally prior to submission with `mvn clean install`?

-----
