### PR TITLE
SWARM-1846: Make MP-restclient usable from behind a firewall

### DIFF
--- a/client-apis/microprofile-restclient/src/main/java/org/wildfly/swarm/microprofile/restclient/BuilderImpl.java
+++ b/client-apis/microprofile-restclient/src/main/java/org/wildfly/swarm/microprofile/restclient/BuilderImpl.java
@@ -109,11 +109,12 @@ class BuilderImpl implements RestClientBuilder {
 
         final T actualClient;
 
-        if (System.getProperty("http.proxyHost") != null
-                && !noProxyHosts.contains(this.baseURI.getHost())) {
+        final String proxyHost = System.getProperty("http.proxyHost");
+
+        if (proxyHost != null && !noProxyHosts.contains(this.baseURI.getHost())) {
             // Use proxy, if defined
             actualClient = this.builderDelegate.defaultProxy(
-                    System.getProperty("http.proxyHost"),
+                    proxyHost,
                     Integer.parseInt(System.getProperty("http.proxyPort", "80")))
                     .build()
                     .target(this.baseURI)

--- a/client-apis/microprofile-restclient/src/main/java/org/wildfly/swarm/microprofile/restclient/BuilderImpl.java
+++ b/client-apis/microprofile-restclient/src/main/java/org/wildfly/swarm/microprofile/restclient/BuilderImpl.java
@@ -22,8 +22,10 @@ import java.lang.reflect.Proxy;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -102,13 +104,33 @@ class BuilderImpl implements RestClientBuilder {
 
         ClassLoader classLoader = aClass.getClassLoader();
 
-        final T actualClient = this.builderDelegate.build()
-                .target(this.baseURI)
-                .proxyBuilder(aClass)
-                .classloader(classLoader)
-                .defaultConsumes(MediaType.TEXT_PLAIN)
-                .defaultProduces(MediaType.TEXT_PLAIN)
-                .build();
+        List<String> noProxyHosts = Arrays.asList(
+                System.getProperty("http.nonProxyHosts", "localhost|127.*|[::1]").split("|"));
+
+        final T actualClient;
+
+        if (System.getProperty("http.proxyHost") != null
+                && !noProxyHosts.contains(this.baseURI.getHost())) {
+            // Use proxy, if defined
+            actualClient = this.builderDelegate.defaultProxy(
+                    System.getProperty("http.proxyHost"),
+                    Integer.parseInt(System.getProperty("http.proxyPort", "80")))
+                    .build()
+                    .target(this.baseURI)
+                    .proxyBuilder(aClass)
+                    .classloader(classLoader)
+                    .defaultConsumes(MediaType.TEXT_PLAIN)
+                    .defaultProduces(MediaType.TEXT_PLAIN)
+                    .build();
+        } else {
+            actualClient = this.builderDelegate.build()
+                    .target(this.baseURI)
+                    .proxyBuilder(aClass)
+                    .classloader(classLoader)
+                    .defaultConsumes(MediaType.TEXT_PLAIN)
+                    .defaultProduces(MediaType.TEXT_PLAIN)
+                    .build();
+        }
 
         return (T) Proxy.newProxyInstance(
                 classLoader,


### PR DESCRIPTION
Motivation
----------
Make MP REST client work behind a firewall.

Modifications
-------------
In BuilderImpl build(Class<T> aClass) first look if a proxy host is
defined before a client is build.

Result
------
RestEasy now uses a proxy if one is defined in the system properties.

- [x ] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x ] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x ] Have you built the project locally prior to submission with `mvn clean install`?

-----
