### PR TITLE
SWARM-1794: Fix MP FT Timeout support.

### DIFF
--- a/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/RetryContext.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/RetryContext.java
@@ -42,16 +42,20 @@ class RetryContext {
         this.delay = Duration.of(config.get(RetryConfig.DELAY), config.get(RetryConfig.DELAY_UNIT)).toMillis();
     }
 
-    public RetryConfig getConfig() {
+    RetryConfig getConfig() {
         return config;
     }
 
-    public void doRetry() {
+    void doRetry() {
         remainingAttempts.decrementAndGet();
     }
 
-    public boolean shouldRetry() {
+    boolean shouldRetry() {
         return remainingAttempts.get() > 0;
+    }
+
+    boolean isLastAttempt() {
+        return remainingAttempts.get() == 1;
     }
 
     boolean shouldRetryOn(Exception exception, long time) {

--- a/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/timeout/TimeoutTest.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/timeout/TimeoutTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.faulttolerance.deployment.timeout;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.microprofile.faulttolerance.deployment.TestArchive;
+
+/**
+ *
+ * @author Martin Kouba
+ */
+@RunWith(Arquillian.class)
+public class TimeoutTest {
+
+    @Deployment
+    public static JavaArchive createTestArchive() {
+        return TestArchive.createBase("TimeoutTest.jar").addPackage(TimeoutTest.class.getPackage());
+    }
+
+    @Inject
+    TimingOutService service;
+
+    @Test
+    public void testTimeout() throws InterruptedException {
+        TimingOutService.INTERRUPTED.set(false);
+        boolean timeoutExceptionThrown = false;
+        try {
+            service.someSlowMethod(1500);
+            fail("No timeout");
+        } catch (TimeoutException expected) {
+            timeoutExceptionThrown = true;
+        } catch (Exception e) {
+            fail("Unexpected: " + e.getMessage());
+        }
+        assertTrue(TimingOutService.INTERRUPTED.get());
+        assertTrue(timeoutExceptionThrown);
+    }
+
+}

--- a/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/timeout/TimingOutService.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/timeout/TimingOutService.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.faulttolerance.deployment.timeout;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.enterprise.context.RequestScoped;
+
+import org.eclipse.microprofile.faulttolerance.Timeout;
+
+@RequestScoped
+public class TimingOutService {
+
+    static final AtomicBoolean INTERRUPTED = new AtomicBoolean(false);
+
+    @Timeout(500)
+    public String someSlowMethod(int timeToSleep) {
+        try {
+            Thread.sleep(timeToSleep);
+            throw new RuntimeException("Timeout did not interrupt");
+        } catch (InterruptedException e) {
+            INTERRUPTED.set(true);
+        }
+        return null;
+    }
+
+}

--- a/testsuite/microprofile-tcks/fault-tolerance/pom.xml
+++ b/testsuite/microprofile-tcks/fault-tolerance/pom.xml
@@ -99,6 +99,11 @@
                      <name>java.util.logging.config.file</name>
                      <value>${project.build.testOutputDirectory}/logging.properties</value>
                   </property>
+                  <!-- Uncomment to debug arquillian test -->
+                  <!-- property>
+                     <name>swarm.debug.port</name>
+                     <value>8787</value>
+                  </property-->
                </systemProperties>
             </configuration>
          </plugin>


### PR DESCRIPTION
Motivation
----------
Timeout does not work as expected - the execution thread is never
interrupted unless the operation is also marked as asynchronous.

Modifications
-------------
Always use THREAD isolation strategy for timeout operations. Also modify
the way the retry logic is implemented.

Result
------
Execution thread should be interrupted when timeout occurs.