### PR TITLE
SWARM-1768: Get rid of harmless CDI warnings during bootstrap.

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/ServerBootstrapImpl.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/ServerBootstrapImpl.java
@@ -117,7 +117,7 @@ public class ServerBootstrapImpl implements ServerBootstrap {
                     logFractions();
                 }
 
-                RuntimeServer outerServer = LogSilencer.silently("org.jboss.weld").execute(() -> {
+                RuntimeServer outerServer = LogSilencer.silently("org.jboss.weld", "ServiceLoader").execute(() -> {
                     Weld weld = new Weld(WELD_INSTANCE_ID);
                     weld.setClassLoader(module.getClassLoader());
 


### PR DESCRIPTION
Motivation
----------
These warnings are harmless but annoying.

Modifications
-------------
Silence "ServiceLoader" logger during bootstrap.

Result
------
No warnings.