### PR TITLE
SWARM-1847 SwaggerArchivePreparer shouldn't be depening that its run …

### DIFF
--- a/fractions/swagger/src/main/java/org/wildfly/swarm/swagger/runtime/SwaggerArchivePreparer.java
+++ b/fractions/swagger/src/main/java/org/wildfly/swarm/swagger/runtime/SwaggerArchivePreparer.java
@@ -10,6 +10,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ArchivePath;
 import org.jboss.shrinkwrap.api.Node;
 import org.wildfly.swarm.container.runtime.cdi.DeploymentContext;
+import org.wildfly.swarm.spi.api.Defaultable;
 import org.wildfly.swarm.spi.api.DeploymentProcessor;
 import org.wildfly.swarm.spi.api.annotations.Configurable;
 import org.wildfly.swarm.spi.runtime.annotations.DeploymentScoped;
@@ -52,6 +53,10 @@ public class SwaggerArchivePreparer implements DeploymentProcessor {
 
     @Configurable("swarm.deployment.*.swagger.root")
     private String root;
+
+    @Configurable("swarm.deployment.*.context.path")
+    @Configurable("swarm.context.path")
+    Defaultable<String> contextPath = Defaultable.string("/");
 
     private final Archive archive;
 
@@ -118,7 +123,11 @@ public class SwaggerArchivePreparer implements DeploymentProcessor {
                 swaggerArchive.setContextRoot(this.root);
             } else {
                 if (!swaggerArchive.hasContextRoot()) {
-                    swaggerArchive.setContextRoot(deployment.getContextRoot());
+                    if (deployment.getContextRoot() != null) {
+                        swaggerArchive.setContextRoot(deployment.getContextRoot());
+                    } else {
+                        swaggerArchive.setContextRoot(contextPath.get());
+                    }
                 }
             }
 


### PR DESCRIPTION
SwaggerArchivePreparer sets root if swarm.deployment.*.swagger.root is set, else it will use contextPath from deployment. The problem is that its ContextPathArchivePreparer thats setting contextpath. 
The deploymentProcessors are injected in no specific order so its no guarantee that ContextPathArchivePreparer has run. This will make SwaggerArchivePreparer independent from ContextPathArchivePreparer


- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
