### PR TITLE
SWARM-1813 Configuring interfaces through YAML doesn't work

### DIFF
--- a/core/container/pom.xml
+++ b/core/container/pom.xml
@@ -220,7 +220,11 @@
         </exclusion>
       </exclusions>
     </dependency>
-
+    <dependency>
+      <groupId>org.jboss.spec.javax.el</groupId>
+      <artifactId>jboss-el-api_3.0_spec</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/NetworkConfigurer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/NetworkConfigurer.java
@@ -84,6 +84,9 @@ public class NetworkConfigurer {
         applyConfiguration(key.append("port-offset"), (portOffset) -> {
             group.portOffset(portOffset.toString());
         });
+        applyConfiguration(key.append("default-interface"), (defaultInterface) -> {
+            group.defaultInterface(defaultInterface.toString());
+        });
 
     }
 

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/InterfaceExtension.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/InterfaceExtension.java
@@ -17,7 +17,6 @@ package org.wildfly.swarm.container.runtime.cdi;
 
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
@@ -63,8 +62,6 @@ public class InterfaceExtension extends AbstractNetworkExtension<Interface> {
 
             Set<Bean<?>> ifaces = beanManager.getBeans(Interface.class, AnyLiteral.INSTANCE);
 
-            AtomicBoolean producerRequired = new AtomicBoolean(false);
-
             if (ifaces
                     .stream()
                     .noneMatch(e -> e.getQualifiers()
@@ -73,8 +70,7 @@ public class InterfaceExtension extends AbstractNetworkExtension<Interface> {
 
                 Interface iface = new Interface(interfaceName.name(), "0.0.0.0");
                 applyConfiguration(iface);
-                if (producerRequired.get()) {
-                    CommonBean<Interface> interfaceBean = CommonBeanBuilder.newBuilder(Interface.class)
+                CommonBean<Interface> interfaceBean = CommonBeanBuilder.newBuilder(Interface.class)
                             .beanClass(InterfaceExtension.class)
                             .scope(ApplicationScoped.class)
                             .addQualifier(AnyLiteral.INSTANCE)
@@ -84,8 +80,7 @@ public class InterfaceExtension extends AbstractNetworkExtension<Interface> {
                             .addType(Object.class)
                             .build();
 
-                    abd.addBean(interfaceBean);
-                }
+                abd.addBean(interfaceBean);
             }
         }
     }

--- a/core/container/src/test/java/org/wildfly/swarm/container/runtime/cdi/InterfaceExtensionTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/container/runtime/cdi/InterfaceExtensionTest.java
@@ -1,0 +1,52 @@
+package org.wildfly.swarm.container.runtime.cdi;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+
+import javax.enterprise.inject.spi.AfterBeanDiscovery;
+import javax.enterprise.inject.spi.BeanManager;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.wildfly.swarm.container.Interface;
+import org.wildfly.swarm.spi.api.cdi.CommonBean;
+import org.wildfly.swarm.spi.api.config.ConfigKey;
+import org.wildfly.swarm.spi.api.config.ConfigView;
+import org.wildfly.swarm.spi.api.config.SimpleKey;
+
+public class InterfaceExtensionTest {
+    
+    @InjectMocks
+    private InterfaceExtension ext;
+    
+    @Test
+    public void testAfterBeanDiscovery() throws Exception {
+        ConfigView configView = mock(ConfigView.class);
+        List<SimpleKey> interfaces = Arrays.asList(new SimpleKey("test"));
+        when(configView.simpleSubkeys(any(ConfigKey.class))).thenReturn(interfaces);
+        when(configView.valueOf(any(ConfigKey.class))).thenReturn("192.168.1.1");
+        ext = new InterfaceExtension(configView);
+        
+        BeanManager beanManager = mock(BeanManager.class);
+        AfterBeanDiscovery abd = mock(AfterBeanDiscovery.class);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<CommonBean<Interface>> captor = ArgumentCaptor.forClass(CommonBean.class);
+        
+        ext.afterBeanDiscovery(abd, beanManager);
+        
+        verify(abd,times(1)).addBean(captor.capture());
+        assertThat(captor.getValue().create(null).getName()).isEqualTo("test");
+        assertThat(captor.getValue().create(null).getExpression()).isEqualTo("192.168.1.1");
+    }
+
+}


### PR DESCRIPTION
InterfaceExtension did handle configuration of interfaces with yaml but it was if statement that always was false, don't really understand the purpose of it. 
So removed the statement added so you can handle defaultInterface in SocketBindingGroup so exempel 
``` 
network:
  socket-binding-groups:
      standard-sockets:
        default-interface: other
    interfaces:
      other:
        bind: 192.168.1.48
      public:
        bind: 127.0.0.1
```
will now work

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
