### PR TITLE
SWARM-1833: Improve index available in DeploymentProcessor.

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/configurable/DeploymentProducer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/configurable/DeploymentProducer.java
@@ -16,19 +16,31 @@
 package org.wildfly.swarm.container.runtime.cdi.configurable;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 
+import org.jboss.jandex.CompositeIndex;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.IndexReader;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.Indexer;
+import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.Node;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.ArchiveAsset;
+import org.jboss.shrinkwrap.api.container.LibraryContainer;
+import org.jboss.shrinkwrap.api.importer.ZipImporter;
 import org.wildfly.swarm.container.runtime.cdi.DeploymentContext;
+import org.wildfly.swarm.spi.api.JARArchive;
 import org.wildfly.swarm.spi.runtime.annotations.DeploymentScoped;
 
 /**
@@ -37,34 +49,76 @@ import org.wildfly.swarm.spi.runtime.annotations.DeploymentScoped;
 @ApplicationScoped
 public class DeploymentProducer {
 
+    private static final Logger LOGGER = Logger.getLogger("org.wildfly.swarm.deployment");
+
     private static final String CLASS_SUFFIX = ".class";
+
+    private static final String JAR_SUFFIX = ".jar";
+
+    static final String INDEX_LOCATION = "META-INF/jandex.idx";
 
     @Inject
     DeploymentContext context;
 
     @Produces
     @DeploymentScoped
-    @Default
     Archive archive() {
         return context.getCurrentArchive();
     }
 
     @Produces
     @DeploymentScoped
-    @Default
     IndexView index() {
-        Indexer indexer = new Indexer();
-        Map<ArchivePath, Node> c = context.getCurrentArchive().getContent();
+        return createDeploymentIndex(context.getCurrentArchive());
+    }
+
+    IndexView createDeploymentIndex(Archive<?> deployment) {
+        List<IndexView> indexes = new ArrayList<IndexView>();
         try {
-            for (Map.Entry<ArchivePath, Node> each : c.entrySet()) {
-                if (each.getKey().get().endsWith(CLASS_SUFFIX)) {
-                    indexer.index(each.getValue().getAsset().openStream());
-                }
-            }
+            index(deployment, indexes);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-
-        return indexer.complete();
+        return CompositeIndex.create(indexes);
     }
+
+    private void index(Archive<?> archive, List<IndexView> indexes) throws IOException {
+        LOGGER.debugv("Indexing archive: {0}", archive.getName());
+
+        // First try to load attached index
+        Node indexNode = archive.get(ArchivePaths.create(INDEX_LOCATION));
+        if (indexNode != null) {
+            try (InputStream indexStream = indexNode.getAsset().openStream()) {
+                LOGGER.debugv("Loading attached index from archive: {0}", archive.getName());
+                indexes.add(new IndexReader(indexStream).read());
+            }
+        } else {
+            // No index found - index all classes found
+            Indexer indexer = new Indexer();
+            for (Map.Entry<ArchivePath, Node> entry : archive.getContent(a -> a.get().endsWith(CLASS_SUFFIX)).entrySet()) {
+                try (InputStream contentStream = entry.getValue().getAsset().openStream()) {
+                    LOGGER.debugv("Indexing asset: {0} from archive: {1}", entry.getKey().get(), archive.getName());
+                    indexer.index(contentStream);
+                }
+            }
+            Index index = indexer.complete();
+            indexes.add(index);
+        }
+
+        if (archive instanceof LibraryContainer) {
+            for (Map.Entry<ArchivePath, Node> entry : archive.getContent(a -> a.get().endsWith(JAR_SUFFIX)).entrySet()) {
+                if (entry.getValue().getAsset() instanceof ArchiveAsset) {
+                    ArchiveAsset archiveAsset = (ArchiveAsset) entry.getValue().getAsset();
+                    index(archiveAsset.getArchive(), indexes);
+                } else {
+                    try (InputStream contentStream = entry.getValue().getAsset().openStream()) {
+                        JARArchive jarArchive = ShrinkWrap.create(JARArchive.class, entry.getKey().get()).as(ZipImporter.class).importFrom(contentStream)
+                                .as(JARArchive.class);
+                        index(jarArchive, indexes);
+                    }
+                }
+            }
+        }
+    }
+
 }

--- a/core/container/src/test/java/org/wildfly/swarm/container/runtime/cdi/configurable/Bar.java
+++ b/core/container/src/test/java/org/wildfly/swarm/container/runtime/cdi/configurable/Bar.java
@@ -1,0 +1,5 @@
+package org.wildfly.swarm.container.runtime.cdi.configurable;
+
+public class Bar {
+
+}

--- a/core/container/src/test/java/org/wildfly/swarm/container/runtime/cdi/configurable/Baz.java
+++ b/core/container/src/test/java/org/wildfly/swarm/container/runtime/cdi/configurable/Baz.java
@@ -1,0 +1,5 @@
+package org.wildfly.swarm.container.runtime.cdi.configurable;
+
+public class Baz {
+
+}

--- a/core/container/src/test/java/org/wildfly/swarm/container/runtime/cdi/configurable/Delta.java
+++ b/core/container/src/test/java/org/wildfly/swarm/container/runtime/cdi/configurable/Delta.java
@@ -1,0 +1,5 @@
+package org.wildfly.swarm.container.runtime.cdi.configurable;
+
+public class Delta {
+
+}

--- a/core/container/src/test/java/org/wildfly/swarm/container/runtime/cdi/configurable/DeploymentIndexTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/container/runtime/cdi/configurable/DeploymentIndexTest.java
@@ -1,0 +1,78 @@
+package org.wildfly.swarm.container.runtime.cdi.configurable;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.jboss.jandex.Index;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.IndexWriter;
+import org.jboss.jandex.Indexer;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ * @author Martin Kouba
+ */
+public class DeploymentIndexTest {
+
+    @Test
+    public void testIndexBuilt() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class);
+        war.addClass(Foo.class);
+        JavaArchive lib1 = ShrinkWrap.create(JavaArchive.class).addClass(Bar.class);
+        war.addAsLibraries(lib1);
+        IndexView index = new DeploymentProducer().createDeploymentIndex(war);
+        assertContains(index, Foo.class);
+        assertDoesNotContain(index, Baz.class);
+        assertContains(index, Bar.class);
+        assertDoesNotContain(index, Delta.class);
+    }
+
+    @Test
+    public void testIndexAttached() throws IOException {
+        WebArchive war = ShrinkWrap.create(WebArchive.class);
+        war.addClass(Foo.class);
+        war.add(createIndexAsset(Foo.class, Baz.class), DeploymentProducer.INDEX_LOCATION);
+        JavaArchive lib1 = ShrinkWrap.create(JavaArchive.class).addClass(Bar.class);
+        lib1.add(createIndexAsset(Delta.class), DeploymentProducer.INDEX_LOCATION);
+        war.addAsLibraries(lib1);
+        IndexView index = new DeploymentProducer().createDeploymentIndex(war);
+        assertContains(index, Foo.class);
+        // Baz should be found in the attached index
+        assertContains(index, Baz.class);
+        assertContains(index, Delta.class);
+        // Bar is not in the attached index
+        assertDoesNotContain(index, Bar.class);
+    }
+
+    private void assertContains(IndexView index, Class<?> clazz) {
+        Assert.assertTrue("Index should contain: " + clazz, index.getKnownClasses().stream().anyMatch(c -> c.name().toString().equals(clazz.getName())));
+    }
+
+    private void assertDoesNotContain(IndexView index, Class<?> clazz) {
+        Assert.assertTrue("Index should not contain: " + clazz, index.getKnownClasses().stream().noneMatch(c -> c.name().toString().equals(clazz.getName())));
+    }
+
+    private Asset createIndexAsset(Class<?>... classes) throws IOException {
+        Indexer indexer = new Indexer();
+        for (Class<?> clazz : classes) {
+            try (InputStream stream = DeploymentIndexTest.class.getClassLoader().getResourceAsStream(clazz.getName().replace(".", "/") + ".class")) {
+                if (stream != null) {
+                    indexer.index(stream);
+                }
+            }
+        }
+        Index index = indexer.complete();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        new IndexWriter(out).write(index);
+        return new ByteArrayAsset(out.toByteArray());
+    }
+
+}

--- a/core/container/src/test/java/org/wildfly/swarm/container/runtime/cdi/configurable/Foo.java
+++ b/core/container/src/test/java/org/wildfly/swarm/container/runtime/cdi/configurable/Foo.java
@@ -1,0 +1,5 @@
+package org.wildfly.swarm.container.runtime.cdi.configurable;
+
+public class Foo {
+
+}


### PR DESCRIPTION
Motivation
----------
Currently, the index only contains classes of the top-level
ClassContainer, e.g. WEB-INF/classes for a WAR. Also we don't load/reuse
attached indexes.

Modifications
-------------
Modified DeploymentProducer.index() producer method.

Result
------
DeploymentProducer.index() returns a composite annotation index
(incl. dependencies, e.g. WEB-INF/lib) and attached indexes (located in
META-INF/jandex.idx) are reused.