### PR TITLE
SWARM-816 Swagger-WebApp Ability to configure and default the discovery PATH

### DIFF
--- a/fractions/swagger-webapp/src/main/java/org/wildfly/swarm/swagger/webapp/runtime/SwaggerDefaultUrlChangerServlet.java
+++ b/fractions/swagger-webapp/src/main/java/org/wildfly/swarm/swagger/webapp/runtime/SwaggerDefaultUrlChangerServlet.java
@@ -1,0 +1,41 @@
+package org.wildfly.swarm.swagger.webapp.runtime;
+
+import java.io.IOException;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.wildfly.swarm.spi.runtime.annotations.ConfigurationValue;
+
+/**
+ * this servlet will listen to /swagger-ui and if swarm.swagger.web-app.json.path
+ * is configured redirect to index.html?url= so swagger will load the swagger.json
+ * configured.
+ * @author john
+ *
+ */
+@ApplicationScoped
+@WebServlet("")
+public class SwaggerDefaultUrlChangerServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+    @Inject
+    @ConfigurationValue ("swarm.swagger.web-app.json.path")
+    private String path;
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+      throws ServletException, IOException {
+      if (path == null) {
+          response.sendRedirect("index.html");
+      } else {
+          response.sendRedirect("index.html?url=" + path);
+      }
+    }
+
+}

--- a/fractions/swagger-webapp/src/main/java/org/wildfly/swarm/swagger/webapp/runtime/SwaggerWebAppDeploymentProducer.java
+++ b/fractions/swagger-webapp/src/main/java/org/wildfly/swarm/swagger/webapp/runtime/SwaggerWebAppDeploymentProducer.java
@@ -68,6 +68,7 @@ public class SwaggerWebAppDeploymentProducer {
         WARArchive war = ShrinkWrap.create(WARArchive.class, "swagger-ui.war")
                 .addAsLibrary(relocatedJar)
                 .setContextRoot(this.fraction.getContext());
+        war.addClass(SwaggerDefaultUrlChangerServlet.class);
 
         // If any user content has been provided, merge that with the swagger-ui bits
         Archive<?> userContent = this.fraction.getWebContent();

--- a/testsuite/testsuite-swagger-webapp/pom.xml
+++ b/testsuite/testsuite-swagger-webapp/pom.xml
@@ -32,6 +32,11 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>cdi</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>arquillian</artifactId>
       <scope>test</scope>
     </dependency>

--- a/testsuite/testsuite-swagger-webapp/src/test/java/org/wildfly/swarm/swagger/webapp/SwaggerWebAppDefaultUrlChangerArquillianTest.java
+++ b/testsuite/testsuite-swagger-webapp/src/test/java/org/wildfly/swarm/swagger/webapp/SwaggerWebAppDefaultUrlChangerArquillianTest.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.swagger.webapp;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.arquillian.CreateSwarm;
+import org.wildfly.swarm.cdi.CDIFraction;
+import org.wildfly.swarm.spi.api.JARArchive;
+
+/**
+ * @author John Alstrom
+ */
+@RunWith(Arquillian.class)
+public class SwaggerWebAppDefaultUrlChangerArquillianTest {
+
+    @SuppressWarnings("rawtypes")
+    @Deployment(testable = false)
+    public static Archive createDeployment() {
+        JARArchive deployment = ShrinkWrap.create(JARArchive.class);
+        deployment.addAsResource("project-application-path.yml");
+        return deployment;
+    }
+
+    @CreateSwarm
+    public static Swarm newContainer() throws Exception {
+        Swarm swarm = new Swarm();
+        swarm.fraction(new CDIFraction());
+        swarm.withProfile("application-path");
+        return swarm;
+    }
+
+    @RunAsClient
+    @Test
+    public void testEndpoints() throws Exception {
+        String newUrl = getUrl("http://127.0.0.1:8080/api/docs/");
+        assertThat(newUrl).isEqualTo("http://127.0.0.1:8080/api/docs/index.html?url=/rest/swagger.json");
+    }
+    
+    private static String getUrl(String theUrl) {
+        StringBuilder content = new StringBuilder();
+
+        try {
+            URL url = new URL(theUrl);
+            HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
+            urlConnection.setInstanceFollowRedirects(false);
+            
+            int responseCode = urlConnection.getResponseCode();
+            if(responseCode == 302) {
+                String newUrl = urlConnection.getHeaderField("Location");
+                content.append(newUrl);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return content.toString();
+    }
+
+}

--- a/testsuite/testsuite-swagger-webapp/src/test/resources/project-application-path.yml
+++ b/testsuite/testsuite-swagger-webapp/src/test/resources/project-application-path.yml
@@ -1,0 +1,6 @@
+swarm:
+  swagger:
+    web-app:
+      json:
+        path: /rest/swagger.json
+      context: /api/docs


### PR DESCRIPTION
Make it possible to set where swagger-ui should find swagger.json.

Didn't want to go in and change the content in org.webjars.swagger-ui and possible break future updates. So the solution is a little bit, well...
I appends a servlet to swagger-ui.war with the purpose to listen to /swagger-ui/ and if the property is set, then do a redirect to /swagger-ui/index.html?url=/rest/swagger.json

feedback is appreciated

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
