### PR TITLE
SWARM-1862: Make default JavaScript engine available in deployment.

### DIFF
--- a/core/container/src/main/resources/modules/sun/jdk/main/module.xml
+++ b/core/container/src/main/resources/modules/sun/jdk/main/module.xml
@@ -28,7 +28,7 @@
     <resource-root path="service-loader-resources"/>
   </resources>
   <dependencies>
-    <module name="sun.scripting" export="true"/>
+    <module name="sun.scripting" export="true" services="export"/>
     <system export="true">
       <paths>
         <path name="com/sun/image/codec/jpeg"/>

--- a/core/container/src/main/resources/modules/sun/scripting/main/module.xml
+++ b/core/container/src/main/resources/modules/sun/scripting/main/module.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<module name="sun.scripting" xmlns="urn:jboss:module:1.6">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+    <resources>
+        <!-- currently jboss modules has not way of importing services from
+        classes.jar so we duplicate them here -->
+        <resource-root path="service-loader-resources"/>
+    </resources>
+    <dependencies>
+        <system export="true">
+            <paths>
+                <path name="apple/applescript"/>
+                <path name="com/sun/script/javascript"/>
+                <path name="jdk/nashorn/api/scripting"/>
+                <path name="jdk/nashorn/api/scripting/resources"/>
+                <path name="jdk/nashorn/internal/codegen"/>
+                <path name="jdk/nashorn/internal/codegen/types"/>
+                <path name="jdk/nashorn/internal/ir"/>
+                <path name="jdk/nashorn/internal/ir/annotations"/>
+                <path name="jdk/nashorn/internal/ir/debug"/>
+                <path name="jdk/nashorn/internal/ir/visitor"/>
+                <path name="jdk/nashorn/internal/lookup"/>
+                <path name="jdk/nashorn/internal/objects"/>
+                <path name="jdk/nashorn/internal/objects/annotations"/>
+                <path name="jdk/nashorn/internal/parser"/>
+                <path name="jdk/nashorn/internal/runtime"/>
+                <path name="jdk/nashorn/internal/runtime/arrays"/>
+                <path name="jdk/nashorn/internal/runtime/linker"/>
+                <path name="jdk/nashorn/internal/runtime/options"/>
+                <path name="jdk/nashorn/internal/runtime/regexp"/>
+                <path name="jdk/nashorn/internal/runtime/regexp/joni"/>
+                <path name="jdk/nashorn/internal/runtime/resources"/>
+                <path name="jdk/nashorn/internal/runtime/resources/fx"/>
+                <path name="jdk/nashorn/internal/runtime/scripts"/>
+                <path name="jdk/nashorn/internal/tools"/>
+                <path name="jdk/nashorn/internal/tools/resources"/>
+                <path name="jdk/internal/dynalink"/>
+                <path name="jdk/internal/dynalink/beans"/>
+                <path name="jdk/internal/dynalink/linker"/>
+                <path name="jdk/internal/dynalink/support"/>
+<!--
+                Prevent services files from being exported as it causes problems with IDE and wildfly-swarm:run
+                <path name="META-INF/services"/>
+-->
+            </paths>
+            <exports>
+                <include-set>
+                    <path name="META-INF/services"/>
+                </include-set>
+            </exports>
+        </system>
+    </dependencies>
+</module>

--- a/core/container/src/main/resources/modules/sun/scripting/main/service-loader-resources/META-INF/services/javax.script.ScriptEngineFactory
+++ b/core/container/src/main/resources/modules/sun/scripting/main/service-loader-resources/META-INF/services/javax.script.ScriptEngineFactory
@@ -1,0 +1,1 @@
+jdk.nashorn.api.scripting.NashornScriptEngineFactory

--- a/testsuite/testsuite-scriptengine/pom.xml
+++ b/testsuite/testsuite-scriptengine/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm.testsuite</groupId>
+    <artifactId>testsuite-parent</artifactId>
+    <version>2018.3.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <artifactId>testsuite-scriptengine</artifactId>
+
+  <name>Test Suite: ScriptEngine</name>
+  <description>Test Suite: ScriptEngine</description>
+
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>arquillian</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.junit</groupId>
+      <artifactId>arquillian-junit-container</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>fluent-hc</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/testsuite/testsuite-scriptengine/src/main/java/org/wildfly/swarm/scriptengine/test/TestResource.java
+++ b/testsuite/testsuite-scriptengine/src/main/java/org/wildfly/swarm/scriptengine/test/TestResource.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.scriptengine.test;
+
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ * @author Martin Kouba
+ */
+@Path("/engine")
+public class TestResource {
+
+    @GET
+    public String get() throws ScriptException  {
+        ScriptEngineManager engineManager = new ScriptEngineManager();
+        ScriptEngine scriptEngine = engineManager.getEngineByName("JavaScript");
+        if (scriptEngine != null) {
+            return scriptEngine.eval("1 + 1").toString();
+        }
+        return "no engine";
+    }
+}

--- a/testsuite/testsuite-scriptengine/src/test/java/org/wildfly/swarm/scriptengine/test/ScriptEngineTest.java
+++ b/testsuite/testsuite-scriptengine/src/test/java/org/wildfly/swarm/scriptengine/test/ScriptEngineTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.scriptengine.test;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.http.client.fluent.Request;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.arquillian.DefaultDeployment;
+
+/**
+ * @author Martin Kouba
+ */
+@RunWith(Arquillian.class)
+@DefaultDeployment
+public class ScriptEngineTest {
+
+    @Test
+    @RunAsClient
+    public void testScriptEngineAvailable() throws Exception {
+        assertEquals("2", Request.Get("http://localhost:8080/engine").execute().returnContent().asString());
+    }
+
+}


### PR DESCRIPTION
Motivation
----------
ScriptEngineFactory.getEngineByName("JavaScript") should work out of the
box. It does in WildFly.

Modifications
-------------
Override module.xml for "sun.scripting" module and modify system
dependency not to export META-INF/services by default.

Result
------
Default engine is available and IDE/wildfly-swarm:run is not broken.

NOTE: I did run `mvn clean test` in `wildfly-swarm-examples` repo manually.