### PR TITLE
SWARM-1870: Allow hollow packaging mode in gradle plugin

### DIFF
--- a/plugins/gradle/src/main/java/org/wildfly/swarm/plugin/gradle/PackageTask.java
+++ b/plugins/gradle/src/main/java/org/wildfly/swarm/plugin/gradle/PackageTask.java
@@ -100,6 +100,7 @@ public class PackageTask extends DefaultTask {
                 .properties(getPropertiesFromFile())
                 .properties(PropertiesUtil.filteredSystemProperties(propertiesFromExtension, false))
                 .fractionDetectionMode(getSwarmExtension().getFractionDetectMode())
+                .hollow(getHollow())
                 .additionalModules(moduleDirs.stream()
                                            .filter(File::exists)
                                            .map(File::getAbsolutePath)
@@ -223,6 +224,12 @@ public class PackageTask extends DefaultTask {
     }
 
     @Input
+    @Optional
+    private Boolean getHollow() {
+        return getSwarmExtension().getHollow();
+    }
+
+    @Input
     private boolean getExecutable() {
         return getSwarmExtension().getExecutable();
     }
@@ -270,7 +277,7 @@ public class PackageTask extends DefaultTask {
     }
 
     private String getBaseName() {
-        return getProject().getName();
+        return getProject().getName() + (this.getHollow() ? "-hollow" : "");
     }
 
     private Path getOutputDirectory() {

--- a/plugins/gradle/src/main/java/org/wildfly/swarm/plugin/gradle/SwarmExtension.java
+++ b/plugins/gradle/src/main/java/org/wildfly/swarm/plugin/gradle/SwarmExtension.java
@@ -51,6 +51,8 @@ public class SwarmExtension {
 
     private BuildTool.FractionDetectionMode fractionDetectMode = BuildTool.FractionDetectionMode.when_missing;
 
+    private Boolean hollow = false;
+
     public SwarmExtension(Project project) {
         this.project = project;
     }
@@ -130,5 +132,13 @@ public class SwarmExtension {
 
     public void setFractionDetectMode(BuildTool.FractionDetectionMode fractionDetectMode) {
         this.fractionDetectMode = fractionDetectMode;
+    }
+
+    public void setHollow(Boolean hollow) {
+        this.hollow = hollow;
+    }
+
+    public Boolean getHollow() {
+        return hollow;
     }
 }


### PR DESCRIPTION
Motivation
----------
The current maven plugin allow for hollow packaging mode.
For gradle users, this feature is not currently present.

Modifications
-------------
A 'hollow' gradle option has been added and used in the gradle packaging task.

Result
------
As a result of a 'gradle build', a *-hollow-swarm.jar file will be created along with a skinny war.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
