### PR TITLE
SWARM-1871: Add a fraction for Java MVC 1.0 with Ozark-RI

### DIFF
--- a/fractions/javaee/mvc/module.conf
+++ b/fractions/javaee/mvc/module.conf
@@ -1,0 +1,3 @@
+org.wildfly.swarm.cdi
+org.wildfly.swarm.jaxrs
+org.wildfly.swarm.bean.validation

--- a/fractions/javaee/mvc/pom.xml
+++ b/fractions/javaee/mvc/pom.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>build-parent</artifactId>
+    <version>2018.4.0-SNAPSHOT</version>
+    <relativePath>../../../build-parent/pom.xml</relativePath>
+  </parent>
+
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>mvc</artifactId>
+
+  <name>MVC</name>
+  <description>MVC 1.0 with Ozark for developing Web UIs</description>
+
+  <packaging>jar</packaging>
+
+  <properties>
+    <swarm.fraction.stability>experimental</swarm.fraction.stability>
+    <swarm.fraction.tags>JavaEE,Web</swarm.fraction.tags>
+    <version.ozark>1.0.0-m03</version.ozark>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>cdi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>bean-validation</artifactId>
+    </dependency>
+
+    <!-- Provided APIs -->
+    <dependency>
+      <groupId>javax.mvc</groupId>
+      <artifactId>javax.mvc-api</artifactId>
+      <version>1.0-pr</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mvc-spec.ozark</groupId>
+      <artifactId>ozark-core</artifactId>
+      <version>${version.ozark}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mvc-spec.ozark</groupId>
+      <artifactId>ozark-resteasy</artifactId>
+      <version>${version.ozark}</version>
+      <scope>runtime</scope>
+    </dependency>
+
+    <!-- Meta SPI -->
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>meta-spi</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.wildfly.core</groupId>
+      <artifactId>wildfly-core-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-servlet-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+</project>

--- a/fractions/javaee/mvc/src/main/java/org/wildfly/swarm/mvc/detect/MvcPackageDetector.java
+++ b/fractions/javaee/mvc/src/main/java/org/wildfly/swarm/mvc/detect/MvcPackageDetector.java
@@ -1,0 +1,14 @@
+package org.wildfly.swarm.mvc.detect;
+
+import org.wildfly.swarm.spi.meta.PackageFractionDetector;
+
+public class MvcPackageDetector extends PackageFractionDetector {
+
+    public MvcPackageDetector() {
+        anyClassOf("javax.mvc.annotation.Controller");
+    }
+
+    public String artifactId() {
+        return "mvc";
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1112,6 +1112,7 @@
 
         <module>fractions/javaee/jpa-spatial</module>
         <module>fractions/javaee/jpa-eclipselink</module>
+        <module>fractions/javaee/mvc</module>
 
 
         <!-- MP 1.3 -->


### PR DESCRIPTION
Motivation
----------
It would be nice to have a fraction for Java MVC, which allows to create
web UIs in a similar fashion to jax-rs services.

Modifications
-------------
This commit adds a new fraction "mvc" in the javaee folder and adds that
fraction to the parent pom.

Result
------
The new fraction will be available under the "web" tag.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
