### PR TITLE
SWARM-1868: Exclude BulkheadSynchRetryTest.testBulkheadQueReplacesDueToClassRetryFailures()

### DIFF
--- a/testsuite/microprofile-tcks/fault-tolerance/src/test/tck-suite.xml
+++ b/testsuite/microprofile-tcks/fault-tolerance/src/test/tck-suite.xml
@@ -26,6 +26,17 @@
       <packages>
          <package name="org.eclipse.microprofile.fault.tolerance.tck.*" />
       </packages>
+
+      <classes>
+         <!-- Issues in the TCK -->
+         <class
+            name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchRetryTest">
+            <methods>
+               <exclude name="testBulkheadQueReplacesDueToClassRetryFailures" />
+            </methods>
+         </class>
+      </classes>
+
    </test>
 
 </suite>


### PR DESCRIPTION
- this test has a timing issue and fails intermittently
- see also https://github.com/eclipse/microprofile-fault-tolerance/issues/227