### PR TITLE
[SWARM-1754] Warning only in case of the multiple factories

### DIFF
--- a/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/deployment/principal/JWTCallerPrincipalFactory.java
+++ b/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/deployment/principal/JWTCallerPrincipalFactory.java
@@ -84,19 +84,21 @@ public abstract class JWTCallerPrincipalFactory {
             URL u = cl.getResource("/META-INF/services/org.eclipse.microprofile.jwt.principal.JWTCallerPrincipalFactory");
             log.debugf("loadSpi, cl=%s, u=%s, sl=%s", cl, u, sl);
             try {
-                for (JWTCallerPrincipalFactory spi : sl) {
-                    if (instance != null) {
-                        throw new MultipleFactoriesException(spi.getClass().getName());
-                    } else {
-                        log.debugf("sl=%s, loaded=%s", sl, spi);
-                        instance = spi;
+                for (Object spi : sl) {
+                    if (spi instanceof JWTCallerPrincipalFactory) {
+                        if (instance != null) {
+                            throw new MultipleFactoriesException(spi.getClass().getName());
+                        } else {
+                            log.debugf("sl=%s, loaded=%s", sl, spi);
+                            instance = (JWTCallerPrincipalFactory)spi;
+                        }
                     }
                 }
             } catch (MultipleFactoriesException e) {
                 log.warn("Multiple JWTCallerPrincipalFactory implementations found: "
                           + e.getSpiClassName() + " and " + instance.getClass().getName());
             } catch (Throwable e) {
-                log.debugf("Failed to locate JWTCallerPrincipalFactory provider, e=%s", e);
+                log.warn("Failed to locate JWTCallerPrincipalFactory provider", e);
             }
         }
         return instance;

--- a/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/deployment/principal/JWTCallerPrincipalFactory.java
+++ b/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/deployment/principal/JWTCallerPrincipalFactory.java
@@ -87,16 +87,15 @@ public abstract class JWTCallerPrincipalFactory {
                 for (Object spi : sl) {
                     if (spi instanceof JWTCallerPrincipalFactory) {
                         if (instance != null) {
-                            throw new MultipleFactoriesException(spi.getClass().getName());
+                            log.warn("Multiple JWTCallerPrincipalFactory implementations found: "
+                                + spi.getClass().getName() + " and " + instance.getClass().getName());
+                            break;
                         } else {
                             log.debugf("sl=%s, loaded=%s", sl, spi);
                             instance = (JWTCallerPrincipalFactory)spi;
                         }
                     }
                 }
-            } catch (MultipleFactoriesException e) {
-                log.warn("Multiple JWTCallerPrincipalFactory implementations found: "
-                          + e.getSpiClassName() + " and " + instance.getClass().getName());
             } catch (Throwable e) {
                 log.warn("Failed to locate JWTCallerPrincipalFactory provider", e);
             }
@@ -121,14 +120,4 @@ public abstract class JWTCallerPrincipalFactory {
      * @throws ParseException on parse or verification failure.
      */
     public abstract JWTCallerPrincipal parse(String token, JWTAuthContextInfo authContextInfo) throws ParseException;
-
-    private static class MultipleFactoriesException extends Exception {
-        String spiClassName;
-        MultipleFactoriesException(String spiClassName) {
-            this.spiClassName = spiClassName;
-        }
-        String getSpiClassName() {
-            return spiClassName;
-        }
-    }
 }

--- a/fractions/microprofile/microprofile-jwt/src/main/resources/META-INF/services/org.wildfly.swarm.microprofile.jwtauth.deployment.principal.JWTCallerPrincipalFactory
+++ b/fractions/microprofile/microprofile-jwt/src/main/resources/META-INF/services/org.wildfly.swarm.microprofile.jwtauth.deployment.principal.JWTCallerPrincipalFactory
@@ -1,1 +1,0 @@
-org.wildfly.swarm.microprofile.jwtauth.deployment.principal.DefaultJWTCallerPrincipalFactory

--- a/fractions/microprofile/microprofile-jwt/src/main/resources/META-INF/services/org.wildfly.swarm.mpjwtauth.deployment.principal.JWTCallerPrincipalFactory
+++ b/fractions/microprofile/microprofile-jwt/src/main/resources/META-INF/services/org.wildfly.swarm.mpjwtauth.deployment.principal.JWTCallerPrincipalFactory
@@ -1,1 +1,0 @@
-org.wildfly.swarm.mpjwtauth.deployment.principal.DefaultJWTCallerPrincipalFactory


### PR DESCRIPTION
Removed the service loader resources given they refer to the default principal factory
Introduced an internal exception to help with deciding when to warn on the exception
Loading the Default factory directly if no custom factory has been found