### PR TITLE
SWARM-1868: Exclude BulkheadAsynchRetryTest.testBulkheadMethodAsynchronousRetry55Trip()

### DIFF
--- a/testsuite/microprofile-tcks/fault-tolerance/src/test/tck-suite.xml
+++ b/testsuite/microprofile-tcks/fault-tolerance/src/test/tck-suite.xml
@@ -35,6 +35,12 @@
                <exclude name="testBulkheadQueReplacesDueToClassRetryFailures" />
             </methods>
          </class>
+         <class
+            name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchRetryTest">
+            <methods>
+               <exclude name="testBulkheadMethodAsynchronousRetry55Trip" />
+            </methods>
+         </class>
       </classes>
 
    </test>


### PR DESCRIPTION
- see also https://github.com/eclipse/microprofile-fault-tolerance/issues/232