### PR TITLE
SWARM-1326 Swarm brings weird Arquillian versions transitively

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -141,6 +141,14 @@
       </dependency>
 
       <dependency>
+        <groupId>org.jboss.arquillian</groupId>
+        <artifactId>arquillian-bom</artifactId>
+        <version>${version.org.arquillian}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
         <groupId>org.wildfly</groupId>
         <artifactId>wildfly-parent</artifactId>
         <version>${version.wildfly}</version>

--- a/testsuite/microprofile-tcks/pom.xml
+++ b/testsuite/microprofile-tcks/pom.xml
@@ -38,6 +38,9 @@
     <properties>
         <!-- Do not upgrade until https://issues.jboss.org/browse/ARQ-2144 is fixed -->
         <version.testng>6.9.9</version.testng>
+        <!-- When upgrading testng, make sure to use swarm version of arquillian -->
+        <version.arquillian.testng>1.1.13.Final</version.arquillian.testng>
+        
         <!-- Overriding 2.19 due to https://issues.apache.org/jira/browse/SUREFIRE-1252 -->
         <version.maven-surefire>2.20.1</version.maven-surefire>
         <!-- commons-logging (needed by httpclient) is for some reason exluded -->
@@ -79,6 +82,13 @@
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <version>${version.testng}</version>
+            <scope>test</scope>
+         </dependency>
+	     
+         <dependency>
+            <groupId>org.jboss.arquillian.testng</groupId>
+            <artifactId>arquillian-testng-container</artifactId>
+            <version>${version.arquillian.testng}</version>
             <scope>test</scope>
          </dependency>
 


### PR DESCRIPTION
The different version seems like its picked up by wildfly-parent, the easy solution is make sure the arquillian-bom gets precedence. 

Or is this a dangerous path to go it may hard to overlook what other transitive dependencies that can be affected? 

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
