### PR TITLE
SWARM-1879: Fix regression caused by a non-definitive change

### DIFF
--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
@@ -275,8 +275,9 @@ public class UberjarSimpleContainer implements SimpleContainer {
                 System.err.println("-> " + each.getKey());
             }*/
 
-        executable = File.createTempFile(TempFileManager.WFSWARM_TMP_PREFIX + "arquillian", "-swarm.jar");
+        File executable = File.createTempFile(TempFileManager.WFSWARM_TMP_PREFIX + "arquillian", "-swarm.jar");
         wrapped.as(ZipExporter.class).exportTo(executable, true);
+        executable.deleteOnExit();
 
         String mavenRepoLocal = System.getProperty("maven.repo.local");
 
@@ -356,7 +357,6 @@ public class UberjarSimpleContainer implements SimpleContainer {
     public void stop() throws Exception {
         this.process.stop();
         TempFileManager.deleteRecursively(workingDirectory);
-        executable.delete();
     }
 
     private String ga(final MavenCoordinate coord) {
@@ -388,22 +388,6 @@ public class UberjarSimpleContainer implements SimpleContainer {
 
     }
 
-    private void deleteRecursively(File file) {
-        if (!file.exists()) {
-            return;
-        }
-        if (file.isDirectory()) {
-            File[] files = file.listFiles();
-            if (files != null) {
-                for (File child : files) {
-                    deleteRecursively(child);
-                }
-            }
-        }
-
-        file.delete();
-    }
-
     private final Class<?> testClass;
 
     private SwarmProcess process;
@@ -413,8 +397,5 @@ public class UberjarSimpleContainer implements SimpleContainer {
     private String javaVmArguments;
 
     private File workingDirectory;
-
-    private File executable;
-
 }
 

--- a/testsuite/microprofile-tcks/openapi/pom.xml
+++ b/testsuite/microprofile-tcks/openapi/pom.xml
@@ -106,7 +106,41 @@
                </systemPropertyVariables>
             </configuration>
          </plugin>
-      </plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <dependencies>
+             <dependency>
+              <groupId>org.wildfly.swarm</groupId>
+              <artifactId>wildfly-swarm-enforcer-pattern-size</artifactId>
+              <version>${project.version}</version>
+            </dependency>
+         </dependencies>
+         <executions>
+           <execution>
+             <id>enforce</id>
+             <phase>verify</phase>
+             <configuration>
+               <rules>
+                 <patternSizeRule implementation="org.wildfly.swarm.plugin.enforcer.patternsize.RequireFilePatternSize">
+                  <requiredFilePatterns>
+                    <requiredFilePattern>
+                        <maxSize>0</maxSize>
+                        <recursive>false</recursive>
+                        <directory>${project.build.directory}</directory>
+                        <pattern>wfswarm\S+[0-9]{5,}.\S{5,}</pattern>
+                     </requiredFilePattern>
+                    </requiredFilePatterns>
+                </patternSizeRule>
+              </rules>
+            </configuration>
+           <goals>
+             <goal>enforce</goal>
+           </goals>
+          </execution>
+        </executions>
+      </plugin>
+     </plugins>
    </build>
 
 </project>


### PR DESCRIPTION
Motivation
 ----------
SWARM-1693 introduced a temporal change that was not intended to be merged. Instead of that fix, removing temp files checks for failing test should be done.

Modifications
-------------
Revert non-intended source change and disable temp files check for java.io.tmpdir directory.

Result
------
All test passing for all environments

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [] Have you built the project locally prior to submission with `mvn clean install`?

-----
