### PR TITLE
SWARM-1883: stop jandex from parsing module-info.class

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/configurable/DeploymentProducer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/configurable/DeploymentProducer.java
@@ -95,10 +95,13 @@ public class DeploymentProducer {
         } else {
             // No index found - index all classes found
             Indexer indexer = new Indexer();
-            for (Map.Entry<ArchivePath, Node> entry : archive.getContent(a -> a.get().endsWith(CLASS_SUFFIX)).entrySet()) {
+            for (Map.Entry<ArchivePath, Node> entry : archive.getContent(this::isClass).entrySet()) {
                 try (InputStream contentStream = entry.getValue().getAsset().openStream()) {
                     LOGGER.debugv("Indexing asset: {0} from archive: {1}", entry.getKey().get(), archive.getName());
                     indexer.index(contentStream);
+                } catch (IOException indexerIOException) {
+                    LOGGER.warn("Failed parsing: " + entry.getKey().get() + " from archive: " + archive.getName(),
+                            indexerIOException);
                 }
             }
             Index index = indexer.complete();
@@ -119,6 +122,11 @@ public class DeploymentProducer {
                 }
             }
         }
+    }
+
+    private boolean isClass(ArchivePath a) {
+        String path = a.get();
+        return path.endsWith(CLASS_SUFFIX) && !path.endsWith("module-info.class");
     }
 
 }

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/configurable/DeploymentProducer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/cdi/configurable/DeploymentProducer.java
@@ -100,8 +100,10 @@ public class DeploymentProducer {
                     LOGGER.debugv("Indexing asset: {0} from archive: {1}", entry.getKey().get(), archive.getName());
                     indexer.index(contentStream);
                 } catch (IOException indexerIOException) {
-                    LOGGER.warn("Failed parsing: " + entry.getKey().get() + " from archive: " + archive.getName(),
-                            indexerIOException);
+                    LOGGER.warnv(indexerIOException,
+                            "Failed parsing: {0} from archive: {1}",
+                            entry.getKey().get(),
+                            archive.getName());
                 }
             }
             Index index = indexer.complete();


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
