### PR TITLE
SWARM-1886: Make use of repackaged war for wildfly-swarm:run.

### DIFF
--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/StartMojo.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/StartMojo.java
@@ -200,7 +200,11 @@ public class StartMojo extends AbstractSwarmMojo {
             finalName = finalName + ".war";
         }
 
-        return executor(Paths.get(this.projectBuildDir, finalName), finalName, false);
+        Path warPath = Paths.get(this.projectBuildDir, finalName);
+        SwarmExecutor executor = executor(warPath, finalName, false);
+        // Specify swarm.app.path property so that repackaged war is used
+        executor.withProperty(BootstrapProperties.APP_PATH, warPath.toString());
+        return executor;
     }
 
 


### PR DESCRIPTION
Motivation
----------
Currently, StartMojo only specifies the swarm.app.name property and
repackaged war is ignored. Instead, Swarm creates a new war and adds
a bunch of project dependencies which are normally removed from the war.
See also DependenciesContainer.ALL_DEPENDENCIES_MARKER.

Modifications
-------------
Modified StartMojo to specify swarm.app.path property and make use
of the repackaged war.

Result
------
When executing app with Maven Plugin and wildfly-swarm.useUberJar=false
(default) the repackaged war is used and some weird classloading issues
should be gone.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
