### PR TITLE
SWARM-1895: [Swagger] Align library & module dependencies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ catalog.xml
 #
 maven-ant-tasks.jar
 test-output
-transaction.log
+
 # vim files
 *.swp
 /.gitk-tmp.*
@@ -35,10 +35,6 @@ atlassian-ide-plugin.xml
 pom.xml.versionsBackup
 # hprof dumps
 /*.hprof
-# ignore 'randomly' strewn around logs
-server.log
-# ignore java crashes
-hs_err_pid*.log
 # H2 databases produced by tests
 *.h2.db
 *.trace.db

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -42,17 +42,17 @@
     <version.jboss-logmanager-ext>1.0.0.Alpha3</version.jboss-logmanager-ext>
     <!-- Weld SE version must be aligned with the version used in WildFly -->
     <version.weld-se>2.4.3.Final</version.weld-se>
+    <!-- Align dependency versions with those present in WildFly parent -->
+    <!-- Doing this explicitly since there is no easy way to import project properties from a pom file -->
+    <version.com.fasterxml.jackson>2.8.9</version.com.fasterxml.jackson>
 
     <version.org.objectweb.asm>6.0</version.org.objectweb.asm>
 
     <version.jolokia>1.3.4</version.jolokia>
     <version.io.swagger>1.5.16</version.io.swagger>
     <version.org.webjars.swagger-ui>3.2.2</version.org.webjars.swagger-ui>
-    <version.swagger.jackson>2.8.4</version.swagger.jackson>
     <version.swagger.reflections>0.9.10</version.swagger.reflections>
     <version.swagger.slf4j>1.6.3</version.swagger.slf4j>
-    <version.swagger.guava>18.0</version.swagger.guava>
-    <version.swagger.javassist>3.18.2-GA</version.swagger.javassist>
     <version.swagger.commons.lang>3.2.1</version.swagger.commons.lang>
 
     <version.hibernate-spatial>5.0.10.Final</version.hibernate-spatial>

--- a/fractions/swagger/pom.xml
+++ b/fractions/swagger/pom.xml
@@ -95,6 +95,19 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
     <!-- Meta SPI -->
     <dependency>
       <groupId>org.wildfly.swarm</groupId>

--- a/fractions/swagger/src/main/resources/modules/com/fasterxml/jackson/swagger/module.xml
+++ b/fractions/swagger/src/main/resources/modules/com/fasterxml/jackson/swagger/module.xml
@@ -1,18 +1,17 @@
 <module xmlns="urn:jboss:module:1.3" name="com.fasterxml.jackson" slot="swagger">
   <resources>
-    <artifact name="com.fasterxml.jackson.core:jackson-core:${version.swagger.jackson}"/>
-    <artifact name="com.fasterxml.jackson.core:jackson-annotations:${version.swagger.jackson}"/>
-    <artifact name="com.fasterxml.jackson.core:jackson-databind:${version.swagger.jackson}"/>
-    <artifact name="com.fasterxml.jackson.datatype:jackson-datatype-joda:${version.swagger.jackson}"/>
-    <artifact name="com.fasterxml.jackson.datatype:jackson-datatype-guava:${version.swagger.jackson}"/>
-    <artifact name="com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${version.swagger.jackson}"/>
-    <artifact name="com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${version.swagger.jackson}"/>
-    <artifact name="com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:${version.swagger.jackson}"/>
-    <artifact name="com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:${version.swagger.jackson}"/>
+    <artifact name="com.fasterxml.jackson.datatype:jackson-datatype-joda:${version.com.fasterxml.jackson}"/>
+    <artifact name="com.fasterxml.jackson.datatype:jackson-datatype-guava:${version.com.fasterxml.jackson}"/>
+    <artifact name="com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${version.com.fasterxml.jackson}"/>
+    <artifact name="com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${version.com.fasterxml.jackson}"/>
   </resources>
 
   <dependencies>
     <module name="javax.ws.rs.api"/>
     <module name="javax.api"/>
+    <module name="com.fasterxml.jackson.core.jackson-core" export="true"/>
+    <module name="com.fasterxml.jackson.core.jackson-databind" export="true"/>
+    <module name="com.fasterxml.jackson.core.jackson-annotations" export="true"/>
+    <module name="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider" export="true"/>
   </dependencies>
 </module>

--- a/fractions/swagger/src/main/resources/modules/io/swagger/main/module.xml
+++ b/fractions/swagger/src/main/resources/modules/io/swagger/main/module.xml
@@ -5,14 +5,14 @@
     <artifact name="io.swagger:swagger-models:${version.io.swagger}"/>
     <artifact name="io.swagger:swagger-annotations:${version.io.swagger}"/>
 
-    <artifact name="com.google.guava:guava:${version.swagger.guava}"/>
     <artifact name="org.reflections:reflections:${version.swagger.reflections}"/>
-    <artifact name="org.javassist:javassist:${version.swagger.javassist}"/>
     <artifact name="org.apache.commons:commons-lang3:${version.swagger.commons.lang}"/>
 
   </resources>
 
   <dependencies>
+    <module name="com.google.guava"/>
+    <module name="org.javassist"/>
     <module name="javax.ws.rs.api"/>
     <module name="javax.servlet.api"/>
     <module name="javax.xml.bind.api"/>


### PR DESCRIPTION
Motivation
----------
The Swagger fraction is pulling in an older version of the Guava dependency (18.0) while the Maven project lists the provided dependency to "20.0". This causes weird issues when using the Gradle plugin for building a "bundled" uber jar file as the dependency is never satisfied. Instead of downgrading the Guava dependency or messing around with the swarmtool / gradle plugin, it makes more sense to add an explicit dependency on the Guava module instead of keeping track / updating the dependency version for each release.

Additionally, at some point in time, if we have the ability to import POM properties of a BOM, we can reuse the library versions easily by referring to the appropriate property names. At a minimum, by aligning the property names, it will help in ensuring that we are copying over the same values from the appropriate bom.

Modifications
-------------
* Refer to the Guava dependency module instead of managing the dependency on our own.
* Align the Jackson & Javassist library versions with those present in WF parent.
* Align the property name for library versions with those present in WF parent.

Result
------
Uber-bundled jars built using the Gradle plugin will no longer complain of missing Javassist, Guava & Jackson libraries.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
