### PR TITLE
SWARM-1792: skipping cache activation for unavailable caches

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
@@ -20,12 +20,14 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.StreamSupport;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Any;
@@ -198,7 +200,9 @@ public class RuntimeServer implements Server {
 
         List<ServiceActivator> activators = new ArrayList<>();
 
-        this.serviceActivators.forEach(activators::add);
+        StreamSupport.stream(serviceActivators.spliterator(), false)
+                .filter(Objects::nonNull)
+                .forEach(activators::add);
 
         activators.add(new ContentRepositoryServiceActivator(this.contentRepository));
 

--- a/fractions/wildfly/infinispan/pom.xml
+++ b/fractions/wildfly/infinispan/pom.xml
@@ -86,6 +86,23 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-annotations</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-processor</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
       <groupId>org.wildfly.core</groupId>
       <artifactId>wildfly-core-feature-pack</artifactId>
       <type>zip</type>

--- a/fractions/wildfly/infinispan/src/main/java/org/wildfly/swarm/infinispan/InfinispanMessages.java
+++ b/fractions/wildfly/infinispan/src/main/java/org/wildfly/swarm/infinispan/InfinispanMessages.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.infinispan;
+
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
+
+/**
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ * <br>
+ * Date: 3/15/18
+ */
+@MessageLogger(projectCode = "WFSISPN", length = 4)
+public interface InfinispanMessages extends BasicLogger {
+
+    InfinispanMessages MESSAGES = Logger.getMessageLogger(InfinispanMessages.class, "org.wildfly.swarm.infinispan");
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 1, value = "Skipping activating cache configuration service: %s. " +
+            "The corresponding fraction is not present.")
+    void skippingCacheActivation(String key);
+}


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
Motivation
----------
To activate the appropriate caches but get rid of error message complaining about the failed services when some caches are not available.

Modifications
-------------
`InfinispanCustomizer` and `CacheActivator` where modified to skip activating caches which are not available (their fractions are not added).
Also, undertow cache was renamed to web and jpa to hibernate. I believe these are the proper names of the cache containers.

Result
------
The error message is no longer printed in the log, yet, when possible, the required caches are started