### PR TITLE
SWARM-1898: fixed counter registration in MP metrics

### DIFF
--- a/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/deployment/MetricsInterceptor.java
+++ b/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/deployment/MetricsInterceptor.java
@@ -102,7 +102,7 @@ import org.jboss.logging.Logger;
             Counted t = counted.metricAnnotation();
             Metadata metadata = getMetadata(counted.metricName(), t.unit(),t.description(),t.displayName(), MetricType.COUNTER, t.tags());
 
-            registry.counter(counted.metricName());
+            registry.counter(metadata);
         }
 
 


### PR DESCRIPTION
Motivation
----------
To respect the user-specified displayName and description for a counter

Modifications
-------------
MetricsInterceptorImpl#registerMetrics modified to register counter by
metadata instead of name

Result
------
The displayName and description are properly applied to the counter
metric

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
