### PR TITLE
Allow the test cases to cleanup after themselves.

### DIFF
--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
@@ -355,7 +355,7 @@ public class UberjarSimpleContainer implements SimpleContainer {
 
     @Override
     public void stop() throws Exception {
-        this.process.stop();
+        this.process.stop(2, TimeUnit.MINUTES); // Because my laptop is slower than yours.
         TempFileManager.deleteRecursively(workingDirectory);
     }
 

--- a/arquillian/arquillian/src/main/java/org/wildfly/swarm/arquillian/runtime/DaemonService.java
+++ b/arquillian/arquillian/src/main/java/org/wildfly/swarm/arquillian/runtime/DaemonService.java
@@ -51,7 +51,7 @@ public class DaemonService implements Service<Server> {
     public void stop(StopContext context) {
         try {
             this.server.stop();
-        } catch (ServerLifecycleException e) {
+        } catch (ServerLifecycleException | InterruptedException e) {
             throw new RuntimeException(e);
         }
     }

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/util/TempFileManager.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/util/TempFileManager.java
@@ -17,7 +17,11 @@ package org.wildfly.swarm.bootstrap.util;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -66,26 +70,43 @@ public class TempFileManager {
         this.registered.add(file);
     }
 
-    public void close() {
-        for (File file : registered) {
-            deleteRecursively(file);
-        }
+    public synchronized void close() {
+        registered.forEach(TempFileManager::deleteRecursively);
+        registered.clear();
     }
 
     public static boolean deleteRecursively(File f) {
         if (!f.exists()) {
             return false;
         }
-        if (f.isDirectory()) {
-            File[] children = f.listFiles();
-            for (int i = 0; i < children.length; ++i) {
-                if (!deleteRecursively(children[i])) {
-                    return false;
+
+        try {
+            Files.walkFileTree(f.toPath(), new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                        throws IOException {
+                    Files.delete(file);
+                    return FileVisitResult.CONTINUE;
                 }
-            }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException e)
+                        throws IOException {
+                    if (e == null) {
+                        Files.delete(dir);
+                        return FileVisitResult.CONTINUE;
+                    } else {
+                        // directory iteration failed
+                        throw e;
+                    }
+                }
+            });
+        } catch (IOException e) {
+            e.printStackTrace();
+            return false;
         }
 
-        return f.delete();
+        return true;
     }
 
     private Set<File> registered = Collections.newSetFromMap(new ConcurrentHashMap<>());

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
@@ -18,7 +18,6 @@ package org.wildfly.swarm.container.runtime;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -53,7 +52,6 @@ import org.wildfly.swarm.bootstrap.modules.MavenResolvers;
 import org.wildfly.swarm.bootstrap.performance.Performance;
 import org.wildfly.swarm.bootstrap.util.JarFileManager;
 import org.wildfly.swarm.bootstrap.util.TempFileManager;
-
 import org.wildfly.swarm.container.internal.Deployer;
 import org.wildfly.swarm.container.internal.Server;
 import org.wildfly.swarm.container.runtime.deployments.DefaultDeploymentCreator;
@@ -301,7 +299,7 @@ public class RuntimeServer implements Server {
         if (shutdownHookHolder != null) {
             Field containersSetField = shutdownHookHolder.getDeclaredField("containers");
             containersSetField.setAccessible(true);
-            Set<?> set = (Set<?>)containersSetField.get(null);
+            Set<?> set = (Set<?>) containersSetField.get(null);
             set.clear();
         }
 
@@ -310,7 +308,15 @@ public class RuntimeServer implements Server {
         this.client = null;
         this.deployer.get().removeAllContent();
         this.deployer = null;
+        cleanup();
+    }
 
+    /**
+     * Clean up all open resources.
+     *
+     * @throws IOException if the close operation fails.
+     */
+    private void cleanup() throws IOException {
         JarFileManager.INSTANCE.close();
         TempFileManager.INSTANCE.close();
         MavenResolvers.close();

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/StopMojo.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/StopMojo.java
@@ -27,6 +27,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.wildfly.swarm.bootstrap.util.TempFileManager;
 import org.wildfly.swarm.tools.exec.SwarmProcess;
 
 /**
@@ -68,28 +69,12 @@ public class StopMojo extends AbstractSwarmMojo {
         if (tmpDir.toFile().exists()) {
             File[] filesTmp = tmpDir.toFile().listFiles();
             for (File tmpFile : filesTmp) {
-                Matcher matcher = tempFilePattern.matcher(tmpFile.getName().toString());
+                Matcher matcher = tempFilePattern.matcher(tmpFile.getName());
                 if (matcher.matches()) {
-                    deleteRecursively(tmpFile);
+                    TempFileManager.deleteRecursively(tmpFile);
                 }
             }
         }
-    }
-
-    public boolean deleteRecursively(File f) {
-        if (!f.exists()) {
-            return false;
-        }
-        if (f.isDirectory()) {
-            File[] children = f.listFiles();
-            for (int i = 0; i < children.length; ++i) {
-                if (!deleteRecursively(children[i])) {
-                    return false;
-                }
-            }
-        }
-
-        return f.delete();
     }
 
     protected void stop(SwarmProcess process) throws MojoFailureException {


### PR DESCRIPTION
Motivation
----------
I have been having a tough time trying to get the code to build on my local machine. I kept hitting the dreaded,

    Some files does not fullfill provided pattern rules:

I found a few issues while debugging the code,

* The thread pools might not be given enough time to clean up.
* The "recursive file delete" operation does not provide enough hints when things go wrong.
* When running with the UberjarSimpleContainer, the process shuts down rather quickly (for slow machines).

Modifications
-------------
1. Ensure that executor pools use the awaitTermination method where applicable.
2. Change the recursive delete operation to use FileWalker instead of the current implementation. This will ensure that if there is an IO exception, it gets printed to the console.
3. Give the Swarm process up to 2 minutes before forcibly killing it.

Result
------
Now the code should build fine on the local laptop (decent hardware specs). This should take care of issues similar to SWARM-1530.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
