### PR TITLE
SWARM-1904: Gradle plugin does not package archiveTask

### DIFF
--- a/plugins/gradle/src/main/java/org/wildfly/swarm/plugin/gradle/PackageTask.java
+++ b/plugins/gradle/src/main/java/org/wildfly/swarm/plugin/gradle/PackageTask.java
@@ -90,7 +90,7 @@ public class PackageTask extends DefaultTask {
 
 
         this.tool = new BuildTool(resolvingHelper)
-                .projectArtifact(project.getGroup().toString(), project.getName(), project.getVersion().toString(),
+                .projectArtifact(this.jarTask.getGroup().toString(), this.jarTask.getBaseName(), this.jarTask.getVersion(),
                                  getPackaging(), getProjectArtifactFile())
                 .mainClass(getMainClassName())
                 .bundleDependencies(getBundleDependencies())


### PR DESCRIPTION
I have changed the gradle plugin for derive the artifact name, group and version from the jarTask that is being wrapped, and not from the project name. This allows the archiveTask configuration option to function correctly