### PR TITLE
SWARM-1905: the MicroProfile TCKs setup requires bom-all

### DIFF
--- a/testsuite/microprofile-tcks/pom.xml
+++ b/testsuite/microprofile-tcks/pom.xml
@@ -72,7 +72,7 @@
 
          <dependency>
             <groupId>org.wildfly.swarm</groupId>
-            <artifactId>bom-all</artifactId>
+            <artifactId>bom</artifactId>
             <version>${project.version}</version>
             <type>pom</type>
             <scope>import</scope>


### PR DESCRIPTION
Motivation
----------
The setup of MicroProfile TCKs requires `bom-all`.
This is unnecessary and also potentially harmful, if the TCKs
were for some reason to depend on things that are outside of
the plain `bom`. It also makes it unnecessarily hard to run
the MicroProfile TCKs in the `swarm.product.build` profile.

Modifications
-------------
The MicroProfile TCKs setup is changed to depend on pure `bom`.

Result
------
MicroProfile TCKs will not inadvertently depend on artifacts
outside of `bom`. MicroProfile TCKs are easier to run
in the `swarm.product.build` profile.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
