### PR TITLE
SWARM-1893: Jaeger/ OpenTracing remote reporting not working

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -84,7 +84,7 @@
     <!-- OpenTracing related versions -->
     <version.opentracing.tracerresolver>0.1.4</version.opentracing.tracerresolver>
     <version.opentracing.servlet>0.1.0</version.opentracing.servlet>
-    <version.jaeger>0.25.0</version.jaeger>
+    <version.jaeger>0.26.0</version.jaeger>
     <version.jaeger.apache.thrift>0.9.2</version.jaeger.apache.thrift>
     <version.jaeger.apache.httpclient>4.2.5</version.jaeger.apache.httpclient>
     <version.jaeger.commons.logging>1.1.1</version.jaeger.commons.logging>


### PR DESCRIPTION
Motivation
----------
To be able to send OpenTracing data to a remote Jeager backend the current dependency towards jaeger-core 0.25.0 need to be updated due to a bug in that particular version (see https://github.com/jaegertracing/jaeger-client-java/commit/ee137d6bcffafafa480c9cc9d504f0359eca8e4a#diff-0162f3d9453acd66f719f9003a23d3dc).

Modifications
-------------
The dependency to jaeger-core has been updated from version 0.25.0 to 0.26.0

Result
------
After updating the jaeger-core dependency the traces are now correctly sent to a remote Jeager backend.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
