### PR TITLE
Code cleanup. Refactor duplicate code in to a utility.

### DIFF
--- a/testsuite/testsuite-buildtool/multi-module/pom.xml
+++ b/testsuite/testsuite-buildtool/multi-module/pom.xml
@@ -72,13 +72,6 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>jaxrs</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>org.wildfly.swarm</groupId>
-      <artifactId>arquillian</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
 

--- a/testsuite/testsuite-buildtool/multi-module/view/pom.xml
+++ b/testsuite/testsuite-buildtool/multi-module/view/pom.xml
@@ -51,7 +51,11 @@
       <groupId>org.wildfly.swarm.testsuite</groupId>
       <artifactId>multi-module-api</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.4</version>
+    </dependency>
   </dependencies>
 
 

--- a/testsuite/testsuite-buildtool/multi-module/view/src/test/java/VerifyBuildArtefactIT.java
+++ b/testsuite/testsuite-buildtool/multi-module/view/src/test/java/VerifyBuildArtefactIT.java
@@ -1,9 +1,8 @@
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.InputStreamReader;
 import java.net.URL;
-import java.net.URLConnection;
+import java.nio.charset.Charset;
 
+import org.apache.commons.io.IOUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
@@ -29,31 +28,8 @@ public class VerifyBuildArtefactIT {
 
     @org.junit.Test
     public void testEndppoint() throws Exception {
-        String urlContents = getUrlContents("http://127.0.0.1:8080/");
-        Assert.assertEquals("something\n", urlContents);
-    }
-
-    private static String getUrlContents(String theUrl) {
-        StringBuilder content = new StringBuilder();
-
-        try {
-            URL url = new URL(theUrl);
-            URLConnection urlConnection = url.openConnection();
-            BufferedReader bufferedReader = new BufferedReader(
-                    new InputStreamReader(urlConnection.getInputStream())
-            );
-
-            String line;
-
-            while ((line = bufferedReader.readLine()) != null) {
-                content.append(line + "\n");
-            }
-            bufferedReader.close();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-
-        return content.toString();
+        String urlContents = IOUtils.toString(new URL("http://127.0.0.1:8080/"), Charset.forName("UTF-8"));
+        Assert.assertEquals("something", urlContents);
     }
 
     private static Swarm container;

--- a/testsuite/testsuite-classloader/src/test/java/org/wildfly/swarm/classloader/test/ClassLoaderTest.java
+++ b/testsuite/testsuite-classloader/src/test/java/org/wildfly/swarm/classloader/test/ClassLoaderTest.java
@@ -15,11 +15,10 @@
  */
 package org.wildfly.swarm.classloader.test;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
 import java.net.URL;
-import java.net.URLConnection;
+import java.nio.charset.Charset;
 
+import org.apache.commons.io.IOUtils;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
@@ -38,31 +37,8 @@ public class ClassLoaderTest {
     @Test
     @RunAsClient
     public void testNothing() throws Exception {
-        String content = getUrlContents("http://127.0.0.1:8080/");
-        assertThat( content ).contains("success: com.fasterxml.jackson.datatype.jdk8.Jdk8BeanSerializerModifier");
-    }
-
-    private static String getUrlContents(String theUrl) {
-        StringBuilder content = new StringBuilder();
-
-        try {
-            URL url = new URL(theUrl);
-            URLConnection urlConnection = url.openConnection();
-            BufferedReader bufferedReader = new BufferedReader(
-                    new InputStreamReader(urlConnection.getInputStream())
-            );
-
-            String line;
-
-            while ((line = bufferedReader.readLine()) != null) {
-                content.append(line + "\n");
-            }
-            bufferedReader.close();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-
-        return content.toString();
+        String content = IOUtils.toString(new URL("http://127.0.0.1:8080/"), Charset.forName("UTF-8"));
+        assertThat(content).contains("success: com.fasterxml.jackson.datatype.jdk8.Jdk8BeanSerializerModifier");
     }
 
 }

--- a/testsuite/testsuite-datasources/src/test/java/org/wildfly/swarm/datasources/test/ArquillianModulesTest.java
+++ b/testsuite/testsuite-datasources/src/test/java/org/wildfly/swarm/datasources/test/ArquillianModulesTest.java
@@ -15,24 +15,15 @@
  */
 package org.wildfly.swarm.datasources.test;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
+import java.io.IOException;
 import java.net.URL;
-import java.net.URLConnection;
+import java.nio.charset.Charset;
 
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.apache.commons.io.IOUtils;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.swarm.Swarm;
-import org.wildfly.swarm.arquillian.CreateSwarm;
 import org.wildfly.swarm.arquillian.DefaultDeployment;
-import org.wildfly.swarm.datasources.test.Main;
-import org.wildfly.swarm.datasources.test.MyResource;
-import org.wildfly.swarm.jaxrs.JAXRSArchive;
 
 import static org.fest.assertions.Assertions.assertThat;
 
@@ -48,31 +39,9 @@ import static org.fest.assertions.Assertions.assertThat;
 public class ArquillianModulesTest {
 
     @Test
-    public void testDatasource() {
-        String response = getUrlContents("http://localhost:8080/");
-        assertThat(response).matches("^(Howdy using connection: org.jboss.jca.adapters.jdbc.jdk)(7|8)(.WrappedConnectionJDK)(7|8)\\@[a-zA-Z\\d]+\n$");
+    public void testDatasource() throws IOException {
+        String response = IOUtils.toString(new URL("http://localhost:8080/"), Charset.forName("UTF-8"));
+        assertThat(response).matches("^(Howdy using connection: org.jboss.jca.adapters.jdbc.jdk)(7|8)(.WrappedConnectionJDK)(7|8)\\@[a-zA-Z\\d]+$");
     }
 
-    private static String getUrlContents(String theUrl) {
-        StringBuilder content = new StringBuilder();
-
-        try {
-            URL url = new URL(theUrl);
-            URLConnection urlConnection = url.openConnection();
-            BufferedReader bufferedReader = new BufferedReader(
-                    new InputStreamReader(urlConnection.getInputStream())
-            );
-
-            String line;
-
-            while ((line = bufferedReader.readLine()) != null) {
-                content.append(line + "\n");
-            }
-            bufferedReader.close();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-
-        return content.toString();
-    }
 }

--- a/testsuite/testsuite-infinispan/src/test/java/org/wildfly/swarm/infinispan/test/Swarm551Test.java
+++ b/testsuite/testsuite-infinispan/src/test/java/org/wildfly/swarm/infinispan/test/Swarm551Test.java
@@ -16,25 +16,16 @@ package org.wildfly.swarm.infinispan.test;
  * limitations under the License.
  */
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
+import java.io.IOException;
 import java.net.URL;
-import java.net.URLConnection;
+import java.nio.charset.Charset;
 import java.util.UUID;
 
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.apache.commons.io.IOUtils;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.swarm.Swarm;
-import org.wildfly.swarm.arquillian.CreateSwarm;
 import org.wildfly.swarm.arquillian.DefaultDeployment;
-import org.wildfly.swarm.infinispan.InfinispanFraction;
-import org.wildfly.swarm.jaxrs.JAXRSArchive;
-import org.wildfly.swarm.jaxrs.JAXRSFraction;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -49,34 +40,12 @@ import static org.junit.Assert.assertNotNull;
 public class Swarm551Test {
 
     @Test
-    public void testAccess() {
-        String response = getUrlContents("http://localhost:8080");
+    public void testAccess() throws IOException {
+        String response = IOUtils.toString(new URL("http://localhost:8080"), Charset.forName("UTF-8"));
         response = response.trim();
 
-        UUID uuid = UUID.fromString( response );
-        assertNotNull( uuid );
+        UUID uuid = UUID.fromString(response);
+        assertNotNull(uuid);
     }
 
-    static String getUrlContents(String theUrl) {
-        StringBuilder content = new StringBuilder();
-
-        try {
-            URL url = new URL(theUrl);
-            URLConnection urlConnection = url.openConnection();
-            BufferedReader bufferedReader = new BufferedReader(
-                    new InputStreamReader(urlConnection.getInputStream())
-            );
-
-            String line;
-
-            while ((line = bufferedReader.readLine()) != null) {
-                content.append(line + "\n");
-            }
-            bufferedReader.close();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-
-        return content.toString();
-    }
 }

--- a/testsuite/testsuite-jaxrs/src/test/java/org/wildfly/swarm/jaxrs/ArqJAXRSExceptionMapperTest.java
+++ b/testsuite/testsuite-jaxrs/src/test/java/org/wildfly/swarm/jaxrs/ArqJAXRSExceptionMapperTest.java
@@ -15,12 +15,11 @@
  */
 package org.wildfly.swarm.jaxrs;
 
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.InputStreamReader;
 import java.net.URL;
-import java.net.URLConnection;
+import java.nio.charset.Charset;
 
+import org.apache.commons.io.IOUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
@@ -56,39 +55,15 @@ public class ArqJAXRSExceptionMapperTest {
     @Test
     @RunAsClient
     public void testCustom() throws Exception {
-        String content = getUrlContents("http://localhost:8080/custom/throw");
-        assertThat( content ).contains( "mapped custom: Custom exception" );
+        String content = IOUtils.toString(new URL("http://localhost:8080/custom/throw"), Charset.forName("UTF-8"));
+        assertThat(content).contains("mapped custom: Custom exception");
     }
 
     @Test
     @RunAsClient
     public void testJson() throws Exception {
-        String content = getUrlContents("http://localhost:8080/json/throw");
-        assertThat( content ).contains( "mapped json: that didn't work" );
+        String content = IOUtils.toString(new URL("http://localhost:8080/json/throw"), Charset.forName("UTF-8"));
+        assertThat(content).contains("mapped json: that didn't work");
     }
-
-    static String getUrlContents(String theUrl) {
-        StringBuilder content = new StringBuilder();
-
-        try {
-            URL url = new URL(theUrl);
-            URLConnection urlConnection = url.openConnection();
-            BufferedReader bufferedReader = new BufferedReader(
-                    new InputStreamReader(urlConnection.getInputStream())
-            );
-
-            String line;
-
-            while ((line = bufferedReader.readLine()) != null) {
-                content.append(line + "\n");
-            }
-            bufferedReader.close();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-
-        return content.toString();
-    }
-
 
 }

--- a/testsuite/testsuite-monitor/src/test/java/org/wildfly/swarm/monitor/MonitorArquillianTest.java
+++ b/testsuite/testsuite-monitor/src/test/java/org/wildfly/swarm/monitor/MonitorArquillianTest.java
@@ -1,10 +1,9 @@
 package org.wildfly.swarm.monitor;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
 import java.net.URL;
-import java.net.URLConnection;
+import java.nio.charset.Charset;
 
+import org.apache.commons.io.IOUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
@@ -38,31 +37,8 @@ public class MonitorArquillianTest {
     @RunAsClient
     @Test
     public void testEndpoints() throws Exception {
-        System.out.println(getUrlContents("http://127.0.0.1:8080/node"));
-        System.out.println(getUrlContents("http://127.0.0.1:8080/heap"));
-        System.out.println(getUrlContents("http://127.0.0.1:8080/threads"));
-    }
-
-    private static String getUrlContents(String theUrl) {
-        StringBuilder content = new StringBuilder();
-
-        try {
-            URL url = new URL(theUrl);
-            URLConnection urlConnection = url.openConnection();
-            BufferedReader bufferedReader = new BufferedReader(
-                    new InputStreamReader(urlConnection.getInputStream())
-            );
-
-            String line;
-
-            while ((line = bufferedReader.readLine()) != null) {
-                content.append(line + "\n");
-            }
-            bufferedReader.close();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-
-        return content.toString();
+        System.out.println(IOUtils.toString(new URL("http://127.0.0.1:8080/node"), Charset.forName("UTF-8")));
+        System.out.println(IOUtils.toString(new URL("http://127.0.0.1:8080/heap"), Charset.forName("UTF-8")));
+        System.out.println(IOUtils.toString(new URL("http://127.0.0.1:8080/threads"), Charset.forName("UTF-8")));
     }
 }

--- a/testsuite/testsuite-swagger-customized/src/test/java/com/mycorp/SwaggerConfiguredArquillianTest.java
+++ b/testsuite/testsuite-swagger-customized/src/test/java/com/mycorp/SwaggerConfiguredArquillianTest.java
@@ -15,12 +15,11 @@
  */
 package com.mycorp;
 
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.InputStreamReader;
 import java.net.URL;
-import java.net.URLConnection;
+import java.nio.charset.Charset;
 
+import org.apache.commons.io.IOUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
@@ -55,31 +54,9 @@ public class SwaggerConfiguredArquillianTest {
     @RunAsClient
     @Test
     public void testEndpoints() throws Exception {
-        String content = getUrlContents("http://127.0.0.1:8080/mycorp/api/swagger.json");
+        String content = IOUtils.toString(new URL("http://127.0.0.1:8080/mycorp/api/swagger.json"), Charset.forName("UTF-8"));
         assertThat(content).contains("\"tags\":[{\"name\":\"theapp\"}]");
         assertThat(content).contains("\"title\":\"My Custom App\"");
     }
 
-    private static String getUrlContents(String theUrl) {
-        StringBuilder content = new StringBuilder();
-
-        try {
-            URL url = new URL(theUrl);
-            URLConnection urlConnection = url.openConnection();
-            BufferedReader bufferedReader = new BufferedReader(
-                    new InputStreamReader(urlConnection.getInputStream())
-            );
-
-            String line;
-
-            while ((line = bufferedReader.readLine()) != null) {
-                content.append(line + "\n");
-            }
-            bufferedReader.close();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-
-        return content.toString();
-    }
 }

--- a/testsuite/testsuite-swagger-webapp/src/test/java/org/wildfly/swarm/swagger/webapp/SwaggerWebAppArquillianTest.java
+++ b/testsuite/testsuite-swagger-webapp/src/test/java/org/wildfly/swarm/swagger/webapp/SwaggerWebAppArquillianTest.java
@@ -15,11 +15,10 @@
  */
 package org.wildfly.swarm.swagger.webapp;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
 import java.net.URL;
-import java.net.URLConnection;
+import java.nio.charset.Charset;
 
+import org.apache.commons.io.IOUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
@@ -61,31 +60,8 @@ public class SwaggerWebAppArquillianTest {
     @RunAsClient
     @Test
     public void testEndpoints() throws Exception {
-        String content = getUrlContents("http://127.0.0.1:8080/swagger-ui");
-        assertThat(content).contains("<title>Swagger UI</title>" );
-    }
-
-    private static String getUrlContents(String theUrl) {
-        StringBuilder content = new StringBuilder();
-
-        try {
-            URL url = new URL(theUrl);
-            URLConnection urlConnection = url.openConnection();
-            BufferedReader bufferedReader = new BufferedReader(
-                    new InputStreamReader(urlConnection.getInputStream())
-            );
-
-            String line;
-
-            while ((line = bufferedReader.readLine()) != null) {
-                content.append(line + "\n");
-            }
-            bufferedReader.close();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-
-        return content.toString();
+        String content = IOUtils.toString(new URL("http://127.0.0.1:8080/swagger-ui"), Charset.forName("UTF-8"));
+        assertThat(content).contains("<title>Swagger UI</title>");
     }
 
 }

--- a/testsuite/testsuite-swagger/src/test/java/com/mycorp/SwaggerArquillianTest.java
+++ b/testsuite/testsuite-swagger/src/test/java/com/mycorp/SwaggerArquillianTest.java
@@ -15,24 +15,15 @@
  */
 package com.mycorp;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
 import java.net.URL;
-import java.net.URLConnection;
+import java.nio.charset.Charset;
 
-import com.mycorp.Resource;
-import org.jboss.arquillian.container.test.api.Deployment;
+import org.apache.commons.io.IOUtils;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.swarm.Swarm;
-import org.wildfly.swarm.arquillian.CreateSwarm;
 import org.wildfly.swarm.arquillian.DefaultDeployment;
-import org.wildfly.swarm.jaxrs.JAXRSArchive;
-import org.wildfly.swarm.swagger.SwaggerFraction;
 
 import static org.fest.assertions.Assertions.assertThat;
 
@@ -46,30 +37,8 @@ public class SwaggerArquillianTest {
     @RunAsClient
     @Test
     public void testEndpoints() throws Exception {
-        String content = getUrlContents("http://127.0.0.1:8080/swagger.json");
-        assertThat( content ).contains("\"tags\":[{\"name\":\"theapp\"}]");
+        String content = IOUtils.toString(new URL("http://127.0.0.1:8080/swagger.json"), Charset.forName("UTF-8"));
+        assertThat(content).contains("\"tags\":[{\"name\":\"theapp\"}]");
     }
 
-    private static String getUrlContents(String theUrl) {
-        StringBuilder content = new StringBuilder();
-
-        try {
-            URL url = new URL(theUrl);
-            URLConnection urlConnection = url.openConnection();
-            BufferedReader bufferedReader = new BufferedReader(
-                    new InputStreamReader(urlConnection.getInputStream())
-            );
-
-            String line;
-
-            while ((line = bufferedReader.readLine()) != null) {
-                content.append(line + "\n");
-            }
-            bufferedReader.close();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-
-        return content.toString();
-    }
 }


### PR DESCRIPTION
Motivation
----------
While working on a solution for SWARM-1667, I noticed (thanks to the IDE) that there was code duplication within the test cases which were trying to read the contents of the deployed archive.

Modifications
-------------
* Moved all such occurrences to the Arquillian module and consumed the utility method in existing test cases.

Result
------
Verified that the build is going through properly.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
