### PR TITLE
SWARM-1891: OpenApiHttpHandler - support graceful startup.

### DIFF
--- a/fractions/microprofile/microprofile-openapi/src/main/java/org/wildfly/swarm/microprofile/openapi/api/OpenApiDocument.java
+++ b/fractions/microprofile/microprofile-openapi/src/main/java/org/wildfly/swarm/microprofile/openapi/api/OpenApiDocument.java
@@ -90,6 +90,15 @@ public class OpenApiDocument {
         }
     }
 
+    /**
+     * @param {{@code true} if model initialized
+     */
+    public boolean isSet() {
+        synchronized (INSTANCE) {
+            return model != null;
+        }
+    }
+
     public synchronized void config(OpenApiConfig config) {
         set(() -> this.config = config);
     }


### PR DESCRIPTION
Motivation
----------
OpenApiHttpHandler currently attempts to load the OpenApi model in
static init block. This results in ExceptionInInitializerError if
Undertow instantiates the handler before the app is deployed completely.

Modifications
-------------
1. Skip execution until the model is available.
2. Cache serialized OpenApi models lazily.

Result
------
Graceful startup is supported, no ExceptionInInitializerError is thrown.
