### PR TITLE
SWARM-1899: MP metrics: handling time unit

### DIFF
--- a/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/exporters/ExporterUtil.java
+++ b/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/exporters/ExporterUtil.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.metrics.runtime.exporters;
+
+import org.eclipse.microprofile.metrics.MetricUnits;
+
+/**
+ * @author hrupp, Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ */
+public class ExporterUtil {
+
+    public static final long NANOS_PER_MICROSECOND = 1_000;
+    public static final long NANOS_PER_MILLI = 1_000_000;
+    public static final long NANOS_PER_SECOND = 1_000_000_000;
+    public static final long NANOS_PER_MINUTE = 60 * 1_000_000_000L;
+    public static final long NANOS_PER_HOUR = 3600 * 1_000_000_000L;
+    public static final long NANOS_PER_DAY = 24 * 3600 * 1_000_000_000L;
+
+    private ExporterUtil() {
+    }
+
+    public static Double convertNanosTo(Double value, String unit) {
+
+        Double out;
+
+        switch (unit) {
+            case MetricUnits.NANOSECONDS:
+                out = value;
+                break;
+            case MetricUnits.MICROSECONDS:
+                out = value / NANOS_PER_MICROSECOND;
+                break;
+            case MetricUnits.MILLISECONDS:
+                out = value / NANOS_PER_MILLI;
+                break;
+            case MetricUnits.SECONDS:
+                out = value / NANOS_PER_SECOND;
+                break;
+            case MetricUnits.MINUTES:
+                out = value / NANOS_PER_MINUTE;
+                break;
+            case MetricUnits.HOURS:
+                out = value / NANOS_PER_HOUR;
+                break;
+            case MetricUnits.DAYS:
+                out = value / NANOS_PER_DAY;
+                break;
+            default:
+                out = value;
+        }
+        return out;
+    }
+}

--- a/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/exporters/PrometheusExporter.java
+++ b/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/exporters/PrometheusExporter.java
@@ -167,7 +167,7 @@ public class PrometheusExporter implements Exporter {
         String suffix = USCORE + PrometheusUnit.getBaseUnitAsPrometheusString(md.getUnit());
         writeHelpLine(sb, scope, md.getName(), md, suffix);
         writeTypeLine(sb,scope,md.getName(),md, suffix,SUMMARY);
-        writeValueLine(sb,scope,suffix + "_count",timer.getCount(),md);
+        writeValueLine(sb,scope,suffix + "_count",timer.getCount(),md, null, false);
 
         writeSnapshotQuantiles(sb, scope, md, snapshot, theUnit);
     }
@@ -183,7 +183,7 @@ public class PrometheusExporter implements Exporter {
         writeHelpLine(sb, scope, md.getName(), md, SUMMARY);
         writeSnapshotBasics(sb, scope, md, snapshot, theUnit);
         writeTypeLine(sb,scope,md.getName(),md, theUnit,SUMMARY);
-        writeValueLine(sb,scope,theUnit + "_count",histogram.getCount(),md);
+        writeValueLine(sb,scope,theUnit + "_count",histogram.getCount(),md, null, false);
         writeSnapshotQuantiles(sb, scope, md, snapshot, theUnit);
     }
 
@@ -229,6 +229,16 @@ public class PrometheusExporter implements Exporter {
     }
 
     private void writeValueLine(StringBuilder sb, MetricRegistry.Type scope, String suffix, double valueRaw, Metadata md, Tag extraTag) {
+        writeValueLine(sb, scope, suffix, valueRaw, md, extraTag, true);
+    }
+
+    private void writeValueLine(StringBuilder sb,
+                                MetricRegistry.Type scope,
+                                String suffix,
+                                double valueRaw,
+                                Metadata md,
+                                Tag extraTag,
+                                boolean scaled) {
         String name = md.getName();
         name = getPrometheusMetricName(md, name);
         fillBaseName(sb, scope, name);
@@ -246,7 +256,8 @@ public class PrometheusExporter implements Exporter {
         }
 
         sb.append(SPACE);
-        sb.append(PrometheusUnit.scaleToBase(md.getUnit(), valueRaw)).append(LF);
+        Double value = scaled ? PrometheusUnit.scaleToBase(md.getUnit(), valueRaw) : valueRaw;
+        sb.append(value).append(LF);
 
     }
 

--- a/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/exporters/PrometheusUnit.java
+++ b/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/exporters/PrometheusUnit.java
@@ -122,25 +122,13 @@ public class PrometheusUnit {
                 out = value * 1_000_000_000;
                 break;
             case MetricUnits.NANOSECONDS:
-                out = value / 1_000_000_000;
-                break;
             case MetricUnits.MICROSECONDS:
-                out = value / 1_000_000;
-                break;
             case MetricUnits.MILLISECONDS:
-                out = value / 1000;
-                break;
             case MetricUnits.SECONDS:
-                out = value;
-                break;
             case MetricUnits.MINUTES:
-                out = value * 60;
-                break;
             case MetricUnits.HOURS:
-                out = value * 3600;
-                break;
             case MetricUnits.DAYS:
-                out = value * 24 * 3600;
+                out = ExporterUtil.convertNanosTo(value, MetricUnits.SECONDS);
                 break;
             default:
                 out = value;

--- a/fractions/microprofile/microprofile-metrics/src/test/java/org/wildfly/swarm/microprofile/metrics/runtime/exporters/ExporterUtilTest.java
+++ b/fractions/microprofile/microprofile-metrics/src/test/java/org/wildfly/swarm/microprofile/metrics/runtime/exporters/ExporterUtilTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.metrics.runtime.exporters;
+
+import org.eclipse.microprofile.metrics.MetricUnits;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+/**
+ *
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ * <br>
+ * Date: 3/23/18
+ */
+public class ExporterUtilTest {
+    @Test
+    public void shouldScaleNanosToSecods() {
+        Double out = ExporterUtil.convertNanosTo(1.0, MetricUnits.MINUTES);
+        Assert.assertEquals(out, 0.0, 1e-10);
+    }
+
+    @Test
+    public void shouldScaleNanosToMillis() {
+        Double out = ExporterUtil.convertNanosTo(1.0, MetricUnits.MILLISECONDS);
+        Assert.assertEquals(out, 0.000001, 1e-10);
+    }
+
+    @Test
+    public void testScaleHoursToSeconds() {
+        String foo = MetricUnits.HOURS;
+        Double out = ExporterUtil.convertNanosTo(3 * 3600 * 1000_000_000., foo);
+        Assert.assertEquals(out, 3., 1e-10);
+    }
+}

--- a/fractions/microprofile/microprofile-metrics/src/test/java/org/wildfly/swarm/microprofile_metrics/PrometheusUnitScalingTest.java
+++ b/fractions/microprofile/microprofile-metrics/src/test/java/org/wildfly/swarm/microprofile_metrics/PrometheusUnitScalingTest.java
@@ -26,29 +26,15 @@ import org.wildfly.swarm.microprofile.metrics.runtime.exporters.PrometheusUnit;
 public class PrometheusUnitScalingTest {
 
     @Test
-    public void testScaleMinutesToSeconds() {
-        String foo = MetricUnits.MINUTES;
-        double out = PrometheusUnit.scaleToBase(foo, 1.0);
-        assert out == 60;
-    }
-
-    @Test
-    public void testScaleHoursToSeconds() {
-        String foo = MetricUnits.HOURS;
+    public void testScaleToSeconds() {
+        String foo = MetricUnits.SECONDS;
         double out = PrometheusUnit.scaleToBase(foo, 3.0);
-        assert out == 3 * 3600;
+        assert out == 0.000_000_003 : "Out was " + out;
     }
 
     @Test
-    public void testScaleMillisecondsToSeconds() {
-        String foo = MetricUnits.MILLISECONDS;
-        double out = PrometheusUnit.scaleToBase(foo, 3.0);
-        assert out == 0.003 : "Out was " + out;
-    }
-
-    @Test
-    public void testScaleNanosecondsToSeconds() {
-        String foo = MetricUnits.NANOSECONDS;
+    public void testScaleToSecondsForDays() {
+        String foo = MetricUnits.DAYS;
         double out = PrometheusUnit.scaleToBase(foo, 3.0);
         assert out == 0.000_000_003 : "Out was " + out;
     }


### PR DESCRIPTION
Motivation
----------
To respect the time unit in MP Metrics \@Timed annotation.

Modifications
-------------
Added ExporterUtil class that handles the conversion of time values,
modified JsonExporter to use it.
Also, modified PrometheusExporter to always scale time metrics to seconds
and not scale the count

Result
------
The time metric returns proper values

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
