### PR TITLE
SWARM-1926: Adding better support for ENV varibles by

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/config/EnvironmentConfigNodeFactory.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/EnvironmentConfigNodeFactory.java
@@ -53,14 +53,23 @@ public class EnvironmentConfigNodeFactory {
         Set<String> names = input.keySet();
 
         for (String name : names) {
-            if (name.startsWith("swarm.")) {
+            String after = normalizeName(name);
+            if (after.startsWith("swarm.")) {
                 String value = input.get(name);
-                ConfigKey key = ConfigKey.parse(name);
+                ConfigKey key = ConfigKey.parse(after);
                 config.recursiveChild(key, value);
             }
         }
     }
 
+    protected static String normalizeName(String key) {
+        key = key.replace("_DASH_", "-");
+        key = key.replace("_UNDERSCORE_", "---");
+        key = key.replace('_', '.');
+        key = key.replace("---", "_");
+        key = key.toLowerCase();
+        return key;
+    }
 }
 
 

--- a/core/container/src/test/java/org/wildfly/swarm/container/config/EnvironmentConfigNodeFactoryTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/container/config/EnvironmentConfigNodeFactoryTest.java
@@ -49,11 +49,14 @@ public class EnvironmentConfigNodeFactoryTest {
         Map<String, String> env = new HashMap<String, String>() {{
             put("swarm.http.port", "8080");
             put("swarm.data-sources.ExampleDS.url", "jdbc:db");
+            put("SWARM_DATA_DASH_SOURCES_EXAMPLEDS_JNDI_DASH_NAME", "java:/jboss/datasources/example");
+            put("SWARM_DATA_UNDERSCORE_SOURCES_EXAMPLEDS_USER_DASH_NAME", "joe");
         }};
 
         ConfigNode node = EnvironmentConfigNodeFactory.load(env);
 
         assertThat(node.valueOf(ConfigKey.of("swarm", "http", "port"))).isEqualTo("8080");
         assertThat(node.valueOf(ConfigKey.of("swarm", "data-sources", "ExampleDS", "url"))).isEqualTo("jdbc:db");
+        assertThat(node.valueOf(ConfigKey.of("swarm", "data_sources", "ExampleDS", "user-name"))).isEqualTo("joe");
     }
 }

--- a/core/spi/src/main/java/org/wildfly/swarm/spi/api/config/SimpleKey.java
+++ b/core/spi/src/main/java/org/wildfly/swarm/spi/api/config/SimpleKey.java
@@ -109,7 +109,7 @@ public class SimpleKey implements ConfigKey {
         if (this == ConfigKey.EMPTY) {
             return System.identityHashCode(this);
         }
-        return this.name.hashCode();
+        return this.name.toLowerCase().hashCode();
     }
 
     @Override
@@ -119,7 +119,7 @@ public class SimpleKey implements ConfigKey {
         }
 
         if (obj instanceof SimpleKey) {
-            return this.name.equals((((SimpleKey) obj).name));
+            return this.name.equalsIgnoreCase((((SimpleKey) obj).name));
         }
 
         return false;

--- a/docs/reference/configuration.adoc
+++ b/docs/reference/configuration.adoc
@@ -2,15 +2,15 @@
 = Configuring a WildFly Swarm application
 
 You can configure numerous options with applications built with WildFly Swarm.
-For all options, reasonable defaults are already applied, so you do not have to change any options unless you explicitly want to.
+For most options, reasonable defaults are already applied, so you do not have to change any options unless you explicitly want to.
 
 This reference is a complete list of all configurable items, grouped by the fraction that introduces them.
 Only the items related to the fractions that your application uses are relevant to you.
 
-[#configuring-an-application-using-properties]
-== Configuring an application using properties
+[#configuring-an-application-using-system-properties]
+== Configuring an application using system properties
 
-Here, configuration items are presented using dotted notation, and are suitable for use as Java property names, which your application consumes through explicit setting in the Maven plugin configuration, or through the command line when your application is being executed.
+Configuration properties are presented using dotted notation, and are suitable for use as Java system property names, which your application consumes through explicit setting in the Maven plugin configuration, or through the command line when your application is being executed.
 
 Any property that has the _KEY_ parameter in its name indicates that you must supply a key or identifier in that segment of the name.
 
@@ -22,7 +22,7 @@ In practical usage, the property would be, for example, `swarm.undertow.servers.
 ====
 
 [discrete]
-=== Maven plugin properties
+=== Setting System Properties using Maven Plugin
 
 If you want to set explicit configuration values as defaults through the Maven plugin, add a `<properties>` section to the `<configuration>` block of the plugin in the `pom.xml` file in your application.
 
@@ -55,9 +55,10 @@ NOTE: It is not recommended to set properties using the Maven plugin to control 
 Instead, use the xref:configuring-an-application-using-yaml[YAML method].
 
 [discrete]
-=== Setting properties using the Command Line
+=== Setting System Properties using the Command Line
 
 Setting properties using the Maven plugin is useful for temporarily changing a configuration item for a single execution of your application.
+
 You can customize an environment-specific setting or experiment with configuration items before setting them in a YAML configuration file.
 
 To use a property on the command line, pass it as a command-line parameter to the Java binary:
@@ -164,3 +165,47 @@ $ java -jar myapp-swarm.jar -Scloud -Stesting -s/home/app/openshift.yml
 ----
 ====
 
+[#configuring-an-application-using-env]
+== Configuring an application using Environment Variables
+
+When working with containerized deployments like running your WildFly Swarm application in a Docker container use
+of environment variables is recommended. However, they can be used with non-container deployments too.
+
+  
+Environment Variables configuration
+====
+For example, for a property documented as `swarm.undertow.servers.KEY.default-host` translates to the following ENV structure, substituting the `KEY` segment with the `default` identifier:
+
+[source,yaml]
+----
+export SWARM.UNDERTOW.SERVERS.DEFAULT.DEFAULT_DASH_HOST=<myhost>
+----
+====
+
+Unlike other configuration options, when properties are defined as environment variables in Linux based containers they do not allow defining non-alphanumeric characters like dot(.), DASH/HYPHEN(-) or any other characters not in [A-Za-z0-9_] range. However, since there are lot of configuration properties in WildFly Swarm that do have these characters, the following rules need to followed when defining the environment variables. When properties are defined using these conditions, then they will be correctly converted back to their respective configuration properties at runtime. For environments where there is no restrictions, they can use original names as is.
+
+Linux based container Rules
+====
+* It is a naming convention that all environment properties are defined using UPPERCASE letters. For example: property `serveraddress` is defined as `SERVERADDRESS`. 
+* All the dot(.) characters MUST to be replaced with underscore (_). For example: property `swarm.bind.address=127.0.0.1` should be defined as `SWARM_BIND_ADDRESS=127.0.0.1`
+* All dash(-) characters MUST be replaced with string "__DASH__". For example: a property `swarm.data-sources.foo.url=<url>` needs to be `SWARM_DATA_DASH_SOURCES_FOO_URL=<url>`
+* If the property name has underscores then all underscore(-) characters MUST be replaced with string "__UNDERSCORE__". For example: a property `swarm.data_sources.foo.url=<url>` needs to be `SWARM_DATA_UNDERSCORE_SOURCES_FOO_URL=<url>`
+=====
+
+Example Data Source Configuration, if your System properties are defined as
+====
+ -Dswarm.datasources.data-sources.devwf.connection-url=jdbc:postgresql://localhost:5432/sampledb
+ -Dswarm.datasources.data-sources.devwf.driver-name=postgresql
+ -Dswarm.datasources.data-sources.devwf.jndiname=java:/jboss/datasources/devwf
+ -Dswarm.datasources.data-sources.devwf.user-name=postgres
+ -Dswarm.datasources.data-sources.devwf.password=admin
+====
+
+Then same can be achieved by defining following environment based properties
+====
+SWARM_DATASOURCES_DATA_DASH_SOURCES_DEVWF_CONNECTION_DASH_URL='jdbc:postgresql://localhost:5432/sampledb'
+SWARM_DATASOURCES_DATA_DASH_SOURCES_DEVWF_DRIVER_DASH_NAME='postgresql'
+SWARM_DATASOURCES_DATA_DASH_SOURCES_DEVWF_JNDI_DASH_NAME='java:/jboss/datasources/devwf'
+SWARM_DATASOURCES_DATA_DASH_SOURCES_DEVWF_USER_DASH_NAME='postgres'
+SWARM_DATASOURCES_DATA_DASH_SOURCES_DEVWF_PASSWORD='admin'
+====

--- a/docs/reference/configuration.adoc
+++ b/docs/reference/configuration.adoc
@@ -22,7 +22,7 @@ In practical usage, the property would be, for example, `swarm.undertow.servers.
 ====
 
 [discrete]
-=== Setting System Properties using Maven Plugin
+=== Setting system properties using Maven plugin
 
 If you want to set explicit configuration values as defaults through the Maven plugin, add a `<properties>` section to the `<configuration>` block of the plugin in the `pom.xml` file in your application.
 
@@ -55,7 +55,7 @@ NOTE: It is not recommended to set properties using the Maven plugin to control 
 Instead, use the xref:configuring-an-application-using-yaml[YAML method].
 
 [discrete]
-=== Setting System Properties using the Command Line
+=== Setting system properties using the command line
 
 Setting properties using the Maven plugin is useful for temporarily changing a configuration item for a single execution of your application.
 
@@ -165,47 +165,81 @@ $ java -jar myapp-swarm.jar -Scloud -Stesting -s/home/app/openshift.yml
 ----
 ====
 
-[#configuring-an-application-using-env]
-== Configuring an application using Environment Variables
+[#configuring-an-application-using-environment-variables]
+== Configuring an application using environment variables
 
-When working with containerized deployments like running your WildFly Swarm application in a Docker container use
-of environment variables is recommended. However, they can be used with non-container deployments too.
+Use environment variables to configure your application in various deployments--especially in a containerized environment, such as Docker.
 
-  
-Environment Variables configuration
+.Environment variables configuration
 ====
-For example, for a property documented as `swarm.undertow.servers.KEY.default-host` translates to the following ENV structure, substituting the `KEY` segment with the `default` identifier:
+A property documented as `swarm.undertow.servers.KEY.default-host` translates to the following environment variable (substituting the `KEY` segment with the `default` identifier):
 
-[source,yaml]
+[source,bash]
 ----
 export SWARM.UNDERTOW.SERVERS.DEFAULT.DEFAULT_DASH_HOST=<myhost>
 ----
 ====
 
-Unlike other configuration options, when properties are defined as environment variables in Linux based containers they do not allow defining non-alphanumeric characters like dot(.), DASH/HYPHEN(-) or any other characters not in [A-Za-z0-9_] range. However, since there are lot of configuration properties in WildFly Swarm that do have these characters, the following rules need to followed when defining the environment variables. When properties are defined using these conditions, then they will be correctly converted back to their respective configuration properties at runtime. For environments where there is no restrictions, they can use original names as is.
+Unlike other configuration options, properties defined as environment variables in Linux-based containers do not allow defining non-alphanumeric characters like _dot_ (.), _dash/hyphen_ (-) or any other characters not in the `[A-Za-z0-9_]` range.
+Many configuration properties in WildFly Swarm contain these characters, so you must follow these rules when defining the environment variables in the following environments:
 
-Linux based container Rules
-====
-* It is a naming convention that all environment properties are defined using UPPERCASE letters. For example: property `serveraddress` is defined as `SERVERADDRESS`. 
-* All the dot(.) characters MUST to be replaced with underscore (_). For example: property `swarm.bind.address=127.0.0.1` should be defined as `SWARM_BIND_ADDRESS=127.0.0.1`
-* All dash(-) characters MUST be replaced with string "__DASH__". For example: a property `swarm.data-sources.foo.url=<url>` needs to be `SWARM_DATA_DASH_SOURCES_FOO_URL=<url>`
-* If the property name has underscores then all underscore(-) characters MUST be replaced with string "__UNDERSCORE__". For example: a property `swarm.data_sources.foo.url=<url>` needs to be `SWARM_DATA_UNDERSCORE_SOURCES_FOO_URL=<url>`
-=====
+.Linux-based container rules
+* It is a naming convention that all environment properties are defined using uppercase letters.
+For example, define the `serveraddress` property as `SERVERADDRESS`.
+* All the _dot_ (.) characters must be replaced with _underscore_ (_).
+For example, define the `swarm.bind.address=127.0.0.1` property as `SWARM_BIND_ADDRESS=127.0.0.1`.
+* All _dash/hyphen_ (-) characters must be replaced with the `_DASH_` string.
+For example, define the `swarm.data-sources.foo.url=<url>` property as `SWARM_DATA_DASH_SOURCES_FOO_URL=<url>`.
+* If the property name contains underscores, all _underscore_ (\_) characters must be replaced with the `_UNDERSCORE_` string.
+For example, define the `swarm.data_sources.foo.url=<url>` property as `SWARM_DATA_UNDERSCORE_SOURCES_FOO_URL=<url>`.
 
-Example Data Source Configuration, if your System properties are defined as
+.An example data source configuration
 ====
- -Dswarm.datasources.data-sources.devwf.connection-url=jdbc:postgresql://localhost:5432/sampledb
- -Dswarm.datasources.data-sources.devwf.driver-name=postgresql
- -Dswarm.datasources.data-sources.devwf.jndiname=java:/jboss/datasources/devwf
- -Dswarm.datasources.data-sources.devwf.user-name=postgres
- -Dswarm.datasources.data-sources.devwf.password=admin
+[cols="1,5"]
+|===
+| System property
+| `-Dswarm.datasources.data-sources.devwf.connection-url=
+jdbc:postgresql://localhost:5432/sampledb`
+
+| Env. variable
+| `SWARM_DATASOURCES_DATA_DASH_SOURCES_DEVWF_CONNECTION_DASH_URL=
+'jdbc:postgresql://localhost:5432/sampledb'`
+|===
+
+[cols="1,5"]
+|===
+| System property
+| `-Dswarm.datasources.data-sources.devwf.driver-name=postgresql`
+
+| Env. variable
+| `SWARM_DATASOURCES_DATA_DASH_SOURCES_DEVWF_DRIVER_DASH_NAME='postgresql'`
+|===
+
+[cols="1,5"]
+|===
+| System property
+| `-Dswarm.datasources.data-sources.devwf.jndiname=java:/jboss/datasources/devwf`
+
+| Env. variable
+| `SWARM_DATASOURCES_DATA_DASH_SOURCES_DEVWF_JNDI_DASH_NAME='java:/jboss/datasources/devwf'`
+|===
+
+[cols="1,5"]
+|===
+| System property
+| `-Dswarm.datasources.data-sources.devwf.user-name=postgres`
+
+| Env. variable
+| `SWARM_DATASOURCES_DATA_DASH_SOURCES_DEVWF_USER_DASH_NAME='postgres'`
+|===
+
+[cols="1,5"]
+|===
+| System property
+| `-Dswarm.datasources.data-sources.devwf.password=admin`
+
+| Env. variable
+| `SWARM_DATASOURCES_DATA_DASH_SOURCES_DEVWF_PASSWORD='admin'`
+|===
 ====
 
-Then same can be achieved by defining following environment based properties
-====
-SWARM_DATASOURCES_DATA_DASH_SOURCES_DEVWF_CONNECTION_DASH_URL='jdbc:postgresql://localhost:5432/sampledb'
-SWARM_DATASOURCES_DATA_DASH_SOURCES_DEVWF_DRIVER_DASH_NAME='postgresql'
-SWARM_DATASOURCES_DATA_DASH_SOURCES_DEVWF_JNDI_DASH_NAME='java:/jboss/datasources/devwf'
-SWARM_DATASOURCES_DATA_DASH_SOURCES_DEVWF_USER_DASH_NAME='postgres'
-SWARM_DATASOURCES_DATA_DASH_SOURCES_DEVWF_PASSWORD='admin'
-====


### PR DESCRIPTION
1) Allowing the CAPITAL letter based properties, where they will be evaluated as lowercase keys. The values are not altered.
2) Support for escaping dash(-) and UNDERSCORE(_) in the properties. More on this below.
3) Treats any UNDERSCORE in ENV variable as dot(.) delimiter, similar to other implementations.

The escaping for dash(-) in the ENV property is achieved through _DASH_, and underscore as _UNDERSCORE_. 

For example, a swarm property like

- swarm.datasources.data-sources.DEVWF.connection-url  is represented as "SWARM_DATASOURCES_DATA_DASH_SOURCES_DEVWF_USER_DASH_NAME"

- swarm.datasources.data-sources.DEVWF.jndi_name is represented as "SWARM_DATASOURCES_DATA_DASH_SOURCES_DEVWF_JNDI_UNDERSCORE_NAME"

To do as how Spring's relaxed binding will require all the WildFly fractions to allow properties both ways or fixed in the Wildfly DMR configuration modules to allow as such, which I thought as much bigger change. The above allows a cheaper way to accomplish the same, as long as it is documented well.  I am open to alternative suggestions for escaping, this was just simple.

- [x ] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x ] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ x] Have you built the project locally prior to submission with `mvn clean install`?

-----
