### PR TITLE
SWARM-1932: MP fault tolerance: circuit breaker doesn't open if there was at least one success

### DIFF
--- a/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/SynchronousCircuitBreaker.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/SynchronousCircuitBreaker.java
@@ -164,7 +164,7 @@ class SynchronousCircuitBreaker implements HystrixCircuitBreaker {
         if (requestCount < requestVolumeThreshold) {
             return false;
         }
-        double failureCheck = failureCount.get() / requestCount;
+        double failureCheck = failureCount.get() / (double) requestCount;
         double failureRatio = config.get(CircuitBreakerConfig.FAILURE_RATIO);
         return (failureCheck >= failureRatio) || (failureRatio <= 0 && failureCheck == 1);
     }


### PR DESCRIPTION
Motivation
----------
The code in `SynchronousCircuitBreaker` used for figuring out
if the failure threshold of the circuit breaker has been reached
used to divide two `int`s and expect it will be a proper `double`.
That's obviously wrong in Java.

Modifications
-------------
Cast one of the `int`s to `double` so that we get proper division.

Result
------
The `SynchronousCircuitBreaker` is now better able to figure out
if the failure threshold has been reached.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
