### PR TITLE
SWARM-1929: MP FT - circuit breaker never opens if there is a fallback.

### DIFF
--- a/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/FailureNotHandledException.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/FailureNotHandledException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.faulttolerance.deployment;
+
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+
+/**
+ * This exception is thrown if a hystrix command has a fallback defined but the failure is not assignable from any failure exception listed in
+ * {@link CircuitBreaker#failOn()}.
+ *
+ * @author Martin Kouba
+ * @see DefaultCommand
+ */
+public class FailureNotHandledException extends RuntimeException {
+
+    private static final long serialVersionUID = -4482803990615567626L;
+
+    public FailureNotHandledException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/circuitbreaker/failon/CircuitBreakerFailOnTest.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/circuitbreaker/failon/CircuitBreakerFailOnTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.faulttolerance.deployment.circuitbreaker.failon;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.microprofile.faulttolerance.deployment.TestArchive;
+
+/**
+ *
+ * @author Martin Kouba
+ */
+@RunWith(Arquillian.class)
+public class CircuitBreakerFailOnTest {
+
+    @Deployment
+    public static JavaArchive createTestArchive() {
+        return TestArchive.createBase("CircuitBreakerFailOnTest.war").addPackage(CircuitBreakerFailOnTest.class.getPackage());
+    }
+
+    @Test
+    public void testCircuitBreakerOpens(PingService pingService) throws InterruptedException {
+        int loop = 8;
+        for (int i = 1; i <= loop; i++) {
+            try {
+                pingService.ping();
+                fail("Fallback should not be used");
+            } catch (IllegalStateException expected) {
+            }
+        }
+        // Circuit should never be open - failOn and failure do not match
+        assertEquals(loop, pingService.getPingCounter().get());
+    }
+
+}

--- a/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/circuitbreaker/failon/PingService.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/circuitbreaker/failon/PingService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.faulttolerance.deployment.circuitbreaker.failon;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+import org.eclipse.microprofile.faulttolerance.Fallback;
+
+@ApplicationScoped
+public class PingService {
+
+    private AtomicInteger pingCounter = new AtomicInteger(0);
+
+    @Fallback(fallbackMethod="getFallback")
+    @CircuitBreaker(requestVolumeThreshold=5, failOn= {IllegalArgumentException.class})
+    public String ping() {
+        pingCounter.incrementAndGet();
+        throw new IllegalStateException();
+    }
+
+    String getFallback() {
+        return PingService.class.getName();
+    }
+
+    AtomicInteger getPingCounter() {
+        return pingCounter;
+    }
+
+}

--- a/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/fallback/CircuitBreakerWithFallbackTest.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/fallback/CircuitBreakerWithFallbackTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.faulttolerance.deployment.fallback;
+
+import static org.junit.Assert.assertEquals;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.microprofile.faulttolerance.deployment.TestArchive;
+
+/**
+ *
+ * @author Martin Kouba
+ */
+@RunWith(Arquillian.class)
+public class CircuitBreakerWithFallbackTest {
+
+    @Deployment
+    public static JavaArchive createTestArchive() {
+        return TestArchive.createBase("CircuitBreakerWithFallbackTest.war").addPackage(CircuitBreakerWithFallbackTest.class.getPackage());
+    }
+
+    @Test
+    public void testCircuitBreakerOpens(PingService pingService) throws InterruptedException {
+        int loop = 8;
+        for (int i = 1; i <= loop; i++) {
+            // Fallback is always used
+            assertEquals(PingService.class.getName(), pingService.ping());
+        }
+        // After 5 invocations the circuit should be open
+        assertEquals(5, pingService.getPingCounter().get());
+    }
+
+}

--- a/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/fallback/PingService.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/fallback/PingService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.faulttolerance.deployment.fallback;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+import org.eclipse.microprofile.faulttolerance.Fallback;
+
+@ApplicationScoped
+public class PingService {
+
+    private AtomicInteger pingCounter = new AtomicInteger(0);
+
+    @Fallback(fallbackMethod="getFallback")
+    @CircuitBreaker(requestVolumeThreshold=5)
+    public String ping() {
+        pingCounter.incrementAndGet();
+        throw new IllegalStateException();
+    }
+
+    String getFallback() {
+        return PingService.class.getName();
+    }
+
+    AtomicInteger getPingCounter() {
+        return pingCounter;
+    }
+
+}


### PR DESCRIPTION
Motivation
----------
There is a bug in MP FT implementation.

Modifications
-------------
Fix HystrixCommandInterceptor and DefaultCommand to support this basic
scenario. Also add basic support for CircuitBreaker.failOn() which was
so far completely ignored. We should align the functionality once the
spec issue is resolved.

Result
------
The bug should be fixed now.