### PR TITLE
Fixed config path for Resource Adapters fraction (SWARM-1927)

### DIFF
--- a/fractions/javaee/resource-adapters/src/main/java/org/wildfly/swarm/resource/adapters/ResourceAdapterFraction.java
+++ b/fractions/javaee/resource-adapters/src/main/java/org/wildfly/swarm/resource/adapters/ResourceAdapterFraction.java
@@ -18,6 +18,7 @@ package org.wildfly.swarm.resource.adapters;
 import org.wildfly.swarm.config.ResourceAdapters;
 import org.wildfly.swarm.config.resource.adapters.ResourceAdapter;
 import org.wildfly.swarm.spi.api.Fraction;
+import org.wildfly.swarm.spi.api.annotations.Configurable;
 import org.wildfly.swarm.spi.api.annotations.MarshalDMR;
 import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
 
@@ -26,6 +27,7 @@ import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
  */
 @WildFlyExtension(module = "org.jboss.as.connector", classname = "org.jboss.as.connector.subsystems.resourceadapters.ResourceAdaptersExtension")
 @MarshalDMR
+@Configurable("swarm.resource-adapters")
 public class ResourceAdapterFraction extends ResourceAdapters<ResourceAdapterFraction> implements Fraction<ResourceAdapterFraction> {
 
     @Override


### PR DESCRIPTION
Resolves SWARM-1927

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

The fraction documentation is generated automatically from the code.