### PR TITLE
SWARM-1900: Remove useless test metric from mapping.yml.

### DIFF
--- a/fractions/microprofile/microprofile-metrics/src/main/resources/org/wildfly/swarm/microprofile/metrics/runtime/mapping.yml
+++ b/fractions/microprofile/microprofile-metrics/src/main/resources/org/wildfly/swarm/microprofile/metrics/runtime/mapping.yml
@@ -112,12 +112,4 @@ vendor:
     description: Peak usage of the %s memory pool
     multi: true
     type: gauge
-  - name: "test"
-    mbean: "jboss.modules:type=ModuleLoader,name=BootModuleLoader-2/LoadedModuleCount"
-    description: Just testing
-    unit: "none"
-    type: "gauge"
-    labels:
-      - key: "domain"
-        value: "test"
 


### PR DESCRIPTION
- https://issues.jboss.org/browse/SWARM-1900
