### PR TITLE
SWARM-1943: Mark opentracing as stable

### DIFF
--- a/fractions/opentracing/pom.xml
+++ b/fractions/opentracing/pom.xml
@@ -23,7 +23,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <swarm.fraction.stability>experimental</swarm.fraction.stability>
+    <swarm.fraction.stability>stable</swarm.fraction.stability>
     <swarm.fraction.tags>OpenTracing, Tracing, Monitoring</swarm.fraction.tags>
   </properties>
 


### PR DESCRIPTION
Something we forgot, we led to the exclusion the the bom. But in order for it to be in the supported product profile it needs to be `stable`
