### PR TITLE
SWARM-1944: MP FT - support @Asynchronous @Retry.

### DIFF
--- a/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/RetryContext.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/RetryContext.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceException;
 import org.wildfly.swarm.microprofile.faulttolerance.deployment.config.RetryConfig;
 
 class RetryContext {
@@ -46,8 +47,29 @@ class RetryContext {
         return config;
     }
 
-    void doRetry() {
+    /**
+     *
+     * @param retryContext
+     * @param throwable
+     * @return {@code true} if we should try again or rethrows the specified exception
+     */
+    boolean nextRetry(Throwable throwable) throws Exception {
+        // Decrement the retry count for this attempt
         remainingAttempts.decrementAndGet();
+        // Check the exception type
+        if (shouldRetryOn(throwable, System.nanoTime())) {
+            delayIfNeeded();
+            return true;
+        } else {
+            if (throwable instanceof Error) {
+                throw (Error) throwable;
+            } else if (throwable instanceof Exception) {
+                throw (Exception) throwable;
+            } else {
+                // Business method interceptors may only throw exceptions
+                throw new FaultToleranceException(throwable);
+            }
+        }
     }
 
     boolean shouldRetry() {
@@ -58,7 +80,7 @@ class RetryContext {
         return remainingAttempts.get() == 1;
     }
 
-    boolean shouldRetryOn(Exception exception, long time) {
+    boolean shouldRetryOn(Throwable exception, long time) {
         return
         // There are some remaining attempts left
         shouldRetry()
@@ -70,16 +92,15 @@ class RetryContext {
                 && (time - start <= maxDuration);
     }
 
-    private boolean retryOn(Exception exception) {
+    private boolean retryOn(Throwable throwable) {
         Class<?>[] retryOn = config.getRetryOn();
         if (retryOn.length == 0) {
             return false;
         }
-        if (retryOn.length == 1 && retryOn[0].equals(Exception.class)) {
-            // By default, retry on any exception
-            return true;
+        if (retryOn.length == 1) {
+            return retryOn[0].isAssignableFrom(throwable.getClass());
         }
-        return Arrays.stream(retryOn).anyMatch(ex -> ex.isAssignableFrom(exception.getClass()));
+        return Arrays.stream(retryOn).anyMatch(t -> t.isAssignableFrom(throwable.getClass()));
     }
 
     void delayIfNeeded() throws InterruptedException {

--- a/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/async/future/AsynchronousMethodNotFutureTest.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/async/future/AsynchronousMethodNotFutureTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.swarm.microprofile.faulttolerance.deployment.asynchronous.future;
+package org.wildfly.swarm.microprofile.faulttolerance.deployment.async.future;
 
 import javax.enterprise.inject.spi.DefinitionException;
 

--- a/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/async/future/WrongReturnType.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/async/future/WrongReturnType.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.swarm.microprofile.faulttolerance.deployment.asynchronous.future;
+package org.wildfly.swarm.microprofile.faulttolerance.deployment.async.future;
 
 import javax.enterprise.context.Dependent;
 

--- a/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/async/retry/AsyncHelloService.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/async/retry/AsyncHelloService.java
@@ -1,0 +1,54 @@
+package org.wildfly.swarm.microprofile.faulttolerance.deployment.async.retry;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+@ApplicationScoped
+public class AsyncHelloService {
+
+    static final AtomicInteger COUNTER = new AtomicInteger(0);
+
+    @Asynchronous
+    @Retry(maxRetries = 2)
+    public Future<String> retry(Result result) throws IOException {
+        COUNTER.incrementAndGet();
+        switch (result) {
+            case FAILURE:
+                throw new IOException("Simulated IO error");
+            case COMPLETE_EXCEPTIONALLY:
+                CompletableFuture<String> future = new CompletableFuture<>();
+                future.completeExceptionally(new IOException("Simulated IO error"));
+                return future;
+            default:
+                return completedFuture("Hello");
+        }
+    }
+
+    @Asynchronous
+    @Retry(maxRetries = 2)
+    @Fallback(fallbackMethod = "fallback")
+    public Future<String> retryWithFallback(Result result) throws IOException {
+        return retry(result);
+    }
+
+    public Future<String> fallback(Result result) {
+        return completedFuture("Fallback");
+    }
+
+    enum Result {
+
+        SUCCESS, FAILURE, COMPLETE_EXCEPTIONALLY
+
+    }
+
+}

--- a/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/async/retry/AsynchronousRetryTest.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/async/retry/AsynchronousRetryTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.faulttolerance.deployment.async.retry;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.wildfly.swarm.microprofile.faulttolerance.deployment.async.retry.AsyncHelloService.COUNTER;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.microprofile.faulttolerance.deployment.TestArchive;
+import org.wildfly.swarm.microprofile.faulttolerance.deployment.async.retry.AsyncHelloService.Result;
+
+/**
+ *
+ * @author Martin Kouba
+ */
+@RunWith(Arquillian.class)
+public class AsynchronousRetryTest {
+
+    @Deployment
+    public static JavaArchive createTestArchive() {
+        return TestArchive.createBase("AsynchronousRetryTest.jar").addPackage(AsynchronousRetryTest.class.getPackage());
+    }
+
+    @Test
+    public void testAsyncRetry(AsyncHelloService helloService) throws IOException, InterruptedException, ExecutionException {
+        COUNTER.set(0);
+        assertEquals("Hello", helloService.retry(Result.SUCCESS).get());
+        assertEquals(1, COUNTER.get());
+        COUNTER.set(0);
+        try {
+            helloService.retry(Result.FAILURE).get();
+            fail();
+        } catch (ExecutionException expected) {
+            assertTrue(expected.getCause() instanceof IOException);
+        }
+        assertEquals(3, COUNTER.get());
+    }
+
+    @Test
+    public void testAsyncRetryFutureCompletesExceptionally(AsyncHelloService helloService) throws IOException, InterruptedException, ExecutionException {
+        COUNTER.set(0);
+        try {
+            helloService.retry(Result.COMPLETE_EXCEPTIONALLY).get();
+            fail();
+        } catch (ExecutionException expected) {
+            assertTrue(expected.getCause() instanceof IOException);
+        }
+        assertEquals(1, COUNTER.get());
+    }
+
+    @Test
+    public void testAsyncRetryFallback(AsyncHelloService helloService) throws IOException, InterruptedException, ExecutionException {
+        COUNTER.set(0);
+        assertEquals("Fallback", helloService.retryWithFallback(Result.FAILURE).get());
+        assertEquals(3, COUNTER.get());
+    }
+
+}

--- a/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/retryonerror/HelloService.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/retryonerror/HelloService.java
@@ -1,0 +1,22 @@
+package org.wildfly.swarm.microprofile.faulttolerance.deployment.retry;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+@ApplicationScoped
+public class HelloService {
+
+    static final AtomicInteger COUNTER = new AtomicInteger(0);
+
+    @Retry(maxRetries = 2, retryOn = Error.class)
+    public String retry() {
+        if (COUNTER.incrementAndGet() == 3) {
+            return "ok";
+        }
+        throw new AssertionError();
+    }
+
+}

--- a/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/retryonerror/RetryOnErrorTest.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/retryonerror/RetryOnErrorTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.faulttolerance.deployment.retry;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.wildfly.swarm.microprofile.faulttolerance.deployment.retry.HelloService.COUNTER;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.microprofile.faulttolerance.deployment.TestArchive;
+
+/**
+ *
+ * @author Martin Kouba
+ */
+@RunWith(Arquillian.class)
+public class RetryOnErrorTest {
+
+    @Deployment
+    public static JavaArchive createTestArchive() {
+        return TestArchive.createBase("RetryOnErrorTest.jar").addPackage(RetryOnErrorTest.class.getPackage());
+    }
+
+    @Test
+    public void testRetry(HelloService helloService) {
+        COUNTER.set(0);
+        try {
+            helloService.retry();
+            fail();
+        } catch (AssertionError expected) {
+        }
+        assertEquals(3, COUNTER.get());
+    }
+
+}


### PR DESCRIPTION
Motivation
----------
There is a bug in MP FT implementation.

Modifications
-------------
Fixed the relevant parts of the code.

Result
------
@Retry with @Asynchronous (and with fallback) works  if an exception is
thrown from within a business method.