### PR TITLE
SWARM-1782: Allow finalname of uberjar to be customized

### DIFF
--- a/plugins/gradle/src/main/java/org/wildfly/swarm/plugin/gradle/PackageTask.java
+++ b/plugins/gradle/src/main/java/org/wildfly/swarm/plugin/gradle/PackageTask.java
@@ -273,7 +273,7 @@ public class PackageTask extends DefaultTask {
 
     @OutputFile
     private File getOutputFile() {
-        return BuildTool.getOutputFile(getBaseName(), getOutputDirectory());
+        return BuildTool.getOutputFile(getBaseName() + "-swarm.jar", getOutputDirectory());
     }
 
     private String getBaseName() {

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/PackageMojo.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/PackageMojo.java
@@ -69,6 +69,9 @@ public class PackageMojo extends AbstractSwarmMojo {
     @Parameter(alias = "hollow", defaultValue = "false", property = "swarm.hollow")
     protected boolean hollow;
 
+    @Parameter(property = "finalName")
+    public String finalName;
+
     /**
      * Flag to skip packaging entirely.
      */
@@ -200,8 +203,12 @@ public class PackageMojo extends AbstractSwarmMojo {
                 .forEach(tool::additionalModule);
 
         try {
-            File jar = tool.build(finalName + (this.hollow ? "-hollow" : ""), Paths.get(this.projectBuildDir));
-
+            String jarFinalName = finalName + (this.hollow ? "-hollow" : "") + "-swarm";
+            if (this.finalName != null) {
+                jarFinalName = this.finalName;
+            }
+            jarFinalName += ".jar";
+            File jar = tool.build(jarFinalName, Paths.get(this.projectBuildDir));
             ArtifactHandler handler = new DefaultArtifactHandler("jar");
             Artifact swarmJarArtifact = new DefaultArtifact(
                     primaryArtifact.getGroupId(),

--- a/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
@@ -438,7 +438,7 @@ public class BuildTool {
     }
 
     public static File getOutputFile(String baseName, Path directory) {
-        return new File(directory.toFile(), baseName + "-swarm.jar");
+        return new File(directory.toFile(), baseName);
     }
 
     private File createJar(String baseName, Path dir) throws IOException {


### PR DESCRIPTION
Allow finalname to be set in maven builds.

For gradle builds it will use the old behaviour, so the hardcoded "-swarm.jar " is moved from BuildTool.java to PackageTask.java.

If no name is set, it will default to the old value (finalName + (this.hollow ? "-hollow" : "") + "-swarm.jar").

- [x ] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [ x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ x] Have you built the project locally prior to submission with `mvn clean install`?

-----
