### PR TITLE
SWARM-1953: MP JWT - resource without @RolesAllowed is secured.

### DIFF
--- a/testsuite/microprofile-tcks/jwt-auth/pom.xml
+++ b/testsuite/microprofile-tcks/jwt-auth/pom.xml
@@ -129,6 +129,11 @@
                <dependenciesToScan>
                   <dependency>org.eclipse.microprofile.jwt:microprofile-jwt-auth-tck</dependency>
                </dependenciesToScan>
+               <systemPropertyVariables>
+                  <!-- Uncomment to debug arquillian test -->
+                  <!-- swarm.debug.port>8787</swarm.debug.port-->
+                  <!-- swarm.logging>FINEST</swarm.logging-->
+               </systemPropertyVariables>
             </configuration>
          </plugin>
       </plugins>

--- a/testsuite/microprofile-tcks/jwt-auth/src/test/java/org/eclipse/microprofile/jwt/TestArchive.java
+++ b/testsuite/microprofile-tcks/jwt-auth/src/test/java/org/eclipse/microprofile/jwt/TestArchive.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.jwt;
+
+import java.net.URL;
+
+import org.eclipse.microprofile.jwt.tck.container.jaxrs.TCKApplication;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+public class TestArchive {
+
+    static final String SUFFIX = ".war";
+
+    public static WebArchive createBase(Class<?> testClass) {
+        URL publicKey = TestArchive.class.getResource("/publicKey.pem");
+        return ShrinkWrap.create(WebArchive.class, testClass.getSimpleName() + SUFFIX)
+                .addAsResource(publicKey, "/publicKey.pem")
+                .addClass(TCKApplication.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+}

--- a/testsuite/microprofile-tcks/jwt-auth/src/test/java/org/eclipse/microprofile/jwt/roles/absent/DenyAllClassLevel.java
+++ b/testsuite/microprofile-tcks/jwt-auth/src/test/java/org/eclipse/microprofile/jwt/roles/absent/DenyAllClassLevel.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.jwt.roles.absent;
+
+import java.security.Principal;
+
+import javax.annotation.security.DenyAll;
+import javax.annotation.security.PermitAll;
+import javax.enterprise.context.RequestScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.SecurityContext;
+
+@Path("/denyAll")
+@DenyAll
+@RequestScoped
+public class DenyAllClassLevel {
+
+    @GET
+    public String echo(@Context SecurityContext sec, @QueryParam("input") String input) {
+        Principal user = sec.getUserPrincipal();
+        return input + ", user="+user.getName();
+    }
+
+    @GET
+    @Path("/permitAll")
+    @PermitAll
+    public String echoPermitAll(@Context SecurityContext sec, @QueryParam("input") String input) {
+        Principal user = sec.getUserPrincipal();
+        return input + ", user="+user.getName();
+    }
+
+}

--- a/testsuite/microprofile-tcks/jwt-auth/src/test/java/org/eclipse/microprofile/jwt/roles/absent/RolesAllowedAbsentTest.java
+++ b/testsuite/microprofile-tcks/jwt-auth/src/test/java/org/eclipse/microprofile/jwt/roles/absent/RolesAllowedAbsentTest.java
@@ -14,11 +14,10 @@
  *   limitations under the License.
  *
  */
-package org.eclipse.microprofile.jwt.roles;
+package org.eclipse.microprofile.jwt.roles.absent;
 
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 
-import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.HashMap;
@@ -40,9 +39,10 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
- * See also <a href= "https://github.com/eclipse/microprofile-jwt-auth/issues/77">https://github.com/eclipse/microprofile-jwt-auth/issues/77</a>.
+ *
+ * @author Martin Kouba
  */
-public class RolesAllowedTest extends Arquillian {
+public class RolesAllowedAbsentTest extends Arquillian {
 
     /**
      * The test generated JWT token string
@@ -56,8 +56,8 @@ public class RolesAllowedTest extends Arquillian {
     private URL baseURL;
 
     @Deployment
-    public static WebArchive createDeployment() throws IOException {
-        return TestArchive.createBase(RolesAllowedTest.class).addClasses(RolesEndpointMethodLevel.class, RolesEndpointClassLevel.class);
+    public static WebArchive createDeployment() {
+        return TestArchive.createBase(RolesAllowedAbsentTest.class).addClasses(DenyAllClassLevel.class);
     }
 
     @BeforeClass
@@ -67,20 +67,17 @@ public class RolesAllowedTest extends Arquillian {
 
     @RunAsClient
     @Test
-    public void testRolesMethod() throws Exception {
-        String uri = baseURL.toExternalForm() + "/rolesMethod";
+    public void testDenyAllClass() throws Exception {
+        String uri = baseURL.toExternalForm() + "/denyAll";
         WebTarget echoEndpointTarget = ClientBuilder.newClient().target(uri).queryParam("input", "hello");
         Response response = echoEndpointTarget.request(TEXT_PLAIN).header(HttpHeaders.AUTHORIZATION, "Bearer " + token).get();
-        Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_OK);
-        String reply = response.readEntity(String.class);
-        // Must return hello, user={token upn claim}
-        Assert.assertEquals(reply, "hello, user=jdoe@example.com");
+        Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_FORBIDDEN);
     }
 
     @RunAsClient
     @Test
-    public void testRolesClass() throws Exception {
-        String uri = baseURL.toExternalForm() + "/rolesClass";
+    public void testPermitAllMethod() throws Exception {
+        String uri = baseURL.toExternalForm() + "/denyAll/permitAll";
         WebTarget echoEndpointTarget = ClientBuilder.newClient().target(uri).queryParam("input", "hello");
         Response response = echoEndpointTarget.request(TEXT_PLAIN).header(HttpHeaders.AUTHORIZATION, "Bearer " + token).get();
         Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_OK);


### PR DESCRIPTION
Motivation
----------
Currently, if there is no @RolesAllowed declared on a JAX-RS resource,
no resource method is secured. This is rather a corner case but still a
valid use case.

Modifications
-------------
Fix MPJWTAuthExtensionArchivePreparer to also handle JAX-RS resource
classes which only declare @DenyAll/@PermitAll.

Result
------
JAX-RS resource without @RolesAllowed is secured (if needed).