### PR TITLE
Simplify POM files

### DIFF
--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/UberjarSimpleContainer.java
@@ -355,7 +355,7 @@ public class UberjarSimpleContainer implements SimpleContainer {
 
     @Override
     public void stop() throws Exception {
-        this.process.stop(2, TimeUnit.MINUTES); // Because my laptop is slower than yours.
+        this.process.stop(5, TimeUnit.MINUTES); // Because my laptop is slower than yours.
         TempFileManager.deleteRecursively(workingDirectory);
     }
 

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -126,9 +126,68 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.4.1</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>wildfly-swarm-enforcer-pattern-size</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <phase>verify</phase>
+            <configuration>
+              <rules>
+                <patternSizeRule implementation="org.wildfly.swarm.plugin.enforcer.patternsize.RequireFilePatternSize">
+                  <requiredFilePatterns>
+                    <requiredFilePattern>
+                      <maxSize>0</maxSize>
+                      <recursive>false</recursive>
+                      <directory>${project.build.directory}</directory>
+                      <pattern>wfswarm\S+[0-9]{5,}.\S{5,}</pattern>
+                    </requiredFilePattern>
+                    <requiredFilePattern>
+                      <maxSize>0</maxSize>
+                      <recursive>false</recursive>
+                      <directory>${java.io.tmpdir}</directory>
+                      <pattern>wfswarm\S+[0-9]{5,}.\S{5,}</pattern>
+                    </requiredFilePattern>
+                  </requiredFilePatterns>
+                </patternSizeRule>
+              </rules>
+            </configuration>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>build-resources</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
     </plugins>
   </build>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>build-resources</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/build-resources/pom.xml
+++ b/build-resources/pom.xml
@@ -4,9 +4,9 @@
 
   <parent>
     <groupId>org.wildfly.swarm</groupId>
-    <artifactId>parent</artifactId>
-    <version>9</version>
-    <relativePath />
+    <artifactId>wildfly-swarm</artifactId>
+    <version>2018.5.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.wildfly.swarm</groupId>

--- a/fractions/netflix/pom.xml
+++ b/fractions/netflix/pom.xml
@@ -42,47 +42,47 @@
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>archaius</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>netflix-guava</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>hystrix</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>ribbon</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>ribbon-secured</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>ribbon-secured-client</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>netflix-rxjava</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>netflix-rxnetty</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>servo</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>

--- a/maven-enforcer-pattern-size/pom.xml
+++ b/maven-enforcer-pattern-size/pom.xml
@@ -9,9 +9,9 @@
 
   <parent>
     <groupId>org.wildfly.swarm</groupId>
-    <artifactId>parent</artifactId>
-    <version>9</version>
-    <relativePath />
+    <artifactId>wildfly-swarm</artifactId>
+    <version>2018.5.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.wildfly.swarm</groupId>

--- a/maven-enforcer-pattern-size/src/main/java/org/wildfly/swarm/plugin/enforcer/patternsize/RequireFilePatternSize.java
+++ b/maven-enforcer-pattern-size/src/main/java/org/wildfly/swarm/plugin/enforcer/patternsize/RequireFilePatternSize.java
@@ -34,9 +34,7 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
 
 /**
- *
  * @author Juan Gonzalez
- *
  */
 public class RequireFilePatternSize implements EnforcerRule {
 
@@ -68,19 +66,19 @@ public class RequireFilePatternSize implements EnforcerRule {
 
         if (Files.isDirectory(directoryFile.toPath())) {
             Files.walkFileTree(directoryFile.toPath(), EnumSet.of(FileVisitOption.FOLLOW_LINKS),
-                requiredFilePattern.isRecursive() ? Integer.MAX_VALUE : 1,
-                        new SimpleFileVisitor<Path>() {
-                        @Override
-                        public FileVisitResult visitFile(Path filePath, BasicFileAttributes attrs) throws IOException {
-                             Matcher matcher = pattern.matcher(filePath.getFileName().toString());
-                             if (matcher.matches()) {
-                                 File file = filePath.toFile();
-                                 matchedFiles.add(file);
-                             }
+                               requiredFilePattern.isRecursive() ? Integer.MAX_VALUE : 1,
+                               new SimpleFileVisitor<Path>() {
+                                   @Override
+                                   public FileVisitResult visitFile(Path filePath, BasicFileAttributes attrs) throws IOException {
+                                       Matcher matcher = pattern.matcher(filePath.getFileName().toString());
+                                       if (matcher.matches()) {
+                                           File file = filePath.toFile();
+                                           matchedFiles.add(file);
+                                       }
 
-                            return super.visitFile(filePath, attrs);
-                        }
-             });
+                                       return super.visitFile(filePath, attrs);
+                                   }
+                               });
         }
 
         List<RequiredFilePatternFailure> failures = new ArrayList<RequiredFilePatternFailure>();
@@ -103,14 +101,14 @@ public class RequireFilePatternSize implements EnforcerRule {
         List<RequiredFilePatternFailure> failures = new ArrayList<RequiredFilePatternFailure>();
 
         if (requiredFilePatterns.length > 0) {
-            for (RequiredFilePattern requiredFilePattern: requiredFilePatterns) {
+            for (RequiredFilePattern requiredFilePattern : requiredFilePatterns) {
                 if (requiredFilePattern == null) {
                     failures.add(new RequiredFilePatternFailure(requiredFilePattern, "File pattern is empty"));
                 }
 
                 List<RequiredFilePatternFailure> failure = null;
 
-                try{
+                try {
                     failure = checkFilePattern(requiredFilePattern);
                 } catch (IOException e) {
                     failures.add(new RequiredFilePatternFailure(requiredFilePattern, "Error while traversing files"));
@@ -120,7 +118,7 @@ public class RequireFilePatternSize implements EnforcerRule {
                     failures.addAll(failure);
                 }
             }
-        }  else {
+        } else {
             throw new EnforcerRuleException("The file pattern list is empty.");
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -106,13 +106,6 @@
             <org.apache.maven.user-settings>${session.request.userSettingsFile.path}</org.apache.maven.user-settings>
           </systemPropertyVariables>
         </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.wildfly.swarm</groupId>
-            <artifactId>build-resources</artifactId>
-            <version>${project.version}</version>
-          </dependency>
-        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -159,47 +152,6 @@
             </configuration>
             <goals>
               <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-         <groupId>org.apache.maven.plugins</groupId>
-         <artifactId>maven-enforcer-plugin</artifactId>
-         <version>1.4.1</version>
-         <dependencies>
-            <dependency>
-            <groupId>org.wildfly.swarm</groupId>
-            <artifactId>wildfly-swarm-enforcer-pattern-size</artifactId>
-            <version>${project.version}</version>
-          </dependency>
-        </dependencies>
-        <executions>
-          <execution>
-            <id>enforce</id>
-            <phase>verify</phase>
-            <configuration>
-              <rules>
-          <patternSizeRule implementation="org.wildfly.swarm.plugin.enforcer.patternsize.RequireFilePatternSize">
-            <requiredFilePatterns>
-                <requiredFilePattern>
-                  <maxSize>0</maxSize>
-                  <recursive>false</recursive>
-	          <directory>${project.build.directory}</directory>
-                  <pattern>wfswarm\S+[0-9]{5,}.\S{5,}</pattern>
-                </requiredFilePattern>
-               <requiredFilePattern>
-                  <maxSize>0</maxSize>
-                  <recursive>false</recursive>
-                  <directory>${java.io.tmpdir}</directory>
-                  <pattern>wfswarm\S+[0-9]{5,}.\S{5,}</pattern>
-               </requiredFilePattern>
-            </requiredFilePatterns>
-          </patternSizeRule>
-              </rules>
-            </configuration>
-            <goals>
-              <goal>enforce</goal>
             </goals>
           </execution>
         </executions>
@@ -261,11 +213,6 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.wildfly.swarm</groupId>
-      <artifactId>build-resources</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <dependencyManagement>
@@ -297,658 +244,658 @@
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>build-parent</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>build-resources</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>wildfly-swarm-enforcer-pattern-size</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>cli</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>tools</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>meta-spi</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>fraction-metadata</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>spi</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>arquillian</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>arquillian-daemon</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>arquillian-adapter</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>arquillian-resolver</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>asciidoctorj</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>batch-jberet</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>bean-validation</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>bootstrap</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>camel-core</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>camel-activemq</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>camel-cdi</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>camel-cxf</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>camel-ejb</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>camel-jaxb</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>camel-jms</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>camel-jmx</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>camel-jpa</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>camel-mail</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>camel-ognl</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>camel-swagger</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>camel-undertow</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>cdi</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>cdi-config</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>jaxrs-client-api</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>microprofile-restclient-api</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>cdi-jaxrsapi</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>connector</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>container</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>datasources</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>drools-server</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>ee</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>ejb</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>ejb-remote</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>elytron</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>full</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>flyway</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>hibernate-search</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>hibernate-validator</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>infinispan</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>io</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>jaeger</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>javafx</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>jaxrs</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>jaxrs-cdi</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>jaxrs-jaxb</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>jaxrs-multipart</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>jaxrs-validator</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>jaxrs-jsonp</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>jca</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>jdr</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>jgroups</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>jmx</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>jolokia</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>jpa</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>jpa-spatial</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>jpa-eclipselink</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>jsf</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>jsonp</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>keycloak</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>keycloak-server</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>logging</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>logstash</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>mail</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>management</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>management-console</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>messaging</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>microprofile</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>microprofile-config</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>microprofile-health</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>microprofile-jwt</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>microprofile-metrics</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>microprofile-openapi</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>microprofile-fault-tolerance</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>microprofile-restclient</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>mod_cluster</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>monitor</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>msc</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>naming</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <!-- NoSQL -->
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>cassandra</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>mongodb</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>neo4j</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>orientdb</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>opentracing</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>remoting</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>request-controller</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>resource-adapters</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>hystrix</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>ribbon</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>ribbon-secured</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>security</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>spring</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>swagger</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>swagger-webapp</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>teiid</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>topology</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>topology-consul</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>topology-jgroups</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>topology-openshift</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>topology-webapp</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>transactions</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>undertow</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>vertx</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>web</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>webservices</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>zipkin-jaxrs</artifactId>
-        <version>2018.5.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -59,6 +59,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>build-resources</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+        </dependencies>
       </plugin>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
@@ -82,6 +89,47 @@
             <phase>verify</phase>
             <goals>
               <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.4.1</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>wildfly-swarm-enforcer-pattern-size</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <phase>verify</phase>
+            <configuration>
+              <rules>
+                <patternSizeRule implementation="org.wildfly.swarm.plugin.enforcer.patternsize.RequireFilePatternSize">
+                  <requiredFilePatterns>
+                    <requiredFilePattern>
+                      <maxSize>0</maxSize>
+                      <recursive>false</recursive>
+                      <directory>${project.build.directory}</directory>
+                      <pattern>wfswarm\S+[0-9]{5,}.\S{5,}</pattern>
+                    </requiredFilePattern>
+                    <requiredFilePattern>
+                      <maxSize>0</maxSize>
+                      <recursive>false</recursive>
+                      <directory>${java.io.tmpdir}</directory>
+                      <pattern>wfswarm\S+[0-9]{5,}.\S{5,}</pattern>
+                    </requiredFilePattern>
+                  </requiredFilePatterns>
+                </patternSizeRule>
+              </rules>
+            </configuration>
+            <goals>
+              <goal>enforce</goal>
             </goals>
           </execution>
         </executions>
@@ -153,6 +201,11 @@
       <artifactId>graphene-webdriver</artifactId>
       <version>${version.org.arquillian.graphene}</version>
       <type>pom</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>build-resources</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Motivation
----------
When testing out changes locally, I tend to use `mvn versions:set -DnewVersion=xxx` a lot. As a habit, I tend to look at the changed files. In the current form, there are a lot of changes that show up in two POM files in particular - the root POM and the Netflix POM.

Modifications
-------------
* Use ${project.version} instead of an explicit version detail.
* Set `wildfly-swarm` as the parent of `build-resources` & `maven-enforcer-pattern-size`.
* Moved the enforcer plugin configuration from root to one level below. This is needed to avoid circular dependencies during POM evaluation.

Result
------
* Verified that the build is going through properly.
* Generated a custom build and verified that the new behavior is working properly.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
