### PR TITLE
SWARM-1963: Unify MicroProfile configuration keys.

### DIFF
--- a/fractions/microprofile/microprofile-config/src/main/java/org/wildfly/swarm/microprofile/config/fraction/MicroProfileConfigFraction.java
+++ b/fractions/microprofile/microprofile-config/src/main/java/org/wildfly/swarm/microprofile/config/fraction/MicroProfileConfigFraction.java
@@ -24,6 +24,7 @@ package org.wildfly.swarm.microprofile.config.fraction;
 
 import org.wildfly.swarm.config.MicroprofileConfig;
 import org.wildfly.swarm.spi.api.Fraction;
+import org.wildfly.swarm.spi.api.annotations.Configurable;
 import org.wildfly.swarm.spi.api.annotations.DeploymentModule;
 import org.wildfly.swarm.spi.api.annotations.MarshalDMR;
 import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
@@ -34,6 +35,7 @@ import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
 @WildFlyExtension(module = "org.wildfly.extension.microprofile.config")
 @MarshalDMR
 @DeploymentModule(name = "org.eclipse.microprofile.config.api")
+@Configurable("swarm.microprofile.config")
 public class MicroProfileConfigFraction extends MicroprofileConfig<MicroProfileConfigFraction> implements Fraction<MicroProfileConfigFraction> {
 
     public MicroProfileConfigFraction() {

--- a/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/MicroProfileFaultToleranceFraction.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/MicroProfileFaultToleranceFraction.java
@@ -37,6 +37,6 @@ public class MicroProfileFaultToleranceFraction implements Fraction<MicroProfile
     }
 
     @AttributeDocumentation("Enable/disable synchronous circuit breaker functionality. If disabled, `CircuitBreaker#successThreshold()` of value greater than 1 is not supported. Moreover, circuit breaker does not necessarily transition from `CLOSED` to `OPEN` immediately when a fault tolerance operation completes. However, applications are encouraged to disable this feature on high-volume circuits.")
-    @Configurable("swarm.micro-profile-faulttolerance.synchronousCircuitBreaker")
+    @Configurable("swarm.microprofile.fault-tolerance.synchronous-circuit-breaker")
     private Defaultable<Boolean> synchronousCircuitBreaker = Defaultable.bool(true);
 }

--- a/fractions/microprofile/microprofile-health/src/main/java/org/wildfly/swarm/microprofile/health/HealthFraction.java
+++ b/fractions/microprofile/microprofile-health/src/main/java/org/wildfly/swarm/microprofile/health/HealthFraction.java
@@ -15,11 +15,16 @@
  */
 package org.wildfly.swarm.microprofile.health;
 
-import org.wildfly.swarm.spi.api.Fraction;
-import org.wildfly.swarm.spi.api.Module;
-import org.wildfly.swarm.spi.api.annotations.DeploymentModule;
+import static org.wildfly.swarm.spi.api.Defaultable.string;
 
 import java.util.Optional;
+
+import org.wildfly.swarm.config.runtime.AttributeDocumentation;
+import org.wildfly.swarm.spi.api.Defaultable;
+import org.wildfly.swarm.spi.api.Fraction;
+import org.wildfly.swarm.spi.api.Module;
+import org.wildfly.swarm.spi.api.annotations.Configurable;
+import org.wildfly.swarm.spi.api.annotations.DeploymentModule;
 
 /**
  * @author Heiko Braun
@@ -31,14 +36,17 @@ import java.util.Optional;
 @DeploymentModule(name = "org.eclipse.microprofile.health", services = Module.ServiceHandling.IMPORT, export = true)
 public class HealthFraction implements Fraction<HealthFraction> {
 
-    private Optional<String> securityRealm = Optional.empty();
+    @AttributeDocumentation("Security realm configuration")
+    @Configurable("swarm.microprofile.health.security-realm")
+    @Configurable("swarm.health.security-realm")
+    private Defaultable<String> securityRealm = string("");
 
     public HealthFraction securityRealm(String realmName) {
-        this.securityRealm = Optional.of(realmName);
+        this.securityRealm.set(realmName);
         return this;
     }
 
     public Optional<String> securityRealm() {
-        return this.securityRealm;
+        return securityRealm.explicit();
     }
 }

--- a/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/MicroProfileJWTAuthFraction.java
+++ b/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/MicroProfileJWTAuthFraction.java
@@ -29,19 +29,22 @@ import org.wildfly.swarm.spi.api.annotations.DeploymentModule;
 /**
  * A fraction that adds support for the MicroProfile 1.0 JWT RBAC authentication and authorization spec.
  */
-@Configurable("swarm.microprofile.jwtauth")
+@Configurable("swarm.microprofile.jwt")
 @DeploymentModule(name = "org.wildfly.swarm.microprofile.jwtauth", slot = "deployment", export = true, metaInf = DeploymentModule.MetaInfDisposition.IMPORT)
 public class MicroProfileJWTAuthFraction implements Fraction<MicroProfileJWTAuthFraction> {
 
     @AttributeDocumentation("The URI of the JWT token issuer")
+    @Configurable("swarm.microprofile.jwt.token.issued-by")
     @Configurable("swarm.microprofile.jwtauth.token.issuedBy")
     private Defaultable<String> tokenIssuer = string("http://localhost");
 
     @AttributeDocumentation("The public key of the JWT token signer")
+    @Configurable("swarm.microprofile.jwt.token.signer-pub-key")
     @Configurable("swarm.microprofile.jwtauth.token.signerPubKey")
     private String publicKey;
 
     @AttributeDocumentation("The JWT token expiration grace period in seconds ")
+    @Configurable("swarm.microprofile.jwt.token.exp-grace-period")
     @Configurable("swarm.microprofile.jwtauth.token.expGracePeriod")
     private Defaultable<Integer> expGracePeriodSecs = integer(60);
 


### PR DESCRIPTION
Motivation
----------
MP implementations use various templates for config property names.

Modifications
-------------
Unify the keys to use the following template:
swarm.microprofile.${spec}.${lower-case-hyphen-separated-name}.

Result
------
Keys are unified. Original values should still work but are not listed
in docs.

NOTE: https://issues.jboss.org/browse/SWARM-1974 must be fixed (https://github.com/wildfly-swarm/wildfly-swarm-fraction-plugin/pull/71) and fraction plugin upgraded before we merge this PR.

