### PR TITLE
SWARM-1937 passivate stateful session beans

### DIFF
--- a/fractions/wildfly/infinispan/src/main/java/org/wildfly/swarm/infinispan/runtime/InfinispanCustomizer.java
+++ b/fractions/wildfly/infinispan/src/main/java/org/wildfly/swarm/infinispan/runtime/InfinispanCustomizer.java
@@ -106,6 +106,7 @@ public class InfinispanCustomizer implements Customizer {
             this.fraction.cacheContainer("ejb",
                     cc -> cc.defaultCache(DIST)
                             .alias("sfsb")
+                            .module("org.wildfly.clustering.ejb.infinispan")
                             .jgroupsTransport(t -> t.lockTimeout(60000L))
                             .distributedCache(DIST,
                                     c -> c.mode(Mode.ASYNC)
@@ -159,6 +160,7 @@ public class InfinispanCustomizer implements Customizer {
             this.fraction.cacheContainer("ejb",
                     cc -> cc.alias("sfsb")
                             .defaultCache(PASSIVATION)
+                            .module("org.wildfly.clustering.ejb.infinispan")
                             .localCache(PASSIVATION,
                                     c -> c.lockingComponent(lc -> lc.isolation(LockingComponent.Isolation.REPEATABLE_READ))
                                             .transactionComponent(tc -> tc.mode(TransactionComponent.Mode.BATCH))


### PR DESCRIPTION
Error when passivate sfsb, because it cant serialize the sessionn key.
Solution use the same module as standard wildfly

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
