### PR TITLE
SWARM-1892: Add a testsuite for the MVC fraction

### DIFF
--- a/fractions/javaee/mvc/module.conf
+++ b/fractions/javaee/mvc/module.conf
@@ -1,3 +1,0 @@
-org.wildfly.swarm.cdi
-org.wildfly.swarm.jaxrs
-org.wildfly.swarm.bean.validation

--- a/fractions/javaee/mvc/pom.xml
+++ b/fractions/javaee/mvc/pom.xml
@@ -27,7 +27,17 @@
     <swarm.fraction.stability>experimental</swarm.fraction.stability>
     <swarm.fraction.tags>JavaEE,Web</swarm.fraction.tags>
     <version.ozark>1.0.0-m03</version.ozark>
+    <version.mvc>1.0-pr</version.mvc>
   </properties>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+  </build>
 
   <dependencies>
     <dependency>
@@ -47,20 +57,20 @@
     <dependency>
       <groupId>javax.mvc</groupId>
       <artifactId>javax.mvc-api</artifactId>
-      <version>1.0-pr</version>
+      <version>${version.mvc}</version>
     </dependency>
 
     <dependency>
       <groupId>org.mvc-spec.ozark</groupId>
       <artifactId>ozark-core</artifactId>
       <version>${version.ozark}</version>
-      <scope>runtime</scope>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.mvc-spec.ozark</groupId>
       <artifactId>ozark-resteasy</artifactId>
       <version>${version.ozark}</version>
-      <scope>runtime</scope>
+      <scope>provided</scope>
     </dependency>
 
     <!-- Meta SPI -->

--- a/fractions/javaee/mvc/src/main/java/org/wildfly/swarm/mvc/MvcFraction.java
+++ b/fractions/javaee/mvc/src/main/java/org/wildfly/swarm/mvc/MvcFraction.java
@@ -1,0 +1,9 @@
+package org.wildfly.swarm.mvc;
+
+import org.wildfly.swarm.spi.api.Fraction;
+import org.wildfly.swarm.spi.api.Module;
+import org.wildfly.swarm.spi.api.annotations.DeploymentModule;
+
+@DeploymentModule(name = "org.mvcspec.ozark", services = Module.ServiceHandling.IMPORT)
+public class MvcFraction implements Fraction<MvcFraction> {
+}

--- a/fractions/javaee/mvc/src/main/resources/modules/org/mvcspec/ozark/main/module.xml
+++ b/fractions/javaee/mvc/src/main/resources/modules/org/mvcspec/ozark/main/module.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<module xmlns="urn:jboss:module:1.5" name="org.mvcspec.ozark">
+  <resources>
+    <artifact name="javax.mvc:javax.mvc-api:${version.mvc}"/>
+    <artifact name="org.mvc-spec.ozark:ozark-core:${version.ozark}"/>
+    <artifact name="org.mvc-spec.ozark:ozark-resteasy:${version.ozark}"/>
+  </resources>
+  <dependencies>
+    <module name="javax.servlet.api"/>
+    <module name="javax.ws.rs.api"/>
+    <module name="javax.enterprise.api"/>
+    <module name="javax.annotation.api"/>
+    <module name="javax.validation.api"/>
+    <module name="org.jboss.weld.core"/>
+    <module name="org.jboss.weld.spi"/>
+  </dependencies>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -783,6 +783,12 @@
 
       <dependency>
         <groupId>org.wildfly.swarm</groupId>
+        <artifactId>mvc</artifactId>
+        <version>2018.5.0-SNAPSHOT</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.wildfly.swarm</groupId>
         <artifactId>naming</artifactId>
         <version>2018.5.0-SNAPSHOT</version>
       </dependency>
@@ -1289,6 +1295,7 @@
         <module>testsuite/testsuite-messaging-remote</module>
         <module>testsuite/testsuite-microprofile-openapi</module>
         <module>testsuite/testsuite-mod_cluster</module>
+        <module>testsuite/testsuite-mvc</module>
         <module>testsuite/testsuite-opentracing</module>
         <module>testsuite/testsuite-resource-adapters</module>
         <module>testsuite/testsuite-spring</module>

--- a/testsuite/testsuite-mvc/pom.xml
+++ b/testsuite/testsuite-mvc/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm.testsuite</groupId>
+    <artifactId>testsuite-parent</artifactId>
+    <version>2018.5.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <artifactId>testsuite-mvc</artifactId>
+
+  <name>Test Suite: MVC</name>
+  <description>Test Suite: MVC</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>mvc</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>arquillian</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>fluent-hc</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/testsuite/testsuite-mvc/src/main/java/org/wildfly/swarm/mvc/test/MvcApplication.java
+++ b/testsuite/testsuite-mvc/src/main/java/org/wildfly/swarm/mvc/test/MvcApplication.java
@@ -1,0 +1,9 @@
+package org.wildfly.swarm.mvc.test;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class MvcApplication extends Application {
+
+}

--- a/testsuite/testsuite-mvc/src/main/java/org/wildfly/swarm/mvc/test/MvcController.java
+++ b/testsuite/testsuite-mvc/src/main/java/org/wildfly/swarm/mvc/test/MvcController.java
@@ -1,0 +1,15 @@
+package org.wildfly.swarm.mvc.test;
+
+import javax.mvc.annotation.Controller;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/hello")
+@Controller
+public class MvcController  {
+
+    @GET
+    public String greet() {
+        return "hello.jsp";
+    }
+}

--- a/testsuite/testsuite-mvc/src/main/resources/views/hello.jsp
+++ b/testsuite/testsuite-mvc/src/main/resources/views/hello.jsp
@@ -1,0 +1,9 @@
+<%@ page contentType="text/html;charset=UTF-8" %>
+<html>
+<head>
+    <title>Hello</title>
+</head>
+<body>
+    <h1>Hello World!</h1>
+</body>
+</html>

--- a/testsuite/testsuite-mvc/src/test/java/org/wildfly/swarm/mvc/test/MvcTest.java
+++ b/testsuite/testsuite-mvc/src/test/java/org/wildfly/swarm/mvc/test/MvcTest.java
@@ -1,0 +1,47 @@
+package org.wildfly.swarm.mvc.test;
+
+import org.apache.http.client.fluent.Content;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.client.fluent.Response;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.ClassLoaderAsset;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+
+import org.wildfly.swarm.jaxrs.JAXRSArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.net.URL;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(Arquillian.class)
+public class MvcTest {
+
+    @ArquillianResource
+    private URL baseUrl;
+
+    @Deployment(testable = false)
+    public static Archive createDeployment() throws Exception {
+        return ShrinkWrap.create(JAXRSArchive.class, "myapp.war")
+                .addClass(MvcApplication.class)
+                .addClass(MvcController.class)
+                .addAsWebInfResource(new ClassLoaderAsset("views/hello.jsp"), "views/hello.jsp")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    @RunAsClient
+    public void testGettingView() throws IOException {
+        Response response = Request.Get(baseUrl.toString() + "/hello").execute();
+        Content content = response.returnContent();
+        assertThat(content.asString(), containsString("Hello World!"));
+    }
+}


### PR DESCRIPTION
Motivation
----------
We want a testsuite that checks the basic functions of the MVC fraction

Modifications
-------------
* A test was added that installs the fraction and tests that ozark is
activated and views can be rendered.
* The MVC-fraction now uses a deployment module to activate ozark

Result
------
The MVC fraction is covered by automatic tests

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
