### PR TITLE
SWARM-1945: MP FT - refactor internals to support async circuit breaker.

### DIFF
--- a/fractions/microprofile/microprofile-fault-tolerance/pom.xml
+++ b/fractions/microprofile/microprofile-fault-tolerance/pom.xml
@@ -34,6 +34,7 @@
     <swarm.fraction.stability>stable</swarm.fraction.stability>
     <swarm.fraction.tags>Eclipse MicroProfile,MicroServices,Fault Tolerance</swarm.fraction.tags>
     <version.arquillian-weld-embedded>2.0.0.Beta5</version.arquillian-weld-embedded>
+    <version.awaitility>3.1.0</version.awaitility>
   </properties>
 
   <build>
@@ -43,6 +44,17 @@
         <filtering>true</filtering>
       </resource>
     </resources>
+    <plugins>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+               <systemPropertyVariables>
+                  <java.util.logging.config.file>${project.build.testOutputDirectory}/logging.properties</java.util.logging.config.file>
+               </systemPropertyVariables>
+            </configuration>
+         </plugin>
+      </plugins>
   </build>
 
   <dependencies>
@@ -101,6 +113,12 @@
    <dependency>
      <groupId>org.slf4j</groupId>
      <artifactId>slf4j-simple</artifactId>
+   </dependency>
+   <dependency>
+     <groupId>org.awaitility</groupId>
+     <artifactId>awaitility</artifactId>
+     <version>${version.awaitility}</version>
+     <scope>test</scope>
    </dependency>
 
   </dependencies>

--- a/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/CompositeCommand.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/CompositeCommand.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.swarm.microprofile.faulttolerance.deployment;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.wildfly.swarm.microprofile.faulttolerance.deployment.config.FaultToleranceOperation;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixCommandKey;
+import com.netflix.hystrix.HystrixCommandProperties;
+import com.netflix.hystrix.HystrixThreadPoolKey;
+import com.netflix.hystrix.HystrixThreadPoolProperties;
+
+/**
+ * This command is used to wrap any {@link Asynchronous} operation.
+ *
+ * @author Martin Kouba
+ */
+public class CompositeCommand extends HystrixCommand<Object> {
+
+    public static Future<Object> createAndQueue(Callable<Object> callable, FaultToleranceOperation operation) {
+        return new CompositeCommand(callable, operation).queue();
+    }
+
+    private final Callable<Object> callable;
+
+    /**
+     *
+     * @param callable
+     * @param operation
+     */
+    protected CompositeCommand(Callable<Object> callable, FaultToleranceOperation operation) {
+        super(initSetter(operation));
+        this.callable = callable;
+    }
+
+    @Override
+    protected Object run() throws Exception {
+        return callable.call();
+    }
+
+    private static Setter initSetter(FaultToleranceOperation operation) {
+        HystrixCommandProperties.Setter properties = HystrixCommandProperties.Setter();
+        HystrixCommandKey commandKey = HystrixCommandKey.Factory
+                .asKey(CompositeCommand.class.getSimpleName() + "#" + SimpleCommand.getCommandKey(operation.getMethod()));
+
+        properties.withExecutionIsolationStrategy(HystrixCommandProperties.ExecutionIsolationStrategy.THREAD);
+        properties.withFallbackEnabled(false);
+        properties.withCircuitBreakerEnabled(false);
+
+        Setter setter = Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("CompositeCommandGroup")).andCommandKey(commandKey)
+                .andCommandPropertiesDefaults(properties);
+
+        // We use a dedicated thread pool for each async operation
+        setter.andThreadPoolKey(HystrixThreadPoolKey.Factory.asKey(commandKey.name()));
+        HystrixThreadPoolProperties.Setter threadPoolSetter = HystrixThreadPoolProperties.Setter();
+        threadPoolSetter.withAllowMaximumSizeToDivergeFromCoreSize(true);
+        setter.andThreadPoolPropertiesDefaults(threadPoolSetter);
+
+        return setter;
+    }
+
+}

--- a/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/DefaultHystrixConcurrencyStrategy.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/DefaultHystrixConcurrencyStrategy.java
@@ -54,7 +54,7 @@ class DefaultHystrixConcurrencyStrategy extends HystrixConcurrencyStrategy {
         int dynamicCoreSize = corePoolSize.get();
         int dynamicMaximumSize = maximumPoolSize.get();
 
-        LOGGER.debugf("Get thread pool executor [core: %s, max: %s]", dynamicCoreSize, dynamicMaximumSize);
+        LOGGER.debugf("Get thread pool executor for %s [core: %s, max: %s]", threadPoolKey.name(), dynamicCoreSize, dynamicMaximumSize);
 
         return new ThreadPoolExecutor(dynamicCoreSize, dynamicCoreSize > dynamicMaximumSize ? dynamicCoreSize : dynamicMaximumSize, keepAliveTime.get(), unit,
                 workQueue, threadFactory);
@@ -70,7 +70,7 @@ class DefaultHystrixConcurrencyStrategy extends HystrixConcurrencyStrategy {
         int maxQueueSize = threadPoolProperties.maxQueueSize().get();
         BlockingQueue<Runnable> workQueue = getBlockingQueue(maxQueueSize);
 
-        LOGGER.debugf("Get thread pool executor [allowMaximumSizeToDivergeFromCoreSize: %s, core: %s, max: %s]", allowMaximumSizeToDivergeFromCoreSize,
+        LOGGER.debugf("Get thread pool executor for %s [allowMaximumSizeToDivergeFromCoreSize: %s, core: %s, max: %s]", threadPoolKey.name(), allowMaximumSizeToDivergeFromCoreSize,
                 dynamicCoreSize, dynamicMaximumSize);
 
         if (allowMaximumSizeToDivergeFromCoreSize) {

--- a/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/FailureNotHandledException.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/FailureNotHandledException.java
@@ -22,7 +22,6 @@ import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
  * {@link CircuitBreaker#failOn()}.
  *
  * @author Martin Kouba
- * @see DefaultCommand
  */
 public class FailureNotHandledException extends RuntimeException {
 

--- a/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/RetryContext.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/RetryContext.java
@@ -51,23 +51,22 @@ class RetryContext {
      *
      * @param retryContext
      * @param throwable
-     * @return {@code true} if we should try again or rethrows the specified exception
+     * @return an exception to rethrow or null if we should try again
      */
-    boolean nextRetry(Throwable throwable) throws Exception {
+    Exception nextRetry(Throwable throwable) {
         // Decrement the retry count for this attempt
         remainingAttempts.decrementAndGet();
         // Check the exception type
         if (shouldRetryOn(throwable, System.nanoTime())) {
-            delayIfNeeded();
-            return true;
+            return delayIfNeeded();
         } else {
             if (throwable instanceof Error) {
                 throw (Error) throwable;
             } else if (throwable instanceof Exception) {
-                throw (Exception) throwable;
+                return (Exception) throwable;
             } else {
                 // Business method interceptors may only throw exceptions
-                throw new FaultToleranceException(throwable);
+                return new FaultToleranceException(throwable);
             }
         }
     }
@@ -103,12 +102,22 @@ class RetryContext {
         return Arrays.stream(retryOn).anyMatch(t -> t.isAssignableFrom(throwable.getClass()));
     }
 
-    void delayIfNeeded() throws InterruptedException {
+    /**
+     *
+     * @return an exception to rethrow or null if we should try again
+     */
+    Exception delayIfNeeded() {
         if (delay > 0) {
             long jitterBase = config.getJitter();
             long jitter = (long) (Math.random() * ((jitterBase * 2) + 1)) - jitterBase; // random number between -jitter and +jitter
-            TimeUnit.MILLISECONDS.sleep(delay + Duration.of(jitter, config.getJitterDelayUnit()).toMillis());
+            try {
+                TimeUnit.MILLISECONDS.sleep(delay + Duration.of(jitter, config.getJitterDelayUnit()).toMillis());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return e;
+            }
         }
+        return null;
     }
 
     @Override

--- a/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/config/FaultToleranceOperation.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/config/FaultToleranceOperation.java
@@ -126,6 +126,10 @@ public class FaultToleranceOperation {
         return timeout != null;
     }
 
+    public Method getMethod() {
+        return method;
+    }
+
     public boolean isLegitimate() {
         return async || bulkhead != null || circuitBreaker != null || fallback != null || retry != null || timeout != null;
     }

--- a/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/SimpleCommandTest.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/SimpleCommandTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.faulttolerance.deployment;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.junit.Test;
+
+public class SimpleCommandTest {
+
+    @Test
+    public void testGetCommandKey() throws NoSuchMethodException, SecurityException {
+        assertEquals("org_wildfly_swarm_microprofile_faulttolerance_deployment_SimpleCommandTest#testGetCommandKey()",
+                SimpleCommand.getCommandKey(SimpleCommandTest.class.getMethod("testGetCommandKey")));
+        assertEquals("org_wildfly_swarm_microprofile_faulttolerance_deployment_SimpleCommandTest$Foo#ping(java.lang.String,java.lang.Integer)",
+                SimpleCommand.getCommandKey(Foo.class.getMethod("ping", String.class, Integer.class)));
+        assertEquals("org_wildfly_swarm_microprofile_faulttolerance_deployment_SimpleCommandTest$Foo#pong(java.util.List<java.lang.String>,T)",
+                SimpleCommand.getCommandKey(Foo.class.getMethod("pong", List.class, Object.class)));
+    }
+
+    static class Foo<T> {
+
+        public void ping(String name, Integer integer) {
+        }
+
+        public void pong(List<String> name, T type) {
+        }
+    }
+
+}

--- a/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/async/circuitbreaker/AsyncHelloService.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/async/circuitbreaker/AsyncHelloService.java
@@ -1,0 +1,48 @@
+package org.wildfly.swarm.microprofile.faulttolerance.deployment.async.circuitbreaker;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+
+@ApplicationScoped
+public class AsyncHelloService {
+
+    static final AtomicInteger COUNTER = new AtomicInteger(0);
+
+    static final int THRESHOLD = 10;
+
+    static final int DELAY = 500;
+
+    static final String OK = "Hello";
+
+    @Asynchronous
+    @CircuitBreaker(requestVolumeThreshold = THRESHOLD, failureRatio = 0.5, delay = DELAY, successThreshold = 1)
+    public Future<String> hello(Result result) throws IOException {
+        COUNTER.incrementAndGet();
+        switch (result) {
+            case FAILURE:
+                throw new IOException("Simulated IO error");
+            case COMPLETE_EXCEPTIONALLY:
+                CompletableFuture<String> future = new CompletableFuture<>();
+                future.completeExceptionally(new IOException("Simulated IO error"));
+                return future;
+            default:
+                return completedFuture(OK);
+        }
+    }
+
+    enum Result {
+
+        SUCCESS, FAILURE, COMPLETE_EXCEPTIONALLY
+
+    }
+
+}

--- a/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/async/circuitbreaker/AsynchronousCircuitBreakerTest.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/async/circuitbreaker/AsynchronousCircuitBreakerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.faulttolerance.deployment.async.circuitbreaker;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.wildfly.swarm.microprofile.faulttolerance.deployment.async.circuitbreaker.AsyncHelloService.COUNTER;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.microprofile.faulttolerance.deployment.TestArchive;
+import org.wildfly.swarm.microprofile.faulttolerance.deployment.async.circuitbreaker.AsyncHelloService.Result;
+
+/**
+ *
+ * @author Martin Kouba
+ */
+@RunWith(Arquillian.class)
+public class AsynchronousCircuitBreakerTest {
+
+    @Deployment
+    public static JavaArchive createTestArchive() {
+        return TestArchive.createBase(AsynchronousCircuitBreakerTest.class).addPackage(AsynchronousCircuitBreakerTest.class.getPackage());
+    }
+
+    @Test
+    public void testAsyncCircuitBreaker(AsyncHelloService helloService) throws IOException, InterruptedException, ExecutionException {
+        COUNTER.set(0);
+        for (int i = 0; i < AsyncHelloService.THRESHOLD; i++) {
+            try {
+                helloService.hello(Result.FAILURE).get();
+                Assert.fail();
+            } catch (ExecutionException e) {
+                Assert.assertTrue("Unexpected expection on iteration " + i + ": " + e, e.getCause() instanceof IOException);
+            }
+        }
+        // Circuit should be open now
+        try {
+            helloService.hello(Result.SUCCESS).get();
+            Assert.fail();
+        } catch (ExecutionException expected) {
+            assertTrue(expected.getCause() instanceof CircuitBreakerOpenException);
+        }
+        assertEquals(AsyncHelloService.THRESHOLD, COUNTER.get());
+        await().atMost(AsyncHelloService.DELAY * 2, TimeUnit.MILLISECONDS).untilAsserted(() -> {
+            try {
+                assertEquals(AsyncHelloService.OK, helloService.hello(Result.SUCCESS).get());
+            } catch (ExecutionException e) {
+                if (!(e.getCause() instanceof CircuitBreakerOpenException)) {
+                    // CircuitBreakerOpenException is expected
+                    throw e;
+                }
+            }
+        });
+    }
+
+}

--- a/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/retryonerror/HelloService.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/retryonerror/HelloService.java
@@ -1,4 +1,4 @@
-package org.wildfly.swarm.microprofile.faulttolerance.deployment.retry;
+package org.wildfly.swarm.microprofile.faulttolerance.deployment.retryonerror;
 
 import java.util.concurrent.atomic.AtomicInteger;
 

--- a/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/retryonerror/RetryOnErrorTest.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/retryonerror/RetryOnErrorTest.java
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.swarm.microprofile.faulttolerance.deployment.retry;
+package org.wildfly.swarm.microprofile.faulttolerance.deployment.retryonerror;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.wildfly.swarm.microprofile.faulttolerance.deployment.retry.HelloService.COUNTER;
+import static org.wildfly.swarm.microprofile.faulttolerance.deployment.retryonerror.HelloService.COUNTER;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -35,7 +35,7 @@ public class RetryOnErrorTest {
 
     @Deployment
     public static JavaArchive createTestArchive() {
-        return TestArchive.createBase("RetryOnErrorTest.jar").addPackage(RetryOnErrorTest.class.getPackage());
+        return TestArchive.createBase(RetryOnErrorTest.class).addPackage(RetryOnErrorTest.class.getPackage());
     }
 
     @Test

--- a/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/sync/SyncCircuitBreakerDisabledTest.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/sync/SyncCircuitBreakerDisabledTest.java
@@ -35,6 +35,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.swarm.microprofile.faulttolerance.deployment.HystrixCommandInterceptor;
+import org.wildfly.swarm.microprofile.faulttolerance.deployment.SimpleCommand;
 import org.wildfly.swarm.microprofile.faulttolerance.deployment.TestArchive;
 
 import com.netflix.config.DynamicLongProperty;
@@ -85,7 +86,7 @@ public class SyncCircuitBreakerDisabledTest {
 
     private String getCommandKey() {
         try {
-            return ShakyServiceClient.class.getDeclaredMethod("ping").toGenericString();
+            return SimpleCommand.getCommandKey(ShakyServiceClient.class.getDeclaredMethod("ping"));
         } catch (NoSuchMethodException | SecurityException e) {
             throw new IllegalStateException();
         }

--- a/fractions/microprofile/microprofile-fault-tolerance/src/test/resources/logging.properties
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/test/resources/logging.properties
@@ -15,4 +15,6 @@
 #
 
 handlers = java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.level = FINEST
 org.jboss.weld.level = WARNING
+org.wildfly.swarm.microprofile.faulttolerance.level = INFO

--- a/testsuite/microprofile-tcks/fault-tolerance/pom.xml
+++ b/testsuite/microprofile-tcks/fault-tolerance/pom.xml
@@ -95,9 +95,10 @@
                   <dependency>org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-tck</dependency>
                </dependenciesToScan>
                <systemProperties>
+                  <!-- Set the log level for FT  -->
                   <property>
-                     <name>java.util.logging.config.file</name>
-                     <value>${project.build.testOutputDirectory}/logging.properties</value>
+                     <name>swarm.logging.loggers.[org.wildfly.swarm.microprofile.faulttolerance].level</name>
+                     <value>INFO</value>
                   </property>
                   <!-- Uncomment to debug arquillian test -->
                   <!-- property>

--- a/testsuite/microprofile-tcks/fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/tck/FaultToleranceApplicationArchiveProcessor.java
+++ b/testsuite/microprofile-tcks/fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/tck/FaultToleranceApplicationArchiveProcessor.java
@@ -15,12 +15,12 @@
  */
 package org.wildfly.swarm.microprofile.faulttolerance.tck;
 
+import java.io.File;
 import java.util.logging.Logger;
 
 import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
 import org.jboss.arquillian.test.spi.TestClass;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.container.ResourceContainer;
 
 /**
@@ -34,19 +34,11 @@ public class FaultToleranceApplicationArchiveProcessor implements ApplicationArc
     @Override
     public void process(Archive<?> applicationArchive, TestClass testClass) {
         if (!(applicationArchive instanceof ResourceContainer)) {
-            LOGGER.warning("Unable to add Hystrix config.properties - not a resource container: " + applicationArchive);
+            LOGGER.warning("Unable to add Hystrix-related project-defaults.yaml - not a resource container: " + applicationArchive);
             return;
         }
-        LOGGER.info("Adding customized Hystrix config.properties to " + applicationArchive);
         ResourceContainer<?> resourceContainer = (ResourceContainer<?>) applicationArchive;
-        resourceContainer.addAsResource(buildProperties(), "config.properties");
+        resourceContainer.addAsResource(new File("src/test/resources/project-defaults.yml"));
+        LOGGER.info("Added project-defaults.yaml to " + applicationArchive.toString(true));
     }
-
-    private StringAsset buildProperties() {
-        StringBuilder builder = new StringBuilder();
-        // Do not interrupt command execution when a timeout occurs - needed for bulkhead tests
-        builder.append("hystrix.command.default.execution.isolation.thread.interruptOnTimeout=false");
-        return new StringAsset(builder.toString());
-    }
-
 }

--- a/testsuite/microprofile-tcks/fault-tolerance/src/test/resources/logging.properties
+++ b/testsuite/microprofile-tcks/fault-tolerance/src/test/resources/logging.properties
@@ -1,2 +1,0 @@
-handlers = java.util.logging.ConsoleHandler
-org.wildfly.swarm.microprofile.level = DEBUG

--- a/testsuite/microprofile-tcks/fault-tolerance/src/test/resources/project-defaults.yml
+++ b/testsuite/microprofile-tcks/fault-tolerance/src/test/resources/project-defaults.yml
@@ -1,0 +1,15 @@
+swarm:
+  hystrix:
+    threadpool:
+      default:
+        # Needed for extreme load in some bulkhead tests
+        maximumSize:
+          40
+    command:
+      default:
+        execution:
+          isolation:
+            thread:
+              # Do not interrupt command execution when a timeout occurs - needed for bulkhead tests
+              interruptOnTimeout:
+                false

--- a/testsuite/microprofile-tcks/fault-tolerance/src/test/tck-suite.xml
+++ b/testsuite/microprofile-tcks/fault-tolerance/src/test/tck-suite.xml
@@ -32,13 +32,22 @@
          <class
             name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchRetryTest">
             <methods>
+               <!-- https://github.com/eclipse/microprofile-fault-tolerance/issues/227 -->
+               <exclude name="testBulkheadQueReplacesDueToClassRetryFailures" />
+               <exclude name="testBulkheadRetryClassSynchronous55" />
                <exclude name="testBulkheadQueReplacesDueToClassRetryFailures" />
             </methods>
          </class>
          <class
             name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchRetryTest">
             <methods>
+               <!-- https://github.com/eclipse/microprofile-fault-tolerance/issues/232 -->
                <exclude name="testBulkheadMethodAsynchronousRetry55Trip" />
+               <!-- https://github.com/eclipse/microprofile-fault-tolerance/issues/250 -->
+               <exclude name="testBulkheadClassAsynchronous55RetryOverload"/>
+               <exclude name="testBulkheadMethodAsynchronous55RetryOverload"/>
+               <!-- https://github.com/eclipse/microprofile-fault-tolerance/issues/227 -->
+               <exclude name="testBulkheadMethodAsynchronousQueueing10"/>
             </methods>
          </class>
       </classes>


### PR DESCRIPTION
Motivation
----------
Refactor the internals to support async circuit breaker. This will pose
various challenges related to unclear spec wording around async retry logic
and also related to the nature of Hystrix.

Modifications
-------------
Do not use HystrixCommand#queue() for async execution. Instead, to
workaround various problems of Asynchronous Retry combination,
create a "composite" command which wraps any async execution, i.e. executes
nested commands synchronously.

Note that if SynchronousCircuitBreaker is used (default) it is not possible
to track the execution inside a Hystrix command because a TimeoutException should be
always counted as a failure, even if the command execution completes normally.

Result
------
Async circuit breaker is supported. MP FT 1.0 TCK should pass with known
exludes (each exclude refers to a spec issue).

NOTES
------

@Ladicek @antoinesd  @heiko-braun @michalszynkiewicz @sberyozkin Guys, I really need your review here. It's a non-trival change and to be honest, I'm not very proud of this piece of code. I had to go back and forth many times during the last couple of days and this is probably the best version I came up with. Any tips for improvements would be appreciated.

Few 1.0 TCK tests fail but all excludes should have reasonable justification.

The most problematic are of course `@Asynchronous` + `@Retry` + `someOf(@Timeout,@Bulkhead,@CircuitBreaker)` combinations.