### PR TITLE
SWARM-1917: Mail - allow to modify defaults through project-defaults.yml

### DIFF
--- a/core/spi/src/main/java/org/wildfly/swarm/spi/api/Fraction.java
+++ b/core/spi/src/main/java/org/wildfly/swarm/spi/api/Fraction.java
@@ -34,19 +34,30 @@ package org.wildfly.swarm.spi.api;
  */
 public interface Fraction<T extends Fraction> {
 
-    /** Apply whatever defaults are required if this fraction
-     * was not explicitly configured by a user.
+    /**
+     * Apply whatever defaults are required.
      *
      * @implNote The default implementation for this is a no-op.
      *
      * @return this fraction.
+     * @see Fraction#applyDefaults(boolean)
      */
     @SuppressWarnings("unchecked")
     default T applyDefaults() {
         return (T) this;
     }
 
-    @SuppressWarnings("unchecked")
+    /**
+     * The container always calls this method, but the default implementation delegates to {@link #applyDefaults()}.
+     *
+     * <p>
+     * Unlike {@link #applyDefaults()} this method allows a fraction to customize the defaults depending on whether this fraction was explicitly configured by a
+     * user or not.
+     * </p>
+     *
+     * @param hasConfiguration
+     * @return this fraction
+     */
     default T applyDefaults(boolean hasConfiguration) {
         return applyDefaults();
     }


### PR DESCRIPTION
Motivation
----------
It is not possible to modify attributes of the default mail session.

Modifications
-------------
Fix MailFraction so that it does not attempt to create a new mail
session when applying config values from project-defaults.yml.

Result
------
It should be possible to modify attributes of the default mail session.