### PR TITLE
SWARM-1954: MP JWT - allow to skip unconstrained resource method.

### DIFF
--- a/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/MicroProfileJWTAuthFraction.java
+++ b/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/MicroProfileJWTAuthFraction.java
@@ -17,6 +17,7 @@
  */
 package org.wildfly.swarm.microprofile.jwtauth;
 
+import static org.wildfly.swarm.spi.api.Defaultable.bool;
 import static org.wildfly.swarm.spi.api.Defaultable.integer;
 import static org.wildfly.swarm.spi.api.Defaultable.string;
 
@@ -48,6 +49,9 @@ public class MicroProfileJWTAuthFraction implements Fraction<MicroProfileJWTAuth
     @Configurable("swarm.microprofile.jwtauth.token.expGracePeriod")
     private Defaultable<Integer> expGracePeriodSecs = integer(60);
 
+    @AttributeDocumentation("If a JAX-RS resource has no class-level security metadata, then if this property is set to `true` and at least one resource method has security metadata all other resource methods without security metadata have an implicit `@DenyAll`, otherwise resource methods without security metadata are not secured")
+    @Configurable("swarm.microprofile.jwt.default-missing-method-permissions-deny-access")
+    private Defaultable<Boolean> defaultMissingMethodPermissionsDenyAccess = bool(true);
 
     public Defaultable<String> getTokenIssuer() {
         return tokenIssuer;
@@ -72,4 +76,9 @@ public class MicroProfileJWTAuthFraction implements Fraction<MicroProfileJWTAuth
     public void setExpGracePeriodSecs(Defaultable<Integer> expGracePeriodSecs) {
         this.expGracePeriodSecs = expGracePeriodSecs;
     }
+
+    public boolean isDefaultMissingMethodPermissionsDenyAccess() {
+        return defaultMissingMethodPermissionsDenyAccess.get();
+    }
+
 }

--- a/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/runtime/MPJWTAuthExtensionArchivePreparer.java
+++ b/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/runtime/MPJWTAuthExtensionArchivePreparer.java
@@ -253,7 +253,10 @@ public class MPJWTAuthExtensionArchivePreparer implements DeploymentProcessor {
                     } else if (classRolesAllowed != null) {
                         localRoles = classRolesAllowed.value().asStringArray();
                     }
-                    newConstraints.add(createSecurityConstraint(webXml, getUriPath(subpath, fullAppPath.toString()), localRoles));
+
+                    if (localRoles != null || (localRoles == null && (classDenyAll != null || fraction.isDefaultMissingMethodPermissionsDenyAccess()))) {
+                        newConstraints.add(createSecurityConstraint(webXml, getUriPath(subpath, fullAppPath.toString()), localRoles));
+                    }
                 }
             }
         }

--- a/testsuite/microprofile-tcks/jwt-auth/src/test/java/org/eclipse/microprofile/jwt/roles/implicit/NoClassLevelUnconstrainedDefaultDenyAllTest.java
+++ b/testsuite/microprofile-tcks/jwt-auth/src/test/java/org/eclipse/microprofile/jwt/roles/implicit/NoClassLevelUnconstrainedDefaultDenyAllTest.java
@@ -1,0 +1,93 @@
+/*
+ *   Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.jwt.roles.implicit;
+
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.HashMap;
+
+import javax.annotation.security.DenyAll;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.jwt.TestArchive;
+import org.eclipse.microprofile.jwt.tck.util.TokenUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wildfly.swarm.microprofile.jwtauth.MicroProfileJWTAuthFraction;
+
+/**
+ * Test that if there is no class-level security annotation an unconstrained resource method has an implicit {@link DenyAll} (default).
+ *
+ * @author Martin Kouba
+ * @see MicroProfileJWTAuthFraction#isDefaultMissingMethodPermissionsDenyAccess()
+ */
+public class NoClassLevelUnconstrainedDefaultDenyAllTest extends Arquillian {
+
+    /**
+     * The test generated JWT token string
+     */
+    private static String token;
+
+    /**
+     * The base URL for the container under test
+     */
+    @ArquillianResource
+    private URL baseURL;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return TestArchive.createBase(NoClassLevelUnconstrainedDefaultDenyAllTest.class).addClasses(NoClassLevelWithUnconstrainedMethodEndpoint.class);
+    }
+
+    @BeforeClass
+    public static void generateToken() throws Exception {
+        token = TokenUtils.generateTokenString("/Token1.json", null, new HashMap<>());
+    }
+
+    @RunAsClient
+    @Test
+    public void testUnconstrainedHasDenyAll() throws Exception {
+        String uri = baseURL.toExternalForm() + "/endpoint";
+        WebTarget echoEndpointTarget = ClientBuilder.newClient().target(uri);
+        Response response = echoEndpointTarget.request(TEXT_PLAIN).header(HttpHeaders.AUTHORIZATION, "Bearer " + token).get();
+        Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_FORBIDDEN);
+    }
+
+    @RunAsClient
+    @Test
+    public void testRolesAllowedMethod() throws Exception {
+        String uri = baseURL.toExternalForm() + "/endpoint/echo";
+        WebTarget echoEndpointTarget = ClientBuilder.newClient().target(uri).queryParam("input", "hello");
+        Response response = echoEndpointTarget.request(TEXT_PLAIN).header(HttpHeaders.AUTHORIZATION, "Bearer " + token).get();
+        Assert.assertEquals(response.getStatus(), HttpURLConnection.HTTP_OK);
+        String reply = response.readEntity(String.class);
+        // Must return hello, user={token upn claim}
+        Assert.assertEquals(reply, "hello, user=jdoe@example.com");
+    }
+
+}

--- a/testsuite/microprofile-tcks/jwt-auth/src/test/java/org/eclipse/microprofile/jwt/roles/implicit/NoClassLevelUnconstrainedSkippedTest.java
+++ b/testsuite/microprofile-tcks/jwt-auth/src/test/java/org/eclipse/microprofile/jwt/roles/implicit/NoClassLevelUnconstrainedSkippedTest.java
@@ -1,0 +1,97 @@
+/*
+ *   Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.jwt.roles.implicit;
+
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static org.testng.Assert.assertEquals;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.HashMap;
+
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.jwt.TestArchive;
+import org.eclipse.microprofile.jwt.tck.util.TokenUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wildfly.swarm.microprofile.jwtauth.MicroProfileJWTAuthFraction;
+
+/**
+ * Test that if there is no class-level security annotation and <code>swarm.microprofile.jwt.default-missing-method-permissions-deny-access</code> is set to
+ * false an unconstrained resource method is skipped.
+ *
+ * @author Martin Kouba
+ * @see MicroProfileJWTAuthFraction#isDefaultMissingMethodPermissionsDenyAccess()
+ */
+public class NoClassLevelUnconstrainedSkippedTest extends Arquillian {
+
+    /**
+     * The test generated JWT token string
+     */
+    private static String token;
+
+    /**
+     * The base URL for the container under test
+     */
+    @ArquillianResource
+    private URL baseURL;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return TestArchive.createBase(NoClassLevelUnconstrainedSkippedTest.class)
+                .addAsResource("project-defaults-skip-unconstrained-method.yml", "/project-defaults.yml")
+                .addClasses(NoClassLevelWithUnconstrainedMethodEndpoint.class);
+    }
+
+    @BeforeClass
+    public static void generateToken() throws Exception {
+        token = TokenUtils.generateTokenString("/Token1.json", null, new HashMap<>());
+    }
+
+    @RunAsClient
+    @Test
+    public void testUnconstrainedSkipped() throws Exception {
+        String uri = baseURL.toExternalForm() + "/endpoint";
+        WebTarget echoEndpointTarget = ClientBuilder.newClient().target(uri);
+        Response response = echoEndpointTarget.request(TEXT_PLAIN).get();
+        assertEquals(response.getStatus(), HttpURLConnection.HTTP_OK);
+        String reply = response.readEntity(String.class);
+        assertEquals(reply, "OK");
+    }
+
+    @RunAsClient
+    @Test
+    public void testRolesAllowedMethod() throws Exception {
+        String uri = baseURL.toExternalForm() + "/endpoint/echo";
+        WebTarget echoEndpointTarget = ClientBuilder.newClient().target(uri).queryParam("input", "hello");
+        Response response = echoEndpointTarget.request(TEXT_PLAIN).header(HttpHeaders.AUTHORIZATION, "Bearer " + token).get();
+        assertEquals(response.getStatus(), HttpURLConnection.HTTP_OK);
+        String reply = response.readEntity(String.class);
+        // Must return hello, user={token upn claim}
+        assertEquals(reply, "hello, user=jdoe@example.com");
+    }
+
+}

--- a/testsuite/microprofile-tcks/jwt-auth/src/test/java/org/eclipse/microprofile/jwt/roles/implicit/NoClassLevelWithUnconstrainedMethodEndpoint.java
+++ b/testsuite/microprofile-tcks/jwt-auth/src/test/java/org/eclipse/microprofile/jwt/roles/implicit/NoClassLevelWithUnconstrainedMethodEndpoint.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICE file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.eclipse.microprofile.jwt.roles.implicit;
+
+import java.security.Principal;
+
+import javax.annotation.security.RolesAllowed;
+import javax.enterprise.context.RequestScoped;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.SecurityContext;
+
+@Path("/endpoint")
+@RequestScoped
+public class NoClassLevelWithUnconstrainedMethodEndpoint {
+
+    @GET
+    public String nonConstrained() {
+        return "OK";
+    }
+
+    @GET
+    @Path("/echo")
+    @RolesAllowed("Echoer")
+    public String echo(@Context SecurityContext sec, @QueryParam("input") String input) {
+        Principal user = sec.getUserPrincipal();
+        return input + ", user="+user.getName();
+    }
+
+}

--- a/testsuite/microprofile-tcks/jwt-auth/src/test/java/org/eclipse/microprofile/jwt/wfswarm/arquillian/WFSwarmWarArchiveProcessor.java
+++ b/testsuite/microprofile-tcks/jwt-auth/src/test/java/org/eclipse/microprofile/jwt/wfswarm/arquillian/WFSwarmWarArchiveProcessor.java
@@ -38,9 +38,11 @@ public class WFSwarmWarArchiveProcessor implements ApplicationArchiveProcessor {
         if (webXml != null) {
             war.setWebXML(webXml);
         }
-        war.addAsResource("project-defaults.yml", "/project-defaults.yml")
-            .addAsWebInfResource("jwt-roles.properties", "classes/jwt-roles.properties")
-            .addAsManifestResource(publicKeyNode.getAsset(), "/MP-JWT-SIGNER");
+        if (!war.contains("/WEB-INF/classes/project-defaults.yml")) {
+            war.addAsResource("project-defaults.yml", "/project-defaults.yml");
+        }
+
+        war.addAsWebInfResource("jwt-roles.properties", "classes/jwt-roles.properties").addAsManifestResource(publicKeyNode.getAsset(), "/MP-JWT-SIGNER");
         log.fine("Augmented war: \n" + war.toString(true));
     }
 }

--- a/testsuite/microprofile-tcks/jwt-auth/src/test/resources/project-defaults-skip-unconstrained-method.yml
+++ b/testsuite/microprofile-tcks/jwt-auth/src/test/resources/project-defaults-skip-unconstrained-method.yml
@@ -1,0 +1,32 @@
+# A project defaults for use with MP-JWT auth-method that include additional role mapping
+swarm:
+  bind:
+    address: localhost
+  # Example of passing in token verification information via project file
+  microprofile:
+    jwt:
+      default-missing-method-permissions-deny-access:
+        false
+    jwtauth:
+      token:
+        issuedBy: "https://server.example.com"
+  security:
+    security-domains:
+      TCK-MP-JWT:
+        jaspi-authentication:
+          login-module-stacks:
+            roles-lm-stack:
+              login-modules:
+                # This stack performs the token verification and group to role mapping
+                - login-module: rm
+                  code: org.wildfly.swarm.microprofile.jwtauth.deployment.auth.jaas.JWTLoginModule
+                  flag: required
+                  module-options:
+                    rolesProperties: jwt-roles.properties
+          auth-modules:
+          # This module integrates the MP-JWT custom authentication mechanism into the web container
+            http:
+              code: org.wildfly.extension.undertow.security.jaspi.modules.HTTPSchemeServerAuthModule
+              module: org.wildfly.extension.undertow
+              flag: required
+              login-module-stack-ref: roles-lm-stack


### PR DESCRIPTION
Motivation
----------
If there is no class-level security annotation an unconstrained resource
method has always an implicit DenyAll. We would like to have this
configurable.

Modifications
-------------
Add
swarm.microprofile.jwt.default-missing-method-permissions-deny-access
config property (true by default). If set to false then if there are no
class-level security annotations an unconstrained resource method is
ignored, i.e. no security containts are implied.

Result
------
It is now possible to configure the default behavior.