### PR TITLE
SWARM-1983: update default fraction configuration to WildFly 11

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -26,7 +26,7 @@
 
     <version.org.snakeyaml>1.17</version.org.snakeyaml>
 
-    <version.wildfly.config-api>1.3.0</version.wildfly.config-api>
+    <version.wildfly.config-api>1.3.1</version.wildfly.config-api>
 
     <version.keycloak.config-api>1.3.1.Final</version.keycloak.config-api>
     <version.teiid.config-api>1.1.2.Final</version.teiid.config-api>

--- a/fractions/javaee/batch-jberet/src/main/java/org/wildfly/swarm/batch/jberet/BatchFraction.java
+++ b/fractions/javaee/batch-jberet/src/main/java/org/wildfly/swarm/batch/jberet/BatchFraction.java
@@ -20,7 +20,6 @@ import java.util.concurrent.TimeUnit;
 
 import javax.annotation.PostConstruct;
 
-import org.wildfly.common.cpu.ProcessorInfo;
 import org.wildfly.swarm.config.BatchJBeret;
 import org.wildfly.swarm.config.batch.jberet.InMemoryJobRepository;
 import org.wildfly.swarm.config.batch.jberet.JDBCJobRepository;
@@ -73,9 +72,9 @@ public class BatchFraction extends BatchJBeret<BatchFraction> implements Fractio
 
         // Default thread-pool
         final ThreadPool<?> threadPool = new ThreadPool<>(DEFAULT_THREAD_POOL_NAME);
-        threadPool.maxThreads(ProcessorInfo.availableProcessors())
-                .keepaliveTime("time", "30")
-                .keepaliveTime("unit", "seconds");
+        threadPool.maxThreads(10)
+                .keepaliveTime("time", 30L)
+                .keepaliveTime("unit", "SECONDS");
 
         return inMemoryJobRepository(jobRepository)
                 .defaultJobRepository(jobRepository.getKey())

--- a/fractions/javaee/ee/src/main/java/org/wildfly/swarm/ee/EEFraction.java
+++ b/fractions/javaee/ee/src/main/java/org/wildfly/swarm/ee/EEFraction.java
@@ -66,7 +66,7 @@ public class EEFraction extends EE<EEFraction> implements Fraction<EEFraction> {
         specDescriptorPropertyReplacement(false)
                 .contextService(new ContextService(DEFAULT_KEY)
                         .jndiName(CONCURRENCY_CONTEXT_DEFAULT)
-                        .useTransactionSetupProvider(false))
+                        .useTransactionSetupProvider(false)) // WildFly defaults to true, but that probably needs transactions
                 .managedThreadFactory(new ManagedThreadFactory(DEFAULT_KEY)
                         .jndiName(CONCURRENCY_FACTORY_DEFAULT)
                         .contextService(DEFAULT_KEY))
@@ -74,14 +74,11 @@ public class EEFraction extends EE<EEFraction> implements Fraction<EEFraction> {
                         .jndiName(CONCURRENCY_EXECUTOR_DEFAULT)
                         .contextService(DEFAULT_KEY)
                         .hungTaskThreshold(60000L)
-                        .coreThreads(5)
-                        .maxThreads(25)
                         .keepaliveTime(5000L))
                 .managedScheduledExecutorService(new ManagedScheduledExecutorService(DEFAULT_KEY)
                         .jndiName(CONCURRENCY_SCHEDULER_DEFAULT)
                         .contextService(DEFAULT_KEY)
                         .hungTaskThreshold(60000L)
-                        .coreThreads(5)
                         .keepaliveTime(3000L));
 
         defaultBindingsService((bindings) -> {

--- a/fractions/javaee/ejb-remote/README.adoc
+++ b/fractions/javaee/ejb-remote/README.adoc
@@ -1,0 +1,4 @@
+= EJB Remote
+
+Enables remote EJB and remote naming.
+If the `messaging` fraction is present, enables remote messaging as well.

--- a/fractions/javaee/ejb-remote/pom.xml
+++ b/fractions/javaee/ejb-remote/pom.xml
@@ -46,6 +46,11 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.swarm</groupId>
+      <artifactId>messaging</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
       <artifactId>remoting</artifactId>
     </dependency>
     <dependency>

--- a/fractions/javaee/ejb-remote/src/main/java/org/wildfly/swarm/ejb/remote/runtime/RemoteMessagingCustomizer.java
+++ b/fractions/javaee/ejb-remote/src/main/java/org/wildfly/swarm/ejb/remote/runtime/RemoteMessagingCustomizer.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.ejb.remote.runtime;
+
+import org.wildfly.swarm.messaging.EnhancedServer;
+import org.wildfly.swarm.messaging.MessagingFraction;
+import org.wildfly.swarm.spi.api.Customizer;
+import org.wildfly.swarm.spi.runtime.annotations.Post;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+@Post
+@ApplicationScoped
+public class RemoteMessagingCustomizer implements Customizer {
+    @Inject
+    @Any
+    Instance<MessagingFraction> messagingInstance;
+
+    @Override
+    public void customize() {
+        if (!messagingInstance.isUnsatisfied()) {
+            messagingInstance.get().defaultServer(EnhancedServer::enableRemote);
+        }
+    }
+}

--- a/fractions/javaee/ejb-remote/src/main/java/org/wildfly/swarm/ejb/remote/runtime/RemoteNamingCustomizer.java
+++ b/fractions/javaee/ejb-remote/src/main/java/org/wildfly/swarm/ejb/remote/runtime/RemoteNamingCustomizer.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.ejb.remote.runtime;
+
+import org.wildfly.swarm.naming.NamingFraction;
+import org.wildfly.swarm.spi.api.Customizer;
+import org.wildfly.swarm.spi.runtime.annotations.Post;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+@Post
+@ApplicationScoped
+public class RemoteNamingCustomizer implements Customizer {
+    @Inject
+    @Any
+    Instance<NamingFraction> namingInstance;
+
+    @Override
+    public void customize() {
+        if (!namingInstance.isUnsatisfied()) {
+            namingInstance.get().remoteNamingService();
+        }
+    }
+}

--- a/fractions/javaee/jca/src/main/java/org/wildfly/swarm/jca/JCAFraction.java
+++ b/fractions/javaee/jca/src/main/java/org/wildfly/swarm/jca/JCAFraction.java
@@ -45,13 +45,13 @@ public class JCAFraction extends JCA<JCAFraction> implements Fraction<JCAFractio
 
     public JCAFraction applyDefaults() {
         Map<Object, Object> keepAlive = new HashMap<>();
-        keepAlive.put("time", "10");
+        keepAlive.put("time", 10L);
         keepAlive.put("unit", "SECONDS");
 
         archiveValidation(new ArchiveValidation()
                                   .enabled(true)
                                   .failOnError(true)
-                                  .failOnWarn(true))
+                                  .failOnWarn(false))
                 .beanValidation(new BeanValidation()
                                         .enabled(true))
                 .workmanager(new Workmanager(DEFAULT)

--- a/fractions/javaee/transactions/src/main/java/org/wildfly/swarm/transactions/TransactionsFraction.java
+++ b/fractions/javaee/transactions/src/main/java/org/wildfly/swarm/transactions/TransactionsFraction.java
@@ -42,7 +42,13 @@ public class TransactionsFraction extends Transactions<TransactionsFraction> imp
     public TransactionsFraction applyDefaults() {
         this.socketBinding("txn-recovery-environment")
                 .statusSocketBinding("txn-status-manager")
-                .processIdUuid(true);
+                .processIdUuid(true)
+                .objectStorePath("tx-object-store")
+                .objectStoreRelativeTo("jboss.server.data.dir")
+                .logStore(log -> {
+                    log.exposeAllLogs(false);
+                    log.type("default");
+                });
         return this;
     }
 

--- a/fractions/wildfly/infinispan/src/main/java/org/wildfly/swarm/infinispan/runtime/InfinispanCustomizer.java
+++ b/fractions/wildfly/infinispan/src/main/java/org/wildfly/swarm/infinispan/runtime/InfinispanCustomizer.java
@@ -23,10 +23,8 @@ import javax.inject.Inject;
 
 import org.jboss.msc.service.ServiceActivator;
 import org.wildfly.swarm.config.EJB3;
-import org.wildfly.swarm.config.JGroups;
 import org.wildfly.swarm.config.JPA;
 import org.wildfly.swarm.config.Undertow;
-import org.wildfly.swarm.config.infinispan.Mode;
 import org.wildfly.swarm.config.infinispan.cache_container.EvictionComponent;
 import org.wildfly.swarm.config.infinispan.cache_container.LockingComponent;
 import org.wildfly.swarm.config.infinispan.cache_container.TransactionComponent;
@@ -45,17 +43,10 @@ public class InfinispanCustomizer implements Customizer {
 
     private static final String DEFAULT = "default";
 
-    private static final String DIST = "dist";
-
-    private static final String LOCAL_QUERY = "local-query";
-
     private static final String PASSIVATION = "passivation";
 
     @Inject
     private InfinispanFraction fraction;
-
-    @Inject
-    private Instance<JGroups> jgroups;
 
     @Inject
     private Instance<Undertow> undertow;
@@ -68,92 +59,25 @@ public class InfinispanCustomizer implements Customizer {
 
     @Override
     public void customize() {
-
         if (this.fraction.isDefaultFraction()) {
-            if (!this.jgroups.isUnsatisfied()) {
-                clusteredCustomization();
-            } else {
-                localCustomization();
-            }
+            localCustomization();
         }
-
-    }
-
-    private void clusteredCustomization() {
-        this.fraction.cacheContainer("server",
-                cc -> cc.defaultCache(DEFAULT)
-                        .alias("singleton")
-                        .alias("cluster")
-                        .module("org.wildfly.clustering.server")
-                        .jgroupsTransport(t -> t.lockTimeout(60000L))
-                        .replicatedCache(DEFAULT,
-                                c -> c.mode(Mode.SYNC)
-                                        .transactionComponent(t -> t.mode(TransactionComponent.Mode.BATCH))));
-        if (!this.undertow.isUnsatisfied()) {
-            this.fraction.cacheContainer("web",
-                    cc -> cc.defaultCache(DIST)
-                            .jgroupsTransport(t -> t.lockTimeout(60000L))
-                            .distributedCache(DIST,
-                                    c -> c.mode(Mode.ASYNC)
-                                            .l1Lifespan(0L)
-                                            .owners(2)
-                                            .lockingComponent(lc -> lc.isolation(LockingComponent.Isolation.REPEATABLE_READ))
-                                            .transactionComponent(tc -> tc.mode(TransactionComponent.Mode.BATCH))
-                                            .fileStore()));
-        }
-
-        if (!this.ejb.isUnsatisfied()) {
-            this.fraction.cacheContainer("ejb",
-                    cc -> cc.defaultCache(DIST)
-                            .alias("sfsb")
-                            .module("org.wildfly.clustering.ejb.infinispan")
-                            .jgroupsTransport(t -> t.lockTimeout(60000L))
-                            .distributedCache(DIST,
-                                    c -> c.mode(Mode.ASYNC)
-                                            .l1Lifespan(0L)
-                                            .owners(2)
-                                            .lockingComponent(lc -> lc.isolation(LockingComponent.Isolation.REPEATABLE_READ))
-                                            .transactionComponent(t -> t.mode(TransactionComponent.Mode.BATCH))
-                                            .fileStore()));
-
-        }
-
-        if (!this.jpa.isUnsatisfied()) {
-            this.fraction.cacheContainer("hibernate",
-                    cc -> cc.defaultCache(LOCAL_QUERY)
-                            .module("org.hibernate.infinispan")
-                            .jgroupsTransport(t -> t.lockTimeout(60000L))
-                            .localCache(LOCAL_QUERY,
-                                    c -> c.evictionComponent(ec -> ec.maxEntries(10000L).strategy(EvictionComponent.Strategy.LRU))
-                                            .expirationComponent(ec -> ec.maxIdle(100000L)))
-                            .invalidationCache("entity",
-                                    c -> c.mode(Mode.SYNC)
-                                            .transactionComponent(tc -> tc.mode(TransactionComponent.Mode.NON_XA))
-                                            .evictionComponent(ec -> ec.maxEntries(10000L).strategy(EvictionComponent.Strategy.LRU))
-                                            .expirationComponent(ec -> ec.maxIdle(100000L)))
-                            .replicatedCache("timestamps", c -> c.mode(Mode.ASYNC)));
-        }
-
     }
 
     private void localCustomization() {
         this.fraction.cacheContainer("server",
                 cc -> cc.defaultCache(DEFAULT)
                         .module("org.wildfly.clustering.server")
-                        .localCache(DEFAULT, c -> c.transactionComponent(t -> t.mode(TransactionComponent.Mode.BATCH)))
-                        .remoteCommandThreadPool());
+                        .localCache(DEFAULT, c -> c.transactionComponent(t -> t.mode(TransactionComponent.Mode.BATCH))));
 
         if (!this.undertow.isUnsatisfied()) {
             this.fraction.cacheContainer("web",
                     cc -> cc.defaultCache(PASSIVATION)
+                            .module("org.wildfly.clustering.web.infinispan")
                             .localCache(PASSIVATION,
                                     c -> c.lockingComponent(lc -> lc.isolation(LockingComponent.Isolation.REPEATABLE_READ))
                                             .transactionComponent(tc -> tc.mode(TransactionComponent.Mode.BATCH))
-                                            .fileStore(fs -> fs.passivation(true).purge(false)))
-                            .localCache("persistent",
-                                    c -> c.lockingComponent(lc -> lc.isolation(LockingComponent.Isolation.REPEATABLE_READ))
-                                            .transactionComponent(tc -> tc.mode(TransactionComponent.Mode.BATCH))
-                                            .fileStore(fs -> fs.passivation(false).purge(false))));
+                                            .fileStore(fs -> fs.passivation(true).purge(false))));
         }
 
         if (!this.ejb.isUnsatisfied()) {
@@ -164,28 +88,18 @@ public class InfinispanCustomizer implements Customizer {
                             .localCache(PASSIVATION,
                                     c -> c.lockingComponent(lc -> lc.isolation(LockingComponent.Isolation.REPEATABLE_READ))
                                             .transactionComponent(tc -> tc.mode(TransactionComponent.Mode.BATCH))
-                                            .fileStore(fs -> fs.passivation(true).purge(false)))
-                            .localCache("persistent",
-                                    c -> c.lockingComponent(lc -> lc.isolation(LockingComponent.Isolation.REPEATABLE_READ))
-                                            .transactionComponent(tc -> tc.mode(TransactionComponent.Mode.BATCH))
-                                            .fileStore(fs -> fs.passivation(false).purge(false))));
+                                            .fileStore(fs -> fs.passivation(true).purge(false))));
         }
 
         if (!this.jpa.isUnsatisfied()) {
             this.fraction.cacheContainer("hibernate",
-                    cc -> cc.defaultCache(LOCAL_QUERY)
-                            .module("org.hibernate.infinispan")
+                    cc -> cc.module("org.hibernate.infinispan")
                             .localCache("entity",
                                     c -> c.transactionComponent(t -> t.mode(TransactionComponent.Mode.NON_XA))
                                             .evictionComponent(e -> e.strategy(EvictionComponent.Strategy.LRU).maxEntries(10000L))
                                             .expirationComponent(e -> e.maxIdle(100000L)))
-                            .localCache("immutable-entity",
-                                    c -> c.transactionComponent(t -> t.mode(TransactionComponent.Mode.NON_XA))
-                                            .evictionComponent(e -> e.strategy(EvictionComponent.Strategy.LRU).maxEntries(10000L))
-                                            .expirationComponent(e -> e.maxIdle(100000L)))
                             .localCache("local-query",
-                                    c -> c.transactionComponent(t -> t.mode(TransactionComponent.Mode.NON_XA))
-                                            .evictionComponent(e -> e.strategy(EvictionComponent.Strategy.LRU).maxEntries(10000L))
+                                    c -> c.evictionComponent(e -> e.strategy(EvictionComponent.Strategy.LRU).maxEntries(10000L))
                                             .expirationComponent(e -> e.maxIdle(100000L)))
                             .localCache("timestamps"));
         }

--- a/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/ManagementFraction.java
+++ b/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/ManagementFraction.java
@@ -65,11 +65,11 @@ public class ManagementFraction extends ManagementCoreService<ManagementFraction
             access.fileHandler(FILE_HANDLER, (handler) -> {
                 handler.formatter(JSON_FORMATTER);
                 handler.path(AUDIT_LOG_FILE);
-                handler.relativeTo("user.dir");
+                handler.relativeTo("user.dir"); // WildFly defaults to jboss.server.data.dir, but that's in /tmp for us
             });
             access.auditLogLogger((logger) -> {
                 logger.logBoot(true);
-                logger.logReadOnly(true);
+                logger.logReadOnly(false);
                 logger.enabled(false);
                 logger.handler(FILE_HANDLER);
             });
@@ -89,7 +89,7 @@ public class ManagementFraction extends ManagementCoreService<ManagementFraction
     public ManagementFraction httpInterfaceManagementInterface(HTTPInterfaceManagementInterfaceConsumer consumer) {
         return super.httpInterfaceManagementInterface((iface) -> {
             iface.consoleEnabled(false);
-            iface.httpUpgrade("enabled", "true");
+            iface.httpUpgrade("enabled", true);
             iface.socketBinding("management-http");
             consumer.accept(iface);
         });


### PR DESCRIPTION
Motivation
----------
Default configuration of fractions corresponding to WildFly
subsystems should be as close as possible to the default subsystems
configuration.

Modifications
-------------
Update to latest WildFly Config API which allows proper composite
values (list of maps of lists).

Update `applyDefaults` methods of fractions to reasonably match
the corresponding subsystems.

Result
------
Default configuration more in line with WildFly's.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
