### PR TITLE
SWARM-1971: make OpenApi work with arrays and generics

### DIFF
--- a/fractions/microprofile/microprofile-openapi/src/main/java/org/wildfly/swarm/microprofile/openapi/runtime/util/JandexUtil.java
+++ b/fractions/microprofile/microprofile-openapi/src/main/java/org/wildfly/swarm/microprofile/openapi/runtime/util/JandexUtil.java
@@ -383,7 +383,7 @@ public class JandexUtil {
         }
         for (short i = 0; i < methodParams.size(); i++) {
             if (JandexUtil.getParameterAnnotations(method, i).isEmpty()) {
-                return methodParams.get(i).asClassType();
+                return methodParams.get(i);
             }
         }
         return null;

--- a/fractions/microprofile/microprofile-openapi/src/test/java/org/wildfly/swarm/microprofile/openapi/ComplexResourceTest.java
+++ b/fractions/microprofile/microprofile-openapi/src/test/java/org/wildfly/swarm/microprofile/openapi/ComplexResourceTest.java
@@ -1,0 +1,69 @@
+package org.wildfly.swarm.microprofile.openapi;
+
+import io.restassured.response.ValidatableResponse;
+import org.eclipse.microprofile.openapi.tck.AppTestBase;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Ignore;
+import org.testng.annotations.Test;
+import test.org.wildfly.swarm.microprofile.openapi.BaseTckTest;
+import test.org.wildfly.swarm.microprofile.openapi.TckTest;
+
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * NOTE: It's not a TCK test, it only leverages the TCK test setup
+ *
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ * <br>
+ * Date: 4/19/18
+ */
+@TckTest(test = ComplexResourceTest.ComplexResourceTestArquillian.class, configProperties = "")
+public class ComplexResourceTest extends BaseTckTest {
+    @Override
+    public ComplexResourceTestArquillian getDelegate() {
+        return new ComplexResourceTestArquillian() {
+            @Override
+            public ValidatableResponse callEndpoint(String format) {
+                return doCallEndpoint(format);
+            }
+        };
+    }
+
+    @Override
+    public Object[] getTestArguments() {
+        return new String[] { "JSON" };
+    }
+
+    public static class ComplexResourceTestArquillian extends AppTestBase {
+        @Deployment(name = "complexTypes")
+        public static WebArchive createDeployment() {
+            return ShrinkWrap.create(WebArchive.class, "airlines.war")
+                    .addPackages(true, new String[]{"org.wildfly.swarm.microprofile.openapi"})
+                    .addAsManifestResource("openapi.yaml", "openapi.yaml");
+        }
+
+        @RunAsClient
+        @Test(dataProvider = "formatProvider")
+        @Ignore
+        public void testArray(String type) {
+            ValidatableResponse vr = this.callEndpoint(type);
+            String arraySchema = "paths.'/complex/array'.post.requestBody.content.'application/json'.schema";
+            vr.body(arraySchema + ".type", equalTo("array"));
+            vr.body(arraySchema + ".items.format", equalTo("int32"));
+            vr.body(arraySchema + ".items.type", equalTo("integer"));
+        }
+
+        @RunAsClient
+        @Test(dataProvider = "formatProvider")
+        public void testList(String type) {
+            ValidatableResponse vr = this.callEndpoint(type);
+            String arraySchema = "paths.'/complex/list'.post.requestBody.content.'application/json'.schema";
+            vr.body(arraySchema + ".type", equalTo("array"));
+            vr.body(arraySchema + ".items.format", equalTo("int32"));
+            vr.body(arraySchema + ".items.type", equalTo("integer"));
+        }
+    }
+}

--- a/fractions/microprofile/microprofile-openapi/src/test/java/org/wildfly/swarm/microprofile/openapi/runtime/app/ComplexResource.java
+++ b/fractions/microprofile/microprofile-openapi/src/test/java/org/wildfly/swarm/microprofile/openapi/runtime/app/ComplexResource.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.openapi.runtime.app;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ * <br>
+ * Date: 4/19/18
+ */
+@Path("/complex")
+@Consumes("application/json")
+public class ComplexResource {
+    @POST
+    @Path("/array")
+    public CollectionWrapper postArrayOfInts(Integer[] ints) {
+        CollectionWrapper result = new CollectionWrapper();
+        result.getValues().addAll(Arrays.asList(ints));
+        return result;
+    }
+
+    @POST
+    @Path("/list")
+    public CollectionWrapper postArrayOfInts(List<Integer> list) {
+        CollectionWrapper result = new CollectionWrapper();
+        result.getValues().addAll(list);
+        return result;
+    }
+
+    public static class CollectionWrapper {
+        private Collection<Integer> values = new ArrayList<>();
+
+        public Collection<Integer> getValues() {
+            return values;
+        }
+
+        public void setValues(Collection<Integer> values) {
+            this.values = values;
+        }
+    }
+}


### PR DESCRIPTION
Motivation
----------
Currently the application cannot be deployed if someone exposes an
endpoint that accepts an array or a generic type.
This commit makes the OpenApi fraction usable in this case.

Modifications
-------------
JandexUtil in microprofile-openapi fixed not to use (unncessary)
`.asClassType`.
Also, a test was added to check if application behaves better.

Result
------
An application that has endpoints consuming arrays or generics can now
use the OpenApi fraction.

Please note that the changes do not fix the data the openapi endpoint returns for arrays.
They are only intended to make OpenApi fraction start with it.
That's why the test for arrays is ignored

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?
I even ran it with -Pmicroprofile-tck ;)

-----
