### PR TITLE
Microprofile fraction names in pom.xml should follow a pattern

### DIFF
--- a/fractions/microprofile/microprofile-config/pom.xml
+++ b/fractions/microprofile/microprofile-config/pom.xml
@@ -16,7 +16,7 @@
 
     <groupId>org.wildfly.swarm</groupId>
     <artifactId>microprofile-config</artifactId>
-    <name>Eclipse MicroProfile Config</name>
+    <name>MicroProfile Config</name>
     <description>WildFly: Swarm Fraction for Eclipse MicroProfile Config</description>
 
     <packaging>jar</packaging>

--- a/fractions/microprofile/microprofile-health/pom.xml
+++ b/fractions/microprofile/microprofile-health/pom.xml
@@ -17,7 +17,7 @@
   <groupId>org.wildfly.swarm</groupId>
   <artifactId>microprofile-health</artifactId>
 
-  <name>Microprofile-Health</name>
+  <name>MicroProfile Health</name>
   <description>Health endpoints for your application</description>
 
   <packaging>jar</packaging>

--- a/fractions/microprofile/microprofile-metrics/pom.xml
+++ b/fractions/microprofile/microprofile-metrics/pom.xml
@@ -17,14 +17,14 @@
   <groupId>org.wildfly.swarm</groupId>
   <artifactId>microprofile-metrics</artifactId>
 
-  <name>Microprofile-Metrics</name>
-  <description>Metrics export for Microprofile</description>
+  <name>MicroProfile Metrics</name>
+  <description>Metrics export for MicroProfile</description>
 
   <packaging>jar</packaging>
 
   <properties>
     <swarm.fraction.stability>stable</swarm.fraction.stability>
-    <swarm.fraction.tags>Eclipse Microprofile,Metrics,Monitoring</swarm.fraction.tags>
+    <swarm.fraction.tags>Eclipse MicroProfile,Metrics,Monitoring</swarm.fraction.tags>
   </properties>
 
   <build>


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----

This matches the pattern adopted by other MicroProfile fractions (and makes the log nicer)
