### PR TITLE
SWARM-1988: added missing export for microprofile config

### DIFF
--- a/fractions/microprofile/microprofile-config/module.conf
+++ b/fractions/microprofile/microprofile-config/module.conf
@@ -1,3 +1,3 @@
-org.wildfly.swarm.configuration.microprofile.config
+org.wildfly.swarm.configuration.microprofile.config export=true
 org.eclipse.microprofile.config.api export=true
 org.wildfly.extension.microprofile.config export=true


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----

SWARM-1988: added missing export for microprofile config
----

Motivation
----------
To enable YAML config for MP Config.

Modifications
-------------
Added export for microprofile config to the fraction's module.conf

Result
------
A user's application is deployed properly. E.g. setting properties from YAML works.
Setting custom config source still does **not** work