### PR TITLE
Microprofile fraction names in pom.xml should follow a pattern (part 2)

### DIFF
--- a/fractions/microprofile/microprofile-fault-tolerance/pom.xml
+++ b/fractions/microprofile/microprofile-fault-tolerance/pom.xml
@@ -25,7 +25,7 @@
   </parent>
 
   <artifactId>microprofile-fault-tolerance</artifactId>
-  <name>Eclipse MicroProfile Fault Tolerance</name>
+  <name>MicroProfile Fault Tolerance</name>
   <description>WildFly: Swarm Fraction for Eclipse MicroProfile Fault Tolerance</description>
 
   <packaging>jar</packaging>

--- a/fractions/microprofile/microprofile-jwt/pom.xml
+++ b/fractions/microprofile/microprofile-jwt/pom.xml
@@ -16,7 +16,7 @@
 
   <artifactId>microprofile-jwt</artifactId>
 
-  <name>MicroProfile JWT RBAC Auth Fraction</name>
+  <name>MicroProfile JWT RBAC Auth</name>
   <description>An implementation of the MP-JWT authentication and authorization</description>
 
   <packaging>jar</packaging>

--- a/fractions/microprofile/microprofile-openapi/pom.xml
+++ b/fractions/microprofile/microprofile-openapi/pom.xml
@@ -16,7 +16,7 @@
 
   <artifactId>microprofile-openapi</artifactId>
 
-  <name>MicroProfile OpenAPI Fraction</name>
+  <name>MicroProfile OpenAPI</name>
   <description>An implementation of the MP-OpenAPI specification first introduced in MP 1.3</description>
 
   <packaging>jar</packaging>

--- a/fractions/microprofile/microprofile-restclient/pom.xml
+++ b/fractions/microprofile/microprofile-restclient/pom.xml
@@ -17,7 +17,7 @@
   <groupId>org.wildfly.swarm</groupId>
   <artifactId>microprofile-restclient</artifactId>
 
-  <name>Microprofile Rest Client</name>
+  <name>MicroProfile Rest Client</name>
 
   <packaging>jar</packaging>
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
This is a follow-up to https://github.com/wildfly-swarm/wildfly-swarm/pull/894, to have a pattern for the MicroProfile fractions and making the log nicer