### PR TITLE
SWARM-1993: support user classes as config sources for MP Config

### DIFF
--- a/fractions/microprofile/microprofile-config/src/main/java/org/wildfly/swarm/microprofile/config/fraction/runtime/MicroProfileConfigDeploymentProcessor.java
+++ b/fractions/microprofile/microprofile-config/src/main/java/org/wildfly/swarm/microprofile/config/fraction/runtime/MicroProfileConfigDeploymentProcessor.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.config.fraction.runtime;
+
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.Node;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.impl.base.path.BasicPath;
+import org.wildfly.swarm.spi.api.DeploymentProcessor;
+import org.wildfly.swarm.spi.api.config.CompositeKey;
+import org.wildfly.swarm.spi.api.config.ConfigView;
+import org.wildfly.swarm.spi.runtime.annotations.DeploymentScoped;
+
+import javax.inject.Inject;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ * <br>
+ * Date: 4/24/18
+ */
+@DeploymentScoped
+public class MicroProfileConfigDeploymentProcessor implements DeploymentProcessor {
+    private static final String CONFIG_SOURCE_SERVICES = "META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource";
+    private static Logger log = Logger.getLogger(MicroProfileConfigDeploymentProcessor.class);
+
+    private final Archive<?> archive;
+    private final ConfigView configView;
+
+    @Inject
+    public MicroProfileConfigDeploymentProcessor(Archive<?> archive, ConfigView configView) {
+        this.archive = archive;
+        this.configView = configView;
+    }
+
+    @Override
+    public void process() throws Exception {
+        CompositeKey key = new CompositeKey("swarm", "microprofile", "config", "config-sources");
+
+        List<String> configSourceClasses = readConfigSourceClasses(key);
+
+        defineServices(configSourceClasses);
+
+        log.debugf("Configured MicroProfile config source classes %s", configSourceClasses);
+    }
+
+    private void defineServices(List<String> configSourceClasses) {
+        StringBuilder servicesContent = new StringBuilder();
+        servicesContent.append(readCurrentServices());
+        configSourceClasses
+                .forEach(source -> servicesContent.append(source).append("\n"));
+
+        archive.add(new StringAsset(servicesContent.toString()), new BasicPath(CONFIG_SOURCE_SERVICES));
+    }
+
+    private String readCurrentServices()  {
+        Node node = archive.get(CONFIG_SOURCE_SERVICES);
+        if (node != null) {
+            try (InputStream stream = node.getAsset().openStream();
+                 InputStreamReader streamReader = new InputStreamReader(stream);
+                 BufferedReader reader = new BufferedReader(streamReader)
+            ) {
+                return reader.lines()
+                        .filter(line -> !line.isEmpty())
+                        .collect(Collectors.joining("\n"));
+            } catch (IOException e) {
+                throw new IllegalStateException("Unable to parse " + CONFIG_SOURCE_SERVICES + " file", e);
+            }
+        }
+        return "";
+    }
+
+    private List<String> readConfigSourceClasses(CompositeKey key) {
+        return configView.simpleSubkeys(key)
+                    .stream()
+                    .map(subKey -> key.append(subKey).append("attribute-class"))
+                    .map(configView::valueOf)
+                    .filter(String.class::isInstance)
+                    .map(String.class::cast)
+                    .collect(Collectors.toList());
+    }
+}

--- a/fractions/microprofile/microprofile-config/src/main/java/org/wildfly/swarm/microprofile/config/fraction/runtime/MicroProfileConfigDeploymentProcessor.java
+++ b/fractions/microprofile/microprofile-config/src/main/java/org/wildfly/swarm/microprofile/config/fraction/runtime/MicroProfileConfigDeploymentProcessor.java
@@ -39,21 +39,22 @@ import java.util.stream.Collectors;
  * Date: 4/24/18
  */
 @DeploymentScoped
+@SuppressWarnings("rawtypes")
 public class MicroProfileConfigDeploymentProcessor implements DeploymentProcessor {
     private static final String CONFIG_SOURCE_SERVICES = "META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource";
     private static Logger log = Logger.getLogger(MicroProfileConfigDeploymentProcessor.class);
 
-    private final Archive<?> archive;
+    private final Archive archive;
     private final ConfigView configView;
 
     @Inject
-    public MicroProfileConfigDeploymentProcessor(Archive<?> archive, ConfigView configView) {
+    public MicroProfileConfigDeploymentProcessor(Archive archive, ConfigView configView) {
         this.archive = archive;
         this.configView = configView;
     }
 
     @Override
-    public void process() throws Exception {
+    public void process() {
         CompositeKey key = new CompositeKey("swarm", "microprofile", "config", "config-sources");
 
         List<String> configSourceClasses = readConfigSourceClasses(key);

--- a/pom.xml
+++ b/pom.xml
@@ -288,6 +288,12 @@
         <version>${version.mockito}</version>
       </dependency>
       <dependency>
+        <groupId>io.rest-assured</groupId>
+        <artifactId>rest-assured</artifactId>
+        <version>3.0.7</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${version.junit}</version>
@@ -1225,6 +1231,7 @@
         <module>testsuite/testsuite-jpa-postgresql</module>
         <module>testsuite/testsuite-jsf</module>
         <module>testsuite/testsuite-jsp</module>
+        <module>testsuite/testsuite-microprofile-config</module>
         <module>testsuite/testsuite-microprofile-jwt</module>
         <module>testsuite/testsuite-keycloak</module>
         <module>testsuite/testsuite-local-dependencies</module>

--- a/testsuite/testsuite-microprofile-config/pom.xml
+++ b/testsuite/testsuite-microprofile-config/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm.testsuite</groupId>
+    <artifactId>testsuite-parent</artifactId>
+    <version>2018.5.0-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <artifactId>testsuite-microprofile-config</artifactId>
+
+  <name>Test Suite: MicroProfile Config</name>
+  <description>Test Suite: MicroProfile Config</description>
+
+  <packaging>war</packaging>
+
+  <properties>
+    <failOnMissingWebXml>false</failOnMissingWebXml>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>undertow</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>microprofile-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>arquillian</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.junit</groupId>
+      <artifactId>arquillian-junit-container</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/testsuite/testsuite-microprofile-config/src/main/java/org/wildfly/swarm/microprofile/config/test/HelloServlet.java
+++ b/testsuite/testsuite-microprofile-config/src/main/java/org/wildfly/swarm/microprofile/config/test/HelloServlet.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.config.test;
+
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import javax.inject.Inject;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static org.wildfly.swarm.microprofile.config.test.ServiceDefinedConfigSource.PROP_FROM_CONFIG_SOURCE_FROM_SERVICE;
+import static org.wildfly.swarm.microprofile.config.test.YamlDefinedConfigSource.PROP_FROM_CONFIG_SOURCE_FROM_YAML;
+
+/**
+ * @author Juan Gonzalez
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ */
+
+@WebServlet("/")
+public class HelloServlet extends HttpServlet {
+    public static final String COMMA = "\",";
+
+    @Inject
+    @ConfigProperty(name = "app.timeout")
+    private long appTimeout;
+
+    @Inject
+    @ConfigProperty(name = "prop.from.config.source")
+    private String propFromConfigSource;
+    @Inject
+    @ConfigProperty(name = PROP_FROM_CONFIG_SOURCE_FROM_SERVICE)
+    private String propFromConfigSourceFromService;
+    @Inject
+    @ConfigProperty(name = PROP_FROM_CONFIG_SOURCE_FROM_YAML)
+    private String propFromConfigSourceFromYaml;
+
+    @Inject
+    @ConfigProperty(name = "missing.property", defaultValue = "it's present anyway")
+    private String missingProperty;
+
+    @Inject
+    private Config config;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        resp.getWriter().println("{");
+        resp.getWriter().println("\"timeout\": " + appTimeout + ",");
+        resp.getWriter().println("\"optionalTimeoutFromConfig\": " +
+                config.getOptionalValue("app.timeout", Integer.class).orElse(-1) + ",");
+        resp.getWriter().println("\"propFromConfigSource\": \"" + propFromConfigSource + COMMA);
+        resp.getWriter().println("\"propFromConfigSourceFromService\": \"" + propFromConfigSourceFromService + COMMA);
+        resp.getWriter().println("\"propFromConfigSourceFromYaml\": \"" + propFromConfigSourceFromYaml + COMMA);
+        resp.getWriter().println("\"missingProperty\": \"" + missingProperty + "\"");
+        resp.getWriter().println("}");
+        resp.setContentType("application/json");
+    }
+}

--- a/testsuite/testsuite-microprofile-config/src/main/java/org/wildfly/swarm/microprofile/config/test/ServiceDefinedConfigSource.java
+++ b/testsuite/testsuite-microprofile-config/src/main/java/org/wildfly/swarm/microprofile/config/test/ServiceDefinedConfigSource.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.config.test;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Juan Gonzalez
+ */
+public class ServiceDefinedConfigSource implements ConfigSource {
+    public static final String PROP_FROM_CONFIG_SOURCE_FROM_SERVICE = "prop.from.config.source.from.service";
+
+    private static final String NAME = ServiceDefinedConfigSource.class.getSimpleName();
+
+    private Map<String, String> props;
+
+    public ServiceDefinedConfigSource() {
+        props = new HashMap<>();
+        props.put("prop.from.config.source", NAME);
+        props.put(PROP_FROM_CONFIG_SOURCE_FROM_SERVICE, NAME);
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return props;
+    }
+
+    @Override
+    public String getValue(String propertyName) {
+        return props.get(propertyName);
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public int getOrdinal() {
+        return 150;
+    }
+}

--- a/testsuite/testsuite-microprofile-config/src/main/java/org/wildfly/swarm/microprofile/config/test/YamlDefinedConfigSource.java
+++ b/testsuite/testsuite-microprofile-config/src/main/java/org/wildfly/swarm/microprofile/config/test/YamlDefinedConfigSource.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.config.test;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Juan Gonzalez
+ */
+public class YamlDefinedConfigSource implements ConfigSource {
+    public static final String PROP_FROM_CONFIG_SOURCE_FROM_YAML = "prop.from.config.source.from.yaml";
+
+    private static final String NAME = YamlDefinedConfigSource.class.getSimpleName();
+
+    private Map<String, String> props;
+
+    public YamlDefinedConfigSource() {
+        props = new HashMap<>();
+        props.put("prop.from.config.source", NAME);
+        props.put(PROP_FROM_CONFIG_SOURCE_FROM_YAML, NAME);
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return props;
+    }
+
+    @Override
+    public String getValue(String propertyName) {
+        return props.get(propertyName);
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public int getOrdinal() {
+        return 200;
+    }
+}

--- a/testsuite/testsuite-microprofile-config/src/main/resources/META-INF/microprofile-config.properties
+++ b/testsuite/testsuite-microprofile-config/src/main/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,2 @@
+app.timeout=314159
+prop.from.config.source=File

--- a/testsuite/testsuite-microprofile-config/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource
+++ b/testsuite/testsuite-microprofile-config/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource
@@ -1,0 +1,1 @@
+org.wildfly.swarm.microprofile.config.test.ServiceDefinedConfigSource

--- a/testsuite/testsuite-microprofile-config/src/main/resources/project-defaults.yml
+++ b/testsuite/testsuite-microprofile-config/src/main/resources/project-defaults.yml
@@ -1,0 +1,6 @@
+swarm:
+   microprofile:
+      config:
+         config-sources:
+            default:
+               attribute-class: org.wildfly.swarm.microprofile.config.test.YamlDefinedConfigSource

--- a/testsuite/testsuite-microprofile-config/src/main/webapp/WEB-INF/web.xml
+++ b/testsuite/testsuite-microprofile-config/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_1.xsd" version="3.1">
+
+</web-app>

--- a/testsuite/testsuite-microprofile-config/src/test/java/org/wildfly/swarm/microprofile/config/test/YamlConfigSourceTest.java
+++ b/testsuite/testsuite-microprofile-config/src/test/java/org/wildfly/swarm/microprofile/config/test/YamlConfigSourceTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.config.test;
+
+import org.hamcrest.Matchers;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.arquillian.DefaultDeployment;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ * <br>
+ * Date: 4/25/18
+ */
+@DefaultDeployment
+@RunWith(Arquillian.class)
+public class YamlConfigSourceTest {
+
+    @Test
+    @RunAsClient
+    public void shouldImportConfigSourceViaYaml() {
+        when()
+                .get("localhost:8080")
+        .then()
+                .body("timeout", is(314159))
+                .body("optionalTimeoutFromConfig", is(314159))
+                .body("propFromConfigSource", is("YamlDefinedConfigSource"))
+                .body("propFromConfigSourceFromService", is("ServiceDefinedConfigSource"))
+                .body("propFromConfigSourceFromYaml", is("YamlDefinedConfigSource"))
+                .body("missingProperty", is("it's present anyway"));
+    }
+    
+}


### PR DESCRIPTION
Motivation
----------
Before the changes, the only possible value for `swarm.microprofile.config.config-sources.KEY.attribute-class` property was:
```
 swarm.microprofile.config.config-sources.KEY.attribute-class:
    module: some.module
    name: my.package.MyClass
```

This change bring the possibility to use classes by class name, e.g:
```
swarm:
   microprofile:
      config:
         config-sources:
            default:
               attribute-class:
                com.test.microprofile.config.TestConfigSource
```

Modifications
-------------
MicroProfileConfigDeploymentProcessor has been added.
The processor checks if the value defined `swarm.microprofile.config.config-sources.KEY.attribute-class`
is a `String` and if it is, assumes it is a name of a class and adds a microprofile config service definition pointing to it.

Result
------
The YAML configuration for attribute-class works as described in the Motivation section

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
