### PR TITLE
SWARM-1077: Make it possible to exclude auto-detected fractions.

### DIFF
--- a/docs/reference/maven-plugin.adoc
+++ b/docs/reference/maven-plugin.adoc
@@ -137,13 +137,32 @@ fractions::
 A list of extra fractions to include when auto-detection is used. It is useful for fractions that cannot be detected or user-provided fractions.
 
 The format of specifying a fraction can be:
-* `group:name:version`
-* `name:version`
-* `name`
+* `group:artifact:version`
+* `artifact:version`
+* `artifact`
 
 If no group is provided, `org.wildfly.swarm` is assumed.
 
 If no version is provided, the version is taken from the WildFly Swarm BOM for the version of the plugin you are using.
+
+If the value starts with the character `!` a corresponding auto-detected fraction is not installed (unless it's a dependency of any other fraction).
+In the following example the Undertow fraction is not installed even if your application references a class from the `javax.servlet` package:
+
+[source,xml]
+----
+<plugin>
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>wildfly-swarm-plugin</artifactId>
+  <version>${version.wildfly-swarm}</version>
+  <executions>
+    <configuration>
+     <fractions>
+       <fraction>!undertow</fraction>
+     </fractions>
+    <configuration/>
+  </executions>
+</plugin>
+----
 
 [cols="1,2a"]
 |===

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/AbstractSwarmMojo.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/AbstractSwarmMojo.java
@@ -49,6 +49,8 @@ import org.wildfly.swarm.tools.DeclaredDependencies;
  */
 public abstract class AbstractSwarmMojo extends AbstractMojo {
 
+    protected static final String EXCLUDE_PREFIX = "!";
+
     @Parameter(defaultValue = "${project}", readonly = true)
     protected MavenProject project;
 
@@ -90,7 +92,7 @@ public abstract class AbstractSwarmMojo extends AbstractMojo {
     protected List<String> additionalModules = new ArrayList<>();
 
     @Parameter(alias = "fractions")
-    protected List<String> additionalFractions = new ArrayList<>();
+    protected List<String> fractions = new ArrayList<>();
 
     @Parameter(defaultValue = "when_missing", property = "swarm.detect.mode")
     protected BuildTool.FractionDetectionMode fractionDetectMode;

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/PackageMojo.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/PackageMojo.java
@@ -160,10 +160,13 @@ public class PackageMojo extends AbstractSwarmMojo {
                     }
                 });
 
-        this.additionalFractions.stream()
-                .map(f -> FractionDescriptor.fromGav(FractionList.get(), f))
-                .map(ArtifactSpec::fromFractionDescriptor)
-                .forEach(tool::fraction);
+        this.fractions.forEach(f -> {
+            if (f.startsWith(EXCLUDE_PREFIX)) {
+                tool.excludeFraction(ArtifactSpec.fromFractionDescriptor(FractionDescriptor.fromGav(FractionList.get(), f.substring(1))));
+            } else {
+                tool.fraction(ArtifactSpec.fromFractionDescriptor(FractionDescriptor.fromGav(FractionList.get(), f)));
+            }
+        });
 
         Map<ArtifactSpec, Set<ArtifactSpec>> buckets = createBuckets(this.project.getArtifacts(), this.project.getDependencies());
 

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/StartMojo.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/StartMojo.java
@@ -245,7 +245,7 @@ public class StartMojo extends AbstractSwarmMojo {
                 .map(d -> String.format("%s:%s", d.getGroupId(), d.getArtifactId()))
                 .collect(Collectors.toSet());
 
-        final Set<FractionDescriptor> fractions;
+        final Set<FractionDescriptor> detectedFractions;
         final FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer(FractionList.get()).source(source);
         if (scanDeps) {
             existingDeps.forEach(d -> analyzer.source(d.getFile()));
@@ -253,24 +253,30 @@ public class StartMojo extends AbstractSwarmMojo {
         final Predicate<FractionDescriptor> notExistingDep =
                 d -> !existingDepGASet.contains(String.format("%s:%s", d.getGroupId(), d.getArtifactId()));
         try {
-            fractions = analyzer.detectNeededFractions().stream()
+            detectedFractions = analyzer.detectNeededFractions().stream()
                     .filter(notExistingDep)
                     .collect(Collectors.toSet());
         } catch (IOException e) {
             throw new MojoFailureException("failed to scan for fractions", e);
         }
 
-        getLog().info("Detected fractions: " + String.join(", ", fractions.stream()
+        getLog().info("Detected fractions: " + String.join(", ", detectedFractions.stream()
                 .map(FractionDescriptor::av)
                 .sorted()
                 .collect(Collectors.toList())));
 
-        fractions.addAll(this.additionalFractions.stream()
-                                 .map(f -> FractionDescriptor.fromGav(FractionList.get(), f))
-                                 .collect(Collectors.toSet()));
+        this.fractions.forEach(f -> {
+            if (f.startsWith(EXCLUDE_PREFIX)) {
+                FractionDescriptor descriptor = FractionDescriptor.fromGav(FractionList.get(), f.substring(1));
+                getLog().info("Excluding detected fraction:" + descriptor);
+                detectedFractions.remove(descriptor);
+            } else {
+                detectedFractions.add(FractionDescriptor.fromGav(FractionList.get(), f));
+            }
+        });
 
-        final Set<FractionDescriptor> allFractions = new HashSet<>(fractions);
-        allFractions.addAll(fractions.stream()
+        final Set<FractionDescriptor> allFractions = new HashSet<>(detectedFractions);
+        allFractions.addAll(detectedFractions.stream()
                                     .flatMap(f -> f.getDependencies().stream())
                                     .filter(notExistingDep)
                                     .collect(Collectors.toSet()));

--- a/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
@@ -39,13 +39,10 @@ import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 
-import net.lingala.zip4j.core.ZipFile;
-import net.lingala.zip4j.exception.ZipException;
-import net.lingala.zip4j.model.FileHeader;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.FileAsset;
 import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
+import org.jboss.shrinkwrap.api.asset.FileAsset;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.importer.ExplodedImporter;
 import org.jboss.shrinkwrap.api.importer.ZipImporter;
@@ -59,6 +56,10 @@ import org.wildfly.swarm.fractions.FractionDescriptor;
 import org.wildfly.swarm.fractions.FractionList;
 import org.wildfly.swarm.fractions.FractionUsageAnalyzer;
 import org.wildfly.swarm.spi.meta.SimpleLogger;
+
+import net.lingala.zip4j.core.ZipFile;
+import net.lingala.zip4j.exception.ZipException;
+import net.lingala.zip4j.model.FileHeader;
 
 /**
  * @author Bob McWhirter
@@ -126,6 +127,11 @@ public class BuildTool {
     public BuildTool fraction(ArtifactSpec spec) {
         this.fractions.add(spec);
 
+        return this;
+    }
+
+    public BuildTool excludeFraction(ArtifactSpec spec) {
+        this.excludedFractions.add(spec);
         return this;
     }
 
@@ -326,6 +332,9 @@ public class BuildTool {
         detectedFractions.removeAll(this.fractions.stream()
                 .map(ArtifactSpec::toFractionDescriptor)
                 .collect(Collectors.toSet()));
+
+        // Remove explicitly excluded fractions
+        detectedFractions.removeAll(this.excludedFractions.stream().map(ArtifactSpec::toFractionDescriptor).collect(Collectors.toSet()));
 
         this.log.info(String.format("Detected %sfractions: %s",
                 this.fractions.isEmpty() ? "" : "additional ",
@@ -566,6 +575,8 @@ public class BuildTool {
     }
 
     private final Set<ArtifactSpec> fractions = new HashSet<>();
+
+    private final Set<ArtifactSpec> excludedFractions = new HashSet<>();
 
     private final JavaArchive archive;
 


### PR DESCRIPTION
Motivation
----------
Currently, there is no way to exclude auto-detected fractions.

Modifications
-------------
wildfly-swarm-plugin - enhance the functionality of the "fractions"
parameter.

Result
------
If a fraction value starts with the character ! a corresponding auto-detected
fraction is not installed (unless it is a dependency of any other
fraction).

**NOTE:** This is rather a low priority issue. Also I'm not quite sure whether the solution is correct and if the functionality is worth including.