### PR TITLE
SWARM-1473: Back WARArchive by exploded temp dir.

### DIFF
--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/ApplicationModuleFinder.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/modules/ApplicationModuleFinder.java
@@ -140,8 +140,11 @@ public class ApplicationModuleFinder extends AbstractSingleModuleFinder {
 
         File tmpDir = TempFileManager.INSTANCE.newTempDirectory(name, ext);
 
-        //Explode jar due to some issues in Windows on stopping (JarFiles cannot be deleted)
+        // Explode jar due to some issues in Windows on stopping (JarFiles cannot be deleted)
         BootstrapUtil.explodeJar(jarFile, tmpDir.getAbsolutePath());
+
+        // SWARM-1473: exploded app artifact is also used to back ShrinkWrap archive used by deployment processors
+        TempFileManager.INSTANCE.setExplodedApplicationArtifact(tmpDir);
 
         jarFile.close();
         tmp.delete();

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/util/TempFileManager.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/util/TempFileManager.java
@@ -25,6 +25,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * @author Bob McWhirter
@@ -64,6 +65,14 @@ public class TempFileManager {
         tmp.delete();
         register(tmp);
         return tmp;
+    }
+
+    public File getExplodedApplicationArtifact() {
+        return explodedApplicationArtifact.get();
+    }
+
+    public void setExplodedApplicationArtifact(File explodedApplicationArtifact) {
+        this.explodedApplicationArtifact.set(explodedApplicationArtifact);
     }
 
     private void register(File file) {
@@ -109,7 +118,9 @@ public class TempFileManager {
         return true;
     }
 
-    private Set<File> registered = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private final Set<File> registered = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+    private final AtomicReference<File> explodedApplicationArtifact = new AtomicReference<>();
 
     private File tmpDir;
 

--- a/core/container/src/main/java/org/wildfly/swarm/internal/ExplodedApplicationArtifactLocator.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/ExplodedApplicationArtifactLocator.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.internal;
+
+import java.io.File;
+
+import org.wildfly.swarm.bootstrap.util.TempFileManager;
+
+/**
+ * The only purpose of this util class is to make the exploded app dir (located in tmp) accessible to fractions which do not depend on bootstrap module.
+ *
+ * @author Martin Kouba
+ */
+public class ExplodedApplicationArtifactLocator {
+
+    private ExplodedApplicationArtifactLocator() {
+    }
+
+    public static File get() {
+        return TempFileManager.INSTANCE.getExplodedApplicationArtifact();
+    }
+
+}

--- a/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/StaticContentContainer.java
+++ b/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/StaticContentContainer.java
@@ -61,7 +61,9 @@ public interface StaticContentContainer<T extends Archive<T>> extends Archive<T>
 
         try {
             // Add all the static content from the current app to the archive
-            Archive allResources = DefaultWarDeploymentFactory.archiveFromCurrentApp();
+            // I believe it does not make sense to call archiveFromCurrentApp() again if this archive was created by DefaultWarDeploymentFactory
+            Archive allResources = contains(DefaultWarDeploymentFactory.MARKER_PATH) ? this : DefaultWarDeploymentFactory.archiveFromCurrentApp();
+
             // Here we define static as basically anything that's not a
             // Java class file or under WEB-INF or META-INF
             mergeIgnoringDuplicates(allResources, base, Filters.exclude(".*\\.class$"));


### PR DESCRIPTION
Motivation
----------
Deployment processors can analyze/modify a repackaged WAR through
ShrinkWrap API. However, we currently use ZipImporter which loads
the whole archive in memory. Moreover, the WAR is currently imported
twice (see also StaticContentContainer).

As a result, an app with large repackaged WAR (libs cannot be replaced
by module deps) can run out of memory during bootstrap. E.g. cca 20MB
repackaged WAR + Xmx64m = OutOfMemoryError.

Modifications
-------------
Make use of exploded application artifact (tmp dir) and use ExplodedImporter, i.e.
the ShrinkWrap archive is backed by a directory structure.

Also skip the superfluous import in StaticContentContainer if the
archive was created by DefaultWarDeploymentFactory.

Result
------
Even an app with large repackaged WAR can be deployed. Also the overall memory
load during bootsrtap should be lower.