### PR TITLE
SWARM-2009: Add fix for handling deployment of artifacts with a dot i…

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/ArtifactDeployer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/ArtifactDeployer.java
@@ -44,16 +44,25 @@ public class ArtifactDeployer {
 
         for (SimpleKey subkey : subkeys) {
             String spec = subkey.name();
-            if (spec.contains(":")) {
-                String[] parts = spec.split(":");
-                String groupId = parts[0];
-                parts = parts[1].split("\\.");
-                String artifactId = parts[0];
-                String packaging = parts[1];
-
-                JavaArchive artifact = Swarm.artifact(groupId + ":" + artifactId + ":" + packaging + ":*", artifactId + "." + packaging);
-                deployer.get().deploy(artifact, spec);
+            if (!spec.contains(":")) {
+                // TODO Should we really silently ignore this? Rather warn the user about a problem in his config?
+                continue;
             }
+
+            String[] parts = spec.split(":");
+            String groupId = parts[0];
+            int p = parts[1].lastIndexOf('.');
+            String artifactId;
+            String packaging;
+            if (p == -1) {
+                artifactId = parts[1];
+                packaging = "jar";
+            } else {
+                artifactId = parts[1].substring(0, p);
+                packaging = parts[1].substring(p + 1);
+            }
+            JavaArchive artifact = Swarm.artifact(groupId + ":" + artifactId + ":" + packaging + ":*", artifactId + "." + packaging);
+            deployer.get().deploy(artifact, spec);
         }
 
     }

--- a/core/container/src/test/java/org/wildfly/swarm/container/runtime/ArtifactDeployerTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/container/runtime/ArtifactDeployerTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.wildfly.swarm.container.runtime;
 
 import java.lang.reflect.Field;

--- a/core/container/src/test/java/org/wildfly/swarm/container/runtime/ArtifactDeployerTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/container/runtime/ArtifactDeployerTest.java
@@ -1,0 +1,95 @@
+package org.wildfly.swarm.container.runtime;
+
+import java.lang.reflect.Field;
+
+import javax.enterprise.inject.Instance;
+
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.wildfly.swarm.container.config.ConfigViewImpl;
+import org.wildfly.swarm.spi.api.ArtifactLookup;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ArtifactDeployerTest {
+
+    @Test
+    public void testDeploy() throws Exception {
+        // Given
+        System.setProperty("swarm.deployment.[com.foo:app.war]", "");
+        ArtifactDeployer artifactDeployer = new ArtifactDeployer();
+        artifactDeployer.configView = new ConfigViewImpl();
+
+        // Stub ArtifactLookup
+        JavaArchive archive = stubArtifactLookup("com.foo:app:war:*", "app.war");
+
+        // Stub RuntimeDeployer
+        RuntimeDeployer runtimeDeployer = stubRuntimeDeployer(artifactDeployer);
+
+        // When
+        artifactDeployer.deploy();
+
+        // Then
+        verify(runtimeDeployer).deploy(archive, "com.foo:app.war");
+    }
+
+    @Test
+    public void testDeploy_artifactIdWithDot() throws Exception {
+        // Given
+        System.setProperty("swarm.deployment.[com.ibm:wsmq.jmsra.rar]", "");
+        ArtifactDeployer artifactDeployer = new ArtifactDeployer();
+        artifactDeployer.configView = new ConfigViewImpl();
+
+        // Stub ArtifactLookup
+        JavaArchive archive = stubArtifactLookup("com.ibm:wsmq.jmsra:rar:*", "wsmq.jmsra.rar");
+
+        // Stub RuntimeDeployer
+        RuntimeDeployer runtimeDeployer = stubRuntimeDeployer(artifactDeployer);
+
+        // When
+        artifactDeployer.deploy();
+
+        // Then
+        verify(runtimeDeployer).deploy(archive, "com.ibm:wsmq.jmsra.rar");
+    }
+
+    @Test
+    public void testDeploy_artifactIdWithNoExtension() throws Exception {
+        // Given
+        System.setProperty("swarm.deployment.[com.foo:artifact]", "");
+        ArtifactDeployer artifactDeployer = new ArtifactDeployer();
+        artifactDeployer.configView = new ConfigViewImpl();
+
+        // Stub ArtifactLookup
+        JavaArchive archive = stubArtifactLookup("com.foo:artifact:jar:*", "artifact.jar");
+
+        // Stub RuntimeDeployer
+        RuntimeDeployer runtimeDeployer = stubRuntimeDeployer(artifactDeployer);
+
+        // When
+        artifactDeployer.deploy();
+
+        // Then
+        verify(runtimeDeployer).deploy(archive, "com.foo:artifact");
+    }
+
+    private JavaArchive stubArtifactLookup(String gav, String asName) throws Exception {
+        ArtifactLookup artifactLookup = mock(ArtifactLookup.class);
+        ArtifactLookup.INSTANCE.set(artifactLookup);
+        JavaArchive archive = mock(JavaArchive.class);
+        when(artifactLookup.artifact(gav, asName)).thenReturn(archive);
+        return archive;
+    }
+
+    private RuntimeDeployer stubRuntimeDeployer(ArtifactDeployer artifactDeployer) throws NoSuchFieldException, IllegalAccessException {
+        RuntimeDeployer runtimeDeployer = mock(RuntimeDeployer.class);
+        Instance<RuntimeDeployer> runtimeDeployerInstance = mock(Instance.class);
+        when(runtimeDeployerInstance.get()).thenReturn(runtimeDeployer);
+        Field deployer = ArtifactDeployer.class.getDeclaredField("deployer");
+        deployer.setAccessible(true);
+        deployer.set(artifactDeployer, runtimeDeployerInstance);
+        return runtimeDeployer;
+    }
+}


### PR DESCRIPTION
…n their artifactId.

Motivation
----------
Fix an exception (WFSWARM0009: Unable to determine version number from GAV) when an attempt
is made to deploy an artifact with a dot in its artifactId.

Modifications
-------------
Added a unit test for ArtifactDeployer (ArtifactDeployerTest) to demonstrate the issue. Fixed
the issue itself in ArtifactDeployer by using lastIndexOf('.') instead of split('\\.').
Other (minor) changes to ArtifactDeployer:
- Inverted the 'if' that checks for presence of a colon (:) in the deploy spec and added a TODO
  to consider if we should throw an exception when a colon does not exist (currently this
  case is silently ignored)
- If the artifact has no type specified (e.g. 'groupId:artifact' instead of 'groupId:artifact.jar'
  then 'jar' is now picked as artifact type. It made sense to add this given the changes in the
  code

Result
------
Changes are fully backwards compatible but fix the deployment of artifacts with a dot in their name
(most notably the IBM WebSphere MQ resource adapter whose artifactId is wmq.jmsra).
If the deploy spec does not specify a type, the deployment will now succeed if the type is 'jar'.
Previously this would have resulted in an ArrayIndexOutOfBoundsException as the 'parts' array would
have had only one element in this case.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
