### PR TITLE
SWARM-2015: old version of org.wildfly.swarm:config-api-runtime gets pulled in transitively in certain situations

### DIFF
--- a/boms/src/main/resources/bom-template.xml
+++ b/boms/src/main/resources/bom-template.xml
@@ -50,6 +50,7 @@
     <version.shrinkwrap>${version.org.jboss.shrinkwrap}</version.shrinkwrap>
     <version.shrinkwrap-descriptors>${version.org.jboss.shrinkwrap.descriptors}</version.shrinkwrap-descriptors>
     <version.wildfly-swarm>${project.version}</version.wildfly-swarm>
+    <version.wildfly-config-api-runtime>${version.wildfly.config-api}</version.wildfly-config-api-runtime>
   </properties>
 
   <dependencyManagement>
@@ -58,6 +59,11 @@
         <groupId>org.wildfly.swarm</groupId>
         <artifactId>spi</artifactId>
         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>config-api-runtime</artifactId>
+        <version>${version.wildfly-config-api-runtime}</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.shrinkwrap</groupId>


### PR DESCRIPTION
Motivation
----------
All the Config API projects depend on the WildFly Config API Runtime,
and they all refer to an old version. At the same time, it can easily
happen that the application `pom.xml` has a dependency on something
that brings MP Config / Keycloak / NoSQL / Teiid Config API earlier
than a dependency on something that would bring the core WildFly
Config API. Together, these two conditions lead to an old version
of WildFly Config API Runtime winning over the correct one, and that
results in runtime failures.

Modifications
-------------
The WildFly Swarm BOM now manages version of the WildFly Config API
Runtime to the correct version.

Result
------
WildFly Config API Runtime is always present in the correct version,
which prevents runtime failures.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
