### PR TITLE
THORN-2024: Changed "WildFly Swarm" to a variable in the docs

### DIFF
--- a/docs/concepts/fractions.adoc
+++ b/docs/concepts/fractions.adoc
@@ -1,12 +1,12 @@
 [#fractions]
 = Fractions
 
-WildFly Swarm is defined by an unbounded set of capabilities.
+{Thorntail} is defined by an unbounded set of capabilities.
 Each piece of functionality is called a _fraction._
 Some fractions provide only access to APIs, such as JAX-RS or CDI; other fractions provide higher-level capabilities, such as integration with RHSSO (Keycloak).
 
-The typical method for consuming WildFly Swarm fractions is through Maven coordinates, which you add to the `pom.xml` file in your application.
+The typical method for consuming {Thorntail} fractions is through Maven coordinates, which you add to the `pom.xml` file in your application.
 The functionality the fraction provides is then packaged with your application (see xref:creating-an-uberjar[]).
 
-To enable easier consumption of WildFly Swarm fractions, a bill of materials (BOM) is available. For more information, see xref:using-a-bom[].
+To enable easier consumption of {Thorntail} fractions, a bill of materials (BOM) is available. For more information, see xref:using-a-bom[].
 

--- a/docs/concepts/packaging-types.adoc
+++ b/docs/concepts/packaging-types.adoc
@@ -1,7 +1,7 @@
 [#packaging_types]
 = Packaging Types
 
-When using WildFly Swarm, there are the following ways to package your
+When using {Thorntail}, there are the following ways to package your
 runtime and application, depending on how you intend to use and deploy
 it:
 
@@ -18,7 +18,7 @@ An uberjar is useful for many continuous integration and continuous deployment
 and moved through the testing, validation, and production environments in your
 organization.
 
-The names of the uberjars that WildFly Swarm produces include the name of your
+The names of the uberjars that {Thorntail} produces include the name of your
 application and the `-swarm.jar` suffix.
 
 An uberjar can be executed like any executable JAR:
@@ -40,7 +40,7 @@ in a container image lower in the image hierarchy--which means it changes less
 often--so that the higher layer which contains only your application code can
 be rebuilt more quickly.
 
-The names of the hollow JARs that WildFly Swarm produces include the name of
+The names of the hollow JARs that {Thorntail} produces include the name of
 your application, and the `-hollow-swarm.jar` suffix. You must package the
 `.war` file of your application separately in order to benefit from the hollow
 JAR.
@@ -55,7 +55,7 @@ $ java -jar myapp-hollow-swarm.jar myapp.war
 
 === Pre-Built Hollow JARs
 
-WildFly Swarm ships the following pre-built hollow JARs:
+{Thorntail} ships the following pre-built hollow JARs:
 
 full:: The main Java EE related capabilities
 web:: A smaller functional scope, focused on web technologies
@@ -75,7 +75,7 @@ The hollow JARs are available under the following coordinates:
 ====
 anchor:hollow-jar-limitations[]Using hollow JARs has certain limitations:
 
-* To enable WildFly Swarm to autodetect a JDBC driver, you must add the JAR with the driver to the `swarm.classpath` system property, for example:
+* To enable {Thorntail} to autodetect a JDBC driver, you must add the JAR with the driver to the `swarm.classpath` system property, for example:
 +
 [source,bash,options="nowrap"]
 ----

--- a/docs/howto/autodetect-fractions/index.adoc
+++ b/docs/howto/autodetect-fractions/index.adoc
@@ -1,10 +1,10 @@
 [#auto-detecting-fractions]
 = Auto-detecting fractions
 
-Migrating existing legacy applications to benefit from WildFly Swarm is simple when using fraction auto-detection.
-If you enable the WildFly Swarm Maven plugin in your application, WildFly Swarm detects which APIs you use, and includes the appropriate fractions at build time.
+Migrating existing legacy applications to benefit from {Thorntail} is simple when using fraction auto-detection.
+If you enable the {Thorntail} Maven plugin in your application, {Thorntail} detects which APIs you use, and includes the appropriate fractions at build time.
 
-NOTE: By default, WildFly Swarm only auto-detects if you do not specify any fractions explicitly. This behavior is controlled by the `fractionDetectMode` property. For more information, see the xref:maven-plugin-configuration[Maven plugin configuration reference].
+NOTE: By default, {Thorntail} only auto-detects if you do not specify any fractions explicitly. This behavior is controlled by the `fractionDetectMode` property. For more information, see the xref:maven-plugin-configuration[Maven plugin configuration reference].
 
 For example, consider your `pom.xml` already specifies the API `.jar` file for a specification such as JAX-RS:
 
@@ -15,7 +15,7 @@ include::pom.xml[tag=jaxrs,index=2]
 </dependencies>
 ----
 
-WildFly Swarm then includes the `jaxrs` fraction during the build automatically.
+{Thorntail} then includes the `jaxrs` fraction during the build automatically.
 
 .Prerequisites
 

--- a/docs/howto/create-a-datasource/auto-detecting-jdbc-drivers.adoc
+++ b/docs/howto/create-a-datasource/auto-detecting-jdbc-drivers.adoc
@@ -1,11 +1,11 @@
 [#auto-detecting-jdbc-drivers]
 = Auto-detecting JDBC drivers
 
-WildFly Swarm has the capability to detect, install, and register
+{Thorntail} has the capability to detect, install, and register
 a variety of JDBC drivers based on their inclusion as a dependency
 to your application.
 
-The drivers that WildFly Swarm auto-detects include:
+The drivers that {Thorntail} auto-detects include:
 
 * H2
 * MySQL

--- a/docs/howto/create-a-fraction/index.adoc
+++ b/docs/howto/create-a-fraction/index.adoc
@@ -2,14 +2,14 @@
 
 ## Introduction
 
-The composable pieces of WildFly Swarm are called _fractions_. Each fraction
+The composable pieces of {Thorntail} are called _fractions_. Each fraction
 starts with a single Maven-addressable artifact which may transitively bring
 in others.
 
 ## The `pom.xml`
 
 It is useful to set at least a pair of properties, specifying the version
-of the WildFly Swarm SPI and fraction-plugin being used:
+of the {Thorntail} SPI and fraction-plugin being used:
 
 [source,xml,subs=+attributes]
 ----
@@ -19,7 +19,7 @@ of the WildFly Swarm SPI and fraction-plugin being used:
 </properties>
 ----
 
-You can include all of the primary bits of WildFly Swarm using the
+You can include all of the primary bits of {Thorntail} using the
 `bom-all` artifact in a `<dependencyManagement>` import. Additionally,
 you'll need two more dependencies added in order to write CDI components
 to configure the server.
@@ -311,9 +311,9 @@ the relevant CDI components.
 [[auto-detection]]
 ### Auto-detection
 
-An important point of WildFly Swarm is the capability of the plugin
+An important point of {Thorntail} is the capability of the plugin
 to autodetect that a fraction is required.  Currently this is only supported
-by fractions that are part of the core WildFly Swarm distribution. In
+by fractions that are part of the core {Thorntail} distribution. In
 the event that your fraction is merged into core, you will want to possibly
 also support auto-detection.
 

--- a/docs/howto/create-a-hollow-jar/index.adoc
+++ b/docs/howto/create-a-hollow-jar/index.adoc
@@ -1,7 +1,7 @@
 [#creating-a-hollow-jar]
 = Creating a hollow JAR
 
-The xref:hollow-jar[hollow JAR] is one method of packaging an application for execution with WildFly Swarm.
+The xref:hollow-jar[hollow JAR] is one method of packaging an application for execution with {Thorntail}.
 
 .Prerequisites
 

--- a/docs/howto/create-an-uberjar/index.adoc
+++ b/docs/howto/create-an-uberjar/index.adoc
@@ -2,7 +2,7 @@
 = Creating an Uberjar
 
 One method of packaging an application for execution
-with WildFly Swarm is as an _uberjar_. 
+with {Thorntail} is as an _uberjar_. 
 
 .Prerequisites
 

--- a/docs/howto/enabling-logging/index.adoc
+++ b/docs/howto/enabling-logging/index.adoc
@@ -2,7 +2,7 @@
 [#enabling-logging_{context}]
 = Enabling logging
 
-Each WildFly Swarm fraction is dependent on the Logging fraction, which means that if you use any WildFly Swarm fraction in your application, logging is automatically enabled on the `INFO` level and higher.
+Each {Thorntail} fraction is dependent on the Logging fraction, which means that if you use any {Thorntail} fraction in your application, logging is automatically enabled on the `INFO` level and higher.
 If you want to enable logging explicitly, add the Logging fraction to the POM file of your application.
 
 .Prerequisites

--- a/docs/howto/explicit-fractions/index.adoc
+++ b/docs/howto/explicit-fractions/index.adoc
@@ -11,9 +11,9 @@ When writing your application from scratch, ensure it compiles correctly and use
 
 . Add the BOM to your `pom.xml`. For more information, see xref:using-a-bom[].
 
-. Add the WildFly Swarm Maven plugin to your `pom.xml`. For more information, see xref:creating-an-uberjar[].
+. Add the {Thorntail} Maven plugin to your `pom.xml`. For more information, see xref:creating-an-uberjar[].
 
-. Add one or more dependencies on WildFly Swarm fractions to the `pom.xml` file:
+. Add one or more dependencies on {Thorntail} fractions to the `pom.xml` file:
 +
 [source,xml]
 ----

--- a/docs/howto/logging-to-a-file/index.adoc
+++ b/docs/howto/logging-to-a-file/index.adoc
@@ -5,7 +5,7 @@
 In addition to the console logging, you can save the logs of your application in a file.
 Typically, deployments use rotating logs to save disk space.
 
-In WildFly Swarm, logging is configured using system properties.
+In {Thorntail}, logging is configured using system properties.
 Even though it is possible to use the `-Dproperty=value` syntax when launching your application, it is strongly recommended to configure file logging using the YAML profile files.
 
 .Prerequisites
@@ -60,7 +60,7 @@ periodic-rotating-file-handlers:
 
 Here, a new handler named `FILE` is created, logging events of the `INFO` level and higher.
 It logs in the `target` directory, and each log file is named `MY_APP_NAME.log` with the suffix `.yyyy-MM-dd`.
-WildFly Swarm automatically parses the log rotation period from the suffix, so ensure you use a format compatible with the `java.text.SimpleDateFormat` class.
+{Thorntail} automatically parses the log rotation period from the suffix, so ensure you use a format compatible with the `java.text.SimpleDateFormat` class.
 --
 
 . Configure the root logger.

--- a/docs/howto/test-in-container/index.adoc
+++ b/docs/howto/test-in-container/index.adoc
@@ -3,8 +3,8 @@
 
 Using Arquillian, you have the capability of injecting unit tests into a
 running application. This allows you to verify your application is behaving
-correctly. There is an adapter for WildFly Swarm that makes Arquillian-based
-testing work well with WildFly Swarm{ndash}based applications.
+correctly. There is an adapter for {Thorntail} that makes Arquillian-based
+testing work well with {Thorntail}{ndash}based applications.
 
 .Prerequisites
 
@@ -12,7 +12,7 @@ testing work well with WildFly Swarm{ndash}based applications.
 
 .Procedure
 
-. Include the WildFly Swarm BOM as described in xref:using-a-bom[]:
+. Include the {Thorntail} BOM as described in xref:using-a-bom[]:
 +
 [source,xml]
 ----
@@ -41,8 +41,8 @@ ifdef::product[]
 </project>
 ----
 
-The reason is that the WildFly Swarm productized rutime artifact BOM imports the EAP runtime artifacts BOM (`org.jboss.bom:eap-runtime-artifacts`), which excludes the `commons-logging` artifact from the `org.apache.httpcomponents:httpclient` and `org.apache.james:apache-mime4j` artifacts.
-As a result, when running tests in a Maven project that imports the WildFly Swarm productized runtime artifact BOM, neither the Apache HTTP Client nor any other artifact that depends on it (for example, the JAX-RS Client) works.
+The reason is that the {Thorntail} productized rutime artifact BOM imports the EAP runtime artifacts BOM (`org.jboss.bom:eap-runtime-artifacts`), which excludes the `commons-logging` artifact from the `org.apache.httpcomponents:httpclient` and `org.apache.james:apache-mime4j` artifacts.
+As a result, when running tests in a Maven project that imports the {Thorntail} productized runtime artifact BOM, neither the Apache HTTP Client nor any other artifact that depends on it (for example, the JAX-RS Client) works.
 --
 endif::[]
 
@@ -68,7 +68,7 @@ include::src/main/resources/project-defaults.yml[]
 
 . Create a test class.
 +
-NOTE: Creating an Arquillian test before WildFly Swarm existed usually involved
+NOTE: Creating an Arquillian test before {Thorntail} existed usually involved
 programatically creating `Archive` due to the fact that applications
 were larger, and the aim was to test a single component in isolation.
 +
@@ -97,7 +97,7 @@ include::src/test/java/org/wildfly/swarm/howto/incontainer/InContainerTest.java[
 ----
 
 Using the `@DefaultDeployment` annotation provided by Arquillian integration
-with WildFly Swarm means you should _not_ use the Arquillian `@Deployment`
+with {Thorntail} means you should _not_ use the Arquillian `@Deployment`
 annotation on static methods that return an `Archive`.
 
 The `@DefaultDeployment` annotation inspects the package of the test:

--- a/docs/howto/use-a-bom/index.adoc
+++ b/docs/howto/use-a-bom/index.adoc
@@ -1,9 +1,9 @@
 [#using-a-bom]
 = Using a BOM
 
-To explicitly specify the WildFly Swarm
+To explicitly specify the {Thorntail}
 fractions your application uses, instead of relying
-on auto-detection, WildFly Swarm includes a set of
+on auto-detection, {Thorntail} includes a set of
 BOMs (bill of materials) which you can use instead of
 having to track and update Maven artifact versions
 in several places.
@@ -11,7 +11,7 @@ in several places.
 ifndef::product[]
 == Different types of BOMs
 
-WildFly Swarm is described as _just enough app-server,_
+{Thorntail} is described as _just enough app-server,_
 which means it comprises of multiple pieces.  Your application
 includes only the pieces it needs.
 
@@ -55,7 +55,7 @@ endif::[]
 . Include a `bom` artifact in your `pom.xml`.
 +
 --
-Tracking the current version of WildFly Swarm through a property in your
+Tracking the current version of {Thorntail} through a property in your
 `pom.xml` is recommended.
 
 [source,xml,subs="+attributes"]
@@ -105,20 +105,20 @@ endif::[]
 By including the BOMs of your choice in the `<dependencyManagement>` section,
 you have:
 
-* Provided version-management for any WildFly Swarm artifacts you
+* Provided version-management for any {Thorntail} artifacts you
 subsequently *choose* to use.
 * Provided support to your IDE for auto-completing known artifacts
 when you edit your the `pom.xml` file of your application.
 --
 
-. Include WildFly Swarm dependencies.
+. Include {Thorntail} dependencies.
 +
 --
-Even though you imported the WildFly Swarm BOMs in the `<dependencyManagement>`
-section, your application still has no dependencies on WildFly Swarm
+Even though you imported the {Thorntail} BOMs in the `<dependencyManagement>`
+section, your application still has no dependencies on {Thorntail}
 artifacts.
 
-To include WildFly Swarm artifact dependencies based on the capabilities your
+To include {Thorntail} artifact dependencies based on the capabilities your
 application, enter the relevant artifacts as `<dependency>` elements:
 
 NOTE: You do not have to specify the version of the artifacts because the BOM
@@ -140,10 +140,10 @@ for example `undertow`.
 
 One shortcoming of importing a Maven BOM import is that it does not
 handle the configuration on the level of `<pluginManagement>`. When you use the
-WildFly Swarm Maven Plugin, you must specify the version of the plugin to use.
+{Thorntail} Maven Plugin, you must specify the version of the plugin to use.
 
 Thanks to the property you use in your `pom.xml` file, you can easily ensure
-that your plugin usage matches the release of WildFly Swarm that you are
+that your plugin usage matches the release of {Thorntail} that you are
 targeting with the BOM import.
 
 [source,xml]

--- a/docs/howto/writing-an-application-from-scratch/index.adoc
+++ b/docs/howto/writing-an-application-from-scratch/index.adoc
@@ -2,7 +2,7 @@
 [id='writing-an-application-from-scratch_{context}']
 = Creating an application from scratch
 
-Creating a simple WildFly Swarm{ndash}based application with a REST endpoint from scratch.
+Creating a simple {Thorntail}{ndash}based application with a REST endpoint from scratch.
 
 [discrete]
 == Prerequisites
@@ -68,9 +68,9 @@ $ mvn wildfly-swarm:run
 
 Accessing the `http://localhost:8080/rest/hello` URL in your browser should return the following message:
 
-[source]
+[source,subs="attributes+"]
 ----
-Hello from WildFly Swarm!
+Hello from {Thorntail}!
 ----
 
 After finishing the procedure, there should be a directory on your hard drive with the following contents:

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -6,8 +6,8 @@
 
 :ndash: &#x2013;
 
-= WildFly Swarm Documentation
-The WildFly Swarm Team
+= {Thorntail} Documentation
+The {Thorntail} Team
 v{version}
 
 include::introduction.adoc[]

--- a/docs/introduction.adoc
+++ b/docs/introduction.adoc
@@ -1,6 +1,6 @@
 
-WildFly Swarm is a framework based on the popular {WildFly} Java application server to enable the creation of small, standalone microservice-based applications.
-WildFly Swarm is capable of producing so-called _just enough app-server_ to support each component of your system.
+{Thorntail} is a framework based on the popular {WildFly} Java application server to enable the creation of small, standalone microservice-based applications.
+{Thorntail} is capable of producing so-called _just enough app-server_ to support each component of your system.
 
-For more information, see the WildFly Swarm link:http://wildfly-swarm.io/[home page].
+For more information, see the {Thorntail} link:http://wildfly-swarm.io/[home page].
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -81,6 +81,7 @@
             <version>${project.version}</version>
             <product>${swarm.product.build}</product>
             <WildFly>WildFly</WildFly>
+            <Thorntail>WildFly Swarm</Thorntail>
           </attributes>
           <doctype>book</doctype>
           <backend>html5</backend>

--- a/docs/reference/configuration.adoc
+++ b/docs/reference/configuration.adoc
@@ -1,7 +1,7 @@
 [#configuring-a-wildfly-swarm-application]
-= Configuring a WildFly Swarm application
+= Configuring a {Thorntail} application
 
-You can configure numerous options with applications built with WildFly Swarm.
+You can configure numerous options with applications built with {Thorntail}.
 For most options, reasonable defaults are already applied, so you do not have to change any options unless you explicitly want to.
 
 This reference is a complete list of all configurable items, grouped by the fraction that introduces them.
@@ -110,7 +110,7 @@ swarm:
 [discrete]
 === Default YAML Files
 
-If the original `.war` file with your application contains a file named `project-defaults.yml`, that file represents the defaults applied over the absolute defaults that WildFly Swarm provides.
+If the original `.war` file with your application contains a file named `project-defaults.yml`, that file represents the defaults applied over the absolute defaults that {Thorntail} provides.
 
 In addition to the `project-defaults.yml` file, you can provide specific configuration files using the `-S <name>` command-line option.
 The specified files are loaded, in the order you provided them, before `project-defaults.yml`.
@@ -181,7 +181,7 @@ export SWARM.UNDERTOW.SERVERS.DEFAULT.DEFAULT_DASH_HOST=<myhost>
 ====
 
 Unlike other configuration options, properties defined as environment variables in Linux-based containers do not allow defining non-alphanumeric characters like _dot_ (.), _dash/hyphen_ (-) or any other characters not in the `[A-Za-z0-9_]` range.
-Many configuration properties in WildFly Swarm contain these characters, so you must follow these rules when defining the environment variables in the following environments:
+Many configuration properties in {Thorntail} contain these characters, so you must follow these rules when defining the environment variables in the following environments:
 
 .Linux-based container rules
 * It is a naming convention that all environment properties are defined using uppercase letters.

--- a/docs/reference/elytron.adoc
+++ b/docs/reference/elytron.adoc
@@ -1,6 +1,6 @@
 = Elytron configuration 
 
-Elytron by default will generate an audit log to the same directory that a WildFly Swarm application is run. 
+Elytron by default will generate an audit log to the same directory that a {Thorntail} application is run. 
 However, in some environments (e.g., cloud), it may be necessary to relocate the audit file to a globally writable directory.
 
 Specify the following in your project-defaults.yml:

--- a/docs/reference/maven-plugin.adoc
+++ b/docs/reference/maven-plugin.adoc
@@ -1,11 +1,11 @@
 [#maven-plugin]
 = Maven Plugin
 
-WildFly Swarm provides a Maven plugin to accomplish most of the work of building xref:uberjar[uberjar] packages.
+{Thorntail} provides a Maven plugin to accomplish most of the work of building xref:uberjar[uberjar] packages.
 
 .General Usage
 
-The WildFly Swarm Maven plugin is used like any other Maven plugin, that is through editing the `pom.xml` file in your application and adding a `<plugin>` section:
+The {Thorntail} Maven plugin is used like any other Maven plugin, that is through editing the `pom.xml` file in your application and adding a `<plugin>` section:
 
 [source,xml]
 ----
@@ -29,7 +29,7 @@ The WildFly Swarm Maven plugin is used like any other Maven plugin, that is thro
 
 == Goals
 
-The WildFly Swarm Maven plugin provides several goals:
+The {Thorntail} Maven plugin provides several goals:
 
 package::
 Creates the executable package (see xref:creating-an-uberjar[]).
@@ -40,7 +40,7 @@ Executes your application in the Maven process. The application is stopped if th
 [#maven-plugin-multistart-goal]
 start and multistart::
 Executes your application in a forked process. Generally, it is only useful for running integration tests using a plugin, such as the `maven-failsafe-plugin`.
-The `multistart` variant allows starting multiple WildFly Swarm{ndash}built applications using Maven GAVs to support complex testing scenarios.
+The `multistart` variant allows starting multiple {Thorntail}{ndash}built applications using Maven GAVs to support complex testing scenarios.
 
 stop::
 Stops any previously started applications.
@@ -119,7 +119,7 @@ fractionDetectMode::
 --
 The mode of fraction detection. The available options are:
 
-* `when_missing`: Runs only when no WildFly Swarm dependencies are found.
+* `when_missing`: Runs only when no {Thorntail} dependencies are found.
 * `force`: Always run, and merge any detected fractions with the existing dependencies. Existing dependencies take precedence.
 * `never`: Disable fraction detection.
 
@@ -148,7 +148,7 @@ The format of specifying a fraction can be:
 
 If no group is provided, `org.wildfly.swarm` is assumed.
 
-If no version is provided, the version is taken from the WildFly Swarm BOM for the version of the plugin you are using.
+If no version is provided, the version is taken from the {Thorntail} BOM for the version of the plugin you are using.
 
 If the value starts with the character `!` a corresponding auto-detected fraction is not installed (unless it's a dependency of any other fraction).
 In the following example the Undertow fraction is not installed even if your application references a class from the `javax.servlet` package:

--- a/docs/reference/usage.adoc
+++ b/docs/reference/usage.adoc
@@ -1,6 +1,6 @@
 = The `usage.txt` file
 
-Each WildFly Swarm application can contain a text file with usage instructions at one of the following locations:
+Each {Thorntail} application can contain a text file with usage instructions at one of the following locations:
 
 * `/usage.txt`
 * `/META-INF/usage.txt`

--- a/fractions/javaee/datasources/README.adoc
+++ b/fractions/javaee/datasources/README.adoc
@@ -6,7 +6,7 @@ Provides support for container-managed database connections.
 
 If your application includes the appropriate vendor JDBC
 library in its normal dependencies, these drivers will be detected
-and installed by WildFly Swarm without any additional effort.
+and installed by {Thorntail} without any additional effort.
 
 The list of detectable drivers and their `driver-name` which
 may be used when defining a datasource is as follows:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

This PR only changes the string `WildFly Swarm` in the documentation sources (i. e. `adoc` files) to `{thorntail}`. For the time being, the `{thorntail}` variable is still set to `WildFly Swarm`, so there is no visible change in the built documents. The rename itself should be handled in a separate JIRA.

I have selected the `thorntail` variable name because IMO nothing related to `product` fits (we use that to denote product builds as opposed to community builds) and I wanted to use a name that would not collide with anything in [fabric8-launcher/launcher-documentation](https://github.com/fabric8-launcher/launcher-documentation). I am open to using other variable names if this one is deemed unsatisfactory.

Resolves [THORN-2024](https://issues.jboss.org/browse/THORN-2024).