### PR TITLE
THORN-2027: MP FT - activate CDI request context within async methods.

### DIFF
--- a/fractions/microprofile/microprofile-fault-tolerance/module.conf
+++ b/fractions/microprofile/microprofile-fault-tolerance/module.conf
@@ -12,3 +12,5 @@ org.eclipse.microprofile.config.api
 org.eclipse.microprofile.faulttolerance export=true
 
 org.wildfly.swarm.logging
+
+org.jboss.weld.api

--- a/fractions/microprofile/microprofile-fault-tolerance/pom.xml
+++ b/fractions/microprofile/microprofile-fault-tolerance/pom.xml
@@ -92,6 +92,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- See also THORN-2027 -->
+    <dependency>
+      <groupId>org.jboss.weld</groupId>
+      <artifactId>weld-api</artifactId>
+    </dependency>
 
    <!-- Test dependencies -->
    <dependency>

--- a/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/HystrixCommandInterceptor.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/HystrixCommandInterceptor.java
@@ -51,6 +51,8 @@ import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenExce
 import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceException;
 import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
 import org.jboss.logging.Logger;
+import org.jboss.weld.context.RequestContext;
+import org.jboss.weld.context.unbound.Unbound;
 import org.wildfly.swarm.microprofile.faulttolerance.MicroProfileFaultToleranceFraction;
 import org.wildfly.swarm.microprofile.faulttolerance.deployment.config.BulkheadConfig;
 import org.wildfly.swarm.microprofile.faulttolerance.deployment.config.CircuitBreakerConfig;
@@ -106,13 +108,14 @@ public class HystrixCommandInterceptor {
     @SuppressWarnings("unchecked")
     @Inject
     public HystrixCommandInterceptor(@ConfigProperty(name = "MP_Fault_Tolerance_NonFallback_Enabled", defaultValue = "true") Boolean nonFallBackEnable,
-            Config config, Instance<MicroProfileFaultToleranceFraction> fraction, BeanManager beanManager) {
+            Config config, Instance<MicroProfileFaultToleranceFraction> fraction, BeanManager beanManager, @Unbound RequestContext requestContext) {
         this.nonFallBackEnable = nonFallBackEnable;
         Optional<Boolean> mpSyncCircuitBreaker = config.getOptionalValue(SYNC_CIRCUIT_BREAKER_KEY, Boolean.class);
         this.syncCircuitBreakerEnabled = mpSyncCircuitBreaker.orElse(fraction.isUnsatisfied() ? true : fraction.get().isSynchronousCircuitBreakerEnabled());
         this.beanManager = beanManager;
         this.extension = beanManager.getExtension(HystrixExtension.class);
         this.commandMetadataMap = new ConcurrentHashMap<>();
+        this.requestContext = requestContext;
         // WORKAROUND: Hystrix does not allow to use custom HystrixCircuitBreaker impl
         // See also https://github.com/Netflix/Hystrix/issues/9
         try {
@@ -134,18 +137,20 @@ public class HystrixCommandInterceptor {
         CommandMetadata metadata = commandMetadataMap.computeIfAbsent(method, CommandMetadata::new);
         RetryContext retryContext = nonFallBackEnable && metadata.operation.hasRetry() ? new RetryContext(metadata.operation.getRetry()) : null;
         SynchronousCircuitBreaker syncCircuitBreaker = getSynchronousCircuitBreaker(metadata);
-        Function<Supplier<Object>, SimpleCommand> commandFactory = (fallback) -> new SimpleCommand(metadata.setter, ctx, fallback, metadata.operation);
+        Function<Supplier<Object>, SimpleCommand> commandFactory = (fallback) -> new SimpleCommand(metadata.setter, ctx, fallback, metadata.operation,
+                metadata.operation.isAsync() ? requestContext : null);
 
         if (metadata.operation.isAsync()) {
             LOGGER.debugf("Queue up command for async execution: %s", metadata.operation);
-            return new AsyncFuture(CompositeCommand.createAndQueue(() -> executeCommand(commandFactory, retryContext, metadata, ctx, syncCircuitBreaker), metadata.operation));
+            return new AsyncFuture(
+                    CompositeCommand.createAndQueue(() -> executeCommand(commandFactory, retryContext, metadata, ctx, syncCircuitBreaker), metadata.operation));
         } else {
             LOGGER.debugf("Sync execution: %s]", metadata.operation);
             return executeCommand(commandFactory, retryContext, metadata, ctx, syncCircuitBreaker);
         }
     }
 
-    private static Object executeCommand(Function<Supplier<Object>, SimpleCommand> commandFactory, RetryContext retryContext, CommandMetadata metadata,
+    private Object executeCommand(Function<Supplier<Object>, SimpleCommand> commandFactory, RetryContext retryContext, CommandMetadata metadata,
             ExecutionContextWithInvocationContext ctx, SynchronousCircuitBreaker syncCircuitBreaker) throws Exception {
         while (true) {
             if (retryContext != null) {
@@ -324,6 +329,8 @@ public class HystrixCommandInterceptor {
     private final BeanManager beanManager;
 
     private final HystrixExtension extension;
+
+    private final RequestContext requestContext;
 
     private class CommandMetadata {
 

--- a/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/async/requestcontext/AsyncService.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/async/requestcontext/AsyncService.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.faulttolerance.deployment.async.requestcontext;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+
+@ApplicationScoped
+public class AsyncService {
+
+    @Inject
+    RequestFoo foo;
+
+    @Asynchronous
+    public Future<String> perform() {
+       return CompletableFuture.completedFuture(foo.getFoo());
+    }
+
+}

--- a/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/async/requestcontext/AsynchronousRequestContextTest.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/async/requestcontext/AsynchronousRequestContextTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.faulttolerance.deployment.async.requestcontext;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.microprofile.faulttolerance.deployment.TestArchive;
+
+/**
+ *
+ * @author Martin Kouba
+ */
+@RunWith(Arquillian.class)
+public class AsynchronousRequestContextTest {
+
+    @Deployment
+    public static JavaArchive createTestArchive() {
+        return TestArchive.createBase(AsynchronousRequestContextTest.class).addPackage(AsynchronousRequestContextTest.class.getPackage());
+    }
+
+    @Test
+    public void testRequestContextActive(AsyncService asyncService) throws IOException, InterruptedException, ExecutionException {
+        assertEquals("ok", asyncService.perform().get());
+    }
+
+}

--- a/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/async/requestcontext/RequestFoo.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/async/requestcontext/RequestFoo.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.faulttolerance.deployment.async.requestcontext;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.RequestScoped;
+
+@RequestScoped
+public class RequestFoo {
+
+    private String foo;
+
+    @PostConstruct
+    void init() {
+        foo = "ok";
+    }
+
+    public String getFoo() {
+        return foo;
+    }
+
+}

--- a/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/async/retry/AsyncHelloService.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/async/retry/AsyncHelloService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.wildfly.swarm.microprofile.faulttolerance.deployment.async.retry;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;

--- a/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/async/retry/AsynchronousRetryTest.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/test/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/async/retry/AsynchronousRetryTest.java
@@ -40,7 +40,7 @@ public class AsynchronousRetryTest {
 
     @Deployment
     public static JavaArchive createTestArchive() {
-        return TestArchive.createBase("AsynchronousRetryTest.jar").addPackage(AsynchronousRetryTest.class.getPackage());
+        return TestArchive.createBase(AsynchronousRetryTest.class).addPackage(AsynchronousRetryTest.class.getPackage());
     }
 
     @Test


### PR DESCRIPTION
Motivation
----------
CDI request context is currently not active during a MP FT async method
invocation. It would be reasonable to follow the CDI spec rules for EJB
asynchronous method invocations, i.e. activate the request context
within MP FT async methods.

Modifications
-------------
Make use of Weld context management API to activate the request context.

Result
------
CDI request context is active during MP FT async method invocation.
