### PR TITLE
ENTSWM-447: Removed full fraction from product docs

### DIFF
--- a/docs/concepts/packaging-types.adoc
+++ b/docs/concepts/packaging-types.adoc
@@ -57,17 +57,18 @@ $ java -jar myapp-hollow-swarm.jar myapp.war
 
 {Thorntail} ships the following pre-built hollow JARs:
 
-full:: The main Java EE related capabilities
+ifndef::product[full:: The main Java EE related capabilities]
 web:: A smaller functional scope, focused on web technologies
 microprofile:: Functionality defined by all Eclipse MicroProfile specifications
 
 The hollow JARs are available under the following coordinates:
 
-[source,xml,options="nowrap"]
+[source,xml,options="nowrap",subs="attributes+"]
 ----
 <dependency>
     <groupId>org.wildfly.swarm.servers</groupId>
-    <artifactId>[full|web|microprofile]</artifactId>
+ifndef::product[    <artifactId>[full|web|microprofile]</artifactId>]
+ifdef::product[    <artifactId>[web|microprofile]</artifactId>]
 </dependency>
 ----
 


### PR DESCRIPTION
Resolves ENTSWM-447

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Community docs still have it.