### PR TITLE
THORN-2030: MP Rest Client - CDI interceptors support.

### DIFF
--- a/client-apis/microprofile-restclient/pom.xml
+++ b/client-apis/microprofile-restclient/pom.xml
@@ -53,5 +53,15 @@
       <artifactId>resteasy-client</artifactId>
     </dependency>
 
+    <dependency>
+       <groupId>javax.enterprise</groupId>
+       <artifactId>cdi-api</artifactId>
+    </dependency>
+    
+    <dependency>
+       <groupId>org.jboss.spec.javax.interceptor</groupId>
+       <artifactId>jboss-interceptors-api_1.2_spec</artifactId>
+    </dependency>
+
   </dependencies>
 </project>

--- a/client-apis/microprofile-restclient/src/main/java/org/wildfly/swarm/microprofile/restclient/InvocationContextImpl.java
+++ b/client-apis/microprofile-restclient/src/main/java/org/wildfly/swarm/microprofile/restclient/InvocationContextImpl.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.restclient;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.enterprise.inject.spi.InterceptionType;
+import javax.enterprise.inject.spi.Interceptor;
+import javax.interceptor.InvocationContext;
+import javax.ws.rs.client.ResponseProcessingException;
+
+/**
+ *
+ * @author Martin Kouba
+ */
+class InvocationContextImpl implements InvocationContext {
+
+    private final Object target;
+
+    private final Method method;
+
+    private Object[] args;
+
+    private int position;
+
+    private final Map<String, Object> contextData;
+
+    private final List<InterceptorInvocation> chain;
+
+    /**
+     * @param target
+     * @param method
+     * @param args
+     * @param chain
+     */
+    InvocationContextImpl(Object target, Method method, Object[] args, List<InterceptorInvocation> chain) {
+        this.target = target;
+        this.method = method;
+        this.args = args;
+        this.contextData = new HashMap<>();
+        this.position = 0;
+        this.chain = chain;
+    }
+
+    boolean hasNextInterceptor() {
+        return position < chain.size();
+    }
+
+    protected Object invokeNext() throws Exception {
+        int oldPosition = position;
+        try {
+            return chain.get(position++).invoke(this);
+        } finally {
+            position = oldPosition;
+        }
+    }
+
+    protected Object interceptorChainCompleted() throws Exception {
+        try {
+            return method.invoke(target, args);
+        } catch (InvocationTargetException e) {
+            if (e.getCause() instanceof ResponseProcessingException) {
+                ResponseProcessingException rpe = (ResponseProcessingException) e.getCause();
+                // Note that the default client engine leverages a single connection
+                // MP FT: we need to close the response otherwise we would not be able to retry if the method returns javax.ws.rs.core.Response
+                rpe.getResponse().close();
+                Throwable cause = rpe.getCause();
+                if (cause instanceof RuntimeException) {
+                    throw (RuntimeException) cause;
+                }
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    public Object proceed() throws Exception {
+        try {
+            if (hasNextInterceptor()) {
+                return invokeNext();
+            } else {
+                return interceptorChainCompleted();
+            }
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof Error) {
+                throw (Error) cause;
+            }
+            if (cause instanceof Exception) {
+                throw (Exception) cause;
+            }
+            throw new RuntimeException(cause);
+        }
+    }
+
+    @Override
+    public Object getTarget() {
+        return target;
+    }
+
+    @Override
+    public Method getMethod() {
+        return method;
+    }
+
+    @Override
+    public Constructor<?> getConstructor() {
+        return null;
+    }
+
+    @Override
+    public Object[] getParameters() throws IllegalStateException {
+        return args;
+    }
+
+    @Override
+    public void setParameters(Object[] params) throws IllegalStateException, IllegalArgumentException {
+        this.args = params;
+    }
+
+    @Override
+    public Map<String, Object> getContextData() {
+        return contextData;
+    }
+
+    @Override
+    public Object getTimer() {
+        return null;
+    }
+
+    static class InterceptorInvocation {
+
+        @SuppressWarnings("rawtypes")
+        private final Interceptor interceptor;
+
+        private final Object interceptorInstance;
+
+        public InterceptorInvocation(Interceptor<?> interceptor, Object interceptorInstance) {
+            this.interceptor = interceptor;
+            this.interceptorInstance = interceptorInstance;
+        }
+
+        @SuppressWarnings("unchecked")
+        Object invoke(InvocationContext ctx) throws Exception {
+            return interceptor.intercept(InterceptionType.AROUND_INVOKE, interceptorInstance, ctx);
+        }
+
+    }
+
+}

--- a/client-apis/microprofile-restclient/src/main/java/org/wildfly/swarm/microprofile/restclient/ProxyInvocationHandler.java
+++ b/client-apis/microprofile-restclient/src/main/java/org/wildfly/swarm/microprofile/restclient/ProxyInvocationHandler.java
@@ -19,99 +19,156 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.CDI;
+import javax.enterprise.inject.spi.InterceptionType;
+import javax.enterprise.inject.spi.Interceptor;
 import javax.ws.rs.client.ResponseProcessingException;
 import javax.ws.rs.ext.ParamConverter;
 import javax.ws.rs.ext.ParamConverterProvider;
+
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.wildfly.swarm.microprofile.restclient.InvocationContextImpl.InterceptorInvocation;
 
 /**
  * Created by hbraun on 22.01.18.
  */
 class ProxyInvocationHandler implements InvocationHandler {
 
-    private Object target;
+    private final Object target;
 
-    private Set<Object> providerInstances;
+    private final Set<Object> providerInstances;
 
-    public ProxyInvocationHandler(Object target, Set<Object> providerInstances) {
+    private final Map<Method, List<InterceptorInvocation>> interceptorChains;
+
+    private final ResteasyClient client;
+
+    private final CreationalContext<?> creationalContext;
+
+    public ProxyInvocationHandler(Class<?> restClientInterface, Object target, Set<Object> providerInstances, ResteasyClient client) {
         this.target = target;
         this.providerInstances = providerInstances;
+        this.client = client;
+        BeanManager beanManager = getBeanManager();
+        if (beanManager != null) {
+            this.creationalContext = beanManager.createCreationalContext(null);
+            this.interceptorChains = initInterceptorChains(beanManager, creationalContext, restClientInterface);
+        } else {
+            this.creationalContext = null;
+            this.interceptorChains = Collections.emptyMap();
+        }
     }
 
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-        try {
 
-            boolean replacementNeeded = false;
-            Object[] argsReplacement = args != null ? new Object[args.length] : null;
-            Annotation[][] parameterAnnotations = method.getParameterAnnotations();
+        if (RestClientProxy.class.equals(method.getDeclaringClass())) {
+            return invokeRestClientProxyMethod(proxy, method, args);
+        }
 
-            for (Object p : providerInstances) {
-                if (p instanceof ParamConverterProvider) {
+        boolean replacementNeeded = false;
+        Object[] argsReplacement = args != null ? new Object[args.length] : null;
+        Annotation[][] parameterAnnotations = method.getParameterAnnotations();
 
-                    int index = 0;
-                    for (Object arg : args) {
+        for (Object p : providerInstances) {
+            if (p instanceof ParamConverterProvider) {
 
-                        if (parameterAnnotations[index].length > 0) { // does a parameter converter apply?
+                int index = 0;
+                for (Object arg : args) {
 
-                            ParamConverter<?> converter = ((ParamConverterProvider) p).getConverter(arg.getClass(), null, parameterAnnotations[index]);
-                            if (converter != null) {
-                                Type[] genericTypes = getGenericTypes(converter.getClass());
-                                if (genericTypes.length == 1) {
+                    if (parameterAnnotations[index].length > 0) { // does a parameter converter apply?
 
-                                    // minimum supported types
-                                    switch (genericTypes[0].getTypeName()) {
-                                        case "java.lang.String":
-                                            ParamConverter<String> stringConverter = (ParamConverter<String>) converter;
-                                            argsReplacement[index] = stringConverter.toString((String) arg);
-                                            replacementNeeded = true;
-                                            break;
-                                        case "java.lang.Integer":
-                                            ParamConverter<Integer> intConverter = (ParamConverter<Integer>) converter;
-                                            argsReplacement[index] = intConverter.toString((Integer) arg);
-                                            replacementNeeded = true;
-                                            break;
-                                        case "java.lang.Boolean":
-                                            ParamConverter<Boolean> boolConverter = (ParamConverter<Boolean>) converter;
-                                            argsReplacement[index] = boolConverter.toString((Boolean) arg);
-                                            replacementNeeded = true;
-                                            break;
-                                        default:
-                                            continue;
-                                    }
+                        ParamConverter<?> converter = ((ParamConverterProvider) p).getConverter(arg.getClass(), null, parameterAnnotations[index]);
+                        if (converter != null) {
+                            Type[] genericTypes = getGenericTypes(converter.getClass());
+                            if (genericTypes.length == 1) {
+
+                                // minimum supported types
+                                switch (genericTypes[0].getTypeName()) {
+                                    case "java.lang.String":
+                                        ParamConverter<String> stringConverter = (ParamConverter<String>) converter;
+                                        argsReplacement[index] = stringConverter.toString((String) arg);
+                                        replacementNeeded = true;
+                                        break;
+                                    case "java.lang.Integer":
+                                        ParamConverter<Integer> intConverter = (ParamConverter<Integer>) converter;
+                                        argsReplacement[index] = intConverter.toString((Integer) arg);
+                                        replacementNeeded = true;
+                                        break;
+                                    case "java.lang.Boolean":
+                                        ParamConverter<Boolean> boolConverter = (ParamConverter<Boolean>) converter;
+                                        argsReplacement[index] = boolConverter.toString((Boolean) arg);
+                                        replacementNeeded = true;
+                                        break;
+                                    default:
+                                        continue;
                                 }
                             }
-                        } else {
-                            argsReplacement[index] = arg;
                         }
-                        index++;
+                    } else {
+                        argsReplacement[index] = arg;
+                    }
+                    index++;
+                }
+            }
+        }
+
+        if (replacementNeeded) {
+            args = argsReplacement;
+        }
+
+        List<InterceptorInvocation> chain = interceptorChains.get(method);
+        if (chain != null) {
+            // Invoke business method interceptors
+            return new InvocationContextImpl(target, method, argsReplacement, chain).proceed();
+        } else {
+            try {
+                return method.invoke(target, args);
+            } catch (InvocationTargetException e) {
+                if (e.getCause() instanceof ResponseProcessingException) {
+                    ResponseProcessingException rpe = (ResponseProcessingException) e.getCause();
+                    Throwable cause = rpe.getCause();
+                    if (cause instanceof RuntimeException) {
+                        throw cause;
                     }
                 }
+                throw e;
             }
-
-
-            return  replacementNeeded ?
-                    method.invoke(target, argsReplacement) :
-                    method.invoke(target, args);
-
-        } catch (InvocationTargetException e) {
-
-            if (e.getCause() instanceof ResponseProcessingException) {
-                ResponseProcessingException rpe = (ResponseProcessingException) e.getCause();
-                Throwable cause = rpe.getCause();
-                if (cause instanceof RuntimeException) {
-                    throw cause;
-                }
-            }
-
-            throw e;
         }
     }
 
-    private Type[] getGenericTypes(Class aClass) {
+    private Object invokeRestClientProxyMethod(Object proxy, Method method, Object[] args) throws Throwable {
+        switch (method.getName()) {
+            case "getClient":
+                return client;
+            case "close":
+                close();
+                return null;
+            default:
+                throw new IllegalStateException("Unsupported RestClientProxy method: " + method);
+        }
+    }
+
+    private void close() {
+        if (creationalContext != null) {
+            creationalContext.release();
+        }
+        client.close();
+    }
+
+    private Type[] getGenericTypes(Class<?> aClass) {
         Type[] genericInterfaces = aClass.getGenericInterfaces();
         Type[] genericTypes = new Type[] {};
         for (Type genericInterface : genericInterfaces) {
@@ -121,4 +178,69 @@ class ProxyInvocationHandler implements InvocationHandler {
         }
         return genericTypes;
     }
+
+    private static List<Annotation> getBindings(Annotation[] annotations, BeanManager beanManager) {
+        if (annotations.length == 0) {
+            return Collections.emptyList();
+        }
+        List<Annotation> bindings = new ArrayList<>();
+        for (Annotation annotation : annotations) {
+            if (beanManager.isInterceptorBinding(annotation.annotationType())) {
+                bindings.add(annotation);
+            }
+        }
+        return bindings;
+    }
+
+    private static BeanManager getBeanManager() {
+        try {
+            return CDI.current().getBeanManager();
+        } catch (IllegalStateException e) {
+            return null;
+        }
+    }
+
+    private static Map<Method, List<InterceptorInvocation>> initInterceptorChains(BeanManager beanManager, CreationalContext<?> creationalContext, Class<?> restClientInterface) {
+
+        Map<Method, List<InterceptorInvocation>> chains = new HashMap<>();
+        // Interceptor as a key in a map is not entirely correct (custom interceptors) but should work in most cases
+        Map<Interceptor<?>, Object> interceptorInstances = new HashMap<>();
+
+        List<Annotation> classLevelBindings = getBindings(restClientInterface.getAnnotations(), beanManager);
+
+        for (Method method : restClientInterface.getMethods()) {
+            if (method.isDefault() || Modifier.isStatic(method.getModifiers())) {
+                continue;
+            }
+            List<Annotation> methodLevelBindings = getBindings(method.getAnnotations(), beanManager);
+
+            if (!classLevelBindings.isEmpty() || !methodLevelBindings.isEmpty()) {
+
+                Annotation[] interceptorBindings = merge(methodLevelBindings, classLevelBindings);
+
+                List<Interceptor<?>> interceptors = beanManager.resolveInterceptors(InterceptionType.AROUND_INVOKE, interceptorBindings);
+                if (!interceptors.isEmpty()) {
+                    List<InterceptorInvocation> chain = new ArrayList<>();
+                    for (Interceptor<?> interceptor : interceptors) {
+                        chain.add(new InterceptorInvocation(interceptor,
+                                interceptorInstances.computeIfAbsent(interceptor, i -> beanManager.getReference(i, i.getBeanClass(), creationalContext))));
+                    }
+                    chains.put(method, chain);
+                }
+            }
+        }
+        return chains.isEmpty() ? Collections.emptyMap() : chains;
+    }
+
+    private static Annotation[] merge(List<Annotation> methodLevelBindings, List<Annotation> classLevelBindings) {
+        Set<Class<? extends Annotation>> types = methodLevelBindings.stream().map(a -> a.annotationType()).collect(Collectors.toSet());
+        List<Annotation> merged = new ArrayList<>(methodLevelBindings);
+        for (Annotation annotation : classLevelBindings) {
+            if (!types.contains(annotation.annotationType())) {
+                merged.add(annotation);
+            }
+        }
+        return merged.toArray(new Annotation[] {});
+    }
+
 }

--- a/client-apis/microprofile-restclient/src/main/java/org/wildfly/swarm/microprofile/restclient/ProxyInvocationHandler.java
+++ b/client-apis/microprofile-restclient/src/main/java/org/wildfly/swarm/microprofile/restclient/ProxyInvocationHandler.java
@@ -141,7 +141,7 @@ class ProxyInvocationHandler implements InvocationHandler {
         List<InterceptorInvocation> chain = interceptorChains.get(method);
         if (chain != null) {
             // Invoke business method interceptors
-            return new InvocationContextImpl(target, method, argsReplacement, chain).proceed();
+            return new InvocationContextImpl(target, method, args, chain).proceed();
         } else {
             try {
                 return method.invoke(target, args);

--- a/client-apis/microprofile-restclient/src/main/java/org/wildfly/swarm/microprofile/restclient/RestClientProxy.java
+++ b/client-apis/microprofile-restclient/src/main/java/org/wildfly/swarm/microprofile/restclient/RestClientProxy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,24 @@
  */
 package org.wildfly.swarm.microprofile.restclient;
 
-import org.eclipse.microprofile.rest.client.RestClientBuilder;
-import org.eclipse.microprofile.rest.client.spi.RestClientBuilderResolver;
+import javax.ws.rs.client.Client;
 
 /**
- * Created by hbraun on 22.01.18.
+ * This interface is implemented by every proxy created by {@link RestClientBuilderImpl}.
+ *
+ * @author Martin Kouba
  */
-public class BuilderResolver extends RestClientBuilderResolver {
-    @Override
-    public RestClientBuilder newBuilder() {
-        return new RestClientBuilderImpl();
-    }
+public interface RestClientProxy {
+
+    /**
+     * Release/close all associated resources, including the underlying {@link Client} instance.
+     */
+    void close();
+
+    /**
+     *
+     * @return the underlying {@link Client} instance
+     */
+    Client getClient();
+
 }

--- a/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/HystrixCommandInterceptor.java
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/main/java/org/wildfly/swarm/microprofile/faulttolerance/deployment/HystrixCommandInterceptor.java
@@ -16,8 +16,11 @@
 
 package org.wildfly.swarm.microprofile.faulttolerance.deployment;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.PrivilegedActionException;
 import java.time.Duration;
@@ -396,8 +399,26 @@ public class HystrixCommandInterceptor {
             } else {
                 return () -> {
                     try {
-                        return fallbackMethod.invoke(ctx.getTarget(), ctx.getParameters());
-                    } catch (IllegalAccessException | InvocationTargetException e) {
+                        if (fallbackMethod.isDefault()) {
+                            // Workaround for default methods (used e.g. in MP Rest Client)
+                            Class<?> declaringClazz = fallbackMethod.getDeclaringClass();
+                            try {
+                                // First try java 8 hack
+                                Constructor<Lookup> constructor = Lookup.class.getDeclaredConstructor(Class.class);
+                                constructor.setAccessible(true);
+                                return constructor.newInstance(declaringClazz).in(declaringClazz).unreflectSpecial(fallbackMethod, declaringClazz).bindTo(ctx.getTarget())
+                                        .invokeWithArguments(ctx.getParameters());
+                            } catch (Exception e) {
+                                // Now let's try java 9 hack
+                                return MethodHandles.lookup()
+                                        .findSpecial(declaringClazz, fallbackMethod.getName(),
+                                                MethodType.methodType(fallbackMethod.getReturnType(), fallbackMethod.getParameterTypes()), declaringClazz)
+                                        .bindTo(ctx.getTarget()).invokeWithArguments(ctx.getParameters());
+                            }
+                        } else {
+                            return fallbackMethod.invoke(ctx.getTarget(), ctx.getParameters());
+                        }
+                    } catch (Throwable e) {
                         throw new FaultToleranceException("Error during fallback method invocation", e);
                     }
                 };

--- a/fractions/microprofile/microprofile-restclient/pom.xml
+++ b/fractions/microprofile/microprofile-restclient/pom.xml
@@ -101,7 +101,6 @@
       <scope>provided</scope>
     </dependency>
 
-
     <dependency>
       <groupId>org.wildfly.core</groupId>
       <artifactId>wildfly-core-feature-pack</artifactId>

--- a/fractions/microprofile/microprofile-restclient/src/main/resources/modules/org/wildfly/swarm/microprofile/restclient/impl/main/module.xml
+++ b/fractions/microprofile/microprofile-restclient/src/main/resources/modules/org/wildfly/swarm/microprofile/restclient/impl/main/module.xml
@@ -10,6 +10,7 @@
         <module name="javax.api"/>
         <module name="javax.annotation.api"/>
         <module name="org.wildfly.swarm.undertow" slot="main"/>
+        <module name="org.jboss.logging" slot="main"/>
         <module name="org.eclipse.microprofile.config.api" export="true"/>
         <module name="org.wildfly.extension.microprofile.config" export="true"/>
         <module name="org.eclipse.microprofile.restclient" export="true" services="import"/>

--- a/pom.xml
+++ b/pom.xml
@@ -1229,6 +1229,7 @@
         <module>testsuite/testsuite-jsf</module>
         <module>testsuite/testsuite-jsp</module>
         <module>testsuite/testsuite-microprofile-jwt</module>
+        <module>testsuite/testsuite-microprofile-restclient</module>
         <module>testsuite/testsuite-keycloak</module>
         <module>testsuite/testsuite-local-dependencies</module>
         <module>testsuite/testsuite-logging</module>

--- a/testsuite/testsuite-microprofile-restclient/pom.xml
+++ b/testsuite/testsuite-microprofile-restclient/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ~ Copyright 2015 Red Hat, Inc. and/or its affiliates. ~ ~ Licensed under
+   the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0 -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+   <modelVersion>4.0.0</modelVersion>
+
+   <parent>
+      <groupId>org.wildfly.swarm.testsuite</groupId>
+      <artifactId>testsuite-parent</artifactId>
+      <version>2018.6.0-SNAPSHOT</version>
+      <relativePath>../</relativePath>
+   </parent>
+
+   <artifactId>testsuite-microprofile-restclient</artifactId>
+   <name>Test Suite: MicroProfile Rest Client</name>
+
+   <dependencies>
+      <dependency>
+         <groupId>org.wildfly.swarm</groupId>
+         <artifactId>microprofile-restclient</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>org.wildfly.swarm</groupId>
+         <artifactId>arquillian</artifactId>
+         <scope>test</scope>
+      </dependency>
+      <!-- CDI interceptors -->
+      <dependency>
+         <groupId>org.wildfly.swarm</groupId>
+         <artifactId>microprofile-fault-tolerance</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+   </dependencies>
+
+</project>

--- a/testsuite/testsuite-microprofile-restclient/src/main/java/org/wildfly/swarm/microprofile/restclient/Counter.java
+++ b/testsuite/testsuite-microprofile-restclient/src/main/java/org/wildfly/swarm/microprofile/restclient/Counter.java
@@ -22,20 +22,30 @@ import javax.enterprise.context.ApplicationScoped;
 @ApplicationScoped
 public class Counter {
 
-    private volatile int max = Integer.MAX_VALUE;
+    private volatile int threshold = Integer.MAX_VALUE;
 
     private final AtomicInteger count = new AtomicInteger(0);
 
+    /**
+     * Increments the count and returns true if the threshold is reached.
+     *
+     * @return true if the threshold is reached
+     */
     public boolean incrementAndTest() {
-        return count.incrementAndGet() >= max;
+        return count.incrementAndGet() >= threshold;
     }
 
     int getCount() {
         return count.get();
     }
 
-    public void reset(int max) {
-        this.max = max;
+    /**
+     * Reset the counter. When the given threshold is reached {@link #incrementAndTest()} returns true.
+     *
+     * @param threshold
+     */
+    public void reset(int threshold) {
+        this.threshold = threshold;
         count.set(0);
     }
 

--- a/testsuite/testsuite-microprofile-restclient/src/main/java/org/wildfly/swarm/microprofile/restclient/Counter.java
+++ b/testsuite/testsuite-microprofile-restclient/src/main/java/org/wildfly/swarm/microprofile/restclient/Counter.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,28 @@
  */
 package org.wildfly.swarm.microprofile.restclient;
 
-import org.eclipse.microprofile.rest.client.RestClientBuilder;
-import org.eclipse.microprofile.rest.client.spi.RestClientBuilderResolver;
+import java.util.concurrent.atomic.AtomicInteger;
 
-/**
- * Created by hbraun on 22.01.18.
- */
-public class BuilderResolver extends RestClientBuilderResolver {
-    @Override
-    public RestClientBuilder newBuilder() {
-        return new RestClientBuilderImpl();
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class Counter {
+
+    private volatile int max = Integer.MAX_VALUE;
+
+    private final AtomicInteger count = new AtomicInteger(0);
+
+    public boolean incrementAndTest() {
+        return count.incrementAndGet() >= max;
     }
+
+    int getCount() {
+        return count.get();
+    }
+
+    public void reset(int max) {
+        this.max = max;
+        count.set(0);
+    }
+
 }

--- a/testsuite/testsuite-microprofile-restclient/src/main/java/org/wildfly/swarm/microprofile/restclient/HelloResource.java
+++ b/testsuite/testsuite-microprofile-restclient/src/main/java/org/wildfly/swarm/microprofile/restclient/HelloResource.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.restclient;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+
+@Path("/")
+public class HelloResource {
+
+    @Inject
+    private Counter counter;
+
+    @Inject
+    private Timer timer;
+
+    @GET
+    @Produces("text/plain")
+    @Path("/hello")
+    public String hello() {
+        timer.sleep();
+        if (counter.incrementAndTest()) {
+            return "OK" + counter.getCount();
+        } else {
+            throw new WebApplicationException(500);
+        }
+    }
+
+    @GET
+    @Produces("text/plain")
+    @Path("/helloBulk")
+    public String helloBulk() {
+        timer.sleep();
+        return "OK";
+    }
+}

--- a/testsuite/testsuite-microprofile-restclient/src/main/java/org/wildfly/swarm/microprofile/restclient/JaxRsActivator.java
+++ b/testsuite/testsuite-microprofile-restclient/src/main/java/org/wildfly/swarm/microprofile/restclient/JaxRsActivator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,9 @@
  */
 package org.wildfly.swarm.microprofile.restclient;
 
-import org.eclipse.microprofile.rest.client.RestClientBuilder;
-import org.eclipse.microprofile.rest.client.spi.RestClientBuilderResolver;
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
 
-/**
- * Created by hbraun on 22.01.18.
- */
-public class BuilderResolver extends RestClientBuilderResolver {
-    @Override
-    public RestClientBuilder newBuilder() {
-        return new RestClientBuilderImpl();
-    }
+@ApplicationPath("/v1")
+public class JaxRsActivator extends Application {
 }

--- a/testsuite/testsuite-microprofile-restclient/src/main/java/org/wildfly/swarm/microprofile/restclient/Latch.java
+++ b/testsuite/testsuite-microprofile-restclient/src/main/java/org/wildfly/swarm/microprofile/restclient/Latch.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.restclient;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class Latch {
+
+    private static final String DEFAULT_NAME = "default";
+
+    private final Map<String, CountDownLatch> latches = new ConcurrentHashMap<>();
+
+    public void countDown(String name) {
+        CountDownLatch latch = latches.get(name);
+        if (latch != null) {
+            latch.countDown();
+        }
+    }
+
+    public void countDown() {
+        countDown(DEFAULT_NAME);
+    }
+
+    public boolean await(String name) throws InterruptedException {
+        CountDownLatch latch = latches.get(name);
+        return latch != null ? latch.await(30, TimeUnit.SECONDS) : false;
+    }
+
+    public boolean await() throws InterruptedException {
+        return await(DEFAULT_NAME);
+    }
+
+    public void add(String name, int value) {
+        latches.put(name, new CountDownLatch(value));
+    }
+
+    public void reset(int value) {
+        latches.clear();
+        add(DEFAULT_NAME, value);
+    }
+
+}

--- a/testsuite/testsuite-microprofile-restclient/src/main/java/org/wildfly/swarm/microprofile/restclient/SilentExceptionMapper.java
+++ b/testsuite/testsuite-microprofile-restclient/src/main/java/org/wildfly/swarm/microprofile/restclient/SilentExceptionMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,16 @@
  */
 package org.wildfly.swarm.microprofile.restclient;
 
-import org.eclipse.microprofile.rest.client.RestClientBuilder;
-import org.eclipse.microprofile.rest.client.spi.RestClientBuilderResolver;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
 
-/**
- * Created by hbraun on 22.01.18.
- */
-public class BuilderResolver extends RestClientBuilderResolver {
+@Provider
+public class SilentExceptionMapper implements ExceptionMapper<WebApplicationException> {
+
     @Override
-    public RestClientBuilder newBuilder() {
-        return new RestClientBuilderImpl();
+    public Response toResponse(WebApplicationException exception) {
+        return Response.status(exception.getResponse().getStatus()).build();
     }
 }

--- a/testsuite/testsuite-microprofile-restclient/src/main/java/org/wildfly/swarm/microprofile/restclient/Timer.java
+++ b/testsuite/testsuite-microprofile-restclient/src/main/java/org/wildfly/swarm/microprofile/restclient/Timer.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,27 @@
  */
 package org.wildfly.swarm.microprofile.restclient;
 
-import org.eclipse.microprofile.rest.client.RestClientBuilder;
-import org.eclipse.microprofile.rest.client.spi.RestClientBuilderResolver;
+import java.util.concurrent.TimeUnit;
 
-/**
- * Created by hbraun on 22.01.18.
- */
-public class BuilderResolver extends RestClientBuilderResolver {
-    @Override
-    public RestClientBuilder newBuilder() {
-        return new RestClientBuilderImpl();
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class Timer {
+
+    private volatile int value = 0;
+
+    public void sleep() {
+        if (value > 0) {
+            try {
+                TimeUnit.MILLISECONDS.sleep(value);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
+
+    public void reset(int value) {
+        this.value = value;
+    }
+
 }

--- a/testsuite/testsuite-microprofile-restclient/src/main/webapp/WEB-INF/web.xml
+++ b/testsuite/testsuite-microprofile-restclient/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
+
+</web-app>

--- a/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/ft/DummyFallbackHandler.java
+++ b/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/ft/DummyFallbackHandler.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.swarm.microprofile.restclient;
+package org.wildfly.swarm.microprofile.restclient.ft;
 
-import org.eclipse.microprofile.rest.client.RestClientBuilder;
-import org.eclipse.microprofile.rest.client.spi.RestClientBuilderResolver;
+import org.eclipse.microprofile.faulttolerance.ExecutionContext;
+import org.eclipse.microprofile.faulttolerance.FallbackHandler;
 
-/**
- * Created by hbraun on 22.01.18.
- */
-public class BuilderResolver extends RestClientBuilderResolver {
+public class DummyFallbackHandler implements FallbackHandler<String> {
+
     @Override
-    public RestClientBuilder newBuilder() {
-        return new RestClientBuilderImpl();
+    public String handle(ExecutionContext context) {
+        return "fallback";
     }
+
 }

--- a/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/ft/FaultToleranceTest.java
+++ b/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/ft/FaultToleranceTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.restclient.ft;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import javax.inject.Inject;
+import javax.ws.rs.WebApplicationException;
+
+import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
+import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.RestClientDefinitionException;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.microprofile.restclient.Counter;
+import org.wildfly.swarm.microprofile.restclient.HelloResource;
+import org.wildfly.swarm.microprofile.restclient.Timer;
+
+/**
+ *
+ * @author Martin Kouba
+ */
+@RunWith(Arquillian.class)
+public class FaultToleranceTest {
+
+    static final int BULKHEAD = 2;
+
+    @Inject
+    Counter counter;
+
+    @Inject
+    Timer timer;
+
+    @ArquillianResource
+    URL url;
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return ShrinkWrap.create(WebArchive.class).addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml").addPackage(HelloResource.class.getPackage())
+                .addPackage(FaultToleranceTest.class.getPackage());
+    }
+
+    @Test
+    public void testRetry() throws InterruptedException, IllegalStateException, RestClientDefinitionException, MalformedURLException {
+        counter.reset(3);
+        timer.reset(0);
+
+        HelloClient helloClient = RestClientBuilder.newBuilder().baseUrl(url).build(HelloClient.class);
+
+        assertEquals("OK3", helloClient.helloRetry());
+    }
+
+    @Test
+    public void testFallback() throws InterruptedException, IllegalStateException, RestClientDefinitionException, MalformedURLException {
+        HelloClient helloClient = RestClientBuilder.newBuilder().baseUrl(url).build(HelloClient.class);
+
+        timer.reset(0);
+
+        counter.reset(3);
+        assertEquals("fallback", helloClient.helloFallback());
+
+        counter.reset(3);
+        assertEquals("defaultFallback", helloClient.helloFallbackDefaultMethod());
+    }
+
+    @Test
+    public void testCircuitBreaker() throws InterruptedException, IllegalStateException, RestClientDefinitionException, MalformedURLException {
+        HelloClient helloClient = RestClientBuilder.newBuilder().baseUrl(url).build(HelloClient.class);
+
+        counter.reset(3);
+        timer.reset(0);
+
+        try {
+            helloClient.helloCircuitBreaker();
+            fail();
+        } catch (WebApplicationException expected) {
+        }
+        try {
+            helloClient.helloCircuitBreaker();
+            fail();
+        } catch (WebApplicationException expected) {
+        }
+        try {
+            helloClient.helloCircuitBreaker();
+            fail();
+        } catch (CircuitBreakerOpenException expected) {
+        }
+    }
+
+    @Test
+    public void testCircuitBreakerClassLevel() throws InterruptedException, IllegalStateException, RestClientDefinitionException, MalformedURLException {
+        HelloClientClassLevelCircuitBreaker client = RestClientBuilder.newBuilder().baseUrl(url).build(HelloClientClassLevelCircuitBreaker.class);
+
+        counter.reset(3);
+        timer.reset(0);
+
+        try {
+            client.helloCircuitBreaker();
+            fail();
+        } catch (WebApplicationException expected) {
+        }
+        try {
+            client.helloCircuitBreaker();
+            fail();
+        } catch (WebApplicationException expected) {
+        }
+        try {
+            client.helloCircuitBreaker();
+            fail();
+        } catch (CircuitBreakerOpenException expected) {
+        }
+    }
+
+    @Test
+    public void testTimeout() throws InterruptedException, IllegalStateException, RestClientDefinitionException, MalformedURLException {
+        HelloClient helloClient = RestClientBuilder.newBuilder().baseUrl(url).build(HelloClient.class);
+
+        counter.reset(1);
+        timer.reset(400);
+        try {
+            helloClient.helloTimeout();
+            fail();
+        } catch (TimeoutException expected) {
+        }
+    }
+
+    @Test
+    public void testBulkhead() throws InterruptedException, IllegalStateException, RestClientDefinitionException, MalformedURLException, ExecutionException {
+
+        timer.reset(400);
+
+        int pool = BULKHEAD + 1;
+        ExecutorService executor = Executors.newFixedThreadPool(pool);
+        try {
+            HelloClient helloClient = RestClientBuilder.newBuilder().baseUrl(url).property("resteasy.connectionPoolSize", pool * 2).build(HelloClient.class);
+
+            List<Callable<String>> tasks = new ArrayList<>();
+            for (int i = 0; i < pool; i++) {
+                tasks.add(() -> helloClient.helloBulkhead());
+            }
+            List<Future<String>> futures = executor.invokeAll(tasks);
+            List<String> results = new ArrayList<>();
+            for (Future<String> future : futures) {
+                results.add(future.get());
+            }
+            assertTrue(results.remove("defaultFallback"));
+            assertTrue(results.remove("OK"));
+            assertTrue(results.remove("OK"));
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+}

--- a/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/ft/HelloClient.java
+++ b/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/ft/HelloClient.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.restclient.ft;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.faulttolerance.Bulkhead;
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.faulttolerance.Timeout;
+
+@Path("/v1")
+public interface HelloClient {
+
+    @Retry(maxRetries = 4)
+    @GET
+    @Path("/hello")
+    String helloRetry();
+
+    @Fallback(DummyFallbackHandler.class)
+    @GET
+    @Path("/hello")
+    String helloFallback();
+
+    @Fallback(fallbackMethod = "fallback")
+    @GET
+    @Path("/hello")
+    String helloFallbackDefaultMethod();
+
+    @GET // resteasy client proxies do not ignore default methods, see also RESTEASY-798 fixed in 3.5.1.Final
+    default String fallback() {
+        return "defaultFallback";
+    }
+
+    // Circuit should be open after 2 requests
+    @CircuitBreaker(requestVolumeThreshold = 2)
+    @GET
+    @Path("/hello")
+    String helloCircuitBreaker();
+
+    @Timeout(200)
+    @GET
+    @Path("/hello")
+    String helloTimeout();
+
+    // Note that bulkhead does not make sense without ResteasyClientBuilder.connectionPoolSize()
+    @Bulkhead(FaultToleranceTest.BULKHEAD)
+    @Fallback(fallbackMethod = "fallback")
+    @GET
+    @Path("/helloBulk")
+    String helloBulkhead();
+
+
+}

--- a/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/ft/HelloClient.java
+++ b/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/ft/HelloClient.java
@@ -17,6 +17,7 @@ package org.wildfly.swarm.microprofile.restclient.ft;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
 
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
@@ -60,10 +61,14 @@ public interface HelloClient {
 
     // Note that bulkhead does not make sense without ResteasyClientBuilder.connectionPoolSize()
     @Bulkhead(FaultToleranceTest.BULKHEAD)
-    @Fallback(fallbackMethod = "fallback")
+    @Fallback(fallbackMethod = "bulkheadFallback")
     @GET
     @Path("/helloBulk")
-    String helloBulkhead();
+    String helloBulkhead(@QueryParam("wait") boolean wait);
 
+    @GET // resteasy client proxies do not ignore default methods, see also RESTEASY-798 fixed in 3.5.1.Final
+    default String bulkheadFallback(boolean wait) {
+        return "bulkheadFallback";
+    }
 
 }

--- a/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/ft/HelloClientClassLevelCircuitBreaker.java
+++ b/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/ft/HelloClientClassLevelCircuitBreaker.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.swarm.microprofile.restclient;
+package org.wildfly.swarm.microprofile.restclient.ft;
 
-import org.eclipse.microprofile.rest.client.RestClientBuilder;
-import org.eclipse.microprofile.rest.client.spi.RestClientBuilderResolver;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
 
-/**
- * Created by hbraun on 22.01.18.
- */
-public class BuilderResolver extends RestClientBuilderResolver {
-    @Override
-    public RestClientBuilder newBuilder() {
-        return new RestClientBuilderImpl();
-    }
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+
+// Circuit should be open after 2 requests
+@CircuitBreaker(requestVolumeThreshold = 2)
+@Path("/v1")
+public interface HelloClientClassLevelCircuitBreaker {
+
+    @GET
+    @Path("/hello")
+    String helloCircuitBreaker();
+
 }

--- a/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/interceptor/AlphaInterceptor.java
+++ b/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/interceptor/AlphaInterceptor.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.swarm.microprofile.restclient;
+package org.wildfly.swarm.microprofile.restclient.interceptor;
 
-import org.eclipse.microprofile.rest.client.RestClientBuilder;
-import org.eclipse.microprofile.rest.client.spi.RestClientBuilderResolver;
+import javax.annotation.Priority;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
 
-/**
- * Created by hbraun on 22.01.18.
- */
-public class BuilderResolver extends RestClientBuilderResolver {
-    @Override
-    public RestClientBuilder newBuilder() {
-        return new RestClientBuilderImpl();
+@SuperBinding
+@Priority(10)
+@Interceptor
+public class AlphaInterceptor {
+
+    @AroundInvoke
+    public Object aroundInvoke(InvocationContext ctx) throws Exception {
+        return "A:" + ctx.proceed() + ":A";
     }
 }

--- a/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/interceptor/BravoInterceptor.java
+++ b/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/interceptor/BravoInterceptor.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.swarm.microprofile.restclient;
+package org.wildfly.swarm.microprofile.restclient.interceptor;
 
-import org.eclipse.microprofile.rest.client.RestClientBuilder;
-import org.eclipse.microprofile.rest.client.spi.RestClientBuilderResolver;
+import javax.annotation.Priority;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
 
-/**
- * Created by hbraun on 22.01.18.
- */
-public class BuilderResolver extends RestClientBuilderResolver {
-    @Override
-    public RestClientBuilder newBuilder() {
-        return new RestClientBuilderImpl();
+@SuperBinding
+@Priority(1000)
+@Interceptor
+public class BravoInterceptor {
+
+    @AroundInvoke
+    public Object aroundInvoke(InvocationContext ctx) throws Exception {
+        return "B:" + ctx.proceed() + ":B";
     }
 }

--- a/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/interceptor/CharlieInterceptor.java
+++ b/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/interceptor/CharlieInterceptor.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.swarm.microprofile.restclient;
+package org.wildfly.swarm.microprofile.restclient.interceptor;
 
-import org.eclipse.microprofile.rest.client.RestClientBuilder;
-import org.eclipse.microprofile.rest.client.spi.RestClientBuilderResolver;
+import javax.annotation.Priority;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
 
-/**
- * Created by hbraun on 22.01.18.
- */
-public class BuilderResolver extends RestClientBuilderResolver {
-    @Override
-    public RestClientBuilder newBuilder() {
-        return new RestClientBuilderImpl();
+@SuperBinding
+@Priority(1)
+@Interceptor
+public class CharlieInterceptor {
+
+    @AroundInvoke
+    public Object aroundInvoke(InvocationContext ctx) throws Exception {
+        return "C:" + ctx.proceed() + ":C";
     }
 }

--- a/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/interceptor/HelloClient.java
+++ b/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/interceptor/HelloClient.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.swarm.microprofile.restclient;
+package org.wildfly.swarm.microprofile.restclient.interceptor;
 
-import org.eclipse.microprofile.rest.client.RestClientBuilder;
-import org.eclipse.microprofile.rest.client.spi.RestClientBuilderResolver;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
 
-/**
- * Created by hbraun on 22.01.18.
- */
-public class BuilderResolver extends RestClientBuilderResolver {
-    @Override
-    public RestClientBuilder newBuilder() {
-        return new RestClientBuilderImpl();
-    }
+@Path("/v1")
+public interface HelloClient {
+
+    @SuperBinding
+    @GET
+    @Path("/hello")
+    String hello();
+
 }

--- a/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/interceptor/InterceptorTest.java
+++ b/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/interceptor/InterceptorTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.restclient.interceptor;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.RestClientDefinitionException;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.microprofile.restclient.Counter;
+import org.wildfly.swarm.microprofile.restclient.HelloResource;
+
+/**
+ *
+ * @author Martin Kouba
+ */
+@RunWith(Arquillian.class)
+public class InterceptorTest {
+
+    @Inject
+    Counter counter;
+
+    @ArquillianResource
+    URL url;
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return ShrinkWrap.create(WebArchive.class).addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml").addPackage(HelloResource.class.getPackage())
+                .addPackage(InterceptorTest.class.getPackage());
+    }
+
+    @Test
+    public void testInterception() throws InterruptedException, IllegalStateException, RestClientDefinitionException, MalformedURLException {
+        counter.reset(1);
+
+        HelloClient helloClient = RestClientBuilder.newBuilder().baseUrl(url).build(HelloClient.class);
+
+        // Interceptor ordering should be: Charlie, Alpha, Bravo
+        assertEquals("C:A:B:OK1:B:A:C", helloClient.hello());
+    }
+
+}

--- a/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/interceptor/SuperBinding.java
+++ b/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/interceptor/SuperBinding.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.restclient.interceptor;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.interceptor.InterceptorBinding;
+
+@Target({ TYPE, METHOD })
+@Retention(RUNTIME)
+@Documented
+@Inherited
+@InterceptorBinding
+public @interface SuperBinding {
+}

--- a/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/proxy/CharlieInterceptor.java
+++ b/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/proxy/CharlieInterceptor.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.restclient.proxy;
+
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+@SuperBinding
+@Priority(1)
+@Interceptor
+public class CharlieInterceptor {
+
+    @Inject
+    CharlieService service;
+
+    @AroundInvoke
+    public Object aroundInvoke(InvocationContext ctx) throws Exception {
+        return service.getChar() + ":" + ctx.proceed() + ":" + service.getChar();
+    }
+}

--- a/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/proxy/CharlieService.java
+++ b/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/proxy/CharlieService.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.restclient.proxy;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.Dependent;
+
+@Dependent
+public class CharlieService {
+
+    static final AtomicBoolean DESTROYED = new AtomicBoolean();
+
+    @PostConstruct
+    void init() {
+        DESTROYED.set(false);
+    }
+
+    @PreDestroy
+    void destroy() {
+        DESTROYED.set(true);
+    }
+
+    String getChar() {
+        return "C";
+    }
+
+}

--- a/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/proxy/HelloClient.java
+++ b/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/proxy/HelloClient.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.swarm.microprofile.restclient;
+package org.wildfly.swarm.microprofile.restclient.proxy;
 
-import org.eclipse.microprofile.rest.client.RestClientBuilder;
-import org.eclipse.microprofile.rest.client.spi.RestClientBuilderResolver;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
 
-/**
- * Created by hbraun on 22.01.18.
- */
-public class BuilderResolver extends RestClientBuilderResolver {
-    @Override
-    public RestClientBuilder newBuilder() {
-        return new RestClientBuilderImpl();
-    }
+@Path("/v1")
+public interface HelloClient {
+
+    @SuperBinding
+    @GET
+    @Path("/hello")
+    String hello();
+
 }

--- a/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/proxy/RestClientProxyTest.java
+++ b/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/proxy/RestClientProxyTest.java
@@ -18,6 +18,7 @@ package org.wildfly.swarm.microprofile.restclient.proxy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -80,6 +81,14 @@ public class RestClientProxyTest {
         assertEquals("C:OK1:C", helloClient.hello());
         clientProxy.close();
         assertTrue(CharlieService.DESTROYED.get());
+        // Further calls are no-op
+        clientProxy.close();
+        // Invoking any method on the client proxy should result in ISE
+        try {
+            helloClient.hello();
+            fail();
+        } catch (IllegalStateException expected) {
+        }
     }
 
 }

--- a/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/proxy/RestClientProxyTest.java
+++ b/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/proxy/RestClientProxyTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.restclient.proxy;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import javax.inject.Inject;
+import javax.ws.rs.client.Client;
+
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.RestClientDefinitionException;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.microprofile.restclient.Counter;
+import org.wildfly.swarm.microprofile.restclient.HelloResource;
+import org.wildfly.swarm.microprofile.restclient.RestClientProxy;
+
+/**
+ *
+ * @author Martin Kouba
+ */
+@RunWith(Arquillian.class)
+public class RestClientProxyTest {
+
+    @Inject
+    Counter counter;
+
+    @ArquillianResource
+    URL url;
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return ShrinkWrap.create(WebArchive.class).addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml").addPackage(HelloResource.class.getPackage())
+                .addPackage(RestClientProxyTest.class.getPackage());
+    }
+
+    @Test
+    public void testGetClient() throws InterruptedException, IllegalStateException, RestClientDefinitionException, MalformedURLException {
+        counter.reset(1);
+
+        HelloClient helloClient = RestClientBuilder.newBuilder().baseUrl(url).build(HelloClient.class);
+
+        Client client = ((RestClientProxy) helloClient).getClient();
+        assertNotNull(client);
+        assertEquals("C:OK1:C", helloClient.hello());
+        client.close();
+    }
+
+    @Test
+    public void testClose() throws InterruptedException, IllegalStateException, RestClientDefinitionException, MalformedURLException {
+        counter.reset(1);
+
+        HelloClient helloClient = RestClientBuilder.newBuilder().baseUrl(url).build(HelloClient.class);
+
+        RestClientProxy clientProxy = (RestClientProxy) helloClient;
+        assertEquals("C:OK1:C", helloClient.hello());
+        clientProxy.close();
+        assertTrue(CharlieService.DESTROYED.get());
+    }
+
+}

--- a/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/proxy/SuperBinding.java
+++ b/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/proxy/SuperBinding.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.restclient.proxy;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.interceptor.InterceptorBinding;
+
+@Target({ TYPE, METHOD })
+@Retention(RUNTIME)
+@Documented
+@Inherited
+@InterceptorBinding
+public @interface SuperBinding {
+}


### PR DESCRIPTION
Motivation
----------
It would be useful to support CDI interceptors on MP rest client
proxies. The primary use case is to support MP FT annotations on rest
client interfaces.

Modifications
-------------
ProxyInvocationHandler invokes interceptor chains (if present). Every
proxy client now implements RestClientProxy so that it is possible to
access/close the unerlying client instance. It is also possible to
configure some of the ResteasyClientBuilder delegate properties using
RestClientBuilder#property().

Result
------
CDI interceptors can be bound to a rest client proxy using interceptor
bindings. MP FT annotations are supported and tested, except for
@Asynchronous - resteasy client proxy framework does not support async
return types.