### PR TITLE
THORN-2036: Added autodetect for MicroProfile Metrics, OpenApi and Re…

### DIFF
--- a/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/detect/MetricsPackageDetector.java
+++ b/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/detect/MetricsPackageDetector.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.metrics.detect;
+
+import org.wildfly.swarm.spi.meta.PackageFractionDetector;
+
+/**
+ * @author Phillip Kruger
+ */
+public class MetricsPackageDetector extends PackageFractionDetector {
+
+    public MetricsPackageDetector() {
+        anyPackageOf("org.eclipse.microprofile.metrics");
+    }
+
+    @Override
+    public String artifactId() {
+        return "microprofile-metrics";
+    }
+}

--- a/fractions/microprofile/microprofile-openapi/src/main/java/org/wildfly/swarm/microprofile/openapi/detect/OpenApiPackageDetector.java
+++ b/fractions/microprofile/microprofile-openapi/src/main/java/org/wildfly/swarm/microprofile/openapi/detect/OpenApiPackageDetector.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.openapi.detect;
+
+import org.wildfly.swarm.spi.meta.PackageFractionDetector;
+
+/**
+ * @author Phillip Kruger
+ */
+public class OpenApiPackageDetector extends PackageFractionDetector {
+
+    public OpenApiPackageDetector() {
+        anyPackageOf("org.eclipse.microprofile.openapi");
+    }
+
+    @Override
+    public String artifactId() {
+        return "microprofile-openapi";
+    }
+}

--- a/fractions/microprofile/microprofile-restclient/src/main/java/org/wildfly/swarm/microprofile/restclient/detect/RestClientPackageDetector.java
+++ b/fractions/microprofile/microprofile-restclient/src/main/java/org/wildfly/swarm/microprofile/restclient/detect/RestClientPackageDetector.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.restclient.detect;
+
+import org.wildfly.swarm.spi.meta.PackageFractionDetector;
+
+/**
+ * @author Phillip Kruger
+ */
+public class RestClientPackageDetector extends PackageFractionDetector {
+
+    public RestClientPackageDetector() {
+        anyPackageOf("org.eclipse.microprofile.rest.client");
+    }
+
+    @Override
+    public String artifactId() {
+        return "microprofile-restclient";
+    }
+}


### PR DESCRIPTION
…stClient

Motivation
----------
All MicroProfile APIs should work the same way. Adding autodetect for the APIs that does not have it.

Modifications
-------------
Added a detect package and a class that extends PackageFractionDetector for Metrics, OpenApi and RestClient

Result
------
When building a fat or hollow jar, the build will include the Metrics, OpenApi and RestClient fractions if your code use it.

Changes to be committed:
	new file:   fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/detect/MetricsPackageDetector.java
	new file:   fractions/microprofile/microprofile-openapi/src/main/java/org/wildfly/swarm/microprofile/openapi/detect/OpenApiPackageDetector.java
	new file:   fractions/microprofile/microprofile-restclient/src/main/java/org/wildfly/swarm/microprofile/restclient/detect/RestClientPackageDetector.java

- [yes] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [yes] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [yes] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [yes] Have you built the project locally prior to submission with `mvn clean install`?

-----
