### PR TITLE
ENTSWM-453: Fixed wording in pre-built hollow JARs section

### DIFF
--- a/docs/concepts/packaging-types.adoc
+++ b/docs/concepts/packaging-types.adoc
@@ -57,8 +57,10 @@ $ java -jar myapp-hollow-swarm.jar myapp.war
 
 {Thorntail} ships the following pre-built hollow JARs:
 
-ifndef::product[full:: The main Java EE related capabilities]
-web:: A smaller functional scope, focused on web technologies
+ifndef::product[]
+full:: The main Java EE related capabilities
+endif::[]
+web:: Functionality focused on web technologies
 microprofile:: Functionality defined by all Eclipse MicroProfile specifications
 
 The hollow JARs are available under the following coordinates:


### PR DESCRIPTION
Expanded the ifdef statement above to make sure the document is compatible with older Asciidoctor versions

Resolves ENTSWM-453

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/SWARM) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

This issue mainly affects the product build of the documentation.