### PR TITLE
add initial HibernateSearch support, closes #936

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -572,6 +572,11 @@
       </dependency>
       <dependency>
         <groupId>io.thorntail</groupId>
+        <artifactId>thorntail-hibernate-search</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.thorntail</groupId>
         <artifactId>thorntail-ogm</artifactId>
         <version>4.0.0-SNAPSHOT</version>
       </dependency>

--- a/core/hibernate-search/pom.xml
+++ b/core/hibernate-search/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.thorntail</groupId>
+    <artifactId>thorntail-core-parent</artifactId>
+    <version>4.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>thorntail-hibernate-search</artifactId>
+  <name>Hibernate Search</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.thorntail</groupId>
+      <artifactId>thorntail-jpa-support</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-search-orm</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/core/hibernate-search/src/main/java/io/thorntail/hibernate_search/EntityManagerContext.java
+++ b/core/hibernate-search/src/main/java/io/thorntail/hibernate_search/EntityManagerContext.java
@@ -1,0 +1,18 @@
+package io.thorntail.hibernate_search;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.enterprise.util.Nonbinding;
+import javax.inject.Qualifier;
+
+/**
+ * @author kg6zvp
+ */
+@Qualifier
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EntityManagerContext {
+    @Nonbinding String value() default "";
+}

--- a/core/hibernate-search/src/main/java/io/thorntail/hibernate_search/MissingQueryBuilderContextException.java
+++ b/core/hibernate-search/src/main/java/io/thorntail/hibernate_search/MissingQueryBuilderContextException.java
@@ -1,0 +1,10 @@
+package io.thorntail.hibernate_search;
+
+/**
+ * @author kg6zvp
+ */
+public class MissingQueryBuilderContextException extends Exception {
+    public MissingQueryBuilderContextException(String msg) {
+        super(msg);
+    }
+}

--- a/core/hibernate-search/src/main/java/io/thorntail/hibernate_search/QueryBuilderContext.java
+++ b/core/hibernate-search/src/main/java/io/thorntail/hibernate_search/QueryBuilderContext.java
@@ -1,0 +1,19 @@
+package io.thorntail.hibernate_search;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.enterprise.util.Nonbinding;
+import javax.inject.Qualifier;
+
+/**
+ * @author kg6zvp
+ */
+@Qualifier
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface QueryBuilderContext {
+    @Nonbinding Class<?> value();
+    @Nonbinding String persistenceUnit() default "";
+}

--- a/core/hibernate-search/src/main/java/io/thorntail/hibernate_search/impl/EntityManagerFactory.java
+++ b/core/hibernate-search/src/main/java/io/thorntail/hibernate_search/impl/EntityManagerFactory.java
@@ -1,0 +1,32 @@
+package io.thorntail.hibernate_search.impl;
+
+import io.thorntail.hibernate_search.EntityManagerContext;
+import javax.enterprise.inject.Disposes;
+import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.spi.InjectionPoint;
+import org.hibernate.search.jpa.FullTextEntityManager;
+
+/**
+ * @author kg6zvp
+ */
+public class EntityManagerFactory {
+    @Produces
+    @EntityManagerContext
+    public FullTextEntityManager getFullTextEntityManager(InjectionPoint ip) {
+        EntityManagerContext ctx = InjectionPointUtils.getAnnotation(ip, EntityManagerContext.class);
+        return EntityManagerUtils.getFullTextEntityManager(ctx.value());
+    }
+
+    @Produces
+    public FullTextEntityManager getFullTextEntityManager() {
+        return EntityManagerUtils.getFullTextEntityManager("");
+    }
+
+    public void discardFullTextEntityManager(@Disposes FullTextEntityManager em) {
+        em.close();
+    }
+
+    public void discardQualifiedFullTextEntityManager(@Disposes @EntityManagerContext FullTextEntityManager em) {
+        em.close();
+    }
+}

--- a/core/hibernate-search/src/main/java/io/thorntail/hibernate_search/impl/EntityManagerUtils.java
+++ b/core/hibernate-search/src/main/java/io/thorntail/hibernate_search/impl/EntityManagerUtils.java
@@ -1,0 +1,14 @@
+package io.thorntail.hibernate_search.impl;
+
+import io.thorntail.jpa.impl.JpaServices;
+import org.hibernate.search.jpa.FullTextEntityManager;
+import org.hibernate.search.jpa.Search;
+
+/**
+ * @author kg6zvp
+ */
+public class EntityManagerUtils {
+    static FullTextEntityManager getFullTextEntityManager(String puName) {
+        return Search.getFullTextEntityManager(JpaServices.getEntityManagerFactory(JpaServices.getScopedPuName(puName)).createResource().getInstance().createEntityManager());
+    }
+}

--- a/core/hibernate-search/src/main/java/io/thorntail/hibernate_search/impl/HibernateSearchExtension.java
+++ b/core/hibernate-search/src/main/java/io/thorntail/hibernate_search/impl/HibernateSearchExtension.java
@@ -1,0 +1,23 @@
+package io.thorntail.hibernate_search.impl;
+
+import io.thorntail.hibernate_search.MissingQueryBuilderContextException;
+import io.thorntail.hibernate_search.QueryBuilderContext;
+import static io.thorntail.hibernate_search.impl.InjectionPointUtils.getAnnotation;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.ProcessInjectionPoint;
+import org.hibernate.search.query.dsl.QueryBuilder;
+
+/**
+ * @author kg6zvp
+ */
+public class HibernateSearchExtension implements Extension {
+    public void processQueryBuilderInjectionPoint(@Observes ProcessInjectionPoint pip) {
+        if (!QueryBuilder.class.equals(pip.getInjectionPoint().getType()))
+            return;
+        QueryBuilderContext qc = getAnnotation(pip.getInjectionPoint(), QueryBuilderContext.class);
+        if (qc == null) {
+            pip.addDefinitionError(HibernateSearchMessages.MESSAGES.missingContextAnnotation(pip.getInjectionPoint().getMember()));
+        }
+    }
+}

--- a/core/hibernate-search/src/main/java/io/thorntail/hibernate_search/impl/HibernateSearchMessages.java
+++ b/core/hibernate-search/src/main/java/io/thorntail/hibernate_search/impl/HibernateSearchMessages.java
@@ -1,0 +1,23 @@
+package io.thorntail.hibernate_search.impl;
+
+import io.thorntail.hibernate_search.MissingQueryBuilderContextException;
+import io.thorntail.logging.impl.LoggingUtil;
+import static io.thorntail.logging.impl.LoggingUtil.CODE;
+import static io.thorntail.logging.impl.MessageOffsets.HIBERNATE_SEARCH_OFFSET;
+import java.lang.reflect.Member;
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
+
+/**
+ *
+ * @author smccollum
+ */
+@MessageLogger(projectCode = CODE, length = 6)
+public interface HibernateSearchMessages extends BasicLogger {
+    HibernateSearchMessages MESSAGES = Logger.getMessageLogger(HibernateSearchMessages.class, LoggingUtil.loggerCategory("hibernate-search"));
+
+    @Message(id = 0 + HIBERNATE_SEARCH_OFFSET, value = "Annotation io.thorntail.hibernate_search.QueryBuilderContext is required to inject org.hibernate.search.query.dsl.QueryBuilder, not found on %s")
+    MissingQueryBuilderContextException missingContextAnnotation(Member member);
+}

--- a/core/hibernate-search/src/main/java/io/thorntail/hibernate_search/impl/InjectionPointUtils.java
+++ b/core/hibernate-search/src/main/java/io/thorntail/hibernate_search/impl/InjectionPointUtils.java
@@ -1,0 +1,18 @@
+package io.thorntail.hibernate_search.impl;
+
+import java.lang.annotation.Annotation;
+import javax.enterprise.inject.spi.InjectionPoint;
+
+/**
+ * @author kg6zvp
+ */
+public class InjectionPointUtils {
+    public static <T extends Annotation> T getAnnotation(InjectionPoint ip, Class<T> annotationClass) {
+        for (Annotation a : ip.getQualifiers()) {
+            if (annotationClass.isAssignableFrom(a.getClass())) {
+                return (T) a;
+            }
+        }
+        return null;
+    }
+}

--- a/core/hibernate-search/src/main/java/io/thorntail/hibernate_search/impl/QueryBuilderDelegate.java
+++ b/core/hibernate-search/src/main/java/io/thorntail/hibernate_search/impl/QueryBuilderDelegate.java
@@ -1,0 +1,86 @@
+package io.thorntail.hibernate_search.impl;
+
+import javax.persistence.EntityManager;
+import org.hibernate.search.query.dsl.AllContext;
+import org.hibernate.search.query.dsl.BooleanJunction;
+import org.hibernate.search.query.dsl.FacetContext;
+import org.hibernate.search.query.dsl.MoreLikeThisContext;
+import org.hibernate.search.query.dsl.PhraseContext;
+import org.hibernate.search.query.dsl.QueryBuilder;
+import org.hibernate.search.query.dsl.RangeContext;
+import org.hibernate.search.query.dsl.SimpleQueryStringContext;
+import org.hibernate.search.query.dsl.SpatialContext;
+import org.hibernate.search.query.dsl.TermContext;
+import org.hibernate.search.query.dsl.sort.SortContext;
+
+/**
+ * @author kg6zvp
+ */
+public class QueryBuilderDelegate implements QueryBuilder {
+    QueryBuilder delegate;
+
+    EntityManager em;
+
+    public QueryBuilderDelegate(QueryBuilder delegate, EntityManager em) {
+        this.delegate = delegate;
+        this.em = em;
+    }
+
+    public void close() {
+        em.close();
+    }
+
+    @Override
+    public TermContext keyword() {
+        return delegate.keyword();
+    }
+
+    @Override
+    public RangeContext range() {
+        return delegate.range();
+    }
+
+    @Override
+    public PhraseContext phrase() {
+        return delegate.phrase();
+    }
+
+    @Override
+    public SimpleQueryStringContext simpleQueryString() {
+        return delegate.simpleQueryString();
+    }
+
+    @Override
+    public BooleanJunction<BooleanJunction> bool() {
+        return delegate.bool();
+    }
+
+    @Override
+    public AllContext all() {
+        return delegate.all();
+    }
+
+    @Override
+    public FacetContext facet() {
+        return delegate.facet();
+    }
+
+    @Override
+    public SpatialContext spatial() {
+        return delegate.spatial();
+    }
+
+    @Override
+    public MoreLikeThisContext moreLikeThis() {
+        return delegate.moreLikeThis();
+    }
+
+    @Override
+    public SortContext sort() {
+        return delegate.sort();
+    }
+
+    public QueryBuilder getDelegate() {
+        return this.delegate;
+    }
+}

--- a/core/hibernate-search/src/main/java/io/thorntail/hibernate_search/impl/QueryFactory.java
+++ b/core/hibernate-search/src/main/java/io/thorntail/hibernate_search/impl/QueryFactory.java
@@ -1,0 +1,27 @@
+package io.thorntail.hibernate_search.impl;
+
+import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.spi.InjectionPoint;
+import org.hibernate.search.jpa.FullTextEntityManager;
+import org.hibernate.search.query.dsl.QueryBuilder;
+import io.thorntail.hibernate_search.QueryBuilderContext;
+import static io.thorntail.hibernate_search.impl.InjectionPointUtils.getAnnotation;
+import javax.enterprise.inject.Disposes;
+
+/**
+ * @author kg6zvp
+ */
+public class QueryFactory {
+    @Produces
+    @QueryBuilderContext(Object.class)
+    public QueryBuilder getQueryBuilder(InjectionPoint ip) {
+        QueryBuilderContext qbc = getAnnotation(ip, QueryBuilderContext.class);
+        FullTextEntityManager em = EntityManagerUtils.getFullTextEntityManager(qbc.persistenceUnit());
+        QueryBuilder qb = em.getSearchFactory().buildQueryBuilder().forEntity(qbc.value()).get();
+        return new QueryBuilderDelegate(qb, em);
+    }
+
+    public void disposeQueryBuilder(@Disposes @QueryBuilderContext(Object.class) QueryBuilder qb) {
+        ((QueryBuilderDelegate)qb).close();
+    }
+}

--- a/core/hibernate-search/src/main/java/io/thorntail/hibernate_search/package-info.java
+++ b/core/hibernate-search/src/main/java/io/thorntail/hibernate_search/package-info.java
@@ -1,0 +1,1 @@
+package io.thorntail.hibernate_search;

--- a/core/hibernate-search/src/main/resources/META-INF/beans.xml
+++ b/core/hibernate-search/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,5 @@
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+       bean-discovery-mode="all">
+</beans>

--- a/core/hibernate-search/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
+++ b/core/hibernate-search/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
@@ -1,0 +1,1 @@
+io.thorntail.hibernate_search.impl.HibernateSearchExtension

--- a/core/jpa-support/src/main/java/io/thorntail/jpa/impl/JpaMessages.java
+++ b/core/jpa-support/src/main/java/io/thorntail/jpa/impl/JpaMessages.java
@@ -34,4 +34,7 @@ public interface JpaMessages extends BasicLogger {
     @LogMessage(level = Logger.Level.INFO)
     @Message(id = 11 + JPA_OFFSET, value = "initializing persistence contexts")
     void persistencecontextInitialization();
+
+    @Message(id = 12 + JPA_OFFSET, value = "%s when attempting to wrap EntityManager with FullTextEntityManager")
+    RuntimeException errorWrappingEntityManagerForSearch(Exception e);
 }

--- a/core/jpa-support/src/main/java/io/thorntail/jpa/impl/JpaServices.java
+++ b/core/jpa-support/src/main/java/io/thorntail/jpa/impl/JpaServices.java
@@ -27,7 +27,7 @@ import org.jboss.weld.injection.spi.ResourceReferenceFactory;
  */
 public class JpaServices implements JpaInjectionServices {
 
-    private String emptyScopeDefaultName;
+    private static String emptyScopeDefaultName;
 
     private static Map<String, ResourceReferenceFactory<EntityManagerFactory>> emfs = new ConcurrentHashMap<>();
 
@@ -107,21 +107,21 @@ public class JpaServices implements JpaInjectionServices {
         return injectionPoint.getAnnotated();
     }
 
-    private String getScopedPuName(String unitName) {
+    public static String getScopedPuName(String unitName) {
         return (null != unitName && unitName.trim().length() > 0)
                 ? unitName
                 :
-                (null != this.emptyScopeDefaultName
-                        ? this.emptyScopeDefaultName : getPersistentUnitNameFromDescriptor());
+                (null != emptyScopeDefaultName
+                        ? emptyScopeDefaultName : getPersistentUnitNameFromDescriptor());
     }
 
-    private String getPersistentUnitNameFromDescriptor() {
-        this.emptyScopeDefaultName = getPersistenceUnitDescriptor().getName();
-        return this.emptyScopeDefaultName;
+    public static String getPersistentUnitNameFromDescriptor() {
+        emptyScopeDefaultName = getPersistenceUnitDescriptor().getName();
+        return emptyScopeDefaultName;
     }
 
-    private PersistenceUnitDescriptor getPersistenceUnitDescriptor(){
-        URL url = getClass().getClassLoader().getResource("META-INF/persistence.xml");
+    private static PersistenceUnitDescriptor getPersistenceUnitDescriptor(){
+        URL url = JpaServices.class.getClassLoader().getResource("META-INF/persistence.xml");
         return PersistenceXmlParser.locateIndividualPersistenceUnit(url);
     }
 }

--- a/core/kernel/src/main/java/io/thorntail/logging/impl/MessageOffsets.java
+++ b/core/kernel/src/main/java/io/thorntail/logging/impl/MessageOffsets.java
@@ -21,4 +21,5 @@ public interface MessageOffsets {
     int JCA_OFFSET = 13000;
     int OPENAPI_OFFSET = 14000;
     int VERTX_OFFSET = 15000;
+    int HIBERNATE_SEARCH_OFFSET = 16000;
 }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -106,6 +106,7 @@
     <module>bean-validation</module>
     <module>datasources</module>
     <module>health</module>
+    <module>hibernate-search</module>
     <module>jaxrs</module>
     <module>jca</module>
     <module>jdbc</module>

--- a/docs/src/main/asciidoc/components/other/hibernate-search.adoc
+++ b/docs/src/main/asciidoc/components/other/hibernate-search.adoc
@@ -1,0 +1,69 @@
+[#component-hibernate-search]
+= Hibernate Search
+
+Support for Hibernate Search. By including Thorntail's hibernate-search module, all `EntityManager` injected with `@PersistenceContext` will be instances of `FullTextEntityManager`.
+
+[source,java]
+----
+@PersistenceContext
+EntityManager em;
+
+public void performAction() {
+	FullTextEntityManager searchEntityManager = (FullTextEntityManager)em;
+	...
+----
+
+.Maven Coordinates
+
+[source,xml,subs="verbatim,attributes"]
+----
+<dependency>
+  <groupId>{groupId}</groupId>
+  <artifactId>{project_key}-hibernate-search</artifactId>
+</dependency>
+----
+
+.CDI Helpers
+
+* FullTextEntityManager
+* QueryBuilder
+
+`FullTextEntityManager` can be injected with or without the `@EntityManagerContext` annotation, which is used optionally to specify a specific persistence unit.
+
+[source,java]
+----
+import org.hibernate.search.jpa.FullTextEntityManager;
+import io.thorntail.hibernate_search.EntityManagerContext;
+
+...
+
+@Inject
+FullTextEntityManager em;
+
+@Inject
+@EntityManagerContext("MyAppPU")
+FullTextEntityManager em;
+----
+
+Likewise, an instance of `QueryBuilder` can also be injected. Injection of `QueryBuilder` requires the use of the `@QueryBuilderContext` annotation which accepts the class of the Entity for which the `QueryBuilder` functions. It can also be used to specify the persistence unit for projects that require this functionality.
+
+[source,java]
+----
+import org.hibernate.search.query.dsl.QueryBuilder;
+import io.thorntail.hibernate_search.QueryBuilderContext;
+
+...
+
+@Inject
+@QueryBuilderContext(Employee.class)
+QueryBuilder employeeQb;
+
+@Inject
+@QueryBuilderContext(value = Employee.class, persistenceUnit = "MyAppPU")
+QueryBuilder employeeQb;
+----
+
+.Related Information
+
+* xref:component-jpa-support[]
+* https://docs.jboss.org/hibernate/search/5.9/reference/en-US/html_single/[Hibernate Search 5.9 Documentation]

--- a/docs/src/main/asciidoc/index.adoc
+++ b/docs/src/main/asciidoc/index.adoc
@@ -83,6 +83,7 @@ include::components/microprofile/opentracing.adoc[leveloffset=+2]
 
 include::components/other/vertx.adoc[leveloffset=+2]
 include::components/other/hibernate-ogm.adoc[leveloffset=+2]
+include::components/other/hibernate-search.adoc[leveloffset=+2]
 
 # Guides
 

--- a/testsuite/simple/hibernate-search-should-fail/pom.xml
+++ b/testsuite/simple/hibernate-search-should-fail/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.thorntail.testsuite</groupId>
+    <artifactId>thorntail-testsuite-simple-parent</artifactId>
+    <version>4.0.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>thorntail-testsuite-hibernate-search-should-fail</artifactId>
+  <name>Testsuite: Hibernate Search Deployment Tests</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.thorntail</groupId>
+        <artifactId>thorntail-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.thorntail</groupId>
+      <artifactId>thorntail-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.thorntail</groupId>
+      <artifactId>thorntail-hibernate-search</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/testsuite/simple/hibernate-search-should-fail/src/main/java/io/thorntail/testsuite/hibernate_search/AppUser.java
+++ b/testsuite/simple/hibernate-search-should-fail/src/main/java/io/thorntail/testsuite/hibernate_search/AppUser.java
@@ -1,0 +1,49 @@
+package io.thorntail.testsuite.hibernate_search;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+
+/**
+ * @author kg6zvp
+ */
+@Entity
+@Indexed
+public class AppUser {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    Long id;
+
+    @Field
+    String firstName;
+
+    @Field
+    String lastName;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+}

--- a/testsuite/simple/hibernate-search-should-fail/src/main/java/io/thorntail/testsuite/hibernate_search/HibernateSearchApp.java
+++ b/testsuite/simple/hibernate-search-should-fail/src/main/java/io/thorntail/testsuite/hibernate_search/HibernateSearchApp.java
@@ -1,0 +1,8 @@
+package io.thorntail.testsuite.hibernate_search;
+
+import io.thorntail.Main;
+
+/**
+ * @author kg6zvp
+ */
+public class HibernateSearchApp extends Main { }

--- a/testsuite/simple/hibernate-search-should-fail/src/main/java/io/thorntail/testsuite/hibernate_search/UserDao.java
+++ b/testsuite/simple/hibernate-search-should-fail/src/main/java/io/thorntail/testsuite/hibernate_search/UserDao.java
@@ -1,0 +1,15 @@
+package io.thorntail.testsuite.hibernate_search;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import org.hibernate.search.query.dsl.QueryBuilder;
+
+/**
+ *
+ * @author smccollum
+ */
+@RequestScoped
+public class UserDao {
+    @Inject
+    QueryBuilder qb;
+}

--- a/testsuite/simple/hibernate-search-should-fail/src/main/resources/META-INF/application.properties
+++ b/testsuite/simple/hibernate-search-should-fail/src/main/resources/META-INF/application.properties
@@ -1,0 +1,4 @@
+datasource.ExampleDS.username=sa
+datasource.ExampleDS.password=sa
+datasource.ExampleDS.connection-url=jdbc:h2:mem:
+datasource.ExampleDS.driver=h2

--- a/testsuite/simple/hibernate-search-should-fail/src/main/resources/META-INF/persistence.xml
+++ b/testsuite/simple/hibernate-search-should-fail/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="2.1" xmlns="http://xmlns.jcp.org/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
+  <persistence-unit name="SearchPU" transaction-type="JTA">
+    <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+    <properties>
+      <property name="javax.persistence.schema-generation.database.action" value="drop-and-create"/>
+    </properties>
+  </persistence-unit>
+</persistence>

--- a/testsuite/simple/hibernate-search-should-fail/src/test/java/io/thorntail/testsuite/hibernate_search/HibernateSearchDeploymentTest.java
+++ b/testsuite/simple/hibernate-search-should-fail/src/test/java/io/thorntail/testsuite/hibernate_search/HibernateSearchDeploymentTest.java
@@ -1,0 +1,22 @@
+package io.thorntail.testsuite.hibernate_search;
+
+import io.thorntail.hibernate_search.MissingQueryBuilderContextException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.jboss.weld.exceptions.DefinitionException;
+import org.junit.runners.BlockJUnit4ClassRunner;
+
+/**
+ * @author kg6zvp
+ */
+@RunWith(BlockJUnit4ClassRunner.class)
+public class HibernateSearchDeploymentTest {
+    @Test
+    public void testDeployWithoutContextAnnotationShouldFail() {
+        assertThatThrownBy(() -> HibernateSearchApp.main())
+            .isInstanceOf(DefinitionException.class)
+            .hasMessageContaining("qb");
+    }
+}

--- a/testsuite/simple/hibernate-search/pom.xml
+++ b/testsuite/simple/hibernate-search/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.thorntail.testsuite</groupId>
+    <artifactId>thorntail-testsuite-simple-parent</artifactId>
+    <version>4.0.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>thorntail-testsuite-hibernate-search</artifactId>
+  <name>Testsuite: Hibernate Search</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.thorntail</groupId>
+        <artifactId>thorntail-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.thorntail</groupId>
+      <artifactId>thorntail-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.thorntail</groupId>
+      <artifactId>thorntail-hibernate-search</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/testsuite/simple/hibernate-search/src/main/java/io/thorntail/testsuite/hibernate_search/AppUser.java
+++ b/testsuite/simple/hibernate-search/src/main/java/io/thorntail/testsuite/hibernate_search/AppUser.java
@@ -1,0 +1,49 @@
+package io.thorntail.testsuite.hibernate_search;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+
+/**
+ * @author kg6zvp
+ */
+@Entity
+@Indexed
+public class AppUser {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    Long id;
+
+    @Field
+    String firstName;
+
+    @Field
+    String lastName;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+}

--- a/testsuite/simple/hibernate-search/src/main/java/io/thorntail/testsuite/hibernate_search/HibernateSearchApp.java
+++ b/testsuite/simple/hibernate-search/src/main/java/io/thorntail/testsuite/hibernate_search/HibernateSearchApp.java
@@ -1,0 +1,8 @@
+package io.thorntail.testsuite.hibernate_search;
+
+import io.thorntail.Main;
+
+/**
+ * @author kg6zvp
+ */
+public class HibernateSearchApp extends Main { }

--- a/testsuite/simple/hibernate-search/src/main/resources/META-INF/application.properties
+++ b/testsuite/simple/hibernate-search/src/main/resources/META-INF/application.properties
@@ -1,0 +1,4 @@
+datasource.ExampleDS.username=sa
+datasource.ExampleDS.password=sa
+datasource.ExampleDS.connection-url=jdbc:h2:mem:
+datasource.ExampleDS.driver=h2

--- a/testsuite/simple/hibernate-search/src/main/resources/META-INF/persistence.xml
+++ b/testsuite/simple/hibernate-search/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="2.1" xmlns="http://xmlns.jcp.org/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
+  <persistence-unit name="SearchPU" transaction-type="JTA">
+    <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+    <properties>
+      <property name="javax.persistence.schema-generation.database.action" value="drop-and-create"/>
+      <property name="hibernate.search.default.directory_provider" value="local-heap"/>
+    </properties>
+  </persistence-unit>
+</persistence>

--- a/testsuite/simple/hibernate-search/src/test/java/io/thorntail/testsuite/hibernate_search/HibernateSearchAppTest.java
+++ b/testsuite/simple/hibernate-search/src/test/java/io/thorntail/testsuite/hibernate_search/HibernateSearchAppTest.java
@@ -1,0 +1,54 @@
+package io.thorntail.testsuite.hibernate_search;
+
+import io.thorntail.hibernate_search.EntityManagerContext;
+import io.thorntail.hibernate_search.QueryBuilderContext;
+import io.thorntail.hibernate_search.impl.QueryBuilderDelegate;
+import io.thorntail.test.ThorntailTestRunner;
+import javax.inject.Inject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.hibernate.search.jpa.FullTextEntityManager;
+import org.hibernate.search.query.dsl.QueryBuilder;
+
+/**
+ * @author kg6zvp
+ */
+@RunWith(ThorntailTestRunner.class)
+public class HibernateSearchAppTest {
+    @PersistenceContext
+    EntityManager em;
+
+    @Inject
+    FullTextEntityManager searchEm;
+
+    @Inject
+    @EntityManagerContext("SearchPU")
+    FullTextEntityManager searchEmScoped;
+
+    @Inject
+    @QueryBuilderContext(AppUser.class)
+    QueryBuilder userQueryBuilder;
+
+    @Inject
+    @QueryBuilderContext(value = AppUser.class, persistenceUnit = "SearchPU")
+    QueryBuilder userQueryBuilderScoped;
+
+    @Test
+    public void test() {
+        assertThat(em).isNotNull();
+        assertThat(em).isInstanceOf(FullTextEntityManager.class);
+
+        assertThat(searchEm).isNotNull();
+        assertThat(searchEmScoped).isNotNull();
+
+        assertThat(userQueryBuilder).isNotNull();
+        assertThat(userQueryBuilder).isInstanceOf(QueryBuilderDelegate.class);
+
+        assertThat(userQueryBuilderScoped).isNotNull();
+        assertThat(userQueryBuilderScoped).isInstanceOf(QueryBuilderDelegate.class);
+    }
+}

--- a/testsuite/simple/pom.xml
+++ b/testsuite/simple/pom.xml
@@ -17,6 +17,8 @@
   <modules>
     <module>bean-validation</module>
     <module>config</module>
+    <module>hibernate-search</module>
+    <module>hibernate-search-should-fail</module>
     <module>jaxrs</module>
     <module>jaxrs-jsonp</module>
     <module>jpa</module>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a GitHub Issue and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/wildfly-swarm/wildfly-swarm/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
All `@PersistenceContext` annotated `EntityManager`s are `FullTextEntityManager`s by default if Hibernate Search is on the classpath.

Does not inject `QueryBuilder`. This feels like it should be integrated using a CDI service with a custom annotation so that it can be scoped to a specific PU. I didn't see anything like this in Seam docs, so this is new territory, but I'd love for some expert input.