### PR TITLE
THORN-2051: MP metrics: MetricRegistry.getTimers and similar methods don't filter by type

### DIFF
--- a/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/MetricsRegistryImpl.java
+++ b/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/MetricsRegistryImpl.java
@@ -185,8 +185,8 @@ public class MetricsRegistryImpl extends MetricRegistry {
             LOGGER.infof("Register metric [name: %s, type: %s]", name, type);
             register(metadata, m);
         } else if (!metadataMap.get(name).getTypeRaw().equals(metadata.getTypeRaw())) {
-            throw new IllegalArgumentException("Type of existing previously registered metric " + name + " does not " +
-                                                "match passed type");
+            throw new IllegalArgumentException("Previously registered metric " + name + " is of type "
+                    + metadataMap.get(name).getType() + ", expected " + metadata.getType());
         }
 
         return (T) metricMap.get(name);
@@ -286,13 +286,14 @@ public class MetricsRegistryImpl extends MetricRegistry {
     }
 
     private <T extends Metric> SortedMap<String, T> getMetrics(MetricType type, MetricFilter filter) {
-        SortedMap<String, T> out = new TreeMap<String, T>();
+        SortedMap<String, T> out = new TreeMap<>();
 
-        Iterator<Map.Entry<String, Metric>> iterator = metricMap.entrySet().iterator();
-        while (iterator.hasNext()) {
-            Map.Entry<String, Metric> entry = iterator.next();
-            if (filter.matches(entry.getKey(), entry.getValue())) {
-                out.put(entry.getKey(), (T) entry.getValue());
+        for (Map.Entry<String, Metric> entry : metricMap.entrySet()) {
+            Metadata metadata = metadataMap.get(entry.getKey());
+            if (metadata.getTypeRaw() == type) {
+                if (filter.matches(entry.getKey(), entry.getValue())) {
+                    out.put(entry.getKey(), (T) entry.getValue());
+                }
             }
         }
 

--- a/testsuite/testsuite-microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/HelloService.java
+++ b/testsuite/testsuite-microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/HelloService.java
@@ -17,7 +17,9 @@ package org.wildfly.swarm.microprofile.metrics;
 
 import javax.enterprise.context.ApplicationScoped;
 
+import org.eclipse.microprofile.metrics.MetricUnits;
 import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.eclipse.microprofile.metrics.annotation.Timed;
 
 @ApplicationScoped
 public class HelloService {
@@ -25,5 +27,10 @@ public class HelloService {
     @Counted(monotonic = true, name = "hello-count", absolute = true, displayName = "Hello Count", description = "Number of hello invocations")
     public String hello() {
         return "Hello from counted method";
+    }
+
+    @Timed(unit = MetricUnits.MILLISECONDS, name = "howdy-time", absolute = true, displayName = "Howdy Time", description = "Time of howdy invocations")
+    public String howdy() {
+        return "Howdy from timed method";
     }
 }

--- a/testsuite/testsuite-microprofile-metrics/src/test/java/org/wildfly/swarm/microprofile/metrics/registry/AllMetricsOfGivenTypeTest.java
+++ b/testsuite/testsuite-microprofile-metrics/src/test/java/org/wildfly/swarm/microprofile/metrics/registry/AllMetricsOfGivenTypeTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.metrics.registry;
+
+import org.eclipse.microprofile.metrics.Timer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.microprofile.metrics.HelloService;
+import org.wildfly.swarm.microprofile.metrics.MetricsSummary;
+
+import javax.inject.Inject;
+import java.util.SortedMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Arquillian.class)
+public class AllMetricsOfGivenTypeTest {
+    @Inject
+    HelloService hello;
+
+    @Inject
+    MetricsSummary summary;
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addPackage(HelloService.class.getPackage())
+                .addPackage(AllMetricsOfGivenTypeTest.class.getPackage());
+    }
+
+    @Test
+    public void testGetMetricsOfGivenType() {
+        hello.hello();
+        hello.howdy();
+        SortedMap<String, Timer> timers = summary.getAppMetrics().getTimers();
+        assertEquals(1, timers.size());
+        assertTrue(timers.containsKey("howdy-time"));
+        assertFalse(timers.containsKey("hello-count"));
+    }
+}


### PR DESCRIPTION
Motivation
----------
MP Metrics allow to get all registered metrics of given type
using `MetricRegistry.getTimers()` (and similar: `getMeters`,
`getCounters` etc.). However, these methods currently always
return all registered metrics of all types. That's clearly
wrong and actually ultimately results in `ClassCastException`s.

Modifications
-------------
The internal method `MetricsRegistryImpl.getMetrics`,
which is ultimately called in all these cases, already takes
a `MetricType`. It just wasn't used. Modified the loop to,
in addition to checking the filter, also test the metric type.

Result
------
`MetricRegistry.getTimers` and similar methods now work correctly.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
