### PR TITLE
THORN-2053: MP Metrics API - declare dependency on javax.enterprise.api.

### DIFF
--- a/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/deployment/MetricProducer.java
+++ b/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/deployment/MetricProducer.java
@@ -45,7 +45,7 @@ import org.wildfly.swarm.microprofile.metrics.api.RegistryFactory;
  * @author hrupp
  */
 @ApplicationScoped
-public class AMetricRegistryFactory {
+public class MetricProducer {
 
     @Inject
     private MetricName metricName;
@@ -58,14 +58,14 @@ public class AMetricRegistryFactory {
     }
 
     @Default
-    @Produces
     @RegistryType(type = MetricRegistry.Type.APPLICATION)
-    public MetricRegistry getApplicationRegistry() {
+    @Produces
+    MetricRegistry getApplicationRegistry() {
         return get(MetricRegistry.Type.APPLICATION);
     }
 
     @Produces
-    private <T> Gauge<T> gauge(InjectionPoint ip) {
+    <T> Gauge<T> getGauge(InjectionPoint ip) {
         // A forwarding Gauge must be returned as the Gauge creation happens when the declaring bean gets instantiated and the corresponding Gauge can be injected before which leads to producing a null value
         return new Gauge<T>() {
             @Override
@@ -78,22 +78,22 @@ public class AMetricRegistryFactory {
     }
 
     @Produces
-    public Counter getCounter(InjectionPoint ip) {
+    Counter getCounter(InjectionPoint ip) {
         return getApplicationRegistry().counter(getMetadata(ip, MetricType.COUNTER));
     }
 
     @Produces
-    public Histogram getHistogram(InjectionPoint ip) {
+    Histogram getHistogram(InjectionPoint ip) {
         return getApplicationRegistry().histogram(getMetadata(ip, MetricType.HISTOGRAM));
     }
 
     @Produces
-    public Meter getMeter(InjectionPoint ip) {
+    Meter getMeter(InjectionPoint ip) {
         return getApplicationRegistry().meter(getMetadata(ip, MetricType.METERED));
     }
 
     @Produces
-    public Timer getTimer(InjectionPoint ip) {
+    Timer getTimer(InjectionPoint ip) {
         return getApplicationRegistry().timer(getMetadata(ip, MetricType.TIMER));
     }
 

--- a/fractions/microprofile/microprofile-metrics/src/main/resources/modules/org/eclipse/microprofile/metrics/main/module.xml
+++ b/fractions/microprofile/microprofile-metrics/src/main/resources/modules/org/eclipse/microprofile/metrics/main/module.xml
@@ -1,5 +1,23 @@
+<!--
+  ~ Copyright 2018 Red Hat, Inc, and individual contributors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <module xmlns="urn:jboss:module:1.3" name="org.eclipse.microprofile.metrics">
   <resources>
     <artifact name="org.eclipse.microprofile.metrics:microprofile-metrics-api:${version.microprofile-metrics}"/>
   </resources>
+  <dependencies>
+      <module name="javax.enterprise.api" />
+  </dependencies>
 </module>


### PR DESCRIPTION
Motivation
----------
MP Metrics API module does not declare a dependency on
javax.enterprise.api and so CDI/Interceptors annotations declared on MP
Metrics annotations are ignored.

Modifications
-------------
Added module depednency to MP Metrics API.

Result
------
CDI/Interceptors annotations should not be ignored anymore.
