### PR TITLE
THORN-2050: Inject base and vendor MetricRegistry.

### DIFF
--- a/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/deployment/MetricProducer.java
+++ b/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/deployment/MetricProducer.java
@@ -64,6 +64,18 @@ public class MetricProducer {
         return get(MetricRegistry.Type.APPLICATION);
     }
 
+    @RegistryType(type = MetricRegistry.Type.BASE)
+    @Produces
+    MetricRegistry getBaseRegistry() {
+        return get(MetricRegistry.Type.BASE);
+    }
+
+    @RegistryType(type = MetricRegistry.Type.VENDOR)
+    @Produces
+    MetricRegistry getVendorRegistry() {
+        return get(MetricRegistry.Type.VENDOR);
+    }
+
     @Produces
     <T> Gauge<T> getGauge(InjectionPoint ip) {
         // A forwarding Gauge must be returned as the Gauge creation happens when the declaring bean gets instantiated and the corresponding Gauge can be injected before which leads to producing a null value

--- a/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/JmxWorker.java
+++ b/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/JmxWorker.java
@@ -56,7 +56,7 @@ public class JmxWorker {
 
     public Map<String, Double> getMetrics(MetricRegistry.Type scope) {
 
-        Map<String, Metadata> metadataMap = MetricRegistryFactory.get(scope).getMetadata();
+        Map<String, Metadata> metadataMap = MetricRegistries.get(scope).getMetadata();
         Map<String, Double> outcome = new HashMap<>();
 
         for (Metadata m : metadataMap.values()) {

--- a/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/MetricRegistries.java
+++ b/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/MetricRegistries.java
@@ -16,52 +16,34 @@
  */
 package org.wildfly.swarm.microprofile.metrics.runtime;
 
-import org.eclipse.microprofile.metrics.MetricRegistry;
-
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.microprofile.metrics.MetricRegistry;
 
 /**
  * @author hrupp
  */
-public class MetricRegistryFactory {
+public final class MetricRegistries {
 
-    private static final Map<MetricRegistry.Type, MetricRegistry> registries = new HashMap<>();
+    private static final Map<MetricRegistry.Type, MetricRegistry> REGISTRIES = new ConcurrentHashMap<>();
 
-    private MetricRegistryFactory() { /* Singleton */ }
+    private MetricRegistries() {
+    }
 
-    //  @Produces
-//  @Default
-//  @RegistryType(type = MetricRegistry.Type.APPLICATION)
-//  @ApplicationScoped
     public static MetricRegistry getApplicationRegistry() {
         return get(MetricRegistry.Type.APPLICATION);
     }
 
-    //  @Produces
-//  @ApplicationScoped
-//  @RegistryType(type = MetricRegistry.Type.BASE)
     public static MetricRegistry getBaseRegistry() {
         return get(MetricRegistry.Type.BASE);
     }
 
-    //  @Produces
-//  @ApplicationScoped
-//  @RegistryType(type = MetricRegistry.Type.VENDOR)
     public static MetricRegistry getVendorRegistry() {
         return get(MetricRegistry.Type.VENDOR);
     }
 
     public static MetricRegistry get(MetricRegistry.Type type) {
-
-        synchronized (registries) {
-            if (registries.get(type) == null) {
-
-                MetricRegistry result = new MetricsRegistryImpl();
-                registries.put(type, result);
-            }
-        }
-
-        return registries.get(type);
+        return REGISTRIES.computeIfAbsent(type, (t) -> new MetricsRegistryImpl());
     }
 }

--- a/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/MetricsHttpHandler.java
+++ b/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/MetricsHttpHandler.java
@@ -100,7 +100,7 @@ public class MetricsHttpHandler implements HttpHandler {
                 return;
             }
 
-            MetricRegistry registry = MetricRegistryFactory.get(scope);
+            MetricRegistry registry = MetricRegistries.get(scope);
             Map<String, Metric> metricValuesMap = registry.getMetrics();
 
             if (metricValuesMap.containsKey(attribute)) {
@@ -120,7 +120,7 @@ public class MetricsHttpHandler implements HttpHandler {
                 return;
             }
 
-            MetricRegistry reg = MetricRegistryFactory.get(scope);
+            MetricRegistry reg = MetricRegistries.get(scope);
             if (reg.getMetadata().size() == 0) {
                 exchange.setStatusCode(204);
                 exchange.setReasonPhrase("No data in scope " + scopePath);

--- a/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/MetricsService.java
+++ b/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/MetricsService.java
@@ -79,12 +79,12 @@ public class MetricsService implements Service<MetricsService> {
             for (ExtendedMetadata em : ml.getBase()) {
                 em.processTags(globalTags);
                 Metric type = getType(em);
-                MetricRegistryFactory.getBaseRegistry().register(em, type);
+                MetricRegistries.getBaseRegistry().register(em, type);
             }
             for (ExtendedMetadata em : ml.getVendor()) {
                 em.processTags(globalTags);
                 Metric type = getType(em);
-                MetricRegistryFactory.getVendorRegistry().register(em, type);
+                MetricRegistries.getVendorRegistry().register(em, type);
             }
         } else {
             throw new IllegalStateException("Was not able to find the mapping file 'mapping.yml'");

--- a/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/RegistryFactoryImpl.java
+++ b/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/RegistryFactoryImpl.java
@@ -25,6 +25,6 @@ import org.wildfly.swarm.microprofile.metrics.api.RegistryFactory;
 public class RegistryFactoryImpl implements RegistryFactory {
     @Override
     public MetricRegistry get(MetricRegistry.Type type) {
-        return MetricRegistryFactory.get(type);
+        return MetricRegistries.get(type);
     }
 }

--- a/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/exporters/Helper.java
+++ b/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/exporters/Helper.java
@@ -18,7 +18,7 @@
 package org.wildfly.swarm.microprofile.metrics.runtime.exporters;
 
 import org.eclipse.microprofile.metrics.MetricRegistry;
-import org.wildfly.swarm.microprofile.metrics.runtime.MetricRegistryFactory;
+import org.wildfly.swarm.microprofile.metrics.runtime.MetricRegistries;
 
 /**
  * @author hrupp
@@ -32,7 +32,7 @@ class Helper {
         MetricRegistry.Type[] values = MetricRegistry.Type.values();
         int totalNonEmptyScopes = 0;
         for (MetricRegistry.Type scope : values) {
-            MetricRegistry registry = MetricRegistryFactory.get(scope);
+            MetricRegistry registry = MetricRegistries.get(scope);
             if (registry.getNames().size() > 0) {
                 totalNonEmptyScopes++;
             }

--- a/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/exporters/JsonExporter.java
+++ b/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/exporters/JsonExporter.java
@@ -28,7 +28,7 @@ import org.jboss.logging.Logger;
 import org.wildfly.swarm.microprofile.metrics.runtime.app.HistogramImpl;
 import org.wildfly.swarm.microprofile.metrics.runtime.app.MeterImpl;
 import org.wildfly.swarm.microprofile.metrics.runtime.app.TimerImpl;
-import org.wildfly.swarm.microprofile.metrics.runtime.MetricRegistryFactory;
+import org.wildfly.swarm.microprofile.metrics.runtime.MetricRegistries;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -56,7 +56,7 @@ public class JsonExporter implements Exporter {
 
     private void getMetricsForAScope(StringBuilder sb, MetricRegistry.Type scope) {
 
-        MetricRegistry registry = MetricRegistryFactory.get(scope);
+        MetricRegistry registry = MetricRegistries.get(scope);
         Map<String, Metric> metricMap = registry.getMetrics();
         Map<String, Metadata> metadataMap = registry.getMetadata();
 
@@ -202,7 +202,7 @@ public class JsonExporter implements Exporter {
         int scopes = 0;
         for (int i = 0; i < values.length; i++) {
             MetricRegistry.Type scope = values[i];
-            MetricRegistry registry = MetricRegistryFactory.get(scope);
+            MetricRegistry registry = MetricRegistries.get(scope);
 
             if (registry.getNames().size() > 0) {
                 sb.append('"').append(scope.getName().toLowerCase()).append('"').append(" :\n");
@@ -221,7 +221,7 @@ public class JsonExporter implements Exporter {
 
     @Override
     public StringBuilder exportOneMetric(MetricRegistry.Type scope, String metricName) {
-        MetricRegistry registry = MetricRegistryFactory.get(scope);
+        MetricRegistry registry = MetricRegistries.get(scope);
         Map<String, Metric> metricMap = registry.getMetrics();
         Map<String, Metadata> metadataMap = registry.getMetadata();
 

--- a/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/exporters/JsonMetadataExporter.java
+++ b/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/exporters/JsonMetadataExporter.java
@@ -19,7 +19,7 @@ package org.wildfly.swarm.microprofile.metrics.runtime.exporters;
 
 import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.MetricRegistry;
-import org.wildfly.swarm.microprofile.metrics.runtime.MetricRegistryFactory;
+import org.wildfly.swarm.microprofile.metrics.runtime.MetricRegistries;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -44,7 +44,7 @@ public class JsonMetadataExporter implements Exporter {
     }
 
     private void getDataForOneScope(MetricRegistry.Type scope, StringBuilder sb) {
-        MetricRegistry registry = MetricRegistryFactory.get(scope);
+        MetricRegistry registry = MetricRegistries.get(scope);
         Map<String, Metadata> theMetadata = registry.getMetadata();
 
         sb.append("{");
@@ -101,7 +101,7 @@ public class JsonMetadataExporter implements Exporter {
         int scopes = 0;
         for (int i = 0; i < values.length; i++) {
             MetricRegistry.Type scope = values[i];
-            MetricRegistry registry = MetricRegistryFactory.get(scope);
+            MetricRegistry registry = MetricRegistries.get(scope);
 
             if (registry.getNames().size() > 0) {
                 sb.append('"').append(scope.getName().toLowerCase()).append('"').append(" :\n");
@@ -121,7 +121,7 @@ public class JsonMetadataExporter implements Exporter {
 
     @Override
     public StringBuilder exportOneMetric(MetricRegistry.Type scope, String metricName) {
-        MetricRegistry registry = MetricRegistryFactory.get(scope);
+        MetricRegistry registry = MetricRegistries.get(scope);
         Map<String, Metadata> metadataMap = registry.getMetadata();
 
         Metadata m = metadataMap.get(metricName);

--- a/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/exporters/PrometheusExporter.java
+++ b/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/exporters/PrometheusExporter.java
@@ -33,7 +33,7 @@ import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.MetricUnits;
 import org.eclipse.microprofile.metrics.Snapshot;
 import org.jboss.logging.Logger;
-import org.wildfly.swarm.microprofile.metrics.runtime.MetricRegistryFactory;
+import org.wildfly.swarm.microprofile.metrics.runtime.MetricRegistries;
 import org.wildfly.swarm.microprofile.metrics.runtime.Tag;
 import org.wildfly.swarm.microprofile.metrics.runtime.app.HistogramImpl;
 import org.wildfly.swarm.microprofile.metrics.runtime.app.MeterImpl;
@@ -88,7 +88,7 @@ public class PrometheusExporter implements Exporter {
 
     @Override
     public StringBuilder exportOneMetric(MetricRegistry.Type scope, String metricName) {
-        MetricRegistry registry = MetricRegistryFactory.get(scope);
+        MetricRegistry registry = MetricRegistries.get(scope);
         Map<String, Metric> metricMap = registry.getMetrics();
 
         Metric m = metricMap.get(metricName);
@@ -108,7 +108,7 @@ public class PrometheusExporter implements Exporter {
     }
 
     private void getEntriesForScope(MetricRegistry.Type scope, StringBuilder sb) {
-        MetricRegistry registry = MetricRegistryFactory.get(scope);
+        MetricRegistry registry = MetricRegistries.get(scope);
         Map<String, Metric> metricMap = registry.getMetrics();
 
         exposeEntries(scope, sb, registry, metricMap);

--- a/pom.xml
+++ b/pom.xml
@@ -1236,7 +1236,7 @@
         <module>testsuite/testsuite-jsf</module>
         <module>testsuite/testsuite-jsp</module>
         <module>testsuite/testsuite-microprofile-jwt</module>
-        <module>testsuite/testsuite-microprofile-restclient</module>
+        <module>testsuite/testsuite-microprofile-metrics</module>
         <module>testsuite/testsuite-keycloak</module>
         <module>testsuite/testsuite-local-dependencies</module>
         <module>testsuite/testsuite-logging</module>
@@ -1305,8 +1305,8 @@
         <module>testsuite/testsuite-management-console</module>
         <module>testsuite/testsuite-messaging</module>
         <module>testsuite/testsuite-messaging-remote</module>
-        <module>testsuite/testsuite-microprofile-jwt</module>
         <module>testsuite/testsuite-microprofile-openapi</module>
+        <module>testsuite/testsuite-microprofile-restclient</module>
         <module>testsuite/testsuite-mod_cluster</module>
         <module>testsuite/testsuite-mvc</module>
         <module>testsuite/testsuite-opentracing</module>

--- a/testsuite/testsuite-microprofile-metrics/pom.xml
+++ b/testsuite/testsuite-microprofile-metrics/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ~ Copyright 2015 Red Hat, Inc. and/or its affiliates. ~ ~ Licensed under
+   the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0 -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+   <modelVersion>4.0.0</modelVersion>
+
+   <parent>
+      <groupId>io.thorntail.testsuite</groupId>
+      <artifactId>testsuite-parent</artifactId>
+      <version>2.0.0.Final-SNAPSHOT</version>
+      <relativePath>../</relativePath>
+   </parent>
+
+   <artifactId>testsuite-microprofile-metrics</artifactId>
+   <name>Test Suite: MicroProfile Metrics</name>
+
+   <dependencies>
+      <dependency>
+         <groupId>io.thorntail</groupId>
+         <artifactId>microprofile-metrics</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>io.thorntail</groupId>
+         <artifactId>arquillian</artifactId>
+         <scope>test</scope>
+      </dependency>
+   </dependencies>
+
+</project>

--- a/testsuite/testsuite-microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/HelloService.java
+++ b/testsuite/testsuite-microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/HelloService.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.metrics;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.metrics.annotation.Counted;
+
+@ApplicationScoped
+public class HelloService {
+
+    @Counted(monotonic = true, name = "hello-count", absolute = true, displayName = "Hello Count", description = "Number of hello invocations")
+    public String hello() {
+        return "Hello from counted method";
+    }
+}

--- a/testsuite/testsuite-microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/MetricsSummary.java
+++ b/testsuite/testsuite-microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/MetricsSummary.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.metrics;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.RegistryType;
+
+@ApplicationScoped
+public class MetricsSummary {
+
+    @Inject
+    @RegistryType(type = MetricRegistry.Type.BASE)
+    private MetricRegistry baseMetrics;
+
+    @Inject
+    @RegistryType(type = MetricRegistry.Type.VENDOR)
+    private MetricRegistry vendorMetrics;
+
+    @Inject
+    @RegistryType(type = MetricRegistry.Type.APPLICATION)
+    private MetricRegistry appMetrics;
+
+    @Inject
+    private MetricRegistry defaultMetrics;
+
+    public MetricRegistry getBaseMetrics() {
+        return baseMetrics;
+    }
+
+    public MetricRegistry getVendorMetrics() {
+        return vendorMetrics;
+    }
+
+    public MetricRegistry getAppMetrics() {
+        return appMetrics;
+    }
+
+    public MetricRegistry getDefaultMetrics() {
+        return defaultMetrics;
+    }
+
+}

--- a/testsuite/testsuite-microprofile-metrics/src/main/webapp/WEB-INF/web.xml
+++ b/testsuite/testsuite-microprofile-metrics/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
+
+</web-app>

--- a/testsuite/testsuite-microprofile-metrics/src/test/java/org/wildfly/swarm/microprofile/metrics/registry/MetricRegistryInjectionTest.java
+++ b/testsuite/testsuite-microprofile-metrics/src/test/java/org/wildfly/swarm/microprofile/metrics/registry/MetricRegistryInjectionTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.metrics.registry;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.metrics.Counting;
+import org.eclipse.microprofile.metrics.Metric;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.microprofile.metrics.HelloService;
+import org.wildfly.swarm.microprofile.metrics.MetricsSummary;
+
+/**
+ *
+ * @author Martin Kouba
+ */
+@RunWith(Arquillian.class)
+public class MetricRegistryInjectionTest {
+
+    @Inject
+    HelloService hello;
+
+    @Inject
+    MetricsSummary summary;
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return ShrinkWrap.create(WebArchive.class).addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml").addPackage(MetricsSummary.class.getPackage())
+                .addPackage(MetricRegistryInjectionTest.class.getPackage());
+    }
+
+    @Test
+    public void testInjection() {
+        hello.hello();
+        assertNotNull(summary.getBaseMetrics().getMetrics().containsKey("memory.usedHeap"));
+        assertNotNull(summary.getVendorMetrics().getMetrics().containsKey("loadedModules"));
+        Metric helloCountMetric = summary.getAppMetrics().getMetrics().get("hello-count");
+        assertNotNull(helloCountMetric);
+        assertTrue(helloCountMetric instanceof Counting);
+        Counting helloCount = (Counting) helloCountMetric;
+        assertEquals(1, helloCount.getCount());
+    }
+
+}


### PR DESCRIPTION
Motivation
----------
CDI beans for base and vendor MetricRegistry are not available.

Modifications
-------------
Add relevant MetricRegistry producer methods.

Result
------
MP Metrics impl follows the spec requirements again.