### PR TITLE
Update Hibernate Search component docs to correct version

### DIFF
--- a/docs/src/main/asciidoc/components/other/hibernate-search.adoc
+++ b/docs/src/main/asciidoc/components/other/hibernate-search.adoc
@@ -66,4 +66,4 @@ QueryBuilder employeeQb;
 .Related Information
 
 * xref:component-jpa-support[]
-* https://docs.jboss.org/hibernate/search/5.9/reference/en-US/html_single/[Hibernate Search 5.9 Documentation]
+* https://docs.jboss.org/hibernate/search/5.10/reference/en-US/html_single/[Hibernate Search 5.10 Documentation]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
Hibernate Search version was being updated in the BOM in a separate PR as the Hibernate Search component was simultaneously being added. This lead to the Search component documentation referencing the wrong version once both PRs were accepted.