### PR TITLE
THORN-2041: Fix Teiid OData dependency.

### DIFF
--- a/fractions/teiid/odata/pom.xml
+++ b/fractions/teiid/odata/pom.xml
@@ -36,6 +36,10 @@
       <groupId>io.thorntail</groupId>
       <artifactId>undertow</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.thorntail</groupId>
+      <artifactId>keycloak</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>javax.inject</groupId>
@@ -167,10 +171,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>org.wildfly.swarm</groupId>
-      <artifactId>keycloak</artifactId>
-    </dependency>       
   </dependencies>
   <build>
     <resources>


### PR DESCRIPTION
- org.wildfly.swarm:keycloak does not exist anymore

This is a follow-up of https://github.com/thorntail/thorntail/pull/946 that was merged but not rebased (groupIds changed).
