### PR TITLE
THORN-2068: MP Metrics - basic support of MP Rest Client proxies.

### DIFF
--- a/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/deployment/CountedInterceptor.java
+++ b/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/deployment/CountedInterceptor.java
@@ -70,7 +70,7 @@ import org.jboss.logging.Logger;
     }
 
     private <E extends Member & AnnotatedElement> Object countedCallable(InvocationContext context, E element) throws Exception {
-        MetricResolver.Of<Counted> counted = resolver.counted(bean.getBeanClass(), element);
+        MetricResolver.Of<Counted> counted = resolver.counted(bean != null ? bean.getBeanClass() : element.getDeclaringClass(), element);
         String name = counted.metricName();
         Counter counter = (Counter) registry.getCounters().get(name);
         if (counter == null) {

--- a/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/deployment/MeteredInterceptor.java
+++ b/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/deployment/MeteredInterceptor.java
@@ -18,9 +18,8 @@
 package org.wildfly.swarm.microprofile.metrics.deployment;
 
 
-import org.eclipse.microprofile.metrics.Meter;
-import org.eclipse.microprofile.metrics.MetricRegistry;
-import org.eclipse.microprofile.metrics.annotation.Metered;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Member;
 
 import javax.annotation.Priority;
 import javax.enterprise.inject.Intercepted;
@@ -31,8 +30,10 @@ import javax.interceptor.AroundInvoke;
 import javax.interceptor.AroundTimeout;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
-import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Member;
+
+import org.eclipse.microprofile.metrics.Meter;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.Metered;
 
 @SuppressWarnings("unused")
 @Metered
@@ -69,7 +70,7 @@ import java.lang.reflect.Member;
     }
 
     private <E extends Member & AnnotatedElement> Object meteredCallable(InvocationContext context, E element) throws Exception {
-        String name = resolver.metered(bean.getBeanClass(), element).metricName();
+        String name = resolver.metered(bean != null ? bean.getBeanClass() : element.getDeclaringClass(), element).metricName();
         Meter meter = (Meter) registry.getMetrics().get(name);
         if (meter == null) {
             throw new IllegalStateException("No meter with name [" + name + "] found in registry [" + registry + "]");

--- a/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/deployment/MetricsMetadata.java
+++ b/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/deployment/MetricsMetadata.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package org.wildfly.swarm.microprofile.metrics.deployment;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Member;
+
+import org.eclipse.microprofile.metrics.Metadata;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricType;
+import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.eclipse.microprofile.metrics.annotation.Metered;
+import org.eclipse.microprofile.metrics.annotation.Timed;
+
+class MetricsMetadata {
+
+    private MetricsMetadata() {
+    }
+
+    static <E extends Member & AnnotatedElement> void registerMetrics(MetricRegistry registry, MetricResolver resolver, Class<?> bean, E element) {
+        MetricResolver.Of<Counted> counted = resolver.counted(bean, element);
+        if (counted.isPresent()) {
+            Counted t = counted.metricAnnotation();
+            Metadata metadata = getMetadata(counted.metricName(), t.unit(), t.description(), t.displayName(), MetricType.COUNTER, t.tags());
+            registry.counter(metadata);
+        }
+        MetricResolver.Of<Metered> metered = resolver.metered(bean, element);
+        if (metered.isPresent()) {
+            Metered t = metered.metricAnnotation();
+            Metadata metadata = getMetadata(metered.metricName(), t.unit(), t.description(), t.displayName(), MetricType.METERED, t.tags());
+            registry.meter(metadata);
+        }
+        MetricResolver.Of<Timed> timed = resolver.timed(bean, element);
+        if (timed.isPresent()) {
+            Timed t = timed.metricAnnotation();
+            Metadata metadata = getMetadata(timed.metricName(), t.unit(), t.description(), t.displayName(), MetricType.TIMER, t.tags());
+            registry.timer(metadata);
+        }
+    }
+
+    static Metadata getMetadata(String name, String unit, String description, String displayName, MetricType type, String... tags) {
+        Metadata metadata = new Metadata(name, type);
+        if (!unit.isEmpty()) {
+            metadata.setUnit(unit);
+        }
+        if (!description.isEmpty()) {
+            metadata.setDescription(description);
+        }
+        if (!displayName.isEmpty()) {
+            metadata.setDisplayName(displayName);
+        }
+        if (tags != null && tags.length > 0) {
+            for (String tag : tags) {
+                metadata.addTags(tag);
+            }
+        }
+        return metadata;
+    }
+
+}

--- a/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/deployment/TimedInterceptor.java
+++ b/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/deployment/TimedInterceptor.java
@@ -18,9 +18,8 @@
 package org.wildfly.swarm.microprofile.metrics.deployment;
 
 
-import org.eclipse.microprofile.metrics.MetricRegistry;
-import org.eclipse.microprofile.metrics.Timer;
-import org.eclipse.microprofile.metrics.annotation.Timed;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Member;
 
 import javax.annotation.Priority;
 import javax.enterprise.inject.Intercepted;
@@ -31,8 +30,10 @@ import javax.interceptor.AroundInvoke;
 import javax.interceptor.AroundTimeout;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
-import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Member;
+
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.Timer;
+import org.eclipse.microprofile.metrics.annotation.Timed;
 
 @SuppressWarnings("unused")
 @Timed
@@ -69,7 +70,7 @@ import java.lang.reflect.Member;
     }
 
     private <E extends Member & AnnotatedElement> Object timedCallable(InvocationContext context, E element) throws Exception {
-        String name = resolver.timed(bean.getBeanClass(), element).metricName();
+        String name = resolver.timed(bean != null ? bean.getBeanClass() : element.getDeclaringClass(), element).metricName();
         Timer timer = (Timer) registry.getMetrics().get(name);
         if (timer == null) {
             throw new IllegalStateException("No timer with name [" + name + "] found in registry [" + registry + "]");

--- a/testsuite/testsuite-microprofile-restclient/pom.xml
+++ b/testsuite/testsuite-microprofile-restclient/pom.xml
@@ -24,6 +24,10 @@
       </dependency>
       <dependency>
          <groupId>io.thorntail</groupId>
+         <artifactId>microprofile-metrics</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>io.thorntail</groupId>
          <artifactId>arquillian</artifactId>
          <scope>test</scope>
       </dependency>

--- a/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/metrics/HelloMetricsClassLevelClient.java
+++ b/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/metrics/HelloMetricsClassLevelClient.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.restclient.metrics;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.metrics.annotation.Counted;
+
+@Counted(monotonic = true)
+@Path("/v1")
+public interface HelloMetricsClassLevelClient {
+
+    @GET
+    @Path("/hello")
+    String hello();
+
+}

--- a/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/metrics/HelloMetricsClient.java
+++ b/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/metrics/HelloMetricsClient.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.restclient.metrics;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.eclipse.microprofile.metrics.MetricUnits;
+import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.eclipse.microprofile.metrics.annotation.Timed;
+
+@Path("/v1")
+public interface HelloMetricsClient {
+
+    static final String TIMED_NAME = "hello-time";
+
+    static final String COUNTED_NAME = "hello-count";
+
+    @Timed(unit = MetricUnits.MILLISECONDS, name = TIMED_NAME, absolute = true)
+    @GET
+    @Path("/hello")
+    String helloTimed();
+
+    @Counted(name = COUNTED_NAME, absolute = true, monotonic = true)
+    @GET
+    @Path("/hello")
+    String helloCounted();
+
+}

--- a/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/metrics/MetricsTest.java
+++ b/testsuite/testsuite-microprofile-restclient/src/test/java/org/wildfly/swarm/microprofile/restclient/metrics/MetricsTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.restclient.metrics;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.RegistryType;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.eclipse.microprofile.rest.client.RestClientDefinitionException;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.microprofile.restclient.Counter;
+import org.wildfly.swarm.microprofile.restclient.HelloResource;
+import org.wildfly.swarm.microprofile.restclient.Timer;
+
+/**
+ *
+ * @author Martin Kouba
+ */
+@RunWith(Arquillian.class)
+public class MetricsTest {
+
+    @Inject
+    Counter counter;
+
+    @Inject
+    Timer timer;
+
+    @ArquillianResource
+    URL url;
+
+    @Inject
+    @RegistryType(type = MetricRegistry.Type.APPLICATION)
+    MetricRegistry registry;
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return ShrinkWrap.create(WebArchive.class).addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml").addPackage(HelloResource.class.getPackage())
+                .addPackage(MetricsTest.class.getPackage());
+    }
+
+    @Test
+    public void testTimed() throws InterruptedException, IllegalStateException, RestClientDefinitionException, MalformedURLException {
+        counter.reset(1);
+        timer.reset(0);
+
+        HelloMetricsClient helloClient = RestClientBuilder.newBuilder().baseUrl(url).build(HelloMetricsClient.class);
+        assertEquals("OK1", helloClient.helloTimed());
+
+        org.eclipse.microprofile.metrics.Timer metricsTimer = registry.getTimers().get(HelloMetricsClient.TIMED_NAME);
+        assertNotNull(metricsTimer);
+        assertEquals(1, metricsTimer.getCount());
+    }
+
+    @Test
+    public void testCounted() throws InterruptedException, IllegalStateException, RestClientDefinitionException, MalformedURLException {
+        counter.reset(1);
+        timer.reset(0);
+
+        HelloMetricsClient helloClient = RestClientBuilder.newBuilder().baseUrl(url).build(HelloMetricsClient.class);
+        assertEquals("OK1", helloClient.helloCounted());
+        assertEquals("OK2", helloClient.helloCounted());
+        assertEquals("OK3", helloClient.helloCounted());
+
+        org.eclipse.microprofile.metrics.Counter metricsCounter = registry.getCounters().get(HelloMetricsClient.COUNTED_NAME);
+        assertNotNull(metricsCounter);
+        assertEquals(3, metricsCounter.getCount());
+    }
+
+    @Test
+    public void testClassLevelCounted() throws InterruptedException, IllegalStateException, RestClientDefinitionException, MalformedURLException {
+        counter.reset(1);
+        timer.reset(0);
+
+        HelloMetricsClassLevelClient helloClient = RestClientBuilder.newBuilder().baseUrl(url).build(HelloMetricsClassLevelClient.class);
+        assertEquals("OK1", helloClient.hello());
+        assertEquals("OK2", helloClient.hello());
+
+        org.eclipse.microprofile.metrics.Counter metricsCounter = registry.getCounters().get(HelloMetricsClassLevelClient.class.getName() + "." + "hello");
+        assertNotNull(metricsCounter);
+        assertEquals(2, metricsCounter.getCount());
+    }
+
+}


### PR DESCRIPTION
Motivation
----------
Recently, we added CDI interceptors support to MP Rest Client proxies
(non-portable feature, see also THORN-2030). The primary use case was to
support MP FT annotations. It would be nice to support MP Metrics
annotations as well.

Modifications
-------------
We collect all interfaces annotated with metrics annotations and
register relevant metrics during AfterDeploymentValidation phase. All
metrics interceptors were modified to work with non-contextual instances
such as Java EE components and Rest Client proxies.

Result
------
MP Rest Client proxies can use MP Metrics annotations to register and
update metrics.
