### PR TITLE
THORN-2082: Thorntail Maven plugin uses wrong classifier name for packaging and multistart

### DIFF
--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/MultiStartMojo.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/MultiStartMojo.java
@@ -98,7 +98,7 @@ public class MultiStartMojo extends AbstractSwarmMojo {
         String classifier = process.getChild("classifier").getValue();
         Artifact artifact = findArtifact(groupId, artifactId, classifier);
         if (artifact == null) {
-            artifact = findArtifact(groupId, artifactId, "swarm");
+            artifact = findArtifact(groupId, artifactId, "thorntail");
         }
 
         if (artifact != null) {

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/MultiStartMojo.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/MultiStartMojo.java
@@ -98,7 +98,7 @@ public class MultiStartMojo extends AbstractSwarmMojo {
         String classifier = process.getChild("classifier").getValue();
         Artifact artifact = findArtifact(groupId, artifactId, classifier);
         if (artifact == null) {
-            artifact = findArtifact(groupId, artifactId, "thorntail");
+            artifact = findArtifact(groupId, artifactId, PackageMojo.UBERJAR_SUFFIX);
         }
 
         if (artifact != null) {

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/PackageMojo.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/PackageMojo.java
@@ -51,9 +51,9 @@ import org.wildfly.swarm.tools.DeclaredDependencies;
 )
 public class PackageMojo extends AbstractSwarmMojo {
 
-    static final String UBERJAR_SUFFIX = "-thorntail";
+    static final String UBERJAR_SUFFIX = "thorntail";
 
-    static final String HOLLOWJAR_SUFFIX = "-hollow" + UBERJAR_SUFFIX;
+    static final String HOLLOWJAR_SUFFIX = "hollow" + UBERJAR_SUFFIX;
 
     @Parameter(alias = "bundleDependencies", defaultValue = "true", property = "swarm.bundleDependencies")
     protected boolean bundleDependencies;
@@ -214,7 +214,7 @@ public class PackageMojo extends AbstractSwarmMojo {
             if (this.finalName != null) {
                 jarFinalName = this.finalName;
             } else {
-                jarFinalName = finalName + (this.hollow ? HOLLOWJAR_SUFFIX : UBERJAR_SUFFIX);
+                jarFinalName = finalName + "-" + (this.hollow ? HOLLOWJAR_SUFFIX : UBERJAR_SUFFIX);
             }
             jarFinalName += JAR_FILE_EXTENSION;
             File jar = tool.build(jarFinalName, Paths.get(this.projectBuildDir));

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/PackageMojo.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/PackageMojo.java
@@ -53,7 +53,7 @@ public class PackageMojo extends AbstractSwarmMojo {
 
     static final String UBERJAR_SUFFIX = "thorntail";
 
-    static final String HOLLOWJAR_SUFFIX = "hollow" + UBERJAR_SUFFIX;
+    static final String HOLLOWJAR_SUFFIX = "hollow" + "-" + UBERJAR_SUFFIX;
 
     @Parameter(alias = "bundleDependencies", defaultValue = "true", property = "swarm.bundleDependencies")
     protected boolean bundleDependencies;

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/StartMojo.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/StartMojo.java
@@ -189,7 +189,7 @@ public class StartMojo extends AbstractSwarmMojo {
         }
 
         return new SwarmExecutor()
-                .withExecutableJar(Paths.get(this.projectBuildDir, finalName + PackageMojo.UBERJAR_SUFFIX + JAR_FILE_EXTENSION));
+                .withExecutableJar(Paths.get(this.projectBuildDir, finalName + "-" + PackageMojo.UBERJAR_SUFFIX + JAR_FILE_EXTENSION));
     }
 
     protected SwarmExecutor warExecutor() throws MojoFailureException {


### PR DESCRIPTION
fixing maven plugin to use correct name for classifier and artifacts names during packaging, start and multistart