### PR TITLE
[THORN-2084] Update ElytronFraction not to create audit.log by default

### DIFF
--- a/fractions/wildfly/elytron/src/main/java/org/wildfly/swarm/elytron/ElytronFraction.java
+++ b/fractions/wildfly/elytron/src/main/java/org/wildfly/swarm/elytron/ElytronFraction.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 
 import org.wildfly.swarm.config.Elytron;
-import org.wildfly.swarm.config.elytron.Format;
 import org.wildfly.swarm.config.elytron.SimplePermissionMapper;
 import org.wildfly.swarm.spi.api.Fraction;
 import org.wildfly.swarm.spi.api.annotations.MarshalDMR;

--- a/fractions/wildfly/elytron/src/main/java/org/wildfly/swarm/elytron/ElytronFraction.java
+++ b/fractions/wildfly/elytron/src/main/java/org/wildfly/swarm/elytron/ElytronFraction.java
@@ -79,6 +79,7 @@ public class ElytronFraction extends Elytron<ElytronFraction> implements Fractio
             providers.provider(ELYTRON);
             providers.provider(OPENSSL);
         });
+        // Local audit.log is no longer created by default, please see https://issues.jboss.org/browse/THORN-2084
         securityDomain(APPLICATION_DOMAIN, (domain) -> {
             domain.defaultRealm(APPLICATION_REALM);
             domain.permissionMapper("default-permission-mapper");

--- a/fractions/wildfly/elytron/src/main/java/org/wildfly/swarm/elytron/ElytronFraction.java
+++ b/fractions/wildfly/elytron/src/main/java/org/wildfly/swarm/elytron/ElytronFraction.java
@@ -80,11 +80,6 @@ public class ElytronFraction extends Elytron<ElytronFraction> implements Fractio
             providers.provider(ELYTRON);
             providers.provider(OPENSSL);
         });
-        fileAuditLog(LOCAL_AUDIT, (log) -> {
-            log.path("audit.log");
-            log.relativeTo("jboss.server.log.dir");
-            log.format(Format.JSON);
-        });
         securityDomain(APPLICATION_DOMAIN, (domain) -> {
             domain.defaultRealm(APPLICATION_REALM);
             domain.permissionMapper("default-permission-mapper");


### PR DESCRIPTION
**Motivation**

Empty audit.log files are created when the Thorntail v2 servers are starting

**Changes**

Remove the code creating the audit.log by default from ElytronFraction

**Result**

Better user experience; audit.log files will be created only if the users need them by configuring the elytron subsystem. 

