### PR TITLE
THORN-2091: Maven plugin for automated migration from WildFly Swarm to Thorntail

### DIFF
--- a/plugins/maven/pom.xml
+++ b/plugins/maven/pom.xml
@@ -81,6 +81,11 @@
       <artifactId>aether-util</artifactId>
       <version>1.0.0.v20140518</version>
     </dependency>
+    <dependency>
+      <groupId>org.jooq</groupId>
+      <artifactId>joox-java-6</artifactId>
+      <version>1.6.0</version>
+    </dependency>
   </dependencies>
 
 </project>

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/migrate/DependencyLocation.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/migrate/DependencyLocation.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2015-2018 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.plugin.maven.migrate;
+
+import org.joox.Filter;
+import org.joox.Match;
+
+import java.util.Objects;
+
+import static org.joox.JOOX.$;
+
+final class DependencyLocation {
+    private final PluginLocation pluginLocation;
+
+    private final DependencyLocationType type;
+
+    private final String groupId;
+    private final String artifactId;
+
+    static DependencyLocation dependencyManagement(PluginLocation pluginLocation, Match dependency) {
+        return new DependencyLocation(pluginLocation, DependencyLocationType.DEPENDENCY_MANAGEMENT, dependency);
+    }
+
+    static DependencyLocation dependencies(PluginLocation pluginLocation, Match dependency) {
+        return new DependencyLocation(pluginLocation, DependencyLocationType.DEPENDENCIES, dependency);
+    }
+
+    private DependencyLocation(PluginLocation pluginLocation, DependencyLocationType type, Match dependency) {
+        this.pluginLocation = pluginLocation;
+        this.type = type;
+        this.groupId = dependency.child("groupId").text();
+        this.artifactId = dependency.child("artifactId").text();
+    }
+
+    Match find(Match pom) {
+        Match plugin = pluginLocation.find(pom);
+
+        Filter dependencyFilter = dependency -> {
+            String groupId = $(dependency).child("groupId").text();
+            String artifactId = $(dependency).child("artifactId").text();
+            return this.groupId.equals(groupId) && this.artifactId.equals(artifactId);
+        };
+
+        switch (type) {
+            case DEPENDENCY_MANAGEMENT:
+                return plugin.xpath("m:dependencyManagement/m:dependencies/m:dependency")
+                        .filter(dependencyFilter);
+            case DEPENDENCIES:
+                return plugin.xpath("m:dependencies/m:dependency")
+                        .filter(dependencyFilter);
+            default:
+                throw new AssertionError();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return type + " " + groupId + ":" + artifactId + (pluginLocation.isNone() ? "" : " of ") + pluginLocation;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof DependencyLocation)) {
+            return false;
+        }
+        DependencyLocation that = (DependencyLocation) o;
+        return Objects.equals(pluginLocation, that.pluginLocation) &&
+                type == that.type &&
+                Objects.equals(groupId, that.groupId) &&
+                Objects.equals(artifactId, that.artifactId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pluginLocation, type, groupId, artifactId);
+    }
+}

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/migrate/DependencyLocationType.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/migrate/DependencyLocationType.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2015-2018 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.plugin.maven.migrate;
+
+enum DependencyLocationType {
+    // <plugin>/dependencyManagement/dependencies/dependency
+    DEPENDENCY_MANAGEMENT("dependencyManagement"),
+    // <plugin>/dependencies/dependency
+    DEPENDENCIES("dependency");
+
+    private final String description;
+
+    DependencyLocationType(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public String toString() {
+        return description;
+    }
+}

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/migrate/MavenUtils.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/migrate/MavenUtils.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2015-2018 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.plugin.maven.migrate;
+
+import org.joox.Context;
+import org.joox.Match;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.Result;
+import javax.xml.transform.Source;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.joox.JOOX.$;
+
+final class MavenUtils {
+    private MavenUtils() {
+        // avoid instantiation
+    }
+
+    private static final Pattern PROPERTY_REFERENCE = Pattern.compile("\\$\\{(.*?)\\}");
+
+    static Match $$(Context match) {
+        return $(match).namespace("m", "http://maven.apache.org/POM/4.0.0");
+    }
+
+    static Match parsePomXml(Path path) throws IOException, SAXException, ParserConfigurationException {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setExpandEntityReferences(false);
+        factory.setNamespaceAware(true);
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document document = builder.parse(path.toFile());
+
+        return $(document).namespace("m", "http://maven.apache.org/POM/4.0.0");
+    }
+
+    static void writePomXml(Path path, Match pom) throws TransformerException, IOException {
+        try (OutputStream out = new FileOutputStream(path.toFile())) {
+            Transformer transformer = TransformerFactory.newInstance().newTransformer();
+            Source source = new DOMSource(pom.document());
+            Result target = new StreamResult(out);
+            transformer.transform(source, target);
+        }
+    }
+
+    static boolean refersToProperty(String version) {
+        return version != null && PROPERTY_REFERENCE.matcher(version).find();
+    }
+
+    static Set<String> propertyNamesReferredFrom(String version) {
+        // there should really only be one -- if there are more, should we abort?
+        Set<String> result = new HashSet<>();
+        Matcher matcher = PROPERTY_REFERENCE.matcher(version);
+        while (matcher.find()) {
+            result.add(matcher.group(1));
+        }
+        return result;
+    }
+}

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/migrate/MigrateWildFlySwarmDependency.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/migrate/MigrateWildFlySwarmDependency.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2015-2018 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.plugin.maven.migrate;
+
+import org.joox.Match;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+import static org.joox.JOOX.$;
+import static org.wildfly.swarm.plugin.maven.migrate.MavenUtils.parsePomXml;
+
+final class MigrateWildFlySwarmDependency implements MigrationAction {
+    private final Path pomXml;
+    private final DependencyLocation location;
+    // null = version shouldn't be changed (generally because it uses a property)
+    private final String targetVersion;
+
+    MigrateWildFlySwarmDependency(Path pomXml, DependencyLocation location, String targetVersion) {
+        this.pomXml = pomXml;
+        this.location = location;
+        this.targetVersion = targetVersion;
+    }
+
+    @Override
+    public String describe() {
+        return pomXml + ": migrate " + location + " (target version: " + targetVersion + ")";
+    }
+
+    @Override
+    public void execute() throws Exception {
+        Match pom = parsePomXml(pomXml);
+
+        location.find(pom).each(dependency -> {
+            $(dependency).child("groupId").text("io.thorntail");
+            if (targetVersion != null) {
+                $(dependency).child("version").text(targetVersion);
+            }
+        });
+
+        MavenUtils.writePomXml(pomXml, pom);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof MigrateWildFlySwarmDependency)) {
+            return false;
+        }
+        MigrateWildFlySwarmDependency that = (MigrateWildFlySwarmDependency) o;
+        return Objects.equals(pomXml, that.pomXml) &&
+                Objects.equals(location, that.location) &&
+                Objects.equals(targetVersion, that.targetVersion);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pomXml, location, targetVersion);
+    }
+}

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/migrate/MigrateWildFlySwarmDependencyExclusion.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/migrate/MigrateWildFlySwarmDependencyExclusion.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2015-2018 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.plugin.maven.migrate;
+
+import org.joox.Match;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+import static org.joox.JOOX.$;
+import static org.wildfly.swarm.plugin.maven.migrate.MavenUtils.parsePomXml;
+
+final class MigrateWildFlySwarmDependencyExclusion implements MigrationAction {
+    private final Path pomXml;
+    private final DependencyLocation location;
+    private final String groupId;
+    private final String artifactId;
+
+    MigrateWildFlySwarmDependencyExclusion(Path pomXml, DependencyLocation location, String groupId, String artifactId) {
+        this.pomXml = pomXml;
+        this.location = location;
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+    }
+
+    @Override
+    public String describe() {
+        return pomXml + ": migrate dependency exclusion on " + groupId + ":" + artifactId + " at " + location;
+    }
+
+    @Override
+    public void execute() throws Exception {
+        Match pom = parsePomXml(pomXml);
+
+        location.find(pom)
+                .xpath("m:exclusions/m:exclusion")
+                .filter(exclusion -> {
+                    String groupId = $(exclusion).child("groupId").text();
+                    String artifactId = $(exclusion).child("artifactId").text();
+                    return this.groupId.equals(groupId) && this.artifactId.equals(artifactId);
+                })
+                .each(exclusion -> $(exclusion).child("groupId").text("io.thorntail"));
+
+        MavenUtils.writePomXml(pomXml, pom);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof MigrateWildFlySwarmDependencyExclusion)) {
+            return false;
+        }
+        MigrateWildFlySwarmDependencyExclusion that = (MigrateWildFlySwarmDependencyExclusion) o;
+        return Objects.equals(pomXml, that.pomXml) &&
+                Objects.equals(location, that.location) &&
+                Objects.equals(groupId, that.groupId) &&
+                Objects.equals(artifactId, that.artifactId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pomXml, location, groupId, artifactId);
+    }
+}

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/migrate/MigrateWildFlySwarmPlugin.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/migrate/MigrateWildFlySwarmPlugin.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2015-2018 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.plugin.maven.migrate;
+
+import org.joox.Match;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+import static org.joox.JOOX.$;
+import static org.wildfly.swarm.plugin.maven.migrate.MavenUtils.parsePomXml;
+
+final class MigrateWildFlySwarmPlugin implements MigrationAction {
+    private final Path pomXml;
+    private final PluginLocation location;
+    // null = version shouldn't be changed (generally because it uses a property)
+    private final String targetVersion;
+
+    public MigrateWildFlySwarmPlugin(Path pomXml, PluginLocation location, String targetVersion) {
+        this.pomXml = pomXml;
+        this.location = location;
+        this.targetVersion = targetVersion;
+    }
+
+    @Override
+    public String describe() {
+        return pomXml + ": migrate " + location + " (target version: " + targetVersion + ")";
+    }
+
+    @Override
+    public void execute() throws Exception {
+        Match pom = parsePomXml(pomXml);
+
+        location.find(pom).each(plugin -> {
+            $(plugin).child("groupId").text("io.thorntail");
+            $(plugin).child("artifactId").text("thorntail-maven-plugin");
+            if (targetVersion != null) {
+                $(plugin).child("version").text(targetVersion);
+            }
+        });
+
+        MavenUtils.writePomXml(pomXml, pom);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof MigrateWildFlySwarmPlugin)) {
+            return false;
+        }
+        MigrateWildFlySwarmPlugin that = (MigrateWildFlySwarmPlugin) o;
+        return Objects.equals(pomXml, that.pomXml) &&
+                Objects.equals(location, that.location) &&
+                Objects.equals(targetVersion, that.targetVersion);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pomXml, location, targetVersion);
+    }
+}

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/migrate/MigrateWildFlySwarmVersionProperty.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/migrate/MigrateWildFlySwarmVersionProperty.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2015-2018 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.plugin.maven.migrate;
+
+import org.joox.Match;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.joox.JOOX.$;
+import static org.wildfly.swarm.plugin.maven.migrate.MavenUtils.parsePomXml;
+
+final class MigrateWildFlySwarmVersionProperty implements MigrationAction {
+    private final Path rootDir;
+    private final String versionProperty;
+    private final String targetValue;
+
+    MigrateWildFlySwarmVersionProperty(Path rootDir, String versionProperty, String targetValue) {
+        this.rootDir = rootDir;
+        this.versionProperty = versionProperty;
+        this.targetValue = targetValue;
+    }
+
+    @Override
+    public String describe() {
+        return "migrate version property " + versionProperty + " to value " + targetValue;
+    }
+
+    @Override
+    public void execute() throws Exception {
+        // this is not entirely precise, but respecting Maven POM inheritance hierarchy and profile scoping
+        // would be just too cumbersome
+
+        List<Path> pomXmls;
+        try (Stream<Path> pomXmlsStream = Files.walk(rootDir)) {
+            pomXmls = pomXmlsStream
+                    .filter(Files::isRegularFile)
+                    .filter(p -> "pom.xml".equals(p.getFileName().toString()))
+                    .collect(Collectors.toList());
+        }
+
+        for (Path pomXml : pomXmls) {
+            AtomicBoolean changed = new AtomicBoolean(false);
+
+            Match pom = parsePomXml(pomXml);
+            pom.xpath("/m:project/m:properties | /m:project/m:profiles/m:profile/m:properties")
+                    .children(property -> versionProperty.equals($(property).tag()))
+                    .each(property -> {
+                        $(property).text(targetValue);
+                        changed.set(true);
+                    });
+
+            if (changed.get()) {
+                MavenUtils.writePomXml(pomXml, pom);
+            }
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof MigrateWildFlySwarmVersionProperty)) {
+            return false;
+        }
+        MigrateWildFlySwarmVersionProperty that = (MigrateWildFlySwarmVersionProperty) o;
+        return Objects.equals(versionProperty, that.versionProperty) &&
+                Objects.equals(targetValue, that.targetValue);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(versionProperty, targetValue);
+    }
+}

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/migrate/MigrationAction.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/migrate/MigrationAction.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2015-2018 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.plugin.maven.migrate;
+
+/**
+ * {@code equals} and {@code hashCode} are required
+ */
+interface MigrationAction {
+    String describe();
+
+    void execute() throws Exception;
+}

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/migrate/MigrationMojo.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/migrate/MigrationMojo.java
@@ -1,0 +1,208 @@
+/**
+ * Copyright 2015-2018 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.plugin.maven.migrate;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.joox.Match;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.joox.JOOX.$;
+import static org.wildfly.swarm.plugin.maven.migrate.MavenUtils.$$;
+import static org.wildfly.swarm.plugin.maven.migrate.MavenUtils.parsePomXml;
+import static org.wildfly.swarm.plugin.maven.migrate.MavenUtils.propertyNamesReferredFrom;
+import static org.wildfly.swarm.plugin.maven.migrate.MavenUtils.refersToProperty;
+
+@Mojo(name = "migrate-from-wildfly-swarm", aggregator = true, requiresDirectInvocation = true)
+public class MigrationMojo extends AbstractMojo {
+    @Parameter(property = "targetVersion")
+    private String targetVersion;
+
+    @Parameter(property = "dryRun", defaultValue = "false")
+    private boolean dryRun;
+
+    @Parameter(defaultValue = "${mojoExecution}", readonly = true)
+    private MojoExecution mojo;
+
+    private Path rootDir;
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        findTargetVersion();
+
+        rootDir = Paths.get("."); // could also use MavenSession.getExecutionRootDirectory()
+
+        try {
+            Set<Path> pomXmls = findPomXmls(rootDir);
+
+            Set<MigrationAction> migrationActions = new HashSet<>();
+            for (Path pomXml : pomXmls) {
+                migrationActions.addAll(prepareMigrationActions(pomXml));
+            }
+
+            // sorting just for log readability, doesn't affect outcome
+            List<MigrationAction> sortedMigrationActions = migrationActions.stream()
+                    .sorted(Comparator.comparing(MigrationAction::describe))
+                    .collect(Collectors.toList());
+            for (MigrationAction migrationAction : sortedMigrationActions) {
+                getLog().info(migrationAction.describe());
+
+                if (!dryRun) {
+                    migrationAction.execute();
+                }
+            }
+        } catch (Exception e) {
+            throw new MojoExecutionException(e.getMessage(), e);
+        }
+    }
+
+    private void findTargetVersion() {
+        if (targetVersion == null || targetVersion.isEmpty()) {
+            targetVersion = mojo.getPlugin().getVersion();
+        }
+
+        getLog().info("Upgrading to Thorntail " + targetVersion);
+
+    }
+
+    private Set<Path> findPomXmls(Path rootDir) throws IOException {
+        try (Stream<Path> pomXmls = Files.walk(rootDir)) {
+            return pomXmls
+                    .filter(Files::isRegularFile)
+                    .filter(p -> "pom.xml".equals(p.getFileName().toString()))
+                    .collect(Collectors.toSet());
+        }
+    }
+
+    private Set<MigrationAction> prepareMigrationActions(Path pomXml) throws IOException, SAXException, ParserConfigurationException {
+        Match pom = parsePomXml(pomXml);
+
+        Set<MigrationAction> result = new HashSet<>();
+
+        Match nonProfile = pom.xpath("/m:project");
+        result.addAll(prepareMigrationActionsForProfile(pomXml, nonProfile, ProfileLocation.none()));
+
+        pom.xpath("/m:project/m:profiles/m:profile").each(profile -> {
+            result.addAll(prepareMigrationActionsForProfile(pomXml, $$(profile), ProfileLocation.profile($(profile))));
+        });
+
+        return result;
+    }
+
+    private Set<MigrationAction> prepareMigrationActionsForProfile(Path pomXml, Match profile, ProfileLocation profileLocation) {
+        Set<MigrationAction> result = new HashSet<>();
+
+        Match dependencies = profile.xpath("m:dependencies/m:dependency");
+        result.addAll(prepareMigrationActionsForDependencies(pomXml, dependencies,
+                dependency -> DependencyLocation.dependencies(PluginLocation.none(profileLocation), dependency)));
+
+        Match dependencyManagement = profile.xpath("m:dependencyManagement/m:dependencies/m:dependency");
+        result.addAll(prepareMigrationActionsForDependencies(pomXml, dependencyManagement,
+                dependency -> DependencyLocation.dependencyManagement(PluginLocation.none(profileLocation), dependency)));
+
+        Match plugins = profile.xpath("m:build/m:plugins/m:plugin");
+        result.addAll(prepareMigrationActionsForPlugins(pomXml, plugins,
+                plugin -> PluginLocation.plugins(profileLocation, plugin)));
+
+        Match pluginManagement = profile.xpath("m:build/m:pluginManagement/m:plugins/m:plugin");
+        result.addAll(prepareMigrationActionsForPlugins(pomXml, pluginManagement,
+                plugin -> PluginLocation.pluginManagement(profileLocation, plugin)));
+
+        return result;
+    }
+
+    private Set<MigrationAction> prepareMigrationActionsForDependencies(Path pomXml, Match dependencies, Function<Match, DependencyLocation> locator) {
+        Set<MigrationAction> result = new HashSet<>();
+
+        dependencies.each(dependency -> {
+            String groupId = $(dependency).child("groupId").text();
+            String version = $(dependency).child("version").text();
+
+            if (isWildFlySwarmGroupId(groupId)) {
+                result.add(new MigrateWildFlySwarmDependency(pomXml, locator.apply($(dependency)), targetThorntailVersion(version)));
+
+                if (refersToProperty(version)) {
+                    for (String property : propertyNamesReferredFrom(version)) {
+                        result.add(new MigrateWildFlySwarmVersionProperty(rootDir, property, targetVersion));
+                    }
+                }
+            }
+
+            $(dependency).find("exclusion").each(exclusion -> {
+                String exclusionGroupId = $(exclusion).child("groupId").text();
+                String exclusionArtifactId = $(exclusion).child("artifactId").text();
+                if (isWildFlySwarmGroupId(exclusionGroupId)) {
+                    result.add(new MigrateWildFlySwarmDependencyExclusion(pomXml, locator.apply($(dependency)), exclusionGroupId, exclusionArtifactId));
+                }
+            });
+        });
+
+        return result;
+    }
+
+    private Set<MigrationAction> prepareMigrationActionsForPlugins(Path pomXml, Match plugins, Function<Match, PluginLocation> locator) {
+        Set<MigrationAction> result = new HashSet<>();
+
+        plugins.each(plugin -> {
+            String groupId = $(plugin).child("groupId").text();
+            String artifactId = $(plugin).child("artifactId").text();
+            String version = $(plugin).child("version").text();
+
+            if (isWildFlySwarmGroupId(groupId) && "wildfly-swarm-plugin".equals(artifactId)) {
+                result.add(new MigrateWildFlySwarmPlugin(pomXml, locator.apply($(plugin)), targetThorntailVersion(version)));
+                if (refersToProperty(version)) {
+                    for (String property : propertyNamesReferredFrom(version)) {
+                        result.add(new MigrateWildFlySwarmVersionProperty(rootDir, property, targetVersion));
+                    }
+                }
+            }
+
+            // TODO Fabric8 Maven plugin?
+
+            Function<Match, DependencyLocation> dependencyLocator =
+                    dependency -> DependencyLocation.dependencies(locator.apply($(plugin)), dependency);
+            result.addAll(prepareMigrationActionsForDependencies(pomXml, $(plugin).find("dependency"), dependencyLocator));
+        });
+        return result;
+    }
+
+    private String targetThorntailVersion(String currentWildFlySwarmVersion) {
+        if (currentWildFlySwarmVersion == null || refersToProperty(currentWildFlySwarmVersion)) {
+            return null; // no change
+        }
+        return targetVersion;
+    }
+
+    private static boolean isWildFlySwarmGroupId(String groupId) {
+        return "org.wildfly.swarm".equals(groupId);
+    }
+}

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/migrate/PluginLocation.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/migrate/PluginLocation.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2015-2018 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.plugin.maven.migrate;
+
+import org.joox.Filter;
+import org.joox.Match;
+
+import java.util.Objects;
+
+import static org.joox.JOOX.$;
+
+final class PluginLocation {
+    private final ProfileLocation profileLocation;
+
+    private final PluginLocationType type;
+
+    private final String groupId;
+    private final String artifactId;
+
+    static PluginLocation none(ProfileLocation profileLocation) {
+        return new PluginLocation(profileLocation, PluginLocationType.NONE, null);
+    }
+
+    static PluginLocation pluginManagement(ProfileLocation profileLocation, Match plugin) {
+        return new PluginLocation(profileLocation, PluginLocationType.PLUGIN_MANAGEMENT, plugin);
+    }
+
+    static PluginLocation plugins(ProfileLocation profileLocation, Match plugin) {
+        return new PluginLocation(profileLocation, PluginLocationType.PLUGINS, plugin);
+    }
+
+    private PluginLocation(ProfileLocation profileLocation, PluginLocationType type, Match plugin) {
+        this.profileLocation = profileLocation;
+        this.type = type;
+        if (plugin != null) {
+            this.groupId = plugin.child("groupId").text();
+            this.artifactId = plugin.child("artifactId").text();
+        } else {
+            this.groupId = null;
+            this.artifactId = null;
+        }
+    }
+
+    Match find(Match pom) {
+        Match profile = profileLocation.find(pom);
+
+        Filter pluginFilter = plugin -> {
+            String groupId = $(plugin).child("groupId").text();
+            String artifactId = $(plugin).child("artifactId").text();
+            return this.groupId.equals(groupId) && this.artifactId.equals(artifactId);
+        };
+
+        switch (type) {
+            case NONE:
+                return profile;
+            case PLUGIN_MANAGEMENT:
+                return profile.xpath("m:build/m:pluginManagement/m:plugins/m:plugin")
+                        .filter(pluginFilter);
+            case PLUGINS:
+                return profile.xpath("m:build/m:plugins/m:plugin")
+                        .filter(pluginFilter);
+            default:
+                throw new AssertionError();
+        }
+    }
+
+    boolean isNone() {
+        return type == PluginLocationType.NONE;
+    }
+
+    @Override
+    public String toString() {
+        String base = "";
+        if (type != PluginLocationType.NONE) {
+            base = type + " " + groupId + ":" + artifactId;
+        }
+
+        return base + (profileLocation.isNone() ? "" : " in " + profileLocation);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof PluginLocation)) {
+            return false;
+        }
+        PluginLocation that = (PluginLocation) o;
+        return Objects.equals(profileLocation, that.profileLocation) &&
+                type == that.type &&
+                Objects.equals(groupId, that.groupId) &&
+                Objects.equals(artifactId, that.artifactId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(profileLocation, type, groupId, artifactId);
+    }
+}

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/migrate/PluginLocationType.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/migrate/PluginLocationType.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2015-2018 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.plugin.maven.migrate;
+
+enum PluginLocationType {
+    // <profile>
+    NONE("<no plugin>"),
+
+    // <profile>/build/pluginManagement/plugins/plugin
+    PLUGIN_MANAGEMENT("pluginManagement"),
+    // <profile>/build/plugins/plugin
+    PLUGINS("plugin");
+
+    private final String description;
+
+    PluginLocationType(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public String toString() {
+        return description;
+    }
+}

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/migrate/ProfileLocation.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/migrate/ProfileLocation.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2015-2018 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.plugin.maven.migrate;
+
+import org.joox.Match;
+
+import java.util.Objects;
+
+import static org.joox.JOOX.$;
+
+final class ProfileLocation {
+    private final ProfileLocationType type;
+
+    private final String id;
+
+    static ProfileLocation none() {
+        return new ProfileLocation(ProfileLocationType.NONE, "<no profile>");
+    }
+
+    static ProfileLocation profile(Match profile) {
+        return new ProfileLocation(ProfileLocationType.PROFILE, profile.child("id").text());
+    }
+
+    private ProfileLocation(ProfileLocationType type, String id) {
+        this.type = type;
+        this.id = id;
+    }
+
+    Match find(Match pom) {
+        switch (type) {
+            case NONE:
+                return pom;
+            case PROFILE:
+                return pom.xpath("m:profiles/m:profile")
+                        .filter(profile -> {
+                            String id = $(profile).child("id").text();
+                            return this.id.equals(id);
+                        });
+            default:
+                throw new AssertionError();
+        }
+    }
+
+    boolean isNone() {
+        return type == ProfileLocationType.NONE;
+    }
+
+    @Override
+    public String toString() {
+        if (type == ProfileLocationType.NONE) {
+            return "";
+        } else {
+            return type + " " + id;
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ProfileLocation)) {
+            return false;
+        }
+        ProfileLocation that = (ProfileLocation) o;
+        return type == that.type &&
+                Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, id);
+    }
+}

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/migrate/ProfileLocationType.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/migrate/ProfileLocationType.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2015-2018 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.plugin.maven.migrate;
+
+enum ProfileLocationType {
+    // /
+    NONE("<no profile>"),
+    // /project/profiles/profile
+    PROFILE("profile");
+
+    private final String description;
+
+    ProfileLocationType(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public String toString() {
+        return description;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1319,6 +1319,7 @@
 
         <!-- This testsuite needs to be in a profile that comes after the profiles that build the BOMs as they are a dependency -->
         <module>testsuite/testsuite-maven-plugin</module>
+        <module>testsuite/testsuite-maven-plugin-migration</module>
       </modules>
     </profile>
 

--- a/testsuite/testsuite-maven-plugin-migration/pom.xml
+++ b/testsuite/testsuite-maven-plugin-migration/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.thorntail.testsuite</groupId>
+    <artifactId>testsuite-parent</artifactId>
+    <version>2.0.1.Final-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <artifactId>testsuite-maven-plugin-migration</artifactId>
+
+  <name>Test Suite: Maven Plugin: Migration</name>
+  <description>Test Suite: Maven Plugin: Migration</description>
+
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-verifier</artifactId>
+      <version>1.6</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xmlunit</groupId>
+      <artifactId>xmlunit-core</artifactId>
+      <version>2.6.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/testsuite/testsuite-maven-plugin-migration/src/test/java/org/wildfly/swarm/maven/plugin/MavenPluginMigrationTest.java
+++ b/testsuite/testsuite-maven-plugin-migration/src/test/java/org/wildfly/swarm/maven/plugin/MavenPluginMigrationTest.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.maven.plugin;
+
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.it.Verifier;
+import org.apache.maven.it.util.ResourceExtractor;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.builder.Input;
+import org.xmlunit.diff.Diff;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
+
+public class MavenPluginMigrationTest {
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    private Verifier verifier;
+
+    private Path logPath;
+
+    @Before
+    public void setUpProject() throws IOException, VerificationException {
+        assumeTrue("Set the M2_HOME environment variable", System.getenv("M2_HOME") != null);
+        assumeTrue("Run from Maven or set the project.version system property", System.getProperty("project.version") != null);
+
+        File projectDir = ResourceExtractor.extractResourcePath(getClass(), "/testing-project", tmp.getRoot(), true);
+
+        verifier = new Verifier(projectDir.getAbsolutePath(), true);
+        verifier.setForkJvm(true);
+
+        String settingsXml = System.getProperty("org.apache.maven.user-settings");
+        if (settingsXml != null && new File(settingsXml).isFile()) {
+            verifier.addCliOption("-s");
+            verifier.addCliOption(settingsXml);
+        }
+
+        logPath = Paths.get(verifier.getBasedir()).resolve(verifier.getLogFileName());
+    }
+
+    @Test
+    public void migrationTest() {
+        try {
+            migrateProjectFromWildFlySwarmToThorntail();
+            verifyMigratedPomXml();
+        } catch (Exception e) {
+            throw new AssertionError(e.getMessage());
+        }
+    }
+
+    private void migrateProjectFromWildFlySwarmToThorntail() throws IOException, VerificationException {
+        String thorntailVersion = System.getProperty("project.version");
+        String goal = "io.thorntail:thorntail-maven-plugin:" + thorntailVersion + ":migrate-from-wildfly-swarm";
+
+        verifier.setSystemProperty("targetVersion", "2.0.0.Final"); // hardcoded in expected-pom.xml
+        verifier.executeGoal(goal);
+
+        String log = new String(Files.readAllBytes(logPath), StandardCharsets.UTF_8);
+
+        assertThat(log).contains("Upgrading to Thorntail 2.0.0.Final");
+        assertThat(log).contains(slashes("./pom.xml: migrate dependency exclusion on org.wildfly.swarm:cdi-config at dependency org.wildfly.swarm:cdi"));
+        assertThat(log).contains(slashes("./pom.xml: migrate dependency exclusion on org.wildfly.swarm:datasources at dependency org.wildfly.swarm:jpa of pluginManagement org.wildfly.swarm:wildfly-swarm-plugin in profile my-profile"));
+        assertThat(log).contains(slashes("./pom.xml: migrate dependency exclusion on org.wildfly.swarm:spi at dependency org.wildfly.swarm:management-console of plugin org.apache.maven.plugins:maven-failsafe-plugin"));
+        assertThat(log).contains(slashes("./pom.xml: migrate dependency org.wildfly.swarm:cdi (target version: 2.0.0.Final)"));
+        assertThat(log).contains(slashes("./pom.xml: migrate dependency org.wildfly.swarm:jaxrs (target version: null)"));
+        assertThat(log).contains(slashes("./pom.xml: migrate dependency org.wildfly.swarm:jpa of pluginManagement org.wildfly.swarm:wildfly-swarm-plugin in profile my-profile (target version: null)"));
+        assertThat(log).contains(slashes("./pom.xml: migrate dependency org.wildfly.swarm:jsf in profile my-profile (target version: null)"));
+        assertThat(log).contains(slashes("./pom.xml: migrate dependency org.wildfly.swarm:logging of plugin org.wildfly.swarm:wildfly-swarm-plugin in profile my-profile (target version: 2.0.0.Final)"));
+        assertThat(log).contains(slashes("./pom.xml: migrate dependency org.wildfly.swarm:management of plugin org.apache.maven.plugins:maven-failsafe-plugin (target version: null)"));
+        assertThat(log).contains(slashes("./pom.xml: migrate dependency org.wildfly.swarm:management-console of plugin org.apache.maven.plugins:maven-failsafe-plugin (target version: 2.0.0.Final)"));
+        assertThat(log).contains(slashes("./pom.xml: migrate dependency org.wildfly.swarm:undertow (target version: null)"));
+        assertThat(log).contains(slashes("./pom.xml: migrate dependencyManagement org.wildfly.swarm:bean-validation in profile my-profile (target version: 2.0.0.Final)"));
+        assertThat(log).contains(slashes("./pom.xml: migrate dependencyManagement org.wildfly.swarm:bom (target version: null)"));
+        assertThat(log).contains(slashes("./pom.xml: migrate plugin org.wildfly.swarm:wildfly-swarm-plugin (target version: null)"));
+        assertThat(log).contains(slashes("./pom.xml: migrate plugin org.wildfly.swarm:wildfly-swarm-plugin in profile my-profile (target version: null)"));
+        assertThat(log).contains(slashes("./pom.xml: migrate pluginManagement org.wildfly.swarm:wildfly-swarm-plugin in profile my-profile (target version: null)"));
+        assertThat(log).contains("migrate version property version.org.wildfly.swarm to value 2.0.0.Final");
+        assertThat(log).contains("migrate version property version.wildfly-swarm to value 2.0.0.Final");
+
+        assertThat(log).doesNotContain("[ERROR]");
+        assertThat(log).doesNotContain("[WARNING]");
+        assertThat(log).contains("BUILD SUCCESS");
+    }
+
+    private void verifyMigratedPomXml() {
+        Path projectDir = Paths.get(verifier.getBasedir());
+        Diff diff = DiffBuilder.compare(Input.fromFile(projectDir.resolve("expected-pom.xml").toFile()))
+                .withTest(Input.fromFile(projectDir.resolve("pom.xml").toFile()))
+                .checkForIdentical()
+                .build();
+        assertThat(diff.hasDifferences())
+                .as(diff.getDifferences().toString())
+                .isFalse();
+    }
+
+    @After
+    public void tearDown() {
+        if (verifier != null) {
+            verifier.resetStreams();
+        }
+    }
+
+    private static String slashes(String migrationMessage) {
+        int pathEndIndex = migrationMessage.indexOf(':');
+        String path = migrationMessage.substring(0, pathEndIndex);
+        path = path.replace('/', File.separatorChar);
+        return path + migrationMessage.substring(pathEndIndex);
+    }
+}

--- a/testsuite/testsuite-maven-plugin-migration/src/test/resources/testing-project/expected-pom.xml
+++ b/testsuite/testsuite-maven-plugin-migration/src/test/resources/testing-project/expected-pom.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.thorntail.test</groupId>
+  <artifactId>testing-project</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+    <version.org.wildfly.swarm>2.0.0.Final</version.org.wildfly.swarm>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.thorntail</groupId>
+        <artifactId>bom</artifactId>
+        <version>${version.org.wildfly.swarm}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.thorntail</groupId>
+      <artifactId>undertow</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.thorntail</groupId>
+      <artifactId>jaxrs</artifactId>
+      <version>${version.org.wildfly.swarm}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.thorntail</groupId>
+      <artifactId>cdi</artifactId>
+      <version>2.0.0.Final</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.thorntail</groupId>
+          <artifactId>cdi-config</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.wildfly</groupId>
+          <artifactId>wildfly-weld</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>2.19.1</version>
+        <dependencies>
+          <dependency>
+            <groupId>io.thorntail</groupId>
+            <artifactId>management</artifactId>
+            <version>${version.org.wildfly.swarm}</version>
+          </dependency>
+          <dependency>
+            <groupId>io.thorntail</groupId>
+            <artifactId>management-console</artifactId>
+            <version>2.0.0.Final</version>
+            <exclusions>
+              <exclusion>
+                <groupId>io.thorntail</groupId>
+                <artifactId>spi</artifactId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+        </dependencies>
+      </plugin>
+
+      <plugin>
+        <groupId>io.thorntail</groupId>
+        <artifactId>thorntail-maven-plugin</artifactId>
+        <version>${version.org.wildfly.swarm}</version>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>my-profile</id>
+
+      <properties>
+        <version.wildfly-swarm>2.0.0.Final</version.wildfly-swarm>
+      </properties>
+
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>io.thorntail</groupId>
+            <artifactId>bean-validation</artifactId>
+            <version>2.0.0.Final</version>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+
+      <dependencies>
+        <dependency>
+          <groupId>io.thorntail</groupId>
+          <artifactId>jsf</artifactId>
+          <version>${version.wildfly-swarm}</version>
+        </dependency>
+      </dependencies>
+
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>io.thorntail</groupId>
+              <artifactId>thorntail-maven-plugin</artifactId>
+              <version>${version.org.wildfly.swarm}</version>
+              <dependencies>
+                <dependency>
+                  <groupId>io.thorntail</groupId>
+                  <artifactId>jpa</artifactId>
+                  <exclusions>
+                    <exclusion>
+                      <groupId>io.thorntail</groupId>
+                      <artifactId>datasources</artifactId>
+                    </exclusion>
+                  </exclusions>
+                </dependency>
+              </dependencies>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+
+        <plugins>
+          <plugin>
+            <groupId>io.thorntail</groupId>
+            <artifactId>thorntail-maven-plugin</artifactId>
+            <configuration>
+              <hollow>true</hollow>
+            </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>io.thorntail</groupId>
+                <artifactId>logging</artifactId>
+                <version>2.0.0.Final</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>

--- a/testsuite/testsuite-maven-plugin-migration/src/test/resources/testing-project/pom.xml
+++ b/testsuite/testsuite-maven-plugin-migration/src/test/resources/testing-project/pom.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.thorntail.test</groupId>
+  <artifactId>testing-project</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+    <version.org.wildfly.swarm>2018.5.0</version.org.wildfly.swarm>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>bom</artifactId>
+        <version>${version.org.wildfly.swarm}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>undertow</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>jaxrs</artifactId>
+      <version>${version.org.wildfly.swarm}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>cdi</artifactId>
+      <version>2018.5.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.wildfly.swarm</groupId>
+          <artifactId>cdi-config</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.wildfly</groupId>
+          <artifactId>wildfly-weld</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>2.19.1</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>management</artifactId>
+            <version>${version.org.wildfly.swarm}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>management-console</artifactId>
+            <version>2018.5.0</version>
+            <exclusions>
+              <exclusion>
+                <groupId>org.wildfly.swarm</groupId>
+                <artifactId>spi</artifactId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+        </dependencies>
+      </plugin>
+
+      <plugin>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>wildfly-swarm-plugin</artifactId>
+        <version>${version.org.wildfly.swarm}</version>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>my-profile</id>
+
+      <properties>
+        <version.wildfly-swarm>2018.5.0</version.wildfly-swarm>
+      </properties>
+
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>bean-validation</artifactId>
+            <version>2018.5.0</version>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+
+      <dependencies>
+        <dependency>
+          <groupId>org.wildfly.swarm</groupId>
+          <artifactId>jsf</artifactId>
+          <version>${version.wildfly-swarm}</version>
+        </dependency>
+      </dependencies>
+
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.wildfly.swarm</groupId>
+              <artifactId>wildfly-swarm-plugin</artifactId>
+              <version>${version.org.wildfly.swarm}</version>
+              <dependencies>
+                <dependency>
+                  <groupId>org.wildfly.swarm</groupId>
+                  <artifactId>jpa</artifactId>
+                  <exclusions>
+                    <exclusion>
+                      <groupId>org.wildfly.swarm</groupId>
+                      <artifactId>datasources</artifactId>
+                    </exclusion>
+                  </exclusions>
+                </dependency>
+              </dependencies>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+
+        <plugins>
+          <plugin>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>wildfly-swarm-plugin</artifactId>
+            <configuration>
+              <hollow>true</hollow>
+            </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>org.wildfly.swarm</groupId>
+                <artifactId>logging</artifactId>
+                <version>2018.5.0</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>


### PR DESCRIPTION
Motivation
----------
The set of changes required to migrate from WildFly Swarm to Thorntail v2
is pretty small and is easy to automate. To help our users, we should provide
a Maven plugin that would perform all the necessary steps.

Modifications
-------------
Added one Mojo to the existing Thorntail Maven plugin that will scan `pom.xml`
files of a Maven project and perform all the changes required for migration
from WildFly Swarm to Thorntail v2.

Result
------
Users can just run

  mvn io.thorntail:thorntail-maven-plugin:2.0.1.Final-SNAPSHOT:migrate-from-wildfly-swarm

without having to do anything else.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
