### PR TITLE
THORN-2093: MicroProfile POM missing specs

### DIFF
--- a/fractions/microprofile/microprofile-openapi/module.conf
+++ b/fractions/microprofile/microprofile-openapi/module.conf
@@ -9,8 +9,6 @@ org.apache.commons.io
 org.apache.commons.beanutils
 org.apache.commons.collections
 
-org.jboss.jandex
-
 org.wildfly.swarm.configuration.microprofile.config
 org.wildfly.extension.microprofile.config
 org.eclipse.microprofile.config.api

--- a/fractions/microprofile/microprofile-openapi/pom.xml
+++ b/fractions/microprofile/microprofile-openapi/pom.xml
@@ -69,6 +69,16 @@
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-open-api</artifactId>
       <version>${version.io.smallrye.smallrye-open-api}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss</groupId>
+          <artifactId>jandex</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jboss.shrinkwrap</groupId>
+          <artifactId>shrinkwrap-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Third Party Libs -->

--- a/fractions/microprofile/microprofile-openapi/src/main/resources/modules/io/smallrye/smallrye-open-api/main/module.xml
+++ b/fractions/microprofile/microprofile-openapi/src/main/resources/modules/io/smallrye/smallrye-open-api/main/module.xml
@@ -25,7 +25,7 @@
       <module name="com.fasterxml.jackson.core.jackson-core" />
       <module name="com.fasterxml.jackson.core.jackson-databind" />
       <module name="com.fasterxml.jackson.dataformat.jackson-dataformat-yaml"></module>
-      <module name="org.jboss.jandex"></module>
+      <module name="org.jboss.jandex" export="true"></module>
       <module name="org.jboss.shrinkwrap"></module>
 
       <module name="org.eclipse.microprofile.config.api" />

--- a/fractions/microprofile/microprofile/pom.xml
+++ b/fractions/microprofile/microprofile/pom.xml
@@ -74,6 +74,18 @@
       <groupId>io.thorntail</groupId>
       <artifactId>microprofile-metrics</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.thorntail</groupId>
+      <artifactId>microprofile-openapi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.thorntail</groupId>
+      <artifactId>microprofile-opentracing</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.thorntail</groupId>
+      <artifactId>microprofile-restclient</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.wildfly.core</groupId>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
MP REST Client injection fails on startup when using the `microprofile` dependency.

Investigation determined that there were three specs from MP 1.3 that were not in the dependency.

Modifications
-------------
Add OpenAPI, OpenTracing and REST Client to `microprofile` dependency.

Result
------
Adds MP 1.3 specifications to `microprofile` dependency.
