### PR TITLE
fix: adds *.mv.db to ignored artifacts (created by keycloak tests)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ pom.xml.versionsBackup
 /*.hprof
 # H2 databases produced by tests
 *.h2.db
+*.mv.db
 *.trace.db
 *.lock.db
 # JBoss transaction generated files


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [ ] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

I noticed that there are H2 db leftovers (`standalone-servers/keycloak/keycloak.mv.db
) after running the build, so I added it to `.gitignore`.