### PR TITLE
Make consul TTL check timeout configurable

### DIFF
--- a/fractions/topology-consul/src/main/java/org/wildfly/swarm/topology/consul/ConsulTopologyFraction.java
+++ b/fractions/topology-consul/src/main/java/org/wildfly/swarm/topology/consul/ConsulTopologyFraction.java
@@ -89,6 +89,10 @@ public class ConsulTopologyFraction implements Fraction<ConsulTopologyFraction> 
         return this.url.get();
     }
 
+    public Long ttl() {
+        return this.ttl.get();
+    }
+
     /**
      * The default consul Agent URL (http://localhost:8500/)
      */
@@ -106,5 +110,8 @@ public class ConsulTopologyFraction implements Fraction<ConsulTopologyFraction> 
 
     @AttributeDocumentation("URL of the Consul server")
     private Defaultable<URL> url = Defaultable.url(DEFAULT_URL);
+
+    @AttributeDocumentation("TTL for the consul health check for each service. Default 3s")
+    private Defaultable<Long> ttl = Defaultable.longInteger(3);
 
 }

--- a/fractions/topology-consul/src/main/java/org/wildfly/swarm/topology/consul/runtime/Advertiser.java
+++ b/fractions/topology-consul/src/main/java/org/wildfly/swarm/topology/consul/runtime/Advertiser.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -60,13 +60,13 @@ public class Advertiser implements Service<Advertiser>, Runnable {
                 .id(serviceId(registration))
                 .name(registration.getName())
                 .addTags(registration.getTags().toArray(new String[]{}))
-                .check(com.orbitz.consul.model.agent.Registration.RegCheck.ttl(3L))
+                .check(com.orbitz.consul.model.agent.Registration.RegCheck.ttl(checkTTL))
                 .build();
         client.register(consulReg);
 
         this.advertisements.add(registration);
 
-        log.info("Registered service " + consulReg.getId());
+        log.info("Registered service " + consulReg.getId() + ", checkTTL: " + checkTTL);
     }
 
     public void unadvertise(String name, String address, int port) {
@@ -127,6 +127,14 @@ public class Advertiser implements Service<Advertiser>, Runnable {
 
     }
 
+    public long getCheckTTL() {
+        return checkTTL;
+    }
+
+    public void setCheckTTL(long checkTTL) {
+        this.checkTTL = checkTTL;
+    }
+
     private String serviceId(Registration registration) {
         return registration.getName() + ":" + registration.getAddress() + ":" + registration.getPort();
     }
@@ -138,4 +146,6 @@ public class Advertiser implements Service<Advertiser>, Runnable {
     private Set<Registration> advertisements = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     private Thread thread;
+
+    private long checkTTL = 3L;
 }

--- a/fractions/topology-consul/src/main/java/org/wildfly/swarm/topology/consul/runtime/AgentActivator.java
+++ b/fractions/topology-consul/src/main/java/org/wildfly/swarm/topology/consul/runtime/AgentActivator.java
@@ -50,6 +50,7 @@ public class AgentActivator implements ServiceActivator {
                 .install();
 
         Advertiser advertiser = new Advertiser();
+        advertiser.setCheckTTL(fraction.ttl());
         target.addService(Advertiser.SERVICE_NAME, advertiser)
                 .addDependency(AgentClientService.SERVICE_NAME, AgentClient.class, advertiser.getAgentClientInjector())
                 .install();


### PR DESCRIPTION
Motivation
----------
In topology-consul when a service is advertised the advertiser automatically creates a TTL check for every service. This check is created with a fixed timeout of 3s. In an endless loop the advertiser is then cycling over all services and sends the alive check to consul - but with a 2s sleep timer at the end of each round.
This results in only 1s time window for the alive check. If there are many services to process or slight network delay the alive ping will not arrive in time resulting in flapping reachability of the service in consul.

Modifications
-------------
Added a configurable Long value 'swarm.topology.consul.ttl' which will get passed via AgentActivator to Advertiser and then used as value for the ttl in RegCheck. The value is Defaultable<Long> and has a default value of 3.

Result
------
The deafult behaviour is not changed but the ttl for the consul check can now be configured to a higher value if needed.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [ ] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
