### PR TITLE
THORN-1564 - Enable java.util.Properties for configurations

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigNode.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigNode.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -253,6 +254,20 @@ public class ConfigNode implements ConfigTree {
                 });
 
         return map;
+    }
+
+    @Override
+    public Properties asProperties() {
+        Properties properties = new Properties();
+
+        this.children.entrySet()
+            .stream()
+            .filter(entry -> entry.getValue().value != null)
+            .forEach(entry -> {
+                properties.setProperty(entry.getKey().toString(), entry.getValue().value.toString());
+            });
+
+        return properties;
     }
 
     public String toString() {

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/ConfigurableManager.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/ConfigurableManager.java
@@ -67,7 +67,6 @@ public class ConfigurableManager implements AutoCloseable {
     private static final Set<Class<?>> BLACKLISTED_CLASSES = new HashSet<Class<?>>() {{
         add(List.class);
         add(Map.class);
-        add(Properties.class);
     }};
 
     private static final Set<Class<?>> CONFIGURABLE_VALUE_TYPES = new HashSet<Class<?>>() {{
@@ -130,12 +129,12 @@ public class ConfigurableManager implements AutoCloseable {
             } else if (List.class.isAssignableFrom(resolvedType)) {
                 isList = true;
                 resolver = listResolver((Resolver<String>) resolver, configurable.key());
-            } else if (Map.class.isAssignableFrom(resolvedType)) {
-                isMap = true;
-                resolver = mapResolver((Resolver<String>) resolver, configurable.key());
             } else if (Properties.class.isAssignableFrom(resolvedType)) {
                 isProperties = true;
                 resolver = propertiesResolver((Resolver<String>) resolver, configurable.key());
+            } else if (Map.class.isAssignableFrom(resolvedType)) {
+                isMap = true;
+                resolver = mapResolver((Resolver<String>) resolver, configurable.key());
             } else {
                 resolver = resolver.as(resolvedType);
             }

--- a/core/spi/src/main/java/org/wildfly/swarm/spi/api/config/Builder.java
+++ b/core/spi/src/main/java/org/wildfly/swarm/spi/api/config/Builder.java
@@ -19,6 +19,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 /**
  */
@@ -57,6 +58,8 @@ public class Builder<T> implements Resolver<T> {
         if (originalValue instanceof ConfigTree) {
             if (List.class.isAssignableFrom(this.targetType)) {
                 return (T) ((ConfigTree) originalValue).asList();
+            } else if (Properties.class.isAssignableFrom(this.targetType)) {
+                return (T) ((ConfigTree) originalValue).asProperties();
             } else if (Map.class.isAssignableFrom(this.targetType)) {
                 return (T) ((ConfigTree) originalValue).asMap();
             } else {

--- a/core/spi/src/main/java/org/wildfly/swarm/spi/api/config/ConfigTree.java
+++ b/core/spi/src/main/java/org/wildfly/swarm/spi/api/config/ConfigTree.java
@@ -17,6 +17,7 @@ package org.wildfly.swarm.spi.api.config;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 /**
  * @author Bob McWhirter
@@ -26,4 +27,6 @@ public interface ConfigTree {
     List asList();
 
     Map asMap();
+
+    Properties asProperties();
 }

--- a/pom.xml
+++ b/pom.xml
@@ -998,6 +998,17 @@
         <enabled>false</enabled>
       </snapshots>
     </pluginRepository>
+    <pluginRepository>
+      <id>sonatype-nexus-snapshots</id>
+      <name>Sonatype Nexus Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </pluginRepository>
   </pluginRepositories>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -998,17 +998,6 @@
         <enabled>false</enabled>
       </snapshots>
     </pluginRepository>
-    <pluginRepository>
-      <id>sonatype-nexus-snapshots</id>
-      <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </pluginRepository>
   </pluginRepositories>
 
   <modules>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

This PR enables Fractions to use `java.util.Properties` as configuration properties. This was explicitly blacklisted [here](https://github.com/thorntail/thorntail/blob/79b59c0cf3729fcd33bf1beefb9e1c931a216602/core/container/src/main/java/org/wildfly/swarm/container/runtime/ConfigurableManager.java#L70) before. But most of the code was there already. 
Also the support for `java.util.Map` and `java.util.List` seems to be complete, but stays blacklisted. 