### PR TITLE
THORN-2136: Unable to run Swarm in IDE

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -42,6 +42,7 @@
     <version.jboss-logmanager-ext>1.0.0.Alpha3</version.jboss-logmanager-ext>
     <!-- Weld SE version must be aligned with the version used in WildFly -->
     <version.weld-se>2.4.3.Final</version.weld-se>
+    <version.jandex>2.0.5.Final</version.jandex>
     <!-- Align dependency versions with those present in WildFly parent -->
     <!-- Doing this explicitly since there is no easy way to import project properties from a pom file -->
     <version.com.fasterxml.jackson>2.8.9</version.com.fasterxml.jackson>
@@ -170,7 +171,7 @@
       <dependency>
         <groupId>org.jboss</groupId>
         <artifactId>jandex</artifactId>
-        <version>2.0.3.Final</version>
+        <version>${version.jandex}</version>
       </dependency>
 
       <dependency>

--- a/core/container/src/main/resources/modules/org/jboss/jandex/main/module.xml
+++ b/core/container/src/main/resources/modules/org/jboss/jandex/main/module.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.jandex">
+<properties>
+    <property name="jboss.api" value="private"/>
+  </properties>
+  <resources>
+    <artifact name="org.jboss:jandex:${version.jandex}"/>
+  </resources>
+  <dependencies>
+    </dependencies>
+</module>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
Jandex fails to process asm-tree when running from the IDE.

Modifications
-------------
Update to Jandex 2.0.5.Final and add a custom module.xml to ensure that version is picked up during resolution.

Result
------
Swarm can run in the IDE when Jandex is used.
