### PR TITLE
THORN-2139: Update logging message prefix

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/util/Messages.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/util/Messages.java
@@ -25,7 +25,7 @@ import org.jboss.logging.annotations.MessageLogger;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@MessageLogger(projectCode = "WFSWARM", length = 4)
+@MessageLogger(projectCode = "THORN", length = 4)
 public interface Messages extends BasicLogger {
 
     Messages MESSAGES = Logger.getMessageLogger(Messages.class, "org.wildfly.swarm");

--- a/core/container/src/main/java/org/wildfly/swarm/internal/DeployerMessages.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/DeployerMessages.java
@@ -25,7 +25,7 @@ import org.wildfly.swarm.container.DeploymentException;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@MessageLogger(projectCode = "WFSDEPLOY", length = 4)
+@MessageLogger(projectCode = "TTDEPLOY", length = 4)
 public interface DeployerMessages extends BasicLogger {
 
     DeployerMessages MESSAGES = Logger.getMessageLogger(DeployerMessages.class, "org.wildfly.swarm.deployer");

--- a/core/container/src/main/java/org/wildfly/swarm/internal/SwarmConfigMessages.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/SwarmConfigMessages.java
@@ -25,7 +25,7 @@ import org.jboss.logging.annotations.MessageLogger;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@MessageLogger(projectCode = "WFSCONFIG", length = 4)
+@MessageLogger(projectCode = "TTCONFIG", length = 4)
 public interface SwarmConfigMessages extends BasicLogger {
 
     SwarmConfigMessages MESSAGES = Logger.getMessageLogger(SwarmConfigMessages.class, "org.wildfly.swarm.config");

--- a/core/container/src/main/java/org/wildfly/swarm/internal/SwarmMessages.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/SwarmMessages.java
@@ -33,7 +33,7 @@ import org.wildfly.swarm.spi.api.annotations.DeploymentModule;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@MessageLogger(projectCode = "WFSWARM", length = 4)
+@MessageLogger(projectCode = "THORN", length = 4)
 public interface SwarmMessages extends BasicLogger {
 
     SwarmMessages MESSAGES = Logger.getMessageLogger(SwarmMessages.class, "org.wildfly.swarm");

--- a/core/container/src/main/java/org/wildfly/swarm/internal/SwarmMetricsMessages.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/SwarmMetricsMessages.java
@@ -24,7 +24,7 @@ import org.jboss.logging.annotations.MessageLogger;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@MessageLogger(projectCode = "WFSMETRICS", length = 4)
+@MessageLogger(projectCode = "TTMETRICS", length = 4)
 public interface SwarmMetricsMessages extends BasicLogger {
 
     SwarmMetricsMessages MESSAGES = Logger.getMessageLogger(SwarmMetricsMessages.class, "org.wildfly.swarm.metrics");

--- a/fractions/drools-server/src/main/java/org/wildfly/swarm/drools/server/runtime/DroolsMessages.java
+++ b/fractions/drools-server/src/main/java/org/wildfly/swarm/drools/server/runtime/DroolsMessages.java
@@ -28,7 +28,7 @@ import org.jboss.logging.annotations.MessageLogger;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@MessageLogger(projectCode = "WFSDROOLS", length = 4)
+@MessageLogger(projectCode = "TTDROOLS", length = 4)
 public interface DroolsMessages extends BasicLogger {
 
     DroolsMessages MESSAGES = Logger.getMessageLogger(DroolsMessages.class, "org.wildfly.swarm.drools");

--- a/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/DatasourcesMessages.java
+++ b/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/DatasourcesMessages.java
@@ -25,7 +25,7 @@ import org.jboss.logging.annotations.MessageLogger;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@MessageLogger(projectCode = "WFSWARM", length = 4)
+@MessageLogger(projectCode = "THORN", length = 4)
 public interface DatasourcesMessages extends BasicLogger {
 
     DatasourcesMessages MESSAGES = Logger.getMessageLogger(DatasourcesMessages.class, "org.wildfly.swarm.datasources");

--- a/fractions/javaee/jaxrs/src/main/java/org/wildfly/swarm/jaxrs/JAXRSMessages.java
+++ b/fractions/javaee/jaxrs/src/main/java/org/wildfly/swarm/jaxrs/JAXRSMessages.java
@@ -24,7 +24,7 @@ import org.jboss.logging.annotations.MessageLogger;
 /**
  * @author Martin Kouba
  */
-@MessageLogger(projectCode = " WFSJAXRS", length = 4)
+@MessageLogger(projectCode = "TTJAXRS", length = 4)
 public interface JAXRSMessages extends BasicLogger {
 
     JAXRSMessages MESSAGES = Logger.getMessageLogger(JAXRSMessages.class, "org.wildfly.swarm.jaxrs");

--- a/fractions/keycloak-server/src/main/java/org/wildfly/swarm/keycloak/server/runtime/KeycloakServerMessages.java
+++ b/fractions/keycloak-server/src/main/java/org/wildfly/swarm/keycloak/server/runtime/KeycloakServerMessages.java
@@ -26,7 +26,7 @@ import org.jboss.logging.annotations.MessageLogger;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@MessageLogger(projectCode = "WFSKCSRV", length = 4)
+@MessageLogger(projectCode = "TTKCSRV", length = 4)
 public interface KeycloakServerMessages extends BasicLogger {
 
     KeycloakServerMessages MESSAGES = Logger.getMessageLogger(KeycloakServerMessages.class, "org.wildfly.swarm.keycloak.server");

--- a/fractions/swagger-webapp/src/main/java/org/wildfly/swarm/swagger/webapp/SwaggerWebAppMessages.java
+++ b/fractions/swagger-webapp/src/main/java/org/wildfly/swarm/swagger/webapp/SwaggerWebAppMessages.java
@@ -28,7 +28,7 @@ import org.jboss.logging.annotations.MessageLogger;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@MessageLogger(projectCode = "WFSSWGRUI", length = 4)
+@MessageLogger(projectCode = "TTSWGRUI", length = 4)
 public interface SwaggerWebAppMessages extends BasicLogger {
 
     SwaggerWebAppMessages MESSAGES = Logger.getMessageLogger(SwaggerWebAppMessages.class, "org.wildfly.swarm.swagger.webapp");

--- a/fractions/swagger/src/main/java/org/wildfly/swarm/swagger/SwaggerMessages.java
+++ b/fractions/swagger/src/main/java/org/wildfly/swarm/swagger/SwaggerMessages.java
@@ -31,7 +31,7 @@ import org.jboss.logging.annotations.MessageLogger;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@MessageLogger(projectCode = "WFSSWGR", length = 4)
+@MessageLogger(projectCode = "TTSWGR", length = 4)
 public interface SwaggerMessages extends BasicLogger {
 
     SwaggerMessages MESSAGES = Logger.getMessageLogger(SwaggerMessages.class, "org.wildfly.swarm.swagger");

--- a/fractions/teiid/core/src/main/java/org/wildfly/swarm/teiid/runtime/TeiidMessages.java
+++ b/fractions/teiid/core/src/main/java/org/wildfly/swarm/teiid/runtime/TeiidMessages.java
@@ -22,7 +22,7 @@ import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 
-@MessageLogger(projectCode = "TEIID", length = 4)
+@MessageLogger(projectCode = "TTTEIID", length = 4)
 public interface TeiidMessages extends BasicLogger {
 
     TeiidMessages MESSAGES = Logger.getMessageLogger(TeiidMessages.class, "org.wildfly.swarm.teiid");

--- a/fractions/topology-consul/src/main/java/org/wildfly/swarm/topology/consul/ConsulTopologyMessages.java
+++ b/fractions/topology-consul/src/main/java/org/wildfly/swarm/topology/consul/ConsulTopologyMessages.java
@@ -29,7 +29,7 @@ import org.jboss.logging.annotations.MessageLogger;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@MessageLogger(projectCode = "WFSCNSL", length = 4)
+@MessageLogger(projectCode = "TTCNSL", length = 4)
 public interface ConsulTopologyMessages extends BasicLogger {
 
     ConsulTopologyMessages MESSAGES = Logger.getMessageLogger(ConsulTopologyMessages.class, "org.wildfly.swarm.topology.consul");

--- a/fractions/topology/src/main/java/org/wildfly/swarm/topology/TopologyMessages.java
+++ b/fractions/topology/src/main/java/org/wildfly/swarm/topology/TopologyMessages.java
@@ -25,7 +25,7 @@ import org.jboss.logging.annotations.MessageLogger;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@MessageLogger(projectCode = "WFSTOPO", length = 4)
+@MessageLogger(projectCode = "TTTOPO", length = 4)
 public interface TopologyMessages extends BasicLogger {
 
     TopologyMessages MESSAGES = Logger.getMessageLogger(TopologyMessages.class, "org.wildfly.swarm.topology");

--- a/fractions/wildfly/infinispan/src/main/java/org/wildfly/swarm/infinispan/InfinispanMessages.java
+++ b/fractions/wildfly/infinispan/src/main/java/org/wildfly/swarm/infinispan/InfinispanMessages.java
@@ -27,7 +27,7 @@ import org.jboss.logging.annotations.MessageLogger;
  * <br>
  * Date: 3/15/18
  */
-@MessageLogger(projectCode = "WFSISPN", length = 4)
+@MessageLogger(projectCode = "TTISPN", length = 4)
 public interface InfinispanMessages extends BasicLogger {
 
     InfinispanMessages MESSAGES = Logger.getMessageLogger(InfinispanMessages.class, "org.wildfly.swarm.infinispan");

--- a/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/ManagementMessages.java
+++ b/fractions/wildfly/management/src/main/java/org/wildfly/swarm/management/ManagementMessages.java
@@ -25,7 +25,7 @@ import org.jboss.logging.annotations.MessageLogger;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@MessageLogger(projectCode = "WFSMGMT", length = 4)
+@MessageLogger(projectCode = "TTMGMT", length = 4)
 public interface ManagementMessages extends BasicLogger {
 
     ManagementMessages MESSAGES = Logger.getMessageLogger(ManagementMessages.class, "org.wildfly.swarm.management");

--- a/fractions/wildfly/msc/src/main/java/org/wildfly/swarm/msc/MSCMessages.java
+++ b/fractions/wildfly/msc/src/main/java/org/wildfly/swarm/msc/MSCMessages.java
@@ -25,7 +25,7 @@ import org.jboss.logging.annotations.MessageLogger;
 /**
  * @author Bob McWhirter
  */
-@MessageLogger(projectCode = "WFSMSC", length = 4)
+@MessageLogger(projectCode = "TTMSC", length = 4)
 public interface MSCMessages extends BasicLogger {
     MSCMessages MESSAGES = Logger.getMessageLogger(MSCMessages.class, "org.wildfly.swarm.msc");
 

--- a/tools/src/main/java/org/wildfly/swarm/tools/exec/IOBridge.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/exec/IOBridge.java
@@ -81,7 +81,7 @@ public class IOBridge implements Runnable, Closeable {
             fileOut.newLine();
             fileOut.flush();
         }
-        if (line.contains("WFSWARM99999")) {
+        if (line.contains("THORN99999")) {
             this.latch.countDown();
         }
         if (line.contains("MSC000001: Failed to start service jboss.deployment.unit.")) {


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
After rename the logging messages still use WFSWARM, when they should really be THORN.

Modifications
-------------
Rename project codes on Message Loggers to the new prefix of "THORN" or "TT" depending on the logger.

Result
------
No impact to product other than changing the message log prefix.
