### PR TITLE
THORN-2148: Added unit test to reproduce issue with "hierarchical" pr…

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigNode.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/ConfigNode.java
@@ -52,7 +52,11 @@ public class ConfigNode implements ConfigTree {
         if (value instanceof ConfigNode) {
             this.children.put(key, (ConfigNode) value);
         } else {
-            this.children.put(key, new ConfigNode(value));
+            if (this.children.containsKey(key)) {
+                this.children.get(key).value = value;
+            } else {
+                this.children.put(key, new ConfigNode(value));
+            }
         }
     }
 

--- a/core/container/src/test/java/org/wildfly/swarm/cli/CommandLineTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/cli/CommandLineTest.java
@@ -16,10 +16,17 @@
 package org.wildfly.swarm.cli;
 
 import java.io.File;
+import java.lang.reflect.Field;
+import java.net.URL;
 
 import org.junit.Test;
+import org.wildfly.swarm.Swarm;
+import org.wildfly.swarm.spi.api.config.ConfigView;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.wildfly.swarm.cli.CommandLine.HELP;
 import static org.wildfly.swarm.cli.CommandLine.PROPERTIES_URL;
 import static org.wildfly.swarm.cli.CommandLine.PROPERTY;
@@ -136,6 +143,23 @@ public class CommandLineTest {
         assertThat(cmd.get(PROPERTY).get("bar")).isEqualTo("cheese");
 
 
+    }
+
+    @Test
+    public void testApplyPropertiesWithPropertiesHierarchy() throws Exception {
+        // Given
+        URL props = getClass().getClassLoader().getResource("hierarchy.properties");
+        CommandLine cmd = CommandLine.parse("--properties", props.toExternalForm());
+        Swarm swarm = mock(Swarm.class);
+
+        // When
+        cmd.applyProperties(swarm);
+
+        // Then
+        verify(swarm).withProperty("parent.children", "child1,child2");
+        verify(swarm).withProperty("parent.children.child1.name", "Jack");
+        verify(swarm).withProperty("parent.children.child2.name", "Jill");
+        verifyNoMoreInteractions(swarm);
     }
 
 }

--- a/core/container/src/test/resources/hierarchy.properties
+++ b/core/container/src/test/resources/hierarchy.properties
@@ -1,0 +1,4 @@
+parent.children=child1,child2
+
+parent.children.child1.name=Jack
+parent.children.child2.name=Jill


### PR DESCRIPTION
…operties and implemented a fix.
Github issue: #1094

Motivation
----------
Fix the issue described in THORN-2148: if properties in the properties file have a hierarchy and a node has both children and a value of its own, the result is undefined.

Modifications
-------------
Created a unit test to reproduce the issue (`ConfigViewFactoryTest.java`) and another to isolate the issue as not being in the command line processing (`CommandLineTest.java`). Then
fixed the issue in org.wildfly.swarm.container.config.ConfigNode.

Result
------
Fix is fully backwards compatible and does not affect users not using a properties file or not using a properties file with a hierarchy.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
