### PR TITLE
THORN-2153: the opentracing-tracerresolver fraction should be internal and stable

### DIFF
--- a/fractions/opentracing-tracerresolver/pom.xml
+++ b/fractions/opentracing-tracerresolver/pom.xml
@@ -10,6 +10,14 @@
 
   <artifactId>opentracing-tracerresolver</artifactId>
 
+  <name>OpenTracing TracerResolver</name>
+  <description>OpenTracing TracerResolver</description>
+
+  <properties>
+    <swarm.fraction.internal>true</swarm.fraction.internal>
+    <swarm.fraction.stability>stable</swarm.fraction.stability>
+  </properties>
+
   <build>
     <resources>
       <resource>


### PR DESCRIPTION
Motivation
----------
When running an application that includes the `jaeger` and
`opentracing` fractions, the `opentracing-tracerresolver` fraction
is showed in the list of fractions as unstable.

The fraction should be marked as stable, because all other fractions
that depend on it are also stable, and as internal, because it's not
meant to be used directly.

Modifications
-------------
Marked the `opentracing-tracerresolver` fraction as stable
and internal.

Result
------
Less clutter during application boot.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
