### PR TITLE
THORN-2154: NPE in MetricsHttpHandler.handleRequest

### DIFF
--- a/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/MetricsHttpHandler.java
+++ b/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/MetricsHttpHandler.java
@@ -25,6 +25,7 @@ import io.undertow.util.HttpString;
 import org.jboss.logging.Logger;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.stream.Stream;
 
 /**
  * @author hrupp
@@ -60,7 +61,8 @@ public class MetricsHttpHandler implements HttpHandler {
 
         String method = exchange.getRequestMethod().toString();
         HeaderValues acceptHeaders = exchange.getRequestHeaders().get(Headers.ACCEPT);
-        metricsHandler.handleRequest(requestPath, method, acceptHeaders.stream(), (status, message, headers) -> {
+        Stream<String> acceptHeadersStream = acceptHeaders != null ? acceptHeaders.stream() : null;
+        metricsHandler.handleRequest(requestPath, method, acceptHeadersStream, (status, message, headers) -> {
             exchange.setStatusCode(status);
             headers.forEach(
                     (key, value) -> exchange.getResponseHeaders().put(new HttpString(key), value)


### PR DESCRIPTION
Motivation
----------
The `MetricsHttpHandler.handleRequest` method throws a NPE if there's
no `Accept` header.

Modifications
-------------
Do a `null` check.

Result
------
No NPE.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
