### PR TITLE
THORN-2137: properly handle /metric requests without accept headers

### DIFF
--- a/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/MetricsHttpHandler.java
+++ b/fractions/microprofile/microprofile-metrics/src/main/java/org/wildfly/swarm/microprofile/metrics/runtime/MetricsHttpHandler.java
@@ -60,7 +60,7 @@ public class MetricsHttpHandler implements HttpHandler {
 
         String method = exchange.getRequestMethod().toString();
         HeaderValues acceptHeaders = exchange.getRequestHeaders().get(Headers.ACCEPT);
-        metricsHandler.handleRequest(requestPath, method, acceptHeaders.stream(), (status, message, headers) -> {
+        metricsHandler.handleRequest(requestPath, method, acceptHeaders == null ? null : acceptHeaders.stream(), (status, message, headers) -> {
             exchange.setStatusCode(status);
             headers.forEach(
                     (key, value) -> exchange.getResponseHeaders().put(new HttpString(key), value)

--- a/testsuite/testsuite-microprofile-metrics/pom.xml
+++ b/testsuite/testsuite-microprofile-metrics/pom.xml
@@ -25,6 +25,11 @@
          <artifactId>arquillian</artifactId>
          <scope>test</scope>
       </dependency>
+      <dependency>
+         <groupId>org.apache.httpcomponents</groupId>
+         <artifactId>fluent-hc</artifactId>
+         <scope>test</scope>
+      </dependency>
    </dependencies>
 
 </project>

--- a/testsuite/testsuite-microprofile-metrics/src/test/java/org/wildfly/swarm/microprofile/metrics/registry/NoAcceptHeadersTest.java
+++ b/testsuite/testsuite-microprofile-metrics/src/test/java/org/wildfly/swarm/microprofile/metrics/registry/NoAcceptHeadersTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.metrics.registry;
+
+import org.apache.http.client.fluent.Request;
+import org.apache.http.client.fluent.Response;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.arquillian.DefaultDeployment;
+
+import java.io.IOException;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ *
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ * <br>
+ * Date: 8/28/18
+ */
+@RunWith(Arquillian.class)
+@DefaultDeployment
+public class NoAcceptHeadersTest {
+
+    @Test
+    @RunAsClient
+    public void shouldGetMetricsWithoutAcceptHeadersSet() throws IOException {
+        Response response = Request.Get("http://localhost:8080/metrics").execute();
+        assertThat(response.returnResponse().getStatusLine().getStatusCode()).isEqualTo(200);
+    }
+}


### PR DESCRIPTION
Motivation
----------
During migration to SmallRye I introduced a bug that resulted in
throwing an NPE on metrics request without headers.
This change fixes the bug.

Modifications
-------------
acceptHeaders are translated to stream only if they are present.
Also, a test for the bug has been added.

Result
------
A request without accept headers is handled properly

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
