### PR TITLE
THORN-1890 Thorntail runner

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -22,7 +22,7 @@
   <description>Build Parent to bring in required dependencies</description>
 
   <properties>
-    <version.thorntail.fraction.plugin>89</version.thorntail.fraction.plugin>
+    <version.thorntail.fraction.plugin>90-SNAPSHOT</version.thorntail.fraction.plugin>
 
     <version.org.snakeyaml>1.17</version.org.snakeyaml>
 
@@ -190,6 +190,11 @@
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-aether-provider</artifactId>
+        <version>${version.maven.aether}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-settings-builder</artifactId>
         <version>${version.maven.aether}</version>
       </dependency>
 

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -22,7 +22,7 @@
   <description>Build Parent to bring in required dependencies</description>
 
   <properties>
-    <version.thorntail.fraction.plugin>90-SNAPSHOT</version.thorntail.fraction.plugin>
+    <version.thorntail.fraction.plugin>90</version.thorntail.fraction.plugin>
 
     <version.org.snakeyaml>1.17</version.org.snakeyaml>
 

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/FractionManifest.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/FractionManifest.java
@@ -50,6 +50,8 @@ public class FractionManifest {
 
     private List<String> dependencies = new ArrayList<>();
 
+    private List<String> mavenDependencies = new ArrayList<>();
+
     public FractionManifest() {
 
     }
@@ -79,6 +81,7 @@ public class FractionManifest {
         setArtifactId((String) data.get("artifactId"));
         setVersion((String) data.get("version"));
         setDependencies((Collection<String>) data.get("dependencies"));
+        setMavenDependencies((Collection<String>) data.get("maven-dependencies"));
         Object internal = data.get("internal");
         if (internal != null) {
             setInternal((Boolean) internal);
@@ -136,6 +139,12 @@ public class FractionManifest {
             this.dependencies.addAll(dependencies);
         }
     }
+    public void setMavenDependencies(Collection<String> mavenDependencies) {
+        this.mavenDependencies.clear();
+        if (mavenDependencies != null) {
+            this.mavenDependencies.addAll(mavenDependencies);
+        }
+    }
 
     public List<String> getDependencies() {
         return this.dependencies;
@@ -163,5 +172,9 @@ public class FractionManifest {
 
     public void setVersion(String version) {
         this.version = version;
+    }
+
+    public List<String> getMavenDependencies() {
+        return mavenDependencies;
     }
 }

--- a/plugins/maven-utils/pom.xml
+++ b/plugins/maven-utils/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.thorntail</groupId>
+    <artifactId>build-parent</artifactId>
+    <version>2.3.0.Final-SNAPSHOT</version>
+    <relativePath>../../build-parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>maven-utils</artifactId>
+
+  <name>Utilities for utilizing Maven to build the uber jar</name>
+  <packaging>jar</packaging>
+
+
+  <dependencies>
+    <dependency>
+      <groupId>io.thorntail</groupId>
+      <artifactId>tools</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.aether</groupId>
+      <artifactId>aether-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.aether</groupId>
+      <artifactId>aether-api</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/plugins/maven-utils/src/main/java/org/wildfly/swarm/maven/utils/RepositorySystemSessionWrapper.java
+++ b/plugins/maven-utils/src/main/java/org/wildfly/swarm/maven/utils/RepositorySystemSessionWrapper.java
@@ -1,3 +1,5 @@
+package org.wildfly.swarm.maven.utils;
+
 /**
  * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
  *
@@ -13,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.wildfly.swarm.plugin.maven;
 
 import java.util.Map;
 
@@ -38,20 +39,25 @@ import org.eclipse.aether.repository.WorkspaceReader;
 import org.eclipse.aether.resolution.ArtifactDescriptorPolicy;
 import org.eclipse.aether.resolution.ResolutionErrorPolicy;
 import org.eclipse.aether.transfer.TransferListener;
+import org.eclipse.aether.util.graph.transformer.ConflictResolver;
+import org.eclipse.aether.util.graph.transformer.JavaScopeDeriver;
+import org.eclipse.aether.util.graph.transformer.JavaScopeSelector;
+import org.eclipse.aether.util.graph.transformer.NearestVersionSelector;
+import org.eclipse.aether.util.graph.transformer.SimpleOptionalitySelector;
 import org.wildfly.swarm.fractions.FractionDescriptor;
 
 /**
  * @author Ken Finnigan
  */
-final class RepositorySystemSessionWrapper implements RepositorySystemSession {
+public final class RepositorySystemSessionWrapper implements RepositorySystemSession {
 
-    public RepositorySystemSessionWrapper(RepositorySystemSession delegate, DependencyGraphTransformer transformer) {
-        this(delegate, transformer, false);
-    }
-
-    RepositorySystemSessionWrapper(RepositorySystemSession delegate, DependencyGraphTransformer transformer, boolean excludeSwarm) {
+    public RepositorySystemSessionWrapper(RepositorySystemSession delegate, boolean excludeSwarm) {
         this.delegate = delegate;
-        this.transformer = transformer;
+        this.transformer = new ConflictResolver(new NearestVersionSelector(),
+                new JavaScopeSelector(),
+                new SimpleOptionalitySelector(),
+                new JavaScopeDeriver()
+        );
         this.excludeSwarm = excludeSwarm;
     }
 

--- a/plugins/maven/pom.xml
+++ b/plugins/maven/pom.xml
@@ -82,6 +82,10 @@
       <version>1.0.0.v20140518</version>
     </dependency>
     <dependency>
+      <groupId>io.thorntail</groupId>
+      <artifactId>maven-utils</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jooq</groupId>
       <artifactId>joox-java-6</artifactId>
       <version>1.6.0</version>

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelper.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelper.java
@@ -37,13 +37,9 @@ import org.eclipse.aether.repository.RepositoryPolicy;
 import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
-import org.eclipse.aether.util.graph.transformer.NearestVersionSelector;
-import org.eclipse.aether.util.graph.transformer.ConflictResolver;
-import org.eclipse.aether.util.graph.transformer.JavaScopeDeriver;
-import org.eclipse.aether.util.graph.transformer.JavaScopeSelector;
-import org.eclipse.aether.util.graph.transformer.SimpleOptionalitySelector;
 import org.eclipse.aether.util.graph.visitor.PreorderNodeListGenerator;
 import org.eclipse.aether.util.repository.AuthenticationBuilder;
+import org.wildfly.swarm.maven.utils.RepositorySystemSessionWrapper;
 import org.wildfly.swarm.tools.ArtifactResolvingHelper;
 import org.wildfly.swarm.tools.ArtifactSpec;
 
@@ -157,12 +153,7 @@ public class MavenArtifactResolvingHelper implements ArtifactResolvingHelper {
                                                   "compile")));
 
             RepositorySystemSession tempSession
-                    = new RepositorySystemSessionWrapper(this.session,
-                                                         new ConflictResolver(new NearestVersionSelector(),
-                                                                              new JavaScopeSelector(),
-                                                                              new SimpleOptionalitySelector(),
-                                                                              new JavaScopeDeriver()
-                                                         ), defaultExcludes
+                    = new RepositorySystemSessionWrapper(this.session, defaultExcludes
             );
             CollectResult result = this.system.collectDependencies(tempSession, request);
             PreorderNodeListGenerator gen = new PreorderNodeListGenerator();

--- a/pom.xml
+++ b/pom.xml
@@ -382,7 +382,13 @@
         <artifactId>bootstrap</artifactId>
         <version>2.3.0.Final-SNAPSHOT</version>
       </dependency>
-
+      
+      <dependency>
+        <groupId>io.thorntail</groupId>
+        <artifactId>maven-utils</artifactId>
+        <version>2.3.0.Final-SNAPSHOT</version>
+      </dependency>
+<!--
       <dependency>
         <groupId>io.thorntail</groupId>
         <artifactId>camel-core</artifactId>
@@ -448,7 +454,7 @@
         <artifactId>camel-undertow</artifactId>
         <version>2.3.0.Final-SNAPSHOT</version>
       </dependency>
-
+-->
       <dependency>
         <groupId>io.thorntail</groupId>
         <artifactId>cdi</artifactId>
@@ -1014,6 +1020,7 @@
 
     <module>meta/meta-spi</module>
     <module>meta/fraction-metadata</module>
+    <module>plugins/maven-utils</module>
     <module>plugins/maven</module>
 
     <module>client-apis/health-api</module>
@@ -1081,6 +1088,8 @@
     <module>standalone-servers</module>
     <module>standalone-servers/microprofile</module>
     <module>standalone-servers/web</module>
+
+    <module>thorntail-runner</module>
   </modules>
 
   <profiles>
@@ -1146,7 +1155,7 @@
         <module>fractions/wildfly/jgroups</module>
 
         <module>fractions/asciidoctorj</module>
-        <module>fractions/camel</module>
+<!--        <module>fractions/camel</module> -->
         <module>fractions/drools-server</module>
         <module>fractions/fluentd</module>
         <module>fractions/flyway</module>
@@ -1288,14 +1297,14 @@
         <module>testsuite/testsuite-jose</module>
         <module>testsuite/testsuite-asciidoctorj</module>
         <module>testsuite/testsuite-batch-jberet</module>
-        <module>testsuite/testsuite-camel-cdi</module>
+<!--        <module>testsuite/testsuite-camel-cdi</module>
         <module>testsuite/testsuite-camel-core</module>
         <module>testsuite/testsuite-camel-cxf</module>
         <module>testsuite/testsuite-camel-ejb</module>
         <module>testsuite/testsuite-camel-jms</module>
         <module>testsuite/testsuite-camel-jmx</module>
         <module>testsuite/testsuite-camel-jpa</module>
-        <module>testsuite/testsuite-camel-ognl</module>
+        <module>testsuite/testsuite-camel-ognl</module> -->
         <module>testsuite/testsuite-cdi-jaxrsapi</module>
         <module>testsuite/testsuite-cdi-jaxws</module>
         <module>testsuite/testsuite-classloader</module>

--- a/pom.xml
+++ b/pom.xml
@@ -388,7 +388,7 @@
         <artifactId>maven-utils</artifactId>
         <version>2.3.0.Final-SNAPSHOT</version>
       </dependency>
-<!--
+
       <dependency>
         <groupId>io.thorntail</groupId>
         <artifactId>camel-core</artifactId>
@@ -454,7 +454,7 @@
         <artifactId>camel-undertow</artifactId>
         <version>2.3.0.Final-SNAPSHOT</version>
       </dependency>
--->
+
       <dependency>
         <groupId>io.thorntail</groupId>
         <artifactId>cdi</artifactId>
@@ -1155,7 +1155,7 @@
         <module>fractions/wildfly/jgroups</module>
 
         <module>fractions/asciidoctorj</module>
-<!--        <module>fractions/camel</module> -->
+        <module>fractions/camel</module>
         <module>fractions/drools-server</module>
         <module>fractions/fluentd</module>
         <module>fractions/flyway</module>
@@ -1297,14 +1297,14 @@
         <module>testsuite/testsuite-jose</module>
         <module>testsuite/testsuite-asciidoctorj</module>
         <module>testsuite/testsuite-batch-jberet</module>
-<!--        <module>testsuite/testsuite-camel-cdi</module>
+        <module>testsuite/testsuite-camel-cdi</module>
         <module>testsuite/testsuite-camel-core</module>
         <module>testsuite/testsuite-camel-cxf</module>
         <module>testsuite/testsuite-camel-ejb</module>
         <module>testsuite/testsuite-camel-jms</module>
         <module>testsuite/testsuite-camel-jmx</module>
         <module>testsuite/testsuite-camel-jpa</module>
-        <module>testsuite/testsuite-camel-ognl</module> -->
+        <module>testsuite/testsuite-camel-ognl</module>
         <module>testsuite/testsuite-cdi-jaxrsapi</module>
         <module>testsuite/testsuite-cdi-jaxws</module>
         <module>testsuite/testsuite-classloader</module>

--- a/testsuite/testsuite-management-console-openapi/pom.xml
+++ b/testsuite/testsuite-management-console-openapi/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.thorntail.testsuite</groupId>
     <artifactId>testsuite-parent</artifactId>
-    <version>2.0.1.Final-SNAPSHOT</version>
+    <version>2.3.0.Final-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/thorntail-runner/pom.xml
+++ b/thorntail-runner/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.thorntail</groupId>
+    <artifactId>build-parent</artifactId>
+    <version>2.3.0.Final-SNAPSHOT</version>
+    <relativePath>../build-parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>thorntail-runner</artifactId>
+
+  <name>Helper for a direct run from IDE</name>
+
+  <packaging>jar</packaging>
+
+
+  <dependencies>
+    <dependency>
+      <groupId>io.thorntail</groupId>
+      <artifactId>tools</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.aether</groupId>
+      <artifactId>aether-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.aether</groupId>
+      <artifactId>aether-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.aether</groupId>
+      <artifactId>aether-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.aether</groupId>
+      <artifactId>aether-connector-basic</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-aether-provider</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-settings-builder</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.aether</groupId>
+      <artifactId>aether-transport-file</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.aether</groupId>
+      <artifactId>aether-transport-http</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.thorntail</groupId>
+      <artifactId>maven-utils</artifactId>
+    </dependency>
+
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.thorntail</groupId>
+        <artifactId>thorntail-fraction-plugin</artifactId>
+        <version>${version.thorntail.fraction.plugin}</version>
+        <executions>
+          <execution>
+            <id>generate-dependency-list</id>
+            <goals>
+              <goal>generate-dependency-list</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/thorntail-runner/src/main/java/org/wildfly/swarm/runner/FatJarBuilder.java
+++ b/thorntail-runner/src/main/java/org/wildfly/swarm/runner/FatJarBuilder.java
@@ -78,7 +78,7 @@ public class FatJarBuilder {
 
         buildFatJarTo(fatJar);
 
-        System.out.printf("total time %d ms\n", System.currentTimeMillis() - start);
+        System.out.printf("Uber jar built in %d ms\n", System.currentTimeMillis() - start);
     }
 
     private static File buildFatJarTo(File target) throws Exception {

--- a/thorntail-runner/src/main/java/org/wildfly/swarm/runner/FatJarBuilder.java
+++ b/thorntail-runner/src/main/java/org/wildfly/swarm/runner/FatJarBuilder.java
@@ -1,0 +1,361 @@
+/**
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.runner;
+
+import org.w3c.dom.Document;
+import org.wildfly.swarm.runner.cache.ArtifactResolutionCache;
+import org.wildfly.swarm.runner.maven.CachingArtifactResolvingHelper;
+import org.wildfly.swarm.runner.utils.StdoutLogger;
+import org.wildfly.swarm.tools.ArtifactSpec;
+import org.wildfly.swarm.tools.BuildTool;
+import org.wildfly.swarm.tools.DeclaredDependencies;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathFactory;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+import static org.wildfly.swarm.runner.utils.StringUtils.randomAlphabetic;
+
+/**
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ * <br>
+ * Date: 7/30/18
+ */
+public class FatJarBuilder {
+
+    public static final String FAKE_GROUP_ID = "com.fakegroupid";  // TODO: is this needed?
+    private final List<URL> classPathUrls;
+    private final File target;
+
+    public FatJarBuilder(List<URL> classPathUrls, File target) {
+        this.classPathUrls = classPathUrls;
+        this.target = target;
+    }
+
+    public static void main(String[] args) throws Exception {
+        File fatJar = new File(args[0]);
+
+        long start = System.currentTimeMillis();
+
+        buildFatJarTo(fatJar);
+
+        System.out.printf("total time %d ms\n", System.currentTimeMillis() - start);
+    }
+
+    private static File buildFatJarTo(File target) throws Exception {
+        List<URL> urls = getClasspathUrls();
+
+        FatJarBuilder b = new FatJarBuilder(urls, target);
+        return b.doBuild();
+    }
+
+    private static List<URL> getClasspathUrls() throws MalformedURLException {
+        URLClassLoader urlLoader = (URLClassLoader) ClassLoader.getSystemClassLoader();
+        List<String> urlList =
+                Stream.of(urlLoader.getURLs())
+                        .map(URL::toString)
+                        .collect(Collectors.toList());
+
+        List<URL> urls = new ArrayList<>();
+
+        for (String urlString : urlList) {
+            urls.add(new URL(urlString));
+        }
+        return urls;
+    }
+
+    private File doBuild() throws Exception {
+        final String type = "war";
+
+        // NOTE: we don't know which deps are transitive!!!
+        long start = System.currentTimeMillis();
+        List<ArtifactOrFile> classPathEntries = analyzeClasspath();
+        System.out.println("Classpath analyzing time: " + (System.currentTimeMillis() - start + " ms"));
+
+        File war = buildWar(classPathEntries);
+        final BuildTool tool = new BuildTool(new CachingArtifactResolvingHelper(), true)
+                .projectArtifact("tt",
+                        "wfswarm-user-app",
+                        "0.1-SNAPSHOT",
+                        type,
+                        war,
+                        "users.war")
+                .properties(System.getProperties())
+                .fractionDetectionMode(BuildTool.FractionDetectionMode.when_missing)
+                .hollow(false)
+                .logger(new StdoutLogger());
+
+        String mainClass = System.getProperty("thorntail.runner.main-class");
+        if (mainClass != null) {
+            tool.mainClass(mainClass);
+        }
+
+        tool.declaredDependencies(declaredDependencies(classPathEntries));
+
+
+        this.classPathUrls.parallelStream()
+                .filter(url -> !url.toString().matches(".*\\.[^/]*"))
+                .forEach(r -> tool.resourceDirectory(r.getFile()));
+
+        File uberjarResourcesDir = File.createTempFile("thorntail-runner-uberjar-resources", "placeholder");
+        uberjarResourcesDir.deleteOnExit();
+        tool.uberjarResourcesDirectory(uberjarResourcesDir.toPath());
+
+        File jar = tool.build(target.getName(), target.getParentFile().toPath());
+
+        tool.repackageWar(war);
+
+        ArtifactResolutionCache.INSTANCE.store();
+
+        return jar;
+    }
+
+    /**
+     * builds war with classes inside
+     *
+     * @param classPathEntries class path entries as ArtifactSpec or URLs
+     * @return the war file
+     */
+    private File buildWar(List<ArtifactOrFile> classPathEntries) {
+        try {
+            List<String> classesUrls = classPathEntries.stream()
+                    .map(ArtifactOrFile::file)
+                    .filter(this::isDirectory)
+                    .filter(url -> url.contains("classes"))
+                    .collect(Collectors.toList());
+
+            List<File> classpathJars = classPathEntries.stream()
+                    .map(ArtifactOrFile::file)
+                    .filter(file -> file.endsWith(".jar"))
+                    .map(File::new)
+                    .collect(Collectors.toList());
+
+            return WarBuilder.build(classesUrls, classpathJars);
+        } catch (IOException e) {
+            throw new RuntimeException("failed to build war", e);
+        }
+    }
+
+    private boolean isDirectory(String filePath) {
+        return Files.isDirectory(Paths.get(filePath));
+    }
+
+    private List<ArtifactOrFile> analyzeClasspath() {
+        return classPathUrls.parallelStream()
+                .filter(this::notJdkJar)
+                .map(this::urlToSpec)
+                .collect(toList());
+    }
+
+    private boolean notJdkJar(URL url) {
+        return !url.toString().contains(System.getProperty("java.home"));
+    }
+
+    private DeclaredDependencies declaredDependencies(List<ArtifactOrFile> specsOrUrls) {
+        List<ArtifactSpec> specs =
+                specsOrUrls.stream()
+                        .filter(ArtifactOrFile::isJar)
+                        .filter(ArtifactOrFile::hasSpec)
+                        .map(ArtifactOrFile::spec)
+                        .collect(toList());
+        return new DeclaredDependencies() {
+            @Override
+            public Collection<ArtifactSpec> getDirectDeps() {
+                return specs;
+            }
+
+            @Override
+            public Collection<ArtifactSpec> getTransientDeps(ArtifactSpec parent) {
+                return Collections.emptyList();
+            }
+        };
+    }
+
+    private ArtifactOrFile urlToSpec(URL url) {
+        String file = resolveUrlToFile(url);
+        if (!url.toString().endsWith(".jar")) {
+            return ArtifactOrFile.file(file);
+        }
+        // todo speed up?
+        // todo: maybe speed up xml parsing?
+        try (FileSystem fs = FileSystems.newFileSystem(Paths.get(file), getClass().getClassLoader())) {
+            Optional<Path> maybePomXml = findPom(fs);
+
+            ArtifactSpec spec = maybePomXml
+                    .map(pom -> toArtifactSpec(pom, file))
+                    .orElse(mockArtifactSpec(file)); // we should probably just skip'em
+            return ArtifactOrFile.spec(spec);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to parse jar: " + file, e);
+        }
+    }
+
+    private Optional<Path> findPom(FileSystem fs) throws IOException {
+        Optional<Path> maybePomXml;
+        Path path = fs.getPath("/META-INF/maven");
+
+        if (path == null || !Files.exists(path)) {
+            maybePomXml = Optional.empty();
+        } else {
+
+            maybePomXml = Files.walk(path)
+                    .filter(p -> p.endsWith("pom.xml"))
+                    .findAny();
+        }
+        return maybePomXml;
+    }
+
+    private ArtifactSpec mockArtifactSpec(String jarPath) {
+        return new ArtifactSpec("compile",
+                FAKE_GROUP_ID, randomAlphabetic(10), "0.0.1", "jar", null,
+                new File(jarPath));
+    }
+
+
+    private ArtifactSpec toArtifactSpec(Path pom, String jarPath) {
+        try {
+            // TODO support properties?
+            String groupId = extract(pom, "/project/groupId",
+                    () -> extract(pom, "/project/parent/groupId"));
+            String artifactId = extract(pom, "/project/artifactId");
+            String version = extract(pom, "/project/version",
+                    () -> extract(pom, "/project/parent/version"));
+            String packaging = extract(pom, "/project/packaging", "jar");
+            String classifier = extract(pom, "/project/classifier", (String) null);
+
+            return new ArtifactSpec("compile",
+                    groupId, artifactId, version, packaging, classifier,
+                    new File(jarPath));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to read artifact spec from pom " + pom + " you may have an invalid jar downloaded.", e);
+        }
+    }
+
+    private String extract(Path source, String expression, Supplier<String> defaultValueProvider) {
+        String extracted = extract(source, expression);
+
+        return extracted == null || "".equals(extracted)
+                ? defaultValueProvider.get()
+                : extracted;
+    }
+
+    private String extract(Path source, String expression, String defaultValue) {
+        String extracted = extract(source, expression);
+
+        return extracted == null || "".equals(extracted)
+                ? defaultValue
+                : extracted;
+    }
+
+    private String extract(Path sourcePath, String expression) {
+        try (InputStream source = Files.newInputStream(sourcePath)) {
+            Document doc = parseDocument(source);
+            XPath xpath = createXpath();
+            XPathExpression expr = xpath.compile(expression);
+            return (String) expr.evaluate(doc, XPathConstants.STRING);
+        } catch (Exception any) {
+            throw new RuntimeException("Failure when trying to find a match for " + expression + " in " + sourcePath.toAbsolutePath(), any);
+        }
+    }
+
+    private XPath createXpath() {
+        XPathFactory xPathfactory = XPathFactory.newInstance();
+        return xPathfactory.newXPath();
+    }
+
+    private Document parseDocument(InputStream source) throws ParserConfigurationException, SAXException, IOException {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        return builder.parse(source);
+    }
+
+    private String resolveUrlToFile(URL url) {
+        try {
+            String zipFile = Paths.get(url.toURI()).toFile().getAbsolutePath();
+            if (zipFile == null) {
+                try (InputStream stream = url.openStream()) {
+                    File tempFile = File.createTempFile("tt-dependency", ".jar");
+                    tempFile.deleteOnExit();
+                    zipFile = tempFile.getAbsolutePath();
+                    Files.copy(stream, Paths.get(zipFile));
+                }
+            }
+            return zipFile;
+        } catch (URISyntaxException | IOException e) {
+            throw new RuntimeException("Unable to resolve: " + url);
+        }
+    }
+
+
+    public static class ArtifactOrFile {
+        private final String file;
+        private final ArtifactSpec spec;
+
+        private ArtifactOrFile(String file, ArtifactSpec spec) {
+            this.file = file;
+            this.spec = spec;
+        }
+
+        public String file() {
+            return file;
+        }
+
+        public ArtifactSpec spec() {
+            return spec;
+        }
+
+        public boolean isJar() {
+            return spec != null;
+        }
+
+        public boolean hasSpec() {
+            return !spec.groupId().equals(FAKE_GROUP_ID);
+        }
+
+        private static ArtifactOrFile file(String file) {
+            return new ArtifactOrFile(file, null);
+        }
+        private static ArtifactOrFile spec(ArtifactSpec spec) {
+            return new ArtifactOrFile(spec.file.getAbsolutePath(), spec);
+        }
+    }
+}

--- a/thorntail-runner/src/main/java/org/wildfly/swarm/runner/Runner.java
+++ b/thorntail-runner/src/main/java/org/wildfly/swarm/runner/Runner.java
@@ -1,0 +1,183 @@
+/**
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.runner;
+
+import org.wildfly.swarm.runner.cache.RunnerCacheConstants;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+
+/**
+ * The class to execute when running Thorntail in the IDE.
+ *
+ * During execution, it resolves project's dependencies to ${user.home}
+ *
+ * It first generates an uber-jar and then executes it.
+ * The jar is generated from the IDE classpath by taking the Thorntail dependencies, generating an uber-jar in the similar way
+ * the thorntail-maven-plugin does and removing all the transitive dependencies of the Thorntail elements from WEB-INF/lib
+ * in the internal WAR.
+ *
+ * The following options are available to control the execution:
+ * <ul>
+ *     <li>
+ *         <b>thorntail.runner.preserve-jar</b> - keep the generated uber-jar when the application is stopped; might be useful for debugging
+ *     </li>
+ *     <li>
+ *         <b>thorntail.runner.user-dependencies</b> - a comma-separated list of groupId:artifactId:version[:classifier] of artifacts
+ *         to keep in WEB-INF/lib even though they are dependencies of Swarm elements
+ *     </li>
+ *     <li>
+ *         <b>thorntail.runner.main-class</b> - user's main class replacing the default org.wildfly.swarm.Swarm class.
+ *         Please note that using custom main class is discouraged.
+ *     </li>
+ *     <li>
+ *         <b>thorntail.runner.webapp-location</b> - by default, Runner expects webapp in `src/main/webapp`. This property
+ *         can be used to point to a different location of the webapp directory
+ *     </li>
+ *     <li>
+ *         <b>thorntail.runner.repositories</b> - additional maven repositories to look for artifacts.
+ *         By default Runner searches for artifacts in Maven Central and repository.jboss.org.
+ *         Expects a comma separated list of repositoryUrl[#username#password].
+ *     </li>
+ *     <li>
+ *         <b>thorntail.runner.local-repository</b> - location of the local repository.
+ *         By default, Runner will use ${user.home}/.m2/repository to store any resolved artifacts.
+ *         This is the default Maven location. This property let's you choose a different location.
+ *     </li>
+ * </ul>
+ *
+ */
+public class Runner {
+
+    private static final String PRESERVE_JAR = "thorntail.runner.preserve-jar";
+
+    private Runner() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        System.out.printf("Starting Thorntail Runner. Runner caches will be stored in %s\n", RunnerCacheConstants.CACHE_STORAGE_DIR);
+        URLClassLoader loader = createClassLoader();
+        run((Object) args, loader);
+    }
+
+    private static void run(Object args, URLClassLoader loader) throws Exception {
+        callWithClassloader(loader,
+                "org.wildfly.swarm.bootstrap.Main",
+                "main",
+                new Class<?>[]{String[].class},
+                args);
+    }
+
+    private static <T> T callWithClassloader(ClassLoader loader,
+                                             String className,
+                                             String methodName,
+                                             Class<?>[] argumentTypes,
+                                             Object... arguments) throws Exception {
+        Thread.currentThread().setContextClassLoader(loader);
+        Class<?> aClass = loader.loadClass(className);
+        Method method = aClass.getMethod(methodName, argumentTypes);
+        return (T) method.invoke(null, arguments);
+    }
+
+    private static URLClassLoader createClassLoader() throws Exception {
+        File fatJar = File.createTempFile("wfswarm-user-app", ".jar");
+        buildJar(fatJar);
+
+
+        if (System.getProperties().getProperty(PRESERVE_JAR) == null) {
+            System.out.println("Built " + fatJar.getAbsolutePath() + ", the file will be deleted on shutdown. To keep it, use -D" + PRESERVE_JAR);
+            fatJar.deleteOnExit();
+        }
+
+        URL jarUrl = fatJar.toURI().toURL();
+        return new URLClassLoader(new URL[]{jarUrl}, null);
+    }
+
+    private static void buildJar(File fatJar) throws IOException, InterruptedException {
+        String classpath = Arrays.stream(((URLClassLoader) Thread.currentThread().getContextClassLoader()).getURLs())
+                .map(URL::getFile)
+                .collect(Collectors.joining(File.pathSeparator));
+
+        List<String> command = buildCommand(fatJar, classpath);
+
+        Process fatJarBuilder = new ProcessBuilder(command)
+                .inheritIO()
+                .start();
+
+
+        int exitCode = fatJarBuilder.waitFor();
+        if (exitCode != 0) {
+            throw new RuntimeException("Failed to generate the uber jar.");
+        }
+    }
+
+    /*
+    builds a command like:
+    /my/path/to/java -cp all:elements:of:classpath -Dall -Dsystem=properties JarBuilderClassName pathToTargetJar
+     */
+    private static List<String> buildCommand(File fatJar, String classpath) {
+        List<String> command = new ArrayList<>(
+                asList(
+                        javaCommand(),
+                        "-cp",
+                        classpath)
+        );
+
+        command.addAll(properties());
+        command.addAll(asList(
+                FatJarBuilder.class.getCanonicalName(),
+                fatJar.getAbsolutePath()
+        ));
+        return command;
+    }
+
+    private static Collection<String> properties() {
+        return System.getProperties()
+                .entrySet()
+                .stream()
+                .map(Runner::propertyToString)
+                .collect(Collectors.toList());
+    }
+
+    private static String propertyToString(Map.Entry<Object, Object> property) {
+        return property.getValue() == null
+                ? format("-D%s", property.getKey())
+                : format("-D%s=%s", property.getKey(), property.getValue());
+    }
+
+    private static String javaCommand() {
+        Path javaBinPath = Paths.get(System.getProperty("java.home"), "bin");
+        File javaExecutable = javaBinPath.resolve("java").toFile();
+        if (!javaExecutable.exists()) {
+            javaExecutable = javaBinPath.resolve("java.exe").toFile();
+        }
+        return javaExecutable.getAbsolutePath();
+    }
+}

--- a/thorntail-runner/src/main/java/org/wildfly/swarm/runner/WarBuilder.java
+++ b/thorntail-runner/src/main/java/org/wildfly/swarm/runner/WarBuilder.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.runner;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+/**
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ * <br>
+ * Date: 8/1/18
+ */
+public class WarBuilder {
+
+    public static File build(List<String> classesDirs, List<File> classpathJars) throws IOException {
+        File war = File.createTempFile("wfswarm-user-war", ".war");
+        war.deleteOnExit();
+        try (FileOutputStream fos = new FileOutputStream(war);
+             ZipOutputStream out = new ZipOutputStream(fos)) {
+
+            WarBuilder builder = new WarBuilder(out, classesDirs, classpathJars);
+            builder.build();
+        }
+        System.out.println("built " + war.getAbsolutePath());
+        return war;
+    }
+
+    private WarBuilder(ZipOutputStream output, List<String> classesDirs, List<File> jars) {
+        this.output = output;
+        this.classesDirs = classesDirs;
+        this.jars = jars;
+    }
+
+    private void build() {
+        classesDirs.forEach(this::addClassesToWar);
+        addWebAppResourcesToWar();
+        jars.stream().forEach(this::addJarToWar);
+    }
+
+
+    private void addClassesToWar(String directory) {
+        File classesDirectory = new File(directory);
+        if (!classesDirectory.isDirectory()) {
+            throw new RuntimeException("Invalid classes directory on classpath: " + directory);
+        }
+        addClassesToWar(classesDirectory);
+    }
+
+    private void addWebAppResourcesToWar() {
+        try {
+            Path webappPath = getWebAppLocation();
+            if (!webappPath.toFile().exists()) {
+                return;
+            }
+            Files.walk(webappPath)
+                    .forEach(this::addWebappResourceToWar);
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to get webapp dir");
+        }
+    }
+
+    private Path getWebAppLocation() {
+        Path webappPath;
+        // TODO: if maven project - check in the pom if it's not different than default
+        String webappLocationProperty = System.getProperty("thorntail.runner.webapp-location");
+
+        if (webappLocationProperty != null) {
+            webappPath = Paths.get(webappLocationProperty);
+            if (!webappPath.toFile().exists()) {
+                // user provided a location for webapp dir but it's invalid
+                System.err.println("Invalid web app location directory provided: " + webappLocationProperty);
+                System.exit(1);
+            }
+        } else {
+            webappPath = Paths.get("src", "main", "webapp");
+        }
+        return webappPath;
+    }
+
+    private void addJarToWar(File file) {
+        String jarName = file.getName();
+        try {
+            writeFileToZip(file, "WEB-INF/lib/" + jarName);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to add jar " + file.getAbsolutePath() + " to war", e);
+        }
+    }
+
+    private void addWebappResourceToWar(Path path) {
+        File file = path.toFile();
+        if (file.isFile()) {
+            try {
+                String projectDir = Paths.get("src", "main", "webapp").toFile().getAbsolutePath();
+
+                String fileName = file.getAbsolutePath().replace(projectDir, "");
+                writeFileToZip(file, fileName);
+            } catch (IOException e) {
+                throw new RuntimeException("Unable to add file: " + path.toAbsolutePath() + "  from webapp to the war", e);
+            }
+        }
+    }
+
+    private void addClassesToWar(File classesDirectory) {
+        try {
+            Files.walk(classesDirectory.toPath())
+                    .map(Path::toFile)
+                    .filter(File::isFile)
+                    .forEach(file -> addClassToWar(file, classesDirectory));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to add classes to war", e);
+        }
+    }
+
+    private void addClassToWar(File file, File classesDirectory) {
+        try {
+            String name = getRelativePath(file, classesDirectory.getAbsolutePath());
+            name = "/WEB-INF/classes/" + name;
+            writeFileToZip(file, name);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to add file " + file.getAbsolutePath() + " to war", e);
+        }
+    }
+
+    private String getRelativePath(File file, String parentPath) {
+        String relativePath = file.getAbsolutePath().substring(parentPath.length());
+        String separator = FileSystems.getDefault().getSeparator();
+        if (relativePath.startsWith(separator)) {
+            relativePath = relativePath.substring(separator.length());
+        }
+        return relativePath;
+    }
+
+    private void writeFileToZip(File file, String name) throws IOException {
+        ZipEntry entry = new ZipEntry(name);
+        output.putNextEntry(entry);
+        try (FileInputStream input = new FileInputStream(file)) {
+            byte[] buffer = new byte[4096];
+            int length;
+            while ((length = input.read(buffer)) >= 0) {
+                output.write(buffer, 0, length);
+            }
+        }
+        output.closeEntry();
+    }
+
+    private final ZipOutputStream output;
+    private final List<String> classesDirs;
+    private final List<File> jars;
+}

--- a/thorntail-runner/src/main/java/org/wildfly/swarm/runner/cache/ArtifactResolutionCache.java
+++ b/thorntail-runner/src/main/java/org/wildfly/swarm/runner/cache/ArtifactResolutionCache.java
@@ -61,7 +61,7 @@ public class ArtifactResolutionCache {
             }
         }
         resolutionFailures.add("org.jboss.narayana.jta:cdi:jar:5.5.30.Final");
-        System.out.printf("Cache initialization done in %d [ms]\n", System.currentTimeMillis() - startTime);
+        System.out.printf("Cache initialization done in %d ms\n", System.currentTimeMillis() - startTime);
     }
 
     public void store() {

--- a/thorntail-runner/src/main/java/org/wildfly/swarm/runner/cache/ArtifactResolutionCache.java
+++ b/thorntail-runner/src/main/java/org/wildfly/swarm/runner/cache/ArtifactResolutionCache.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.runner.cache;
+
+import org.wildfly.swarm.tools.ArtifactSpec;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import static org.wildfly.swarm.runner.cache.RunnerCacheConstants.CACHE_STORAGE_DIR;
+
+/**
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ * <br>
+ * Date: 9/7/18
+ */
+public class ArtifactResolutionCache {
+    private static final String RESOLUTION_CACHE_FILE = "resolution-cache";
+    public static final Path CACHE_PATH = Paths.get(CACHE_STORAGE_DIR, RESOLUTION_CACHE_FILE);
+
+    public static final ArtifactResolutionCache INSTANCE = new ArtifactResolutionCache();
+
+    private Map<String, File> resolvedCache = new ConcurrentHashMap<>();
+    private Set<String> resolutionFailures = Collections.newSetFromMap(new ConcurrentHashMap<>()); // transient
+
+    private ArtifactResolutionCache() {
+        long startTime = System.currentTimeMillis();
+        System.out.println("Reading and verifying cache");
+        Path cache = CACHE_PATH;
+        if (!cache.toFile().exists()) {
+            System.out.println("No preexisting artifact resolution cache found. The first execution may take some time.");
+        } else {
+            try {
+                Files.lines(cache).forEach(this::addToCache);
+            } catch (IOException e) {
+                e.printStackTrace();
+                System.out.println("Error reading resolution cache file, caching will be disabled.");
+            }
+        }
+        resolutionFailures.add("org.jboss.narayana.jta:cdi:jar:5.5.30.Final");
+        System.out.printf("Cache initialization done in %d [ms]\n", System.currentTimeMillis() - startTime);
+    }
+
+    public void store() {
+        System.out.println("Storing cache resolution results...");
+        try {
+            Files.deleteIfExists(CACHE_PATH);
+            List<String> lines = resolvedCache.entrySet()
+                    .stream()
+                    .map(entry -> String.format("%s#%s", entry.getKey(), entry.getValue().getAbsolutePath()))
+                    .collect(Collectors.toList());
+            storeToFile(CACHE_PATH, lines);
+        } catch (IOException e) {
+            System.out.println("Failed to store artifact resolution. Next execution won't be able to use full caching capabilities");
+            e.printStackTrace();
+        }
+    }
+
+    private void addToCache(String cacheFileLine) {
+        String[] split = cacheFileLine.split("#");
+        try {
+            String key = split[0];
+            String path = split[1];
+
+            File file = Paths.get(path).toFile();
+            if (file.exists()) {
+                resolvedCache.put(key, file);
+            } else {
+                System.out.printf("Omitting %s -> %s mapping from cache resolution. It points to a non-existent file\n", key, path);
+            }
+        } catch (Exception any) {
+            System.out.printf("Omitting invalid cache line %s\n", cacheFileLine);
+            any.printStackTrace();
+        }
+    }
+
+    private void storeToFile(Path path, List<String> linesToStore) throws IOException {
+        File cacheFile = path.toFile();
+
+        File parent = cacheFile.getParentFile();
+        if (!parent.exists()) {
+            parent.mkdirs();
+        }
+
+        try (FileWriter writer = new FileWriter(cacheFile)) {
+            for (String line : linesToStore) {
+                writer.append(line).append("\n");
+            }
+        }
+    }
+
+    public File getCachedFile(ArtifactSpec spec) {
+        String key = spec.mavenGav();
+        return resolvedCache.get(key);
+    }
+
+    public void storeArtifactFile(ArtifactSpec spec, File maybeFile) {
+        if (maybeFile != null) {
+            resolvedCache.put(spec.mavenGav(), maybeFile);
+        }
+    }
+
+    public void storeResolutionFailure(ArtifactSpec spec) {
+        resolutionFailures.add(spec.mavenGav());
+    }
+
+    public boolean isKnownFailure(ArtifactSpec spec) {
+        return resolutionFailures.contains(spec.mavenGav());
+    }
+
+}

--- a/thorntail-runner/src/main/java/org/wildfly/swarm/runner/cache/DependencyResolutionCache.java
+++ b/thorntail-runner/src/main/java/org/wildfly/swarm/runner/cache/DependencyResolutionCache.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.runner.cache;
+
+import org.eclipse.aether.util.ChecksumUtils;
+import org.wildfly.swarm.tools.ArtifactSpec;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.wildfly.swarm.runner.cache.RunnerCacheConstants.CACHE_STORAGE_DIR;
+
+/**
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ * <br>
+ * Date: 9/7/18
+ */
+public class DependencyResolutionCache {
+
+    public static final DependencyResolutionCache INSTANCE = new DependencyResolutionCache();
+
+
+    private DependencyResolutionCache() {
+    }
+
+
+    public List<ArtifactSpec> getCachedDependencies(Collection<ArtifactSpec> specs, boolean defaultExcludes) {
+        Path cacheFile = getCacheFile(specs, defaultExcludes);
+
+        return readDependencies(cacheFile);
+    }
+
+    public void storeCachedDependencies(Collection<ArtifactSpec> specs, List<ArtifactSpec> dependencySpecs, boolean defaultExcludes) {
+        Path cachePath = getCacheFile(specs, defaultExcludes);
+
+        if (cachePath == null) {
+            return;
+        }
+
+        List<String> linesToStore = dependencySpecs.stream().map(ArtifactSpec::mscGav).collect(Collectors.toList());
+
+        try {
+            storeToFile(cachePath, linesToStore);
+        } catch (IOException e) {
+            System.err.println("Failed to store cached dependencies to " + cachePath.toAbsolutePath().toString());
+            e.printStackTrace();
+            return;
+        }
+    }
+
+    private void storeToFile(Path path, List<String> linesToStore) throws IOException {
+        File cacheFile = path.toFile();
+
+        File parent = cacheFile.getParentFile();
+        if (!parent.exists()) {
+            parent.mkdirs();
+        }
+
+        try (FileWriter writer = new FileWriter(cacheFile)) {
+            for (String line : linesToStore) {
+                writer.append(line).append("\n");
+            }
+        }
+    }
+
+    private Path getCacheFile(Collection<ArtifactSpec> specs, boolean defaultExcludes) {
+        String key = null;
+        try {
+            key = getCacheKey(specs);
+        } catch (NoSuchAlgorithmException e) {
+            System.err.println("No SHA-1 digest algorithm found, caching is disabled");
+            return null;
+        }
+
+        return Paths.get(CACHE_STORAGE_DIR, key + (defaultExcludes ? "-with-excludes" : ""));
+    }
+
+
+    private List<ArtifactSpec> readDependencies(Path cacheFile) {
+        if (cacheFile == null) {
+            return null;
+        }
+        try {
+            return Files.lines(cacheFile)
+                    .map(ArtifactSpec::fromMscGav)
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    private String getCacheKey(Collection<ArtifactSpec> specs) throws NoSuchAlgorithmException {
+        MessageDigest sha1Digest = MessageDigest.getInstance("SHA-1");
+        specs.stream()
+                .map(ArtifactSpec::jarName)
+                .sorted()
+                .forEach(
+                        jarName -> sha1Digest.update(jarName.getBytes())
+                );
+
+        byte[] resultBytes = sha1Digest.digest();
+
+        return ChecksumUtils.toHexString(resultBytes);
+    }
+}

--- a/thorntail-runner/src/main/java/org/wildfly/swarm/runner/cache/RunnerCacheConstants.java
+++ b/thorntail-runner/src/main/java/org/wildfly/swarm/runner/cache/RunnerCacheConstants.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.runner.cache;
+
+/**
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ * <br>
+ * Date: 9/11/18
+ */
+public class RunnerCacheConstants {
+    public static final String CACHE_STORAGE_DIR = System.getProperty("thorntail.runner.cache-location", ".thorntail-runner-cache");
+
+    private RunnerCacheConstants() {
+    }
+}

--- a/thorntail-runner/src/main/java/org/wildfly/swarm/runner/maven/CachingArtifactResolvingHelper.java
+++ b/thorntail-runner/src/main/java/org/wildfly/swarm/runner/maven/CachingArtifactResolvingHelper.java
@@ -1,0 +1,261 @@
+
+/**
+ * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.runner.maven;
+
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.collection.CollectResult;
+import org.eclipse.aether.collection.DependencyCollectionException;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.util.graph.visitor.PreorderNodeListGenerator;
+import org.wildfly.swarm.maven.utils.RepositorySystemSessionWrapper;
+import org.wildfly.swarm.runner.cache.ArtifactResolutionCache;
+import org.wildfly.swarm.runner.cache.DependencyResolutionCache;
+import org.wildfly.swarm.tools.ArtifactResolvingHelper;
+import org.wildfly.swarm.tools.ArtifactSpec;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.wildfly.swarm.runner.maven.MavenInitializer.buildRemoteRepository;
+import static org.wildfly.swarm.runner.maven.MavenInitializer.newRepositorySystem;
+import static org.wildfly.swarm.runner.maven.MavenInitializer.newSession;
+import static org.wildfly.swarm.runner.utils.StringUtils.randomAlphabetic;
+
+public class CachingArtifactResolvingHelper implements ArtifactResolvingHelper {
+
+    public CachingArtifactResolvingHelper() {
+        repoSystem = newRepositorySystem();
+
+        session = newSession(repoSystem);
+
+        this.remoteRepositories.add(buildRemoteRepository(
+                session,
+                "jboss-public-repository-group",
+                "https://repository.jboss.org/nexus/content/groups/public/",
+                null,
+                null));
+        this.remoteRepositories.add(buildRemoteRepository(
+                session,
+                "maven-central",
+                "https://repo.maven.apache.org/maven2/",
+                null,
+                null));
+
+        addUserRepositories();
+    }
+
+    @Override
+    public ArtifactSpec resolve(ArtifactSpec spec) {
+        if (spec.file == null) {
+            File maybeFile = artifactCache.getCachedFile(spec);
+            if (!artifactCache.isKnownFailure(spec) && maybeFile == null) {
+                System.out.println("no cached file for " + spec.mscGav());
+                maybeFile = resolveArtifactFile(spec);
+                artifactCache.storeArtifactFile(spec, maybeFile);
+            }
+
+            if (maybeFile == null) {
+                artifactCache.storeResolutionFailure(spec);
+                return null;
+            }
+            spec.file = maybeFile;
+        }
+
+        return spec;
+    }
+
+    @Override
+    public Set<ArtifactSpec> resolveAll(Collection<ArtifactSpec> specs, boolean transitive, boolean defaultExcludes) throws Exception {
+        if (specs.isEmpty()) {
+            return Collections.emptySet();
+        }
+        Collection<ArtifactSpec> toResolve = specs;
+        if (transitive) {
+            toResolve = resolveDependencies(specs, defaultExcludes);
+        }
+
+        return resolveInParallel(toResolve);
+    }
+
+    private Set<ArtifactSpec> resolveInParallel(Collection<ArtifactSpec> toResolve) throws InterruptedException {
+        ExecutorService threadPool = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors() * 10);
+        List<Callable<ArtifactSpec>> callable = toResolve.stream()
+                .map(spec -> (Callable<ArtifactSpec>) (() -> this.resolve(spec)))
+                .collect(Collectors.toList());
+
+        List<Future<ArtifactSpec>> futures = threadPool.invokeAll(
+                callable
+        );
+        Set<ArtifactSpec> result = futures.stream()
+                .map(this::safeGet)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+        threadPool.shutdown();
+        return result;
+    }
+
+    private <T> T safeGet(Future<T> future) {
+        try {
+            return future.get();
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    private void addUserRepositories() {
+        String repositoriesProperty = System.getProperty("thorntail.runner.repositories");
+        if (repositoriesProperty != null) {
+            Stream.of(repositoriesProperty.split(","))
+                    .forEach(this::addUserRepository);
+
+        }
+    }
+
+    private void addUserRepository(String repositoryAsString) {
+        String[] split = repositoryAsString.split("#");
+        String url = split[0];
+        String username = null;
+        String password = null;
+
+        if (split.length > 2) {
+            username = split[1];
+            password = split[2];
+        }
+        this.remoteRepositories.add(buildRemoteRepository(session, randomAlphabetic(8), url, username, password));
+    }
+
+
+    private Collection<ArtifactSpec> resolveDependencies(final Collection<ArtifactSpec> specs, boolean defaultExcludes) throws DependencyCollectionException {
+        long start = System.currentTimeMillis();
+        List<ArtifactSpec> dependencyNodes = dependencyCache.getCachedDependencies(specs, defaultExcludes);
+        if (dependencyNodes == null) {
+            List<Dependency> dependencies =
+                    specs.stream()
+                            .map(this::artifact)
+                            .map(a -> new Dependency(a, "compile"))
+                            .collect(Collectors.toList());
+
+            CollectRequest collectRequest = new CollectRequest(dependencies, null, remoteRepositories);
+
+            RepositorySystemSession session = new RepositorySystemSessionWrapper(this.session, defaultExcludes);
+            CollectResult result = this.repoSystem.collectDependencies(session, collectRequest);
+            PreorderNodeListGenerator gen = new PreorderNodeListGenerator();
+            result.getRoot().accept(gen);
+            dependencyNodes = gen.getNodes()
+                    .stream()
+                    .map(
+                            node -> {
+                                Artifact artifact = node.getArtifact();
+                                return new ArtifactSpec(node.getDependency().getScope(),
+                                        artifact.getGroupId(),
+                                        artifact.getArtifactId(),
+                                        artifact.getVersion(),
+                                        artifact.getExtension(),
+                                        artifact.getClassifier(),
+                                        artifact.getFile());
+                            }
+                    ).collect(Collectors.toList());
+
+
+            dependencyCache.storeCachedDependencies(specs, dependencyNodes, defaultExcludes);
+        }
+        System.out.println("dependency analysis time: " + (System.currentTimeMillis() - start) + "[ms]");
+        start = System.currentTimeMillis();
+
+        Collection<ArtifactSpec> result = resolveDependencies(dependencyNodes);
+        System.out.println("dependency resolution time: " + (System.currentTimeMillis() - start) + "[ms]");
+        return result;
+    }
+
+    private Collection<ArtifactSpec> resolveDependencies(List<ArtifactSpec> dependencyNodes) {
+        long start = System.currentTimeMillis();
+        // if dependencies were previously resolved, we don't need to resolve using remote repositories
+        dependencyNodes = new ArrayList<>(dependencyNodes);
+
+        System.out.println("parallel resolution time: " + (System.currentTimeMillis() - start));
+
+        try {
+            return dependencyNodes.parallelStream()
+                    .filter(node -> !"system".equals(node.scope))
+                    .map(node -> new ArtifactSpec(node.scope,
+                            node.groupId(),
+                            node.artifactId(),
+                            node.version(),
+                            "bundle".equals(node.type()) ? "jar" : node.type(),
+                            node.classifier(),
+                            null))
+                    .map(this::resolve)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toSet());
+        } finally {
+            System.out.println("total time of dep resolution: " + (System.currentTimeMillis() - start));
+        }
+    }
+
+    private DefaultArtifact artifact(ArtifactSpec spec) {
+        String type = spec.type();
+        type = "bundle".equals(type) ? "jar" : type;
+        return new DefaultArtifact(spec.groupId(), spec.artifactId(), spec.classifier(),
+                type, spec.version());
+    }
+
+    private File resolveArtifactFile(ArtifactSpec spec) {
+        ArtifactRequest request = new ArtifactRequest();
+        request.setArtifact(artifact(spec));
+
+        remoteRepositories.forEach(request::addRepository);
+
+        try {
+            ArtifactResult artifactResult = repoSystem.resolveArtifact(session, request);
+
+            return artifactResult.isResolved()
+                    ? artifactResult.getArtifact().getFile()
+                    : null;
+        } catch (ArtifactResolutionException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    private final DependencyResolutionCache dependencyCache = DependencyResolutionCache.INSTANCE;
+    private final ArtifactResolutionCache artifactCache = ArtifactResolutionCache.INSTANCE;
+    private final List<RemoteRepository> remoteRepositories = new ArrayList<>();
+    private final RepositorySystem repoSystem;
+    private final RepositorySystemSession session;
+
+}

--- a/thorntail-runner/src/main/java/org/wildfly/swarm/runner/maven/MavenInitializer.java
+++ b/thorntail-runner/src/main/java/org/wildfly/swarm/runner/maven/MavenInitializer.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.runner.maven;
+
+import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
+import org.eclipse.aether.impl.DefaultServiceLocator;
+import org.eclipse.aether.repository.LocalRepository;
+import org.eclipse.aether.repository.Proxy;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
+import org.eclipse.aether.spi.connector.transport.TransporterFactory;
+import org.eclipse.aether.transport.file.FileTransporterFactory;
+import org.eclipse.aether.transport.http.HttpTransporterFactory;
+import org.eclipse.aether.util.repository.AuthenticationBuilder;
+
+import java.io.File;
+import java.nio.file.Paths;
+
+/**
+ *
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ * <br>
+ * Date: 9/11/18
+ */
+public class MavenInitializer {
+
+    public static RepositorySystem newRepositorySystem() {
+        DefaultServiceLocator locator = MavenRepositorySystemUtils.newServiceLocator();
+        locator.addService(RepositoryConnectorFactory.class, BasicRepositoryConnectorFactory.class);
+        locator.addService(TransporterFactory.class, FileTransporterFactory.class);
+        locator.addService(TransporterFactory.class, HttpTransporterFactory.class);
+
+        return locator.getService(RepositorySystem.class);
+    }
+
+    public static RepositorySystemSession newSession(RepositorySystem system) {
+        DefaultRepositorySystemSession session = MavenRepositorySystemUtils.newSession();
+
+        LocalRepository localRepo = new LocalRepository(localRepoLocation());
+        session.setLocalRepositoryManager(system.newLocalRepositoryManager(session, localRepo));
+
+        return session;
+    }
+
+    public static File localRepoLocation() {
+        File result = null;
+        String userRepository = System.getProperty("thorntail.runner.local-repository");
+        if (userRepository != null) {
+            result = new File(userRepository);
+            if (!result.isDirectory()) {
+                System.err.println("The defined local repository: " + userRepository + " does not exist or is not a directory");
+            }
+        }
+        if (result == null) {
+            String userHome = System.getProperty("user.home");
+            result = Paths.get(userHome, ".m2", "repository").toFile();
+
+            if (!result.exists()) {
+                result.mkdirs();
+            }
+            // TODO maybe use .thorntail-runner-cache if it does not exist?
+            // TODO check if exists, ask user to create or point to a different location?
+        }
+        return result;
+    }
+
+    public static RemoteRepository buildRemoteRepository(final RepositorySystemSession session,
+                                                         final String id, final String url, final String username, final String password) {
+        RemoteRepository.Builder builder = new RemoteRepository.Builder(id, "default", url);
+        if (username != null) {
+            builder.setAuthentication(new AuthenticationBuilder()
+                    .addUsername(username)
+                    .addPassword(password).build());
+        }
+
+        RemoteRepository repository = builder.build();
+
+        final RemoteRepository mirror = session.getMirrorSelector().getMirror(repository);
+
+        if (mirror != null) {
+            final org.eclipse.aether.repository.Authentication mirrorAuth = session.getAuthenticationSelector()
+                    .getAuthentication(mirror);
+            RemoteRepository.Builder mirrorBuilder = new RemoteRepository.Builder(mirror)
+                    .setId(repository.getId());
+            if (mirrorAuth != null) {
+                mirrorBuilder.setAuthentication(mirrorAuth);
+            }
+            repository = mirrorBuilder.build();
+        }
+
+        Proxy proxy = session.getProxySelector().getProxy(repository);
+
+        if (proxy != null) {
+            repository = new RemoteRepository.Builder(repository).setProxy(proxy).build();
+        }
+
+        return repository;
+    }
+
+    private MavenInitializer() {
+    }
+}

--- a/thorntail-runner/src/main/java/org/wildfly/swarm/runner/utils/StdoutLogger.java
+++ b/thorntail-runner/src/main/java/org/wildfly/swarm/runner/utils/StdoutLogger.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.runner.utils;
+
+import org.wildfly.swarm.spi.meta.SimpleLogger;
+
+/**
+ * TODO: replace with slf4j/logback?
+ *
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ * <br>
+ * Date: 9/11/18
+ */
+public class StdoutLogger implements SimpleLogger {
+    @Override
+    public void debug(String msg) {
+        System.out.println(msg);
+    }
+
+    @Override
+    public void info(String msg) {
+        System.out.println(msg);
+    }
+
+    @Override
+    public void error(String msg) {
+        System.err.println(msg);
+    }
+
+    @Override
+    public void error(String msg, Throwable t) {
+        System.err.println(msg);
+        t.printStackTrace();
+    }
+}

--- a/thorntail-runner/src/main/java/org/wildfly/swarm/runner/utils/StringUtils.java
+++ b/thorntail-runner/src/main/java/org/wildfly/swarm/runner/utils/StringUtils.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.runner.utils;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ * <br>
+ * Date: 8/6/18
+ */
+public class StringUtils {
+    private static final ThreadLocalRandom random = ThreadLocalRandom.current();
+
+    private StringUtils() {
+    }
+
+    public static String randomAlphabetic(int length) {
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < length; i++) {
+
+            char nextChar = (char) ('a' + random.nextInt('z' - 'a'));
+            result.append(nextChar);
+        }
+        return result.toString();
+    }
+
+}

--- a/thorntail-runner/src/test/java/org/wildfly/swarm/runner/CachingArtifactResolvingHelperTest.java
+++ b/thorntail-runner/src/test/java/org/wildfly/swarm/runner/CachingArtifactResolvingHelperTest.java
@@ -1,0 +1,78 @@
+package org.wildfly.swarm.runner;
+
+
+import org.eclipse.aether.repository.NoLocalRepositoryManagerException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.wildfly.swarm.runner.maven.CachingArtifactResolvingHelper;
+import org.wildfly.swarm.tools.ArtifactSpec;
+
+import java.util.List;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.fest.assertions.Assertions.assertThat;
+import static org.wildfly.swarm.tools.ArtifactSpec.fromMavenDependencyDescription;
+
+/**
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ * <br>
+ * Date: 8/31/18
+ */
+public class CachingArtifactResolvingHelperTest {
+
+    private static CachingArtifactResolvingHelper helper;
+
+
+    @BeforeClass
+    public static void init() throws NoLocalRepositoryManagerException {
+        helper = new CachingArtifactResolvingHelper();
+    }
+
+    @Test
+    public void shouldResolveJunit() {
+        ArtifactSpec spec = fromMavenDependencyDescription("junit:junit:4.12#1");
+        ArtifactSpec resolved = helper.resolve(spec);
+        assertThat(resolved).isNotNull();
+    }
+
+    @Test
+    public void shouldResolveJunitAndAssert() throws Exception {
+        List<ArtifactSpec> specs = asList(
+                fromMavenDependencyDescription("junit:junit:4.12#1"),
+                fromMavenDependencyDescription("org.assertj:assertj-core:3.11.1#1")
+        );
+        Set<ArtifactSpec> resolved = helper.resolveAll(specs, false, false);
+        assertThat(resolved).hasSize(2);
+    }
+
+    @Test
+    public void shouldFailToResolveGracefully() throws Exception {
+        List<ArtifactSpec> specs = singletonList(fromMavenDependencyDescription("com.example:nonexistent-project:9.9.9#1"));
+        Set<ArtifactSpec> resolved = helper.resolveAll(specs, false, false);
+        assertThat(resolved).hasSize(0);
+    }
+
+    @Test
+    public void shouldResolveJunitTransitively() throws Exception {
+        List<ArtifactSpec> specs = singletonList(fromMavenDependencyDescription("junit:junit:4.12#12"));
+        Set<ArtifactSpec> resolved = helper.resolveAll(specs, true, false);
+        assertThat(resolved).hasSize(2);
+
+        assertContainsArtifact(resolved, "junit", "junit", "4.12");
+        assertContainsArtifact(resolved, "org.hamcrest", "hamcrest-core", "1.3");
+    }
+
+    private void assertContainsArtifact(Set<ArtifactSpec> resolved, String groupId, String artifactId, String version) {
+        boolean matchFound = resolved.stream()
+                .anyMatch(
+                        spec ->
+                                spec.groupId().equals(groupId)
+                                        && spec.artifactId().equals(artifactId)
+                                        && spec.version().equals(version)
+                );
+        assertThat(matchFound).overridingErrorMessage(String.format("%s:%s:%s has not been resolved", groupId, artifactId, version));
+    }
+
+}

--- a/tools/src/main/java/org/wildfly/swarm/tools/ArtifactSpec.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/ArtifactSpec.java
@@ -27,6 +27,8 @@ public class ArtifactSpec extends MavenArtifactDescriptor {
 
     public final String scope;
 
+    public String sha1sum;
+
     public File file;
 
     public boolean shouldGather = true;
@@ -41,6 +43,17 @@ public class ArtifactSpec extends MavenArtifactDescriptor {
         super(groupId, artifactId, packaging, classifier, version);
         this.scope = scope;
         this.file = file;
+        this.sha1sum = null;
+    }
+
+    private ArtifactSpec(final String groupId,
+                        final String artifactId,
+                        final String version,
+                        final String classifier,
+                        final String sha1sum) {
+        super(groupId, artifactId, "jar", classifier, version);
+        this.sha1sum = sha1sum;
+        this.scope = "compile";
     }
 
     public static ArtifactSpec fromMscGav(String gav) {
@@ -52,6 +65,13 @@ public class ArtifactSpec extends MavenArtifactDescriptor {
         } else {
             throw new RuntimeException("Invalid gav: " + gav);
         }
+    }
+
+    public static ArtifactSpec fromMavenDependencyDescription(String description) {
+        String[] parts = description.split("#");
+        ArtifactSpec result = fromMscGav(parts[0]);
+        result.sha1sum = parts[1];
+        return result;
     }
 
     public FractionDescriptor toFractionDescriptor() {
@@ -86,6 +106,4 @@ public class ArtifactSpec extends MavenArtifactDescriptor {
     public String toString() {
         return mavenGav() + " [" + this.scope + "]";
     }
-
-
 }

--- a/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
@@ -74,9 +74,13 @@ public class BuildTool {
     }
 
     public BuildTool(ArtifactResolvingHelper resolvingHelper) {
+        this(resolvingHelper, false);
+    }
+
+    public BuildTool(ArtifactResolvingHelper resolvingHelper, boolean removeAllThorntailLibs) {
         this.archive = ShrinkWrap.create(JavaArchive.class);
         this.resolver = new DefaultArtifactResolver(resolvingHelper);
-        this.dependencyManager = new DependencyManager(resolver);
+        this.dependencyManager = new DependencyManager(resolver, removeAllThorntailLibs);
     }
 
     public BuildTool declaredDependencies(DeclaredDependencies declaredDependencies) {

--- a/tools/src/main/java/org/wildfly/swarm/tools/DependencyManager.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/DependencyManager.java
@@ -20,8 +20,8 @@ import org.jboss.shrinkwrap.api.asset.Asset;
 import org.wildfly.swarm.bootstrap.env.FractionManifest;
 import org.wildfly.swarm.bootstrap.env.WildFlySwarmManifest;
 import org.wildfly.swarm.fractions.FractionDescriptor;
+import org.wildfly.swarm.tools.utils.ChecksumUtil;
 
-import javax.xml.bind.DatatypeConverter;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.file.Path;
-import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -307,7 +306,7 @@ public class DependencyManager implements ResolvedDependencies {
         }
 
         try (final InputStream inputStream = asset.openStream()) {
-            String checksum = checksum(inputStream);
+            String checksum = ChecksumUtil.calculateChecksum(inputStream);
 
             return this.removableCheckSums.contains(checksum);
         } catch (NoSuchAlgorithmException | IOException e) {
@@ -328,30 +327,17 @@ public class DependencyManager implements ResolvedDependencies {
 
     private String checksum(ArtifactSpec spec) {
         if (spec.sha1sum != null) {
-            return spec.sha1sum.toUpperCase();
+            return spec.sha1sum;
         }
 
         try {
             try (FileInputStream stream = new FileInputStream(spec.file)) {
-                return checksum(stream);
+                return ChecksumUtil.calculateChecksum(stream);
             }
         } catch (Exception any) {
             any.printStackTrace();
             return null;
         }
-    }
-
-    protected String checksum(InputStream in) throws IOException, NoSuchAlgorithmException {
-        byte[] buf = new byte[1024];
-        int len = 0;
-
-        MessageDigest md = MessageDigest.getInstance("SHA1");
-
-        while ((len = in.read(buf)) >= 0) {
-            md.update(buf, 0, len);
-        }
-
-        return DatatypeConverter.printHexBinary(md.digest());
     }
 
     protected boolean isConfigApiModulesJar(File file) {

--- a/tools/src/main/java/org/wildfly/swarm/tools/DependencyManager.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/DependencyManager.java
@@ -15,30 +15,34 @@
  */
 package org.wildfly.swarm.tools;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Path;
-import java.security.DigestException;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.jar.JarFile;
-import java.util.stream.Collectors;
-import java.util.zip.ZipEntry;
-
 import org.jboss.shrinkwrap.api.Node;
 import org.jboss.shrinkwrap.api.asset.Asset;
 import org.wildfly.swarm.bootstrap.env.FractionManifest;
 import org.wildfly.swarm.bootstrap.env.WildFlySwarmManifest;
 import org.wildfly.swarm.fractions.FractionDescriptor;
+
+import javax.xml.bind.DatatypeConverter;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+
+import static java.util.Arrays.asList;
 
 /**
  * @author Bob McWhirter
@@ -47,8 +51,9 @@ import org.wildfly.swarm.fractions.FractionDescriptor;
  */
 public class DependencyManager implements ResolvedDependencies {
 
-    public DependencyManager(ArtifactResolver resolver) {
+    public DependencyManager(ArtifactResolver resolver, boolean removeAllThorntailLibs) {
         this.resolver = resolver;
+        this.removeAllThorntailLibs = removeAllThorntailLibs;
     }
 
     public void addAdditionalModule(Path module) {
@@ -118,16 +123,14 @@ public class DependencyManager implements ResolvedDependencies {
         resolveDependencies(declaredDependencies, autodetect);
 
         // sort out removals, modules, etc
+        analyzeFractionManifests();
         analyzeRemovableDependencies(declaredDependencies);
-        analyzeFractionManifests(declaredDependencies);
 
         this.dependencies.stream()
                 .filter(e -> !this.removableDependencies.contains(e))
-                .forEach(e -> {
-                    this.applicationManifest.addDependency(e.mavenGav());
-                });
+                .forEach(e -> this.applicationManifest.addDependency(e.mavenGav()));
 
-        analyzeModuleDependencies(declaredDependencies);
+        analyzeModuleDependencies();
 
         return this;
     }
@@ -141,66 +144,73 @@ public class DependencyManager implements ResolvedDependencies {
     private void resolveDependencies(DeclaredDependencies declaredDependencies, boolean autodetect) throws Exception {
         this.dependencies.clear();
 
+        // remove thorntail-runner dependencies, if some of them are needed, they should be re-added later
+        Collection<ArtifactSpec> explicitDependencies = new ArrayList<>(declaredDependencies.getDirectDependencies());
+
+        declaredDependencies.runnerDependency().ifPresent(runner -> {
+            filterOutRunnerDependencies(runner, explicitDependencies);
+        });
+
         // resolve the explicit deps to local files
         // expand to transitive if these are not pre-solved
         boolean resolveExplicitsTransitively = !declaredDependencies.isPresolved() || autodetect;
         Collection<ArtifactSpec> resolvedExplicitDependencies = resolveExplicitsTransitively ?
-                resolver.resolveAllArtifactsTransitively(declaredDependencies.getExplicitDependencies(), false) :
-                resolver.resolveAllArtifactsNonTransitively(declaredDependencies.getExplicitDependencies());
+                resolver.resolveAllArtifactsTransitively(explicitDependencies, false) :
+                resolver.resolveAllArtifactsNonTransitively(explicitDependencies);
 
         this.dependencies.addAll(resolvedExplicitDependencies);
 
+        Collection<ArtifactSpec> inputSet;
+        Collection<ArtifactSpec> resolvedTransientDependencies;
         // resolve transitives if not pre-computed (i.e. from maven/gradle plugin)
         if (declaredDependencies.getTransientDependencies().isEmpty()) {
-
-            Collection<ArtifactSpec> inputSet = declaredDependencies.getExplicitDependencies();
+            inputSet = explicitDependencies;
             Collection<ArtifactSpec> filtered = inputSet
                     .stream()
                     .filter(dep -> dep.type().equals(JAR)) // filter out composite types, like ear, war, etc
                     .collect(Collectors.toList());
 
-            Collection<ArtifactSpec> resolvedTransientDependencies = resolver.resolveAllArtifactsTransitively(
+            resolvedTransientDependencies = resolver.resolveAllArtifactsTransitively(
                     filtered, false
             );
 
             this.dependencies.addAll(resolvedTransientDependencies);
-
-            // add the remaining transitive ones that have not been filtered
-            Collection<ArtifactSpec> remainder = new ArrayList<>();
-            inputSet.forEach(remainder::add);
-            remainder.removeAll(resolvedTransientDependencies);
-
-            this.dependencies.addAll(
-                    resolver.resolveAllArtifactsNonTransitively(remainder)
-            );
         } else {
             // if transitive deps are pre-computed, resolve them to local files if needed
-            Collection<ArtifactSpec> inputSet = declaredDependencies.getTransientDependencies();
+            inputSet = declaredDependencies.getTransientDependencies();
             Collection<ArtifactSpec> filtered = inputSet
                     .stream()
                     .filter(dep -> dep.type().equals(JAR))
                     .collect(Collectors.toList());
 
-            Collection<ArtifactSpec> resolvedTransientDependencies = Collections.emptySet();
+            resolvedTransientDependencies = Collections.emptySet();
             if (filtered.size() > 0) {
 
                 resolvedTransientDependencies = resolver.resolveAllArtifactsNonTransitively(filtered);
                 this.dependencies.addAll(resolvedTransientDependencies);
             }
-
-            // add the remaining transitive ones that have not been filtered
-            Collection<ArtifactSpec> remainder = new ArrayList<>();
-            inputSet.forEach(remainder::add);
-            remainder.removeAll(resolvedTransientDependencies);
-
-            this.dependencies.addAll(
-                    resolver.resolveAllArtifactsNonTransitively(remainder)
-            );
         }
 
+        // add the remaining transitive ones that have not been filtered
+        Collection<ArtifactSpec> remainder = new ArrayList<>(inputSet);
+        remainder.removeAll(resolvedTransientDependencies);
+
+        this.dependencies.addAll(
+                resolver.resolveAllArtifactsNonTransitively(remainder)
+        );
     }
 
-    private void analyzeModuleDependencies(DeclaredDependencies declaredDependencies) {
+    private void filterOutRunnerDependencies(ArtifactSpec runnerJar, Collection<ArtifactSpec> explicitDependencies) {
+        removableDependencies.add(runnerJar);
+        explicitDependencies.remove(runnerJar);
+
+        mavenDependencies(runnerJar.file)
+                .stream()
+                .map(ArtifactSpec::fromMavenDependencyDescription)
+                .forEach(removableDependencies::add);
+    }
+
+    private void analyzeModuleDependencies() {
         this.dependencies.stream()
                 .filter(e -> e.type().equals(JAR))
                 .map(e -> e.file)
@@ -210,7 +220,25 @@ public class DependencyManager implements ResolvedDependencies {
     }
 
     private void analyzeModuleDependencies(ModuleAnalyzer analyzer) {
-        this.moduleDependencies.addAll(analyzer.getDependencies());
+        List<ArtifactSpec> thorntailDependencies = analyzer.getDependencies();
+        this.moduleDependencies.addAll(thorntailDependencies);
+    }
+
+    private void analyzeFractionManifests() {
+        this.dependencies.stream()
+                .map(e -> fractionManifest(e.file))
+                .filter(Objects::nonNull)
+                .peek(this.fractionManifests::add)
+                .forEach((manifest) -> {
+                    String module = manifest.getModule();
+                    if (module != null) {
+                        this.applicationManifest.addBootstrapModule(module);
+                    }
+                });
+
+        this.dependencies.stream()
+                .filter(e -> isFractionJar(e.file) || isConfigApiModulesJar(e.file))
+                .forEach((artifact) -> this.applicationManifest.addBootstrapArtifact(artifact.mavenGav()));
     }
 
     /**
@@ -221,43 +249,46 @@ public class DependencyManager implements ResolvedDependencies {
         Collection<ArtifactSpec> bootstrapDeps = this.dependencies.stream()
                 .filter(e -> isFractionJar(e.file))
                 .collect(Collectors.toSet());
+        if (removeAllThorntailLibs) {
+            String whitelistProperty = System.getProperty("thorntail.runner.user-dependencies");
+            Set<String> whitelist = new HashSet<>();
+            if (whitelistProperty != null) {
+                whitelist.addAll(asList(whitelistProperty.split(",")));
+            }
+            Set<String> uniqueMavenDependencies = new HashSet<>();
+            this.dependencies.stream()
+                    .map(e -> e.file)
+                    .flatMap(e -> mavenDependencies(e).stream())
+                    .forEach(uniqueMavenDependencies::add);
+            this.fractionManifests.stream()
+                    .flatMap(manifest -> manifest.getMavenDependencies().stream())
+                    .forEach(uniqueMavenDependencies::add);
 
-        List<ArtifactSpec> nonBootstrapDeps = new ArrayList<>();
-        nonBootstrapDeps.addAll(declaredDependencies.getExplicitDependencies());
-        nonBootstrapDeps.removeAll(bootstrapDeps);
+            uniqueMavenDependencies
+                    .stream()
+                    .map(ArtifactSpec::fromMavenDependencyDescription)
+                    .forEach(this.removableDependencies::add);
 
-        // re-resolve the application's dependencies minus any of our swarm dependencies
-        // [hb] TODO this can be improved to use the previous results if the data-structure allows to reason about the parent of transitive deps
-        Collection<ArtifactSpec> nonBootstrapTransitive = resolver.resolveAllArtifactsTransitively(nonBootstrapDeps, true);
+            removableDependencies.addAll(bootstrapDeps);
 
-        // do not remove .war or .rar or anything else weird-o like.
-        Set<ArtifactSpec> justJars = this.dependencies
-                .stream()
-                .filter(e -> e.type().equals(JAR))
-                .collect(Collectors.toSet());
+            removableDependencies.removeIf(dep -> whitelist.contains(dep.mscGav()));
+        } else {
+            List<ArtifactSpec> nonBootstrapDeps = new ArrayList<>();
+            nonBootstrapDeps.addAll(declaredDependencies.getDirectDependencies());
+            nonBootstrapDeps.removeAll(bootstrapDeps);
+            // re-resolve the application's dependencies minus any of our swarm dependencies
+            // [hb] TODO this can be improved to use the previous results if the data-structure allows to reason about the parent of transitive deps
+            Collection<ArtifactSpec> nonBootstrapTransitive = resolver.resolveAllArtifactsTransitively(nonBootstrapDeps, true);
 
-        this.removableDependencies.addAll(justJars);
-        this.removableDependencies.removeAll(nonBootstrapTransitive);
+            // do not remove .war or .rar or anything else weird-o like.
+            Set<ArtifactSpec> justJars = this.dependencies
+                    .stream()
+                    .filter(e -> e.type().equals(JAR))
+                    .collect(Collectors.toSet());
 
-    }
-
-    private void analyzeFractionManifests(DeclaredDependencies declaredDependencies) {
-        this.dependencies.stream()
-                .map(e -> fractionManifest(e.file))
-                .filter(e -> e != null)
-                .forEach((manifest) -> {
-                    String module = manifest.getModule();
-                    if (module != null) {
-                        this.applicationManifest.addBootstrapModule(module);
-                    }
-                });
-
-        this.dependencies.stream()
-                .filter(e -> isFractionJar(e.file) || isConfigApiModulesJar(e.file))
-                .forEach((artifact) -> {
-                    this.applicationManifest.addBootstrapArtifact(artifact.mavenGav());
-                });
-
+            this.removableDependencies.addAll(justJars);
+            this.removableDependencies.removeAll(nonBootstrapTransitive);
+        }
     }
 
     Set<ArtifactSpec> getRemovableDependencies() {
@@ -271,31 +302,46 @@ public class DependencyManager implements ResolvedDependencies {
             return false;
         }
 
-        String path = node.getPath().get();
-        try (final InputStream inputStream = asset.openStream()) {
-            byte[] checksum = checksum(inputStream);
+        if (removableCheckSums == null) {
+            initCheckSums();
+        }
 
-            return this.removableDependencies.stream()
-                    .filter(e -> path.endsWith(e.artifactId() + "-" + e.version() + ".jar"))
-                    .map(e -> {
-                        try (final FileInputStream in = new FileInputStream(e.file)) {
-                            return checksum(in);
-                        } catch (IOException | NoSuchAlgorithmException | DigestException e1) {
-                            return null;
-                        }
-                    })
-                    .filter(e -> e != null)
-                    .anyMatch(e -> {
-                        return Arrays.equals(e, checksum);
-                    });
-        } catch (NoSuchAlgorithmException | IOException | DigestException e) {
+        try (final InputStream inputStream = asset.openStream()) {
+            String checksum = checksum(inputStream);
+
+            return this.removableCheckSums.contains(checksum);
+        } catch (NoSuchAlgorithmException | IOException e) {
             e.printStackTrace();
         }
 
         return false;
     }
 
-    protected byte[] checksum(InputStream in) throws IOException, NoSuchAlgorithmException, DigestException {
+    private synchronized void initCheckSums() {
+        if (removableCheckSums == null) {
+            removableCheckSums = removableDependencies.stream()
+                    .map(this::checksum)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toSet());
+        }
+    }
+
+    private String checksum(ArtifactSpec spec) {
+        if (spec.sha1sum != null) {
+            return spec.sha1sum.toUpperCase();
+        }
+
+        try {
+            try (FileInputStream stream = new FileInputStream(spec.file)) {
+                return checksum(stream);
+            }
+        } catch (Exception any) {
+            any.printStackTrace();
+            return null;
+        }
+    }
+
+    protected String checksum(InputStream in) throws IOException, NoSuchAlgorithmException {
         byte[] buf = new byte[1024];
         int len = 0;
 
@@ -305,7 +351,7 @@ public class DependencyManager implements ResolvedDependencies {
             md.update(buf, 0, len);
         }
 
-        return md.digest();
+        return DatatypeConverter.printHexBinary(md.digest());
     }
 
     protected boolean isConfigApiModulesJar(File file) {
@@ -333,6 +379,31 @@ public class DependencyManager implements ResolvedDependencies {
             // ignore
         }
         return false;
+    }
+
+    protected List<String> mavenDependencies(File file) {
+        if (file == null) {
+            return Collections.emptyList();
+        }
+
+        List<String> resultList = new ArrayList<>();
+
+        try (JarFile jar = new JarFile(file)) {
+            ZipEntry entry = jar.getEntry("META-INF/maven-dependencies.txt");
+            if (entry != null) {
+                InputStream inputStream = jar.getInputStream(entry);
+                try (InputStreamReader streamReader = new InputStreamReader(inputStream);
+                     BufferedReader reader = new BufferedReader(streamReader)) {
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        resultList.add(line);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            // ignore
+        }
+        return resultList;
     }
 
     protected FractionManifest fractionManifest(File file) {
@@ -369,9 +440,13 @@ public class DependencyManager implements ResolvedDependencies {
 
     private final WildFlySwarmManifest applicationManifest = new WildFlySwarmManifest();
 
+    private final List<FractionManifest> fractionManifests = new ArrayList<>();
+
     private final Set<ArtifactSpec> dependencies = new HashSet<>();
 
     private final Set<ArtifactSpec> removableDependencies = new HashSet<>();
+
+    private volatile Set<String> removableCheckSums;
 
     private final Set<ArtifactSpec> moduleDependencies = new HashSet<>();
 
@@ -379,4 +454,5 @@ public class DependencyManager implements ResolvedDependencies {
 
     private ArtifactResolver resolver;
 
+    private final boolean removeAllThorntailLibs;
 }

--- a/tools/src/main/java/org/wildfly/swarm/tools/WebInfLibFilteringArchive.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/WebInfLibFilteringArchive.java
@@ -46,6 +46,9 @@ public class WebInfLibFilteringArchive extends GenericArchiveImpl {
     protected void filter(Set<ArchivePath> remove, Node node, ResolvedDependencies resolvedDependencies) {
         String path = node.getPath().get();
         if (path.startsWith("/WEB-INF/lib") && path.endsWith(".jar")) {
+            if (path.contains("thorntail-runner")) {
+                remove.add(node.getPath());
+            }
             if (resolvedDependencies.isRemovable(node)) {
                 remove.add(node.getPath());
             }

--- a/tools/src/main/java/org/wildfly/swarm/tools/utils/ChecksumUtil.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/utils/ChecksumUtil.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2015-2018 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.tools.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ * <br>
+ * Date: 9/20/18
+ */
+public class ChecksumUtil {
+
+    private static final char[] DIGITS = "0123456789abcdef".toCharArray();
+
+    public static String calculateChecksum(InputStream stream) throws IOException, NoSuchAlgorithmException {
+        byte[] buf = new byte[1024];
+        int len = 0;
+
+        MessageDigest md = MessageDigest.getInstance("SHA1");
+
+        while ((len = stream.read(buf)) >= 0) {
+            md.update(buf, 0, len);
+        }
+
+        return toHex(md.digest());
+    }
+
+    protected static String toHex(byte[] digest) {
+        char[] result = new char[digest.length * 2];
+
+        for (int i = 0; i < digest.length; i++) {
+            toChars(digest[i], result, i * 2);
+        }
+        return new String(result);
+    }
+
+    private static void toChars(byte b, char[] result, int position) {
+        result[position + 1] = DIGITS[b & 0xF]; // hex digit for the last (least significant) 4 bits of the byte
+        result[position] = DIGITS[(b >> 4) & 0xF]; // first bits moved to the last, 0xF to handle "negative" numbers
+    }
+
+    private ChecksumUtil() {
+    }
+}

--- a/tools/src/test/java/org/wildfly/swarm/tools/DependencyManagerTest.java
+++ b/tools/src/test/java/org/wildfly/swarm/tools/DependencyManagerTest.java
@@ -15,10 +15,6 @@
  */
 package org.wildfly.swarm.tools;
 
-import java.util.HashSet;
-import java.util.Set;
-import java.util.function.Consumer;
-
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -26,6 +22,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.wildfly.swarm.bootstrap.env.FractionManifest;
 import org.wildfly.swarm.bootstrap.env.WildFlySwarmManifest;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Consumer;
 
 import static org.fest.assertions.Assertions.assertThat;
 
@@ -58,7 +58,7 @@ public class DependencyManagerTest {
 
     @Before
     public void setUp() {
-        this.manager = new DependencyManager(RESOLVER);
+        this.manager = new DependencyManager(RESOLVER, false);
     }
 
     @Test


### PR DESCRIPTION
# Thorntail Runner
The change adds a new module - thorntail runner.
The main entry point for it is called `Runner` and it should be used to trigger a Thorntail v2 app in the IDE.

## What's going on
The `Runner` first runs `FatJarBuilder` to generate an uber jar, then sets up a classpath that only contains the generated jar and then invokes `Main#main` in it.

### Dependency filtering
In the standard (maven plugin) scenario, libraries are removed from user's WAR if they are not in the dependency tree for user-defined (non-Thorntail) dependencies.
Here, all the dependencies in the dependency tree of the Thorntail fractions are removed from the WAR. It means that some user dependency might get removed. There's a system property to prevent such dependencies from getting deleted (the dependencies have to be listed explicitly).

## Problems
Potential problems:
- the solution is based on reverse-engineering the classpath. Thorntail fractions (and other Thorntail elements) are identified by the metadata put by Maven into jars' `META-INF`. I'm afraid it might be a bit fragile
- it's all based on `BuildTool` and I used it as a rather black box
- dependency filtering is done based on artifact check sums. To speed it up, check sums for fraction dependencies are calculated when building fractions (calculated because the check sums in Maven Central are sometimes wrong - e.g. for Shrinkwrap). If someone changes an artifact in Central (or some other repository), the artifact won't be filtered out

So far it was tested only on IntelliJ IDEA on Linux and Windows and Eclipse on Linux