### PR TITLE
THORN-2155 - Add detector for microprofile opentracing

### DIFF
--- a/fractions/microprofile/microprofile-opentracing/src/main/java/org/wildfly/swarm/mpopentracing/detect/OpenTracingPackageDetector.java
+++ b/fractions/microprofile/microprofile-opentracing/src/main/java/org/wildfly/swarm/mpopentracing/detect/OpenTracingPackageDetector.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.mpopentracing.detect;
+
+import org.wildfly.swarm.spi.meta.PackageFractionDetector;
+
+/**
+ * @author Michael Kotten
+ */
+public class OpenTracingPackageDetector extends PackageFractionDetector {
+
+    public OpenTracingPackageDetector() {
+        anyPackageOf("org.eclipse.microprofile.opentracing");
+    }
+
+    @Override
+    public String artifactId() {
+        return "microprofile-opentracing";
+    }
+}


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
This PR adds a fraction detector for the MicroProfile open tracing fraction.