### PR TITLE
THORN-2157: make sure we document breaking changes in release announcements

### DIFF
--- a/release/HOWTO_RELEASE.md
+++ b/release/HOWTO_RELEASE.md
@@ -114,6 +114,7 @@ Go to the local `wildfly-swarm.io`.
 
 Create wildfly-swarm.io/src/posts/announce-2.0.0.Final.adoc, replace 2.0.0.Final with the new version.
 Copy the fetched contributors and change log into this document.
+Make sure at least the breaking changes, as listed in the output of `fetch-notes.js`, are documented in detail.
 
 # Update Che image
 

--- a/release/fetch-notes.js
+++ b/release/fetch-notes.js
@@ -10,6 +10,7 @@ https.get( 'https://issues.jboss.org/rest/api/latest/search?maxResults=100&jql=p
   var buf = "";
 
   var partitions = {};
+  var breaking = [];
 
   result.on( 'data', function(d) {
     buf = buf + d.toString();
@@ -28,6 +29,9 @@ https.get( 'https://issues.jboss.org/rest/api/latest/search?maxResults=100&jql=p
         partitions[e.fields.issuetype.name] = members;
       }
       members.push( e );
+      if (e.fields.labels && e.fields.labels.indexOf('breaking_change') >= 0) {
+        breaking.push(e);
+      }
     } );
 
     console.log( "== Changelog" );
@@ -43,6 +47,12 @@ https.get( 'https://issues.jboss.org/rest/api/latest/search?maxResults=100&jql=p
       } );
       console.log( " " );
     } );
+    if (breaking.length > 0) {
+      console.log("== Breaking changes");
+      breaking.forEach(function(e) {
+        console.log('* [https://issues.jboss.org/browse/' + e.key + '[' + e.key + ']] ' + e.fields.summary);
+      });
+    }
   } );
 
   result.resume();


### PR DESCRIPTION
Motivation
----------
The script that fetches the list of fixed issues in given release
could also print the list of all breaking changes in given release
(that is, issues with label `breaking_change`). That of course
won't help with _tracking_ breaking changes, but if we track them,
this should at least help us to not forget about documenting them.

Modifications
-------------
Modified the `fetch-notes.js` script to also include a listing of
all JIRAs that are labeled `breaking_change`.

Result
------
Extra section in the release announcement with a list of breaking
changes. Hopefully, we won't forget to detail them in writing.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
