### PR TITLE
THORN-2163: don't use fraction-list.txt to generate bom-certified

### DIFF
--- a/boms/bom-certified/pom.xml
+++ b/boms/bom-certified/pom.xml
@@ -32,13 +32,6 @@
       <plugin>
         <groupId>io.thorntail</groupId>
         <artifactId>thorntail-fraction-plugin</artifactId>
-        <dependencies>
-          <dependency>
-            <groupId>io.thorntail</groupId>
-            <artifactId>fraction-metadata</artifactId>
-            <version>${version.certified-community}</version>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
             <id>generate-certified-bom</id>
@@ -48,6 +41,7 @@
             </goals>
             <configuration>
               <template>${project.basedir}/../target/bom-template.xml</template>
+              <certifiedVersion>${version.certified-community}</certifiedVersion>
             </configuration>
           </execution>
           <execution>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -22,7 +22,7 @@
   <description>Build Parent to bring in required dependencies</description>
 
   <properties>
-    <version.thorntail.fraction.plugin>88</version.thorntail.fraction.plugin>
+    <version.thorntail.fraction.plugin>89</version.thorntail.fraction.plugin>
 
     <version.org.snakeyaml>1.17</version.org.snakeyaml>
 


### PR DESCRIPTION
Motivation
----------
Stop reading `fraction-list.txt` when generating certified BOM
and instead generate it based solely on `certified.conf`.

Modifications
-------------
Update to latest `thorntail-fraction-plugin` release and how
it's used.

Result
------
Allows successfully generating certified BOM for product again.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
