### PR TITLE
THORN-2165 Fix topology-openshift

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -67,7 +67,8 @@
 
     <version.openshift.client>5.6.0.Final</version.openshift.client>
     <version.com.squareup.okhttp>3.9.0</version.com.squareup.okhttp>
-    <version.com.squareup.okhttp-ws>3.4.2</version.com.squareup.okhttp-ws>
+    <!-- THORN-2165 Align okhttp and okhttp-ws for topology-openshift as there is API dependency and okhttp-ws has older version -->
+    <version.com.squareup.okhttp-openshift>3.4.2</version.com.squareup.okhttp-openshift>
     <version.com.squareup.okio>1.9.0</version.com.squareup.okio>
 
     <version.vertx>3.3.3</version.vertx>
@@ -453,7 +454,7 @@
       <dependency>
         <groupId>com.squareup.okhttp3</groupId>
         <artifactId>okhttp-ws</artifactId>
-        <version>${version.com.squareup.okhttp-ws}</version>
+        <version>${version.com.squareup.okhttp-openshift}</version>
       </dependency>
       <dependency>
         <groupId>com.squareup.okio</groupId>

--- a/fractions/topology-openshift/src/main/resources/modules/com/squareup/okhttp3/main/module.xml
+++ b/fractions/topology-openshift/src/main/resources/modules/com/squareup/okhttp3/main/module.xml
@@ -1,7 +1,7 @@
 <module xmlns="urn:jboss:module:1.3" name="com.squareup.okhttp3">
   <resources>
-    <artifact name="com.squareup.okhttp3:okhttp:${version.com.squareup.okhttp}"/>
-    <artifact name="com.squareup.okhttp3:okhttp-ws:${version.com.squareup.okhttp-ws}"/>
+    <artifact name="com.squareup.okhttp3:okhttp:${version.com.squareup.okhttp-openshift}"/>
+    <artifact name="com.squareup.okhttp3:okhttp-ws:${version.com.squareup.okhttp-openshift}"/>
   </resources>
 
   <dependencies>


### PR DESCRIPTION
Motivation
----------
topology-openshift fraction has some API discrepancy between third party libraries (okhttp and okhttp-ws) due to an upgrade in okhttp, causing this fraction to not work.

Modifications
-------------
As okhttp-ws doesn't have a newer version, downgrade okhttp so they are both compatible.

Result
------
topology-openshift fraction works again.

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
