### PR TITLE
[THORN-2162] Update findbugs version to 2.0.3

### DIFF
--- a/fractions/netflix/archaius/pom.xml
+++ b/fractions/netflix/archaius/pom.xml
@@ -70,6 +70,10 @@
           <groupId>commons-configuration</groupId>
           <artifactId>commons-configuration</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>annotations</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -77,6 +81,11 @@
       <groupId>commons-configuration</groupId>
       <artifactId>commons-configuration</artifactId>
       <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>annotations</artifactId>
     </dependency>
 
     <dependency>

--- a/fractions/netflix/pom.xml
+++ b/fractions/netflix/pom.xml
@@ -34,6 +34,7 @@
     <version.servo>0.9.2</version.servo>
 
     <version.commons-configuration>1.10</version.commons-configuration>
+    <version.findbugs>2.0.3</version.findbugs>
 
   </properties>
 
@@ -95,6 +96,12 @@
         <groupId>commons-configuration</groupId>
         <artifactId>commons-configuration</artifactId>
         <version>${version.commons-configuration}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>annotations</artifactId>
+        <version>${version.findbugs}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
2.0.0 version is coming from archaius-core, no match was found for 2.0.0 by PME, the closest productized version is 2.0.3 and this change proved effective