### PR TITLE
THORN-2169: Unify useUberJar maven plugin property name.

### DIFF
--- a/docs/modules/ref_thorntail-maven-plugin-configuration-options.adoc
+++ b/docs/modules/ref_thorntail-maven-plugin-configuration-options.adoc
@@ -277,4 +277,5 @@ This JAR is not created automatically, so make sure you execute the `package` go
 |`run`, `start`
 |===
 +
-NOTE: Up to version 2.2.0.Final, the property was called `wildfly-swarm.useUberJar` and only the value `true` enabled this behavior: `-Dwildfly-swarm.useUberJar=true`. You can continue to use the old name without change, but we encourage you to migrate to the new variant which doesn't require setting any value: `-Dswarm.useUberJar`.
+NOTE: Before version 2.3.0.Final, this property was called `wildfly-swarm.useUberJar`, and only setting it to `true` enabled this behavior: `-Dwildfly-swarm.useUberJar=true`.
+You can continue using the old name, but consider using the new variant, which does not require setting a value: `-Dswarm.useUberJar`.

--- a/docs/modules/ref_thorntail-maven-plugin-configuration-options.adoc
+++ b/docs/modules/ref_thorntail-maven-plugin-configuration-options.adoc
@@ -262,18 +262,20 @@ A file path where to store the `stdout` output instead of sending it to the `std
 |===
 
 useUberJar::
-If true, the `-thorntail.jar` file specified at `${project.build.directory}` is used.
+If specified, the `-thorntail.jar` file located in `${project.build.directory}` is used.
 This JAR is not created automatically, so make sure you execute the `package` goal first.
 +
 [cols="1,2a"]
 |===
 |Property
-|`wildfly-swarm.useUberJar`
+|`swarm.useUberJar`
 
 |Default
-|false
+|
 
 |Used by
 |`run`, `start`
 |===
++
+NOTE: Up to version 2.2.0.Final the property name was `wildfly-swarm.useUberJar` and only the value `true` enabled the property: `-Dwildfly-swarm.useUberJar=true`. This is no longer the case and any value enables this property, including an empty string: `-Dswarm.useUberJar`. The old property name still works though.
 

--- a/docs/modules/ref_thorntail-maven-plugin-configuration-options.adoc
+++ b/docs/modules/ref_thorntail-maven-plugin-configuration-options.adoc
@@ -277,5 +277,4 @@ This JAR is not created automatically, so make sure you execute the `package` go
 |`run`, `start`
 |===
 +
-NOTE: Up to version 2.2.0.Final the property name was `wildfly-swarm.useUberJar` and only the value `true` enabled the property: `-Dwildfly-swarm.useUberJar=true`. This is no longer the case and any value enables this property, including an empty string: `-Dswarm.useUberJar`. The old property name still works though.
-
+NOTE: Up to version 2.2.0.Final, the property was called `wildfly-swarm.useUberJar` and only the value `true` enabled this behavior: `-Dwildfly-swarm.useUberJar=true`. You can continue to use the old name without change, but we encourage you to migrate to the new variant which doesn't require setting any value: `-Dswarm.useUberJar`.

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/StartMojo.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/StartMojo.java
@@ -64,8 +64,11 @@ public class StartMojo extends AbstractSwarmMojo {
     @Parameter(alias = "stderrFile", property = "swarm.stderr")
     public File stderrFile;
 
-    @Parameter(alias = "useUberJar", defaultValue = "${wildfly-swarm.useUberJar}")
-    public boolean useUberJar;
+    @Parameter(defaultValue = "${wildfly-swarm.useUberJar}")
+    public boolean oldUseUberJar;
+
+    @Parameter(alias = "useUberJar", property = "swarm.useUberJar")
+    public String useUberJar;
 
     @Parameter(alias = "debug", property = SwarmProperties.DEBUG_PORT)
     public Integer debugPort;
@@ -90,7 +93,7 @@ public class StartMojo extends AbstractSwarmMojo {
 
         final SwarmExecutor executor;
 
-        if (this.useUberJar) {
+        if (useUberjar()) {
             executor = uberJarExecutor();
         } else if (this.project.getPackaging().equals(WAR)) {
             executor = warExecutor();
@@ -377,4 +380,9 @@ public class StartMojo extends AbstractSwarmMojo {
                 .map(m -> Paths.get(this.project.getBuild().getOutputDirectory(), m))
                 .collect(Collectors.toList());
     }
+
+    private boolean useUberjar() {
+        return useUberJar != null ? true : oldUseUberJar;
+    }
+
 }


### PR DESCRIPTION
- "wildfly-swarm.useUberJar" -> "swarm.useUberJar"
- old property name is still supported
- simplify the usage: e.g. "-Dswarm.useUberJar" instead of
"-Dwildfly-swarm.useUberJar=true"