### PR TITLE
THORN-2172 Move testsuite-keycloak as unsupported, like its fraction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1244,7 +1244,6 @@
         <module>testsuite/testsuite-microprofile-jwt</module>
         <module>testsuite/testsuite-microprofile-metrics</module>
         <module>testsuite/testsuite-microprofile-fault-tolerance</module>
-        <module>testsuite/testsuite-keycloak</module>
         <module>testsuite/testsuite-local-dependencies</module>
         <module>testsuite/testsuite-logging</module>
         <module>testsuite/testsuite-management</module>
@@ -1308,6 +1307,7 @@
         <module>testsuite/testsuite-jgroups</module>
         <module>testsuite/testsuite-jolokia</module>
         <module>testsuite/testsuite-jolokia-keycloak</module>
+        <module>testsuite/testsuite-keycloak</module>
         <module>testsuite/testsuite-keycloak-server</module>
         <module>testsuite/testsuite-logstash</module>
         <module>testsuite/testsuite-mail</module>


### PR DESCRIPTION
Motivation

keycloak-server fraction is not supported, but testsuite-keycloak is still in product profile, causing errors when executing tests in mentioned profile

Modifications

Move testsuite-keycloak to unsuppported profile.

Result

Thorntail product build now passes all tests

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
