### PR TITLE
THORN-1830: arquillian ignores swarm.http.port setting in project-defaults.yml

### DIFF
--- a/testsuite/microprofile-tcks/config/pom.xml
+++ b/testsuite/microprofile-tcks/config/pom.xml
@@ -79,31 +79,76 @@
 
    </dependencies>
 
-   <build>
-      <plugins>
-         <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-               <suiteXmlFiles>
-                  <suiteXmlFile>src/test/tck-suite.xml</suiteXmlFile>
-               </suiteXmlFiles>
-               <environmentVariables>
-                  <my_int_property>45</my_int_property>
-                  <MY_BOOLEAN_PROPERTY>true</MY_BOOLEAN_PROPERTY>
-                  <my_string_property>haha</my_string_property>
-                  <MY_STRING_PROPERTY>woohoo</MY_STRING_PROPERTY>
-               </environmentVariables>
-               <!-- This workaround allows to run a single test using "test"
-                  system property -->
-               <!-- https://issues.apache.org/jira/browse/SUREFIRE-569 -->
-               <dependenciesToScan>
-                  <dependency>org.eclipse.microprofile.config:microprofile-config-tck</dependency>
-               </dependenciesToScan>
-            </configuration>
-         </plugin>
-      </plugins>
-   </build>
+   <!-- Setting up two different profiles - windows & non-windows. In the Windows environment, we cannot have case sensitive
+        environment variables.
+     -->
+   <profiles>
+      <profile>
+         <id>windows-specific</id>
+         <activation>
+            <os>
+               <family>windows</family>
+            </os>
+         </activation>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-surefire-plugin</artifactId>
+                  <configuration>
+                     <suiteXmlFiles>
+                        <suiteXmlFile>src/test/tck-suite.xml</suiteXmlFile>
+                     </suiteXmlFiles>
+                     <environmentVariables>
+                        <my_int_property>45</my_int_property>
+                        <MY_BOOLEAN_PROPERTY>true</MY_BOOLEAN_PROPERTY>
+                        <MY_STRING_PROPERTY>woohoo</MY_STRING_PROPERTY>
+                     </environmentVariables>
+                     <!-- This workaround allows to run a single test using "test"
+                        system property -->
+                     <!-- https://issues.apache.org/jira/browse/SUREFIRE-569 -->
+                     <dependenciesToScan>
+                        <dependency>org.eclipse.microprofile.config:microprofile-config-tck</dependency>
+                     </dependenciesToScan>
+                  </configuration>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+      <profile>
+         <id>*nix</id>
+         <activation>
+            <os>
+               <family>!windows</family>
+            </os>
+         </activation>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-surefire-plugin</artifactId>
+                  <configuration>
+                     <suiteXmlFiles>
+                        <suiteXmlFile>src/test/tck-suite.xml</suiteXmlFile>
+                     </suiteXmlFiles>
+                     <environmentVariables>
+                        <my_int_property>45</my_int_property>
+                        <MY_BOOLEAN_PROPERTY>true</MY_BOOLEAN_PROPERTY>
+                        <my_string_property>haha</my_string_property>
+                        <MY_STRING_PROPERTY>woohoo</MY_STRING_PROPERTY>
+                     </environmentVariables>
+                     <!-- This workaround allows to run a single test using "test"
+                        system property -->
+                     <!-- https://issues.apache.org/jira/browse/SUREFIRE-569 -->
+                     <dependenciesToScan>
+                        <dependency>org.eclipse.microprofile.config:microprofile-config-tck</dependency>
+                     </dependenciesToScan>
+                  </configuration>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+   </profiles>
 
 </project>
 

--- a/tools/src/main/java/org/wildfly/swarm/tools/exec/SwarmProcess.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/exec/SwarmProcess.java
@@ -119,7 +119,9 @@ public class SwarmProcess {
         }
         this.process.destroy();
         if (!this.process.waitFor(timeout, timeUnit)) {
-            process.destroyForcibly();
+            // Attempt to terminate the process forcibly and also wait for the same amount of time as the base attempt.
+            // This should potentially take care of the issues with the process not terminating on Windows CI build.
+            process.destroyForcibly().waitFor(timeout, timeUnit);
         }
 
         try {


### PR DESCRIPTION
Motivation
----------
Thorntail aims at simplifying the whole development experience. The ability to test code using the prescribed (Arquillian based) methods, right from within the IDE plays a huge role in the experience. I noticed that when running Arquillian based test cases from within IntelliJ, the resources (project-defaults.yml, etc.) were not being picked up as part of the built archive. More details about the IDE behavior can be found in the issue.

Modifications
-------------
Updated the scenario generator to not filter out the resource folders.

Result
------
I can now run Arquillian based tests from within the IDE itself.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
