### PR TITLE
THORN-2174 | Bump jaeger version to 0.30.6

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -88,10 +88,10 @@
     <!-- OpenTracing related versions -->
     <version.opentracing.tracerresolver>0.1.4</version.opentracing.tracerresolver>
     <version.opentracing.servlet>0.1.0</version.opentracing.servlet>
-    <version.jaeger>0.27.0</version.jaeger>
+    <version.jaeger>0.31.0</version.jaeger>
     <version.opentracing.concurrent>0.1.0</version.opentracing.concurrent>
     <version.opentracing.jaxrs>0.1.6</version.opentracing.jaxrs>
-    <version.jaeger.apache.thrift>0.9.2</version.jaeger.apache.thrift>
+    <version.jaeger.apache.thrift>0.11.0</version.jaeger.apache.thrift>
     <version.jaeger.apache.httpclient>4.2.5</version.jaeger.apache.httpclient>
     <version.jaeger.commons.logging>1.1.1</version.jaeger.commons.logging>
     <version.jaeger.commons.codec>1.6</version.jaeger.commons.codec>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -88,7 +88,7 @@
     <!-- OpenTracing related versions -->
     <version.opentracing.tracerresolver>0.1.4</version.opentracing.tracerresolver>
     <version.opentracing.servlet>0.1.0</version.opentracing.servlet>
-    <version.jaeger>0.31.0</version.jaeger>
+    <version.jaeger>0.30.6</version.jaeger>
     <version.opentracing.concurrent>0.1.0</version.opentracing.concurrent>
     <version.opentracing.jaxrs>0.1.6</version.opentracing.jaxrs>
     <version.jaeger.apache.thrift>0.11.0</version.jaeger.apache.thrift>

--- a/fractions/jaeger/pom.xml
+++ b/fractions/jaeger/pom.xml
@@ -71,7 +71,7 @@
 
     <dependency>
       <groupId>io.jaegertracing</groupId>
-      <artifactId>jaeger-core</artifactId>
+      <artifactId>jaeger-client</artifactId>
       <version>${version.jaeger}</version>
     </dependency>
     <dependency>

--- a/fractions/jaeger/pom.xml
+++ b/fractions/jaeger/pom.xml
@@ -71,7 +71,12 @@
 
     <dependency>
       <groupId>io.jaegertracing</groupId>
-      <artifactId>jaeger-client</artifactId>
+      <artifactId>jaeger-core</artifactId>
+      <version>${version.jaeger}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.jaegertracing</groupId>
+      <artifactId>jaeger-thrift</artifactId>
       <version>${version.jaeger}</version>
     </dependency>
     <dependency>

--- a/fractions/jaeger/src/main/java/org/wildfly/swarm/jaeger/JaegerFraction.java
+++ b/fractions/jaeger/src/main/java/org/wildfly/swarm/jaeger/JaegerFraction.java
@@ -114,7 +114,6 @@ public class JaegerFraction implements Fraction<JaegerFraction> {
                 ", reporterFlushInterval='" + reporterFlushInterval.get() + '\'' +
                 ", reporterMaxQueueSize='" + reporterMaxQueueSize.get() + '\'' +
                 ", user='" + user.get() + '\'' +
-                ", password='" + password.get() + '\'' +
                 '}';
     }
 

--- a/fractions/jaeger/src/main/java/org/wildfly/swarm/jaeger/JaegerFraction.java
+++ b/fractions/jaeger/src/main/java/org/wildfly/swarm/jaeger/JaegerFraction.java
@@ -43,6 +43,12 @@ public class JaegerFraction implements Fraction<JaegerFraction> {
     @AttributeDocumentation("Remote Reporter HTTP endpoint for Jaeger collector, such as http://jaeger-collector.istio-system:14268/api/traces")
     private Defaultable<String> remoteReporterHttpEndpoint = Defaultable.string(getDefault(JAEGER_ENDPOINT));
 
+    @AttributeDocumentation("Username to send as part of \"Basic\" authentication to the endpoint")
+    private Defaultable<String> user = Defaultable.string(getDefault(JAEGER_USER));
+
+    @AttributeDocumentation("Password to send as part of \"Basic\" authentication to the endpoint")
+    private Defaultable<String> password = Defaultable.string(getDefault(JAEGER_PASSWORD));
+
     public String getServiceName() {
         return serviceName.get();
     }
@@ -87,6 +93,14 @@ public class JaegerFraction implements Fraction<JaegerFraction> {
         return remoteReporterHttpEndpoint.get();
     }
 
+    public String getUser() {
+        return user.get();
+    }
+
+    public String getPassword() {
+        return password.get();
+    }
+
     @Override
     public String toString() {
         return "JaegerFraction{" +
@@ -99,6 +113,8 @@ public class JaegerFraction implements Fraction<JaegerFraction> {
                 ", agentPort='" + agentPort.get() + '\'' +
                 ", reporterFlushInterval='" + reporterFlushInterval.get() + '\'' +
                 ", reporterMaxQueueSize='" + reporterMaxQueueSize.get() + '\'' +
+                ", user='" + user.get() + '\'' +
+                ", password='" + password.get() + '\'' +
                 '}';
     }
 

--- a/fractions/jaeger/src/main/java/org/wildfly/swarm/jaeger/runtime/JaegerInstaller.java
+++ b/fractions/jaeger/src/main/java/org/wildfly/swarm/jaeger/runtime/JaegerInstaller.java
@@ -55,6 +55,8 @@ public class JaegerInstaller implements DeploymentProcessor {
             setContextParamIfNotNull(webXml, JAEGER_ENDPOINT, fraction.getRemoteReporterHttpEndpoint());
             setContextParamIfNotNull(webXml, JAEGER_REPORTER_FLUSH_INTERVAL, fraction.getReporterFlushInterval());
             setContextParamIfNotNull(webXml, JAEGER_REPORTER_MAX_QUEUE_SIZE, fraction.getReporterMaxQueueSize());
+            setContextParamIfNotNull(webXml, JAEGER_USER, fraction.getUser());
+            setContextParamIfNotNull(webXml, JAEGER_PASSWORD, fraction.getPassword());
             webXml.setContextParam("skipOpenTracingResolver", "true");
 
             if (fraction.isB3HeaderPropagationEnabled()) {

--- a/fractions/jaeger/src/main/resources/modules/io/jaegertracing/main/module.xml
+++ b/fractions/jaeger/src/main/resources/modules/io/jaegertracing/main/module.xml
@@ -1,5 +1,6 @@
 <module xmlns="urn:jboss:module:1.3" name="io.jaegertracing">
   <resources>
+    <artifact name="io.jaegertracing:jaeger-client:${version.jaeger}"/>
     <artifact name="io.jaegertracing:jaeger-core:${version.jaeger}"/>
     <artifact name="io.jaegertracing:jaeger-tracerresolver:${version.jaeger}"/>
     <artifact name="io.jaegertracing:jaeger-thrift:${version.jaeger}"/>

--- a/fractions/jaeger/src/main/resources/modules/io/jaegertracing/main/module.xml
+++ b/fractions/jaeger/src/main/resources/modules/io/jaegertracing/main/module.xml
@@ -1,8 +1,6 @@
 <module xmlns="urn:jboss:module:1.3" name="io.jaegertracing">
   <resources>
-    <artifact name="io.jaegertracing:jaeger-client:${version.jaeger}"/>
     <artifact name="io.jaegertracing:jaeger-core:${version.jaeger}"/>
-    <artifact name="io.jaegertracing:jaeger-tracerresolver:${version.jaeger}"/>
     <artifact name="io.jaegertracing:jaeger-thrift:${version.jaeger}"/>
   </resources>
 

--- a/testsuite/testsuite-jaeger-microprofile-opentracing/src/test/java/org/wildfly/swarm/jaeger/mpot/JaegerAndMicroprofileOpenTracingTest.java
+++ b/testsuite/testsuite-jaeger-microprofile-opentracing/src/test/java/org/wildfly/swarm/jaeger/mpot/JaegerAndMicroprofileOpenTracingTest.java
@@ -63,7 +63,7 @@ public class JaegerAndMicroprofileOpenTracingTest {
   @Test
   public void test() throws IOException {
     String body = hitEndpoint("http://localhost:8080/");
-    assertTrue(body.equals("io.jaegertracing.Span"));
+    assertTrue(body.equals("io.jaegertracing.internal.JaegerSpan"));
   }
 
   private String hitEndpoint(String endpoint) throws IOException {

--- a/testsuite/testsuite-jaeger-opentracing/src/test/java/org/wildfly/swarm/jaeger/ot/JaegerAndOpenTracingTest.java
+++ b/testsuite/testsuite-jaeger-opentracing/src/test/java/org/wildfly/swarm/jaeger/ot/JaegerAndOpenTracingTest.java
@@ -60,7 +60,7 @@ public class JaegerAndOpenTracingTest {
   @Test
   public void test() throws IOException {
     String body = hitEndpoint("http://localhost:8080/");
-    assertTrue(body.equals("io.jaegertracing.Span"));
+    assertTrue(body.equals("io.jaegertracing.internal.JaegerSpan"));
   }
 
   private String hitEndpoint(String endpoint) throws IOException {


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>

https://issues.jboss.org/browse/THORN-2174

Changes:
* bump jaeger version to 0.31.0
* expose missing jaeger configuration to thorntail
* use default service name (`thorntail/unknown`) if it's not provided.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
