### PR TITLE
THORN-2175: Jaeger fraction throws RuntimeException for SamplingStrategyResponse

### DIFF
--- a/fractions/jaeger/src/main/resources/modules/com/google/code/gson/jaeger/module.xml
+++ b/fractions/jaeger/src/main/resources/modules/com/google/code/gson/jaeger/module.xml
@@ -2,4 +2,8 @@
   <resources>
     <artifact name="com.google.code.gson:gson:${version.jaeger.gson}"/>
   </resources>
+
+  <dependencies>
+    <module name="sun.jdk"/>
+  </dependencies>
 </module>


### PR DESCRIPTION
Motivation
----------
When using remote configuration of Jaeger sampling, an exception
is thrown when the Jaeger client is trying to deserialize
the sampling configuration it obtained from the Jaeger server.
This is because the deserializer is using Gson, which is trying
to use `Unsafe` to allocate instance of a class. However, the Gson
module doesn't have a module dependency on `sun.jdk`, so it can't
see the `Unsafe` class.

Modifications
-------------
Add a module dependency to `sun.jdk` to the Gson module.

Result
------
Jaeger client works when remote sampling configuration is used.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
