### PR TITLE
THORN-2178: Ability to specify FileSystemLayout via System properties

### DIFF
--- a/arquillian/gradle-adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/gradle/GradleDependencyAdapter.java
+++ b/arquillian/gradle-adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/gradle/GradleDependencyAdapter.java
@@ -112,6 +112,10 @@ public class GradleDependencyAdapter {
 
                 // parse
                 line = parseLine(line);
+                if (line.startsWith(PROJECT)) { // Always skip 'project' dependencies.
+                    continue;
+                }
+
                 String coord = parseCoordinate(line);
                 ArtifactSpec parent = DeclaredDependencies.createSpec(coord);
                 declaredDependencies.add(parent);
@@ -125,7 +129,13 @@ public class GradleDependencyAdapter {
                 }
 
                 String coord = parseCoordinate(line);
-                declaredDependencies.add(stack.peek(), DeclaredDependencies.createSpec(coord));
+                ArtifactSpec spec = DeclaredDependencies.createSpec(coord);
+                if (stack.empty()) {
+                    // Parent was a project dependency, add this dependency directly.
+                    declaredDependencies.add(spec);
+                } else {
+                    declaredDependencies.add(stack.peek(), spec);
+                }
 
             }
         }

--- a/core/container/src/main/java/org/wildfly/swarm/internal/GradleFileSystemLayout.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/GradleFileSystemLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -49,8 +49,6 @@ public class GradleFileSystemLayout extends FileSystemLayout {
      */
     public static final String BUILD_DIR_NAME = "build";
 
-    private final Path rootPath;
-
     private final Path sourceRoot;
 
     private final Path buildRoot;
@@ -58,7 +56,7 @@ public class GradleFileSystemLayout extends FileSystemLayout {
     private final Path classesDir;
 
     GradleFileSystemLayout(String root) {
-        this.rootPath = Paths.get(root);
+        super(root);
 
         // 1. Determine the sources root.
         //      - See if the developer has overridden the path.

--- a/core/container/src/main/java/org/wildfly/swarm/internal/MavenFileSystemLayout.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/MavenFileSystemLayout.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,6 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * @author Heiko Braun
@@ -28,7 +27,7 @@ import java.nio.file.Paths;
 public class MavenFileSystemLayout extends FileSystemLayout {
 
     MavenFileSystemLayout(String root) {
-        this.rootPath = Paths.get(root);
+        super(root);
     }
 
     @Override
@@ -96,5 +95,4 @@ public class MavenFileSystemLayout extends FileSystemLayout {
 
     private static final String PACKAGING_WAR = "<packaging>war</packaging>";
 
-    private final Path rootPath;
 }

--- a/core/container/src/main/java/org/wildfly/swarm/internal/SwarmMessages.java
+++ b/core/container/src/main/java/org/wildfly/swarm/internal/SwarmMessages.java
@@ -153,6 +153,8 @@ public interface SwarmMessages extends BasicLogger {
     @Message(id = 31, value = "Registered archive-preparer: %s")
     void registeredArchivePreparer(String preparer);
 
+    @Message(id = 32, value = "Invalid file system layout: %s")
+    String invalidFileSystemLayoutProvided(String message);
 
     // ------------------------------------------------------------------------
     // ------------------------------------------------------------------------

--- a/core/container/src/test/java/org/wildfly/swarm/internal/CustomFileSystemLayout.java
+++ b/core/container/src/test/java/org/wildfly/swarm/internal/CustomFileSystemLayout.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wildfly.swarm.internal;
+
+import java.nio.file.Path;
+
+/**
+ * Dummy implementation of {@link FileSystemLayout} which is to be used only in the appropriate test case.
+ */
+public class CustomFileSystemLayout extends FileSystemLayout {
+
+    public CustomFileSystemLayout(String path) {
+        super(path);
+    }
+
+    @Override
+    public String determinePackagingType() {
+        throw new UnsupportedOperationException("Operation not implemented");
+    }
+
+    @Override
+    public Path resolveBuildClassesDir() {
+        throw new UnsupportedOperationException("Operation not implemented");
+    }
+
+    @Override
+    public Path resolveBuildResourcesDir() {
+        throw new UnsupportedOperationException("Operation not implemented");
+    }
+
+    @Override
+    public Path resolveSrcWebAppDir() {
+        throw new UnsupportedOperationException("Operation not implemented");
+    }
+
+    @Override
+    public Path getRootPath() {
+        throw new UnsupportedOperationException("Operation not implemented");
+    }
+
+    /**
+     * Simulate instantiation exception.
+     */
+    public static class CustomInvalidFileSystemLayout extends CustomFileSystemLayout {
+
+        public CustomInvalidFileSystemLayout(String path) {
+            super(path);
+            throw new IllegalArgumentException("Test case needs an exception to be raised.");
+        }
+    }
+}

--- a/core/container/src/test/java/org/wildfly/swarm/internal/FileSystemLayoutTest.java
+++ b/core/container/src/test/java/org/wildfly/swarm/internal/FileSystemLayoutTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wildfly.swarm.internal;
+
+import java.util.function.Consumer;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Basic tests for the {@link FileSystemLayout} class.
+ */
+public class FileSystemLayoutTest {
+
+    /**
+     * Verify the default behavior of the FileSystemLayout w.r.t current build system.
+     */
+    @Test
+    public void verifyDefaultBehavior() {
+        withProperty(null, layout -> {
+            // By default, we should be getting the MavenFileSystemLayout
+            Assert.assertEquals("Unexpected file system layout. Did the default layout change?",
+                                MavenFileSystemLayout.class, layout.getClass());
+        });
+    }
+
+    /**
+     * Verify that we can specify a custom "valid" FileSystemLayout.
+     */
+    @Test
+    public void verifySystemProperty() {
+        withProperty("org.wildfly.swarm.internal.GradleFileSystemLayout", layout -> {
+            Assert.assertEquals("Unexpected file system layout.", GradleFileSystemLayout.class, layout.getClass());
+        });
+    }
+
+    /**
+     * Verify that we get the default layout when using an invalid system property.
+     */
+    @Test
+    public void verifyInvalidSystemProperty() {
+        withProperty("   ", layout -> {
+            // By default, we should be getting the MavenFileSystemLayout
+            Assert.assertEquals("Unexpected file system layout. Did the default layout change?",
+                                MavenFileSystemLayout.class, layout.getClass());
+        });
+    }
+
+    /**
+     * Verify that we can pass in a custom layout via the system properties.
+     */
+    @Test
+    public void verifyCustomLayout() {
+        withProperty("org.wildfly.swarm.internal.CustomFileSystemLayout", layout -> {
+            Assert.assertEquals("Unexpected file system layout.", CustomFileSystemLayout.class, layout.getClass());
+        });
+    }
+
+    /**
+     * Verify that an instantiation exception in the custom layout is propagated all through.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void verifyCustomLayoutFailure() {
+        withProperty("org.wildfly.swarm.internal.CustomFileSystemLayout$CustomInvalidFileSystemLayout", layout -> {
+            Assert.fail("An exception is expected at this point.");
+        });
+    }
+
+    /**
+     * Convenience method that sets & clears out the property for the FileSystemLayout. This method is synchronized so that
+     * we don't run in to race conditions if the tests are run in parallel.
+     *
+     * @param propertyValue the value of the implementation class.
+     * @param consumer      a simple function that needs to be invoked on the FileSystemLayout that was generated.
+     */
+    private synchronized void withProperty(String propertyValue, Consumer<FileSystemLayout> consumer) {
+        try {
+            if (propertyValue != null) {
+                System.setProperty(FileSystemLayout.CUSTOM_LAYOUT_CLASS, propertyValue);
+            }
+            FileSystemLayout layout = FileSystemLayout.create();
+            consumer.accept(layout);
+        } finally {
+            System.clearProperty(FileSystemLayout.CUSTOM_LAYOUT_CLASS);
+        }
+    }
+}


### PR DESCRIPTION
Motivation
----------
I am trying to fix the Gradle Arquillian adapter. As part of the fixes, I wanted to test out the Gradle project in Thorntail examples. What I noticed was that since the project has a pom.xml as well as a build.gradle file, the FileSystemLayout will always select the Maven layout.

This is a corner case and wouldn't happen in most scenarios, because you are either using Gradle or Maven, very rarely will you use both (unless you are building a product like in the case of the examples repository).

This commit attempts to address this problem by providing the ability to customize the implementation on the basis of a System property.

Modifications
-------------
1. Define an expected signature for FileSystemLayout implementations.
2. Implemented the logic for loading custom file system layouts based on the System property.
3. Implemented a test case that validates different scenarios - valid & invalid.

Result
------
The test case proves that the developer can override the layout to use.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
