### PR TITLE
THORN-2180: useless dependency on microprofile-metrics-api in testsuite/microprofile-tcks/metrics

### DIFF
--- a/testsuite/microprofile-tcks/metrics/pom.xml
+++ b/testsuite/microprofile-tcks/metrics/pom.xml
@@ -37,11 +37,6 @@
 
       <dependency>
          <groupId>org.eclipse.microprofile.metrics</groupId>
-         <artifactId>microprofile-metrics-api</artifactId>
-      </dependency>
-
-      <dependency>
-         <groupId>org.eclipse.microprofile.metrics</groupId>
          <artifactId>microprofile-metrics-rest-tck</artifactId>
       </dependency>
 


### PR DESCRIPTION
Motivation
----------
The `testsuite/microprofile-tcks/metrics` POM contains
a dependency on `microprofile-metrics-api-tck` and
a dependency on `microprofile-metrics-api`. The second
dependency is entirely useless, because it's brought in
transitively by the first one. In addition, its presence
breaks product build (when running with `-Dswarm.microprofile.tck`).

Modifications
-------------
Removed the dependency on `microprofile-metrics-api`
from `testsuite/microprofile-tcks/metrics`.

Result
------
No change in community. Should fix product build, when running
MicroProfile TCKs.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
