### PR TITLE
THORN-2183: remove usage of @CreateSwarm in MP JWT tests

### DIFF
--- a/testsuite/testsuite-microprofile-jwt/src/test/java/org/wildfly/swarm/microprofile/jwtauth/JwksKeyWithFractionConfigTest.java
+++ b/testsuite/testsuite-microprofile-jwt/src/test/java/org/wildfly/swarm/microprofile/jwtauth/JwksKeyWithFractionConfigTest.java
@@ -47,18 +47,11 @@ public class JwksKeyWithFractionConfigTest {
                 .addClass(TokenResource.class)
                 .addClass(KeyTool.class)
                 .addClass(JwtTool.class)
-                .addAsResource("project-empty-roles.yml", "project-defaults.yml")
+                .addAsResource("project-empty-roles-jwks-fraction.yml", "project-defaults.yml")
                 .addAsResource("emptyRoles.properties")
                 .addAsResource(new ClassLoaderAsset("keys/pkcs8_bad_key.pem"), "pkcs8_bad_key.pem")
                 .addAsResource(new ClassLoaderAsset("keys/pkcs8_good_key.pem"), "pkcs8_good_key.pem")
                 .setContextRoot("/testsuite");
-    }
-
-    @CreateSwarm
-    public static Swarm newContainer() throws Exception {
-        return new Swarm()
-                .withProperty("swarm.microprofile.jwt.token.jwks-uri", "http://localhost:14145/jwks")
-                .withProperty("swarm.microprofile.jwt.token.issued-by", "http://testsuite-jwt-issuer.io");
     }
 
     @Test

--- a/testsuite/testsuite-microprofile-jwt/src/test/java/org/wildfly/swarm/microprofile/jwtauth/JwksKeyWithMPConfigTest.java
+++ b/testsuite/testsuite-microprofile-jwt/src/test/java/org/wildfly/swarm/microprofile/jwtauth/JwksKeyWithMPConfigTest.java
@@ -47,18 +47,11 @@ public class JwksKeyWithMPConfigTest {
                 .addClass(TokenResource.class)
                 .addClass(KeyTool.class)
                 .addClass(JwtTool.class)
-                .addAsResource("project-empty-roles.yml", "project-defaults.yml")
+                .addAsResource("project-empty-roles-jwks-mpconfig.yml", "project-defaults.yml")
                 .addAsResource("emptyRoles.properties")
                 .addAsResource(new ClassLoaderAsset("keys/pkcs8_bad_key.pem"), "pkcs8_bad_key.pem")
                 .addAsResource(new ClassLoaderAsset("keys/pkcs8_good_key.pem"), "pkcs8_good_key.pem")
                 .setContextRoot("/testsuite");
-    }
-
-    @CreateSwarm
-    public static Swarm newContainer() throws Exception {
-        return new Swarm()
-                .withProperty("mpjwt.jwksUri", "http://localhost:14145/jwks")
-                .withProperty("mpjwt.issuedBy", "http://testsuite-jwt-issuer.io");
     }
 
     @Test

--- a/testsuite/testsuite-microprofile-jwt/src/test/java/org/wildfly/swarm/microprofile/jwtauth/StaticKeyWithFractionConfigTest.java
+++ b/testsuite/testsuite-microprofile-jwt/src/test/java/org/wildfly/swarm/microprofile/jwtauth/StaticKeyWithFractionConfigTest.java
@@ -26,19 +26,11 @@ public class StaticKeyWithFractionConfigTest {
                 .addClass(TokenResource.class)
                 .addClass(KeyTool.class)
                 .addClass(JwtTool.class)
-                .addAsResource("project-empty-roles.yml", "project-defaults.yml")
+                .addAsResource("project-empty-roles-static-fraction.yml", "project-defaults.yml")
                 .addAsResource("emptyRoles.properties")
                 .addAsResource(new ClassLoaderAsset("keys/pkcs8_bad_key.pem"), "pkcs8_bad_key.pem")
                 .addAsResource(new ClassLoaderAsset("keys/pkcs8_good_key.pem"), "pkcs8_good_key.pem")
                 .setContextRoot("/testsuite");
-    }
-
-    @CreateSwarm
-    public static Swarm newContainer() throws Exception {
-        final KeyTool keyTool = KeyTool.newKeyTool(StaticKeyWithFractionConfigTest.class.getResource("/pkcs8_good_key.pem").toURI());
-        return new Swarm()
-                .withProperty("swarm.microprofile.jwt.token.signer-pub-key", keyTool.getPublicKeyPEM())
-                .withProperty("swarm.microprofile.jwt.token.issued-by", "http://testsuite-jwt-issuer.io");
     }
 
     @Test

--- a/testsuite/testsuite-microprofile-jwt/src/test/java/org/wildfly/swarm/microprofile/jwtauth/StaticKeyWithMPConfigTest.java
+++ b/testsuite/testsuite-microprofile-jwt/src/test/java/org/wildfly/swarm/microprofile/jwtauth/StaticKeyWithMPConfigTest.java
@@ -26,19 +26,11 @@ public class StaticKeyWithMPConfigTest {
                 .addClass(TokenResource.class)
                 .addClass(KeyTool.class)
                 .addClass(JwtTool.class)
-                .addAsResource("project-empty-roles.yml", "project-defaults.yml")
+                .addAsResource("project-empty-roles-static-mpconfig.yml", "project-defaults.yml")
                 .addAsResource("emptyRoles.properties")
                 .addAsResource(new ClassLoaderAsset("keys/pkcs8_bad_key.pem"), "pkcs8_bad_key.pem")
                 .addAsResource(new ClassLoaderAsset("keys/pkcs8_good_key.pem"), "pkcs8_good_key.pem")
                 .setContextRoot("/testsuite");
-    }
-
-    @CreateSwarm
-    public static Swarm newContainer() throws Exception {
-        final KeyTool keyTool = KeyTool.newKeyTool(StaticKeyWithMPConfigTest.class.getResource("/pkcs8_good_key.pem").toURI());
-        return new Swarm()
-                .withProperty("mpjwt.signerPublicKey", keyTool.getPublicKeyPEM())
-                .withProperty("mpjwt.issuedBy", "http://testsuite-jwt-issuer.io");
     }
 
     @Test

--- a/testsuite/testsuite-microprofile-jwt/src/test/resources/project-empty-roles-jwks-fraction.yml
+++ b/testsuite/testsuite-microprofile-jwt/src/test/resources/project-empty-roles-jwks-fraction.yml
@@ -1,0 +1,24 @@
+swarm:
+  microprofile:
+    jwt:
+      token:
+        jwks-uri: "http://localhost:14145/jwks"
+        issued-by: "http://testsuite-jwt-issuer.io"
+  security:
+    security-domains:
+      testSuiteRealm:
+        jaspi-authentication:
+          login-module-stacks:
+            roles-lm-stack:
+              login-modules:
+                - login-module: rm
+                  code: org.wildfly.swarm.microprofile.jwtauth.deployment.auth.jaas.JWTLoginModule
+                  flag: required
+                  module-options:
+                    rolesProperties: emptyRoles.properties
+          auth-modules:
+            http:
+              code: org.wildfly.extension.undertow.security.jaspi.modules.HTTPSchemeServerAuthModule
+              module: org.wildfly.extension.undertow
+              flag: required
+              login-module-stack-ref: roles-lm-stack

--- a/testsuite/testsuite-microprofile-jwt/src/test/resources/project-empty-roles-jwks-mpconfig.yml
+++ b/testsuite/testsuite-microprofile-jwt/src/test/resources/project-empty-roles-jwks-mpconfig.yml
@@ -1,0 +1,22 @@
+mpjwt:
+  jwksUri: "http://localhost:14145/jwks"
+  issuedBy: "http://testsuite-jwt-issuer.io"
+swarm:
+  security:
+    security-domains:
+      testSuiteRealm:
+        jaspi-authentication:
+          login-module-stacks:
+            roles-lm-stack:
+              login-modules:
+                - login-module: rm
+                  code: org.wildfly.swarm.microprofile.jwtauth.deployment.auth.jaas.JWTLoginModule
+                  flag: required
+                  module-options:
+                    rolesProperties: emptyRoles.properties
+          auth-modules:
+            http:
+              code: org.wildfly.extension.undertow.security.jaspi.modules.HTTPSchemeServerAuthModule
+              module: org.wildfly.extension.undertow
+              flag: required
+              login-module-stack-ref: roles-lm-stack

--- a/testsuite/testsuite-microprofile-jwt/src/test/resources/project-empty-roles-static-fraction.yml
+++ b/testsuite/testsuite-microprofile-jwt/src/test/resources/project-empty-roles-static-fraction.yml
@@ -1,0 +1,24 @@
+swarm:
+  microprofile:
+    jwt:
+      token:
+        signer-pub-key: MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqOAjDHZU7FisNb9srcITQOpptmT06fbgHh9KiESS/FZJNsIyPs2Hok9qY9++N6boilCBxKnBsznprwcvQzMETkeGK/9EiRyWEyq4n8NRM4hoPsV42UYFV+8zWokwIjwVXtF5ZBM8IVxo70IloVnjIDoxA4ESGVG0WfgeRFEXAknMBnvcTzGuQdGwGdp/eKa32XMYyT+/X+urOHA8wHU8RNjcEVJht1H083wu26rsLdDLJeA3R1wd9OKzUrdTaKFWcJ1/l2F+ekNkZyi5E9M0JE6V1ujCr2KNNkH9OhopmqNCEddDAzksnF/cEn1jkgdjA/kFzWz3GiQgNQr4CGEczQIDAQAB
+        issued-by: "http://testsuite-jwt-issuer.io"
+  security:
+    security-domains:
+      testSuiteRealm:
+        jaspi-authentication:
+          login-module-stacks:
+            roles-lm-stack:
+              login-modules:
+                - login-module: rm
+                  code: org.wildfly.swarm.microprofile.jwtauth.deployment.auth.jaas.JWTLoginModule
+                  flag: required
+                  module-options:
+                    rolesProperties: emptyRoles.properties
+          auth-modules:
+            http:
+              code: org.wildfly.extension.undertow.security.jaspi.modules.HTTPSchemeServerAuthModule
+              module: org.wildfly.extension.undertow
+              flag: required
+              login-module-stack-ref: roles-lm-stack

--- a/testsuite/testsuite-microprofile-jwt/src/test/resources/project-empty-roles-static-mpconfig.yml
+++ b/testsuite/testsuite-microprofile-jwt/src/test/resources/project-empty-roles-static-mpconfig.yml
@@ -1,0 +1,26 @@
+mpjwt:
+  signerPublicKey: MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqOAjDHZU7FisNb9srcITQOpptmT06fbgHh9KiESS/FZJNsIyPs2Hok9qY9++N6boilCBxKnBsznprwcvQzMETkeGK/9EiRyWEyq4n8NRM4hoPsV42UYFV+8zWokwIjwVXtF5ZBM8IVxo70IloVnjIDoxA4ESGVG0WfgeRFEXAknMBnvcTzGuQdGwGdp/eKa32XMYyT+/X+urOHA8wHU8RNjcEVJht1H083wu26rsLdDLJeA3R1wd9OKzUrdTaKFWcJ1/l2F+ekNkZyi5E9M0JE6V1ujCr2KNNkH9OhopmqNCEddDAzksnF/cEn1jkgdjA/kFzWz3GiQgNQr4CGEczQIDAQAB
+  issuedBy: "http://testsuite-jwt-issuer.io"
+swarm:
+  microprofile:
+    jwtauth:
+      token:
+        issuedBy: "http://testsuite-jwt-issuer.io"
+  security:
+    security-domains:
+      testSuiteRealm:
+        jaspi-authentication:
+          login-module-stacks:
+            roles-lm-stack:
+              login-modules:
+                - login-module: rm
+                  code: org.wildfly.swarm.microprofile.jwtauth.deployment.auth.jaas.JWTLoginModule
+                  flag: required
+                  module-options:
+                    rolesProperties: emptyRoles.properties
+          auth-modules:
+            http:
+              code: org.wildfly.extension.undertow.security.jaspi.modules.HTTPSchemeServerAuthModule
+              module: org.wildfly.extension.undertow
+              flag: required
+              login-module-stack-ref: roles-lm-stack


### PR DESCRIPTION
Motivation
----------
These tests are failing in the product build with weird
errors. The errors are provably caused by the usage of `@CreateSwarm`.

Modifications
-------------
Replace usage of `@CreateSwarm` by `project-defaults.yml`.

Result
------
No behavioral change. Fixed tests in product build.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
