### PR TITLE
Gradle Arquillian Adapter Improvements

### DIFF
--- a/arquillian/gradle-adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/gradle/GradleDependencyDeclarationFactory.java
+++ b/arquillian/gradle-adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/gradle/GradleDependencyDeclarationFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,7 +39,7 @@ public class GradleDependencyDeclarationFactory implements DependencyDeclaration
 
         GradleDependencyAdapter gradleAdapter = new GradleDependencyAdapter(fsLayout.getRootPath());
 
-        DeclaredDependencies declaredDependencies = gradleAdapter.parseDependencies(GradleDependencyAdapter.Configuration.TEST_RUNTIME);
+        DeclaredDependencies declaredDependencies = gradleAdapter.getProjectDependencies();
 
         // Resolve to local files.
         resolveDependencies(declaredDependencies.getRuntimeExplicitAndTransientDependencies(), resolvingHelper);


### PR DESCRIPTION
This commit allows developers to make use of the upcoming Gradle 5 features around importing Maven BOM dependency constraints.

* Make use of the default Gradle tooling model to determine the project dependencies, as compared to scanning the command line.
* Verified the plugin's capability on a multi-module Gradle project.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [ ] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
