### PR TITLE
THORN-2206: bring dependency alignment changes from product back upstream

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -46,7 +46,7 @@
     <version.jandex>2.0.5.Final</version.jandex>
     <!-- Align dependency versions with those present in WildFly parent -->
     <!-- Doing this explicitly since there is no easy way to import project properties from a pom file -->
-    <version.com.fasterxml.jackson>2.8.9</version.com.fasterxml.jackson>
+    <version.com.fasterxml.jackson>2.8.11</version.com.fasterxml.jackson>
 
     <version.org.objectweb.asm>6.0</version.org.objectweb.asm>
 
@@ -100,7 +100,7 @@
 
     <version.maven.aether>3.2.5</version.maven.aether>
 
-    <version.resteasy>3.0.24.Final</version.resteasy>
+    <version.resteasy>3.0.26.Final</version.resteasy>
     <version.org.glassfish.javax.json>1.0.4</version.org.glassfish.javax.json>
 
     <!-- MicroProfile APIs -->
@@ -122,7 +122,24 @@
     <version.smallrye.restclient>1.0.1</version.smallrye.restclient>
     <version.smallrye.jwt>1.1.0</version.smallrye.jwt>
     <version.smallrye-fault-tolerance>1.0.4</version.smallrye-fault-tolerance>
+    <version.smallrye.open-api>1.0.1</version.smallrye.open-api>
 
+    <!-- purely for dependency alignment purposes -->
+    <version.xnio>3.5.5.Final</version.xnio>
+    <version.wildfly-client-config>1.0.0.Final</version.wildfly-client-config>
+    <version.wildfly-common>1.2.0.Final</version.wildfly-common>
+    <version.org.slf4j>1.7.22</version.org.slf4j>
+    <version.apache-mime4j>0.6</version.apache-mime4j>
+    <version.httpcore>4.4.4</version.httpcore>
+    <version.httpclient>4.5.2</version.httpclient>
+    <version.commons-codec>1.10</version.commons-codec>
+    <version.commons-logging>1.1.1</version.commons-logging>
+    <version.commons-io>2.5</version.commons-io>
+    <version.jcip-annotations>1.0</version.jcip-annotations>
+    <version.openjdk-orb>8.0.8.Final</version.openjdk-orb>
+    <version.classmate>1.3.3</version.classmate>
+    <version.javax.enterprise.concurrent-api>1.0</version.javax.enterprise.concurrent-api>
+    <version.javax.activation>1.1.1</version.javax.activation>
   </properties>
 
   <build>
@@ -264,17 +281,17 @@
         <artifactId>mongo-config-api</artifactId>
         <version>${version.mongo.config-api}</version>
       </dependency>
-     <dependency>
+      <dependency>
         <groupId>io.thorntail</groupId>
         <artifactId>cassandra-config-api</artifactId>
         <version>${version.cassandra.config-api}</version>
       </dependency>
-     <dependency>
+      <dependency>
         <groupId>io.thorntail</groupId>
         <artifactId>neo4j-config-api</artifactId>
         <version>${version.neo4j.config-api}</version>
       </dependency>
-     <dependency>
+      <dependency>
         <groupId>io.thorntail</groupId>
         <artifactId>orientdb-config-api</artifactId>
         <version>${version.orientdb.config-api}</version>
@@ -376,81 +393,208 @@
         <version>${version.openshift.client}</version>
       </dependency>
 
-      <!-- MicroProfile 1.2 -->
+      <!-- MicroProfile and SmallRye -->
       <dependency>
         <groupId>org.eclipse.microprofile.config</groupId>
         <artifactId>microprofile-config-api</artifactId>
         <version>${version.microprofile-config}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.annotation.versioning</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-config</artifactId>
         <version>${version.smallrye.config}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.annotation.versioning</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
         <groupId>io.thorntail</groupId>
         <artifactId>microprofile-config-api</artifactId>
         <version>${version.wildfly-microprofile-config}</version>
+        <exclusions>
+           <exclusion>
+              <groupId>org.osgi</groupId>
+              <artifactId>org.osgi.annotation.versioning</artifactId>
+           </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
         <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
         <artifactId>microprofile-fault-tolerance-api</artifactId>
         <version>${version.microprofile-fault-tolerance}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.eclipse.microprofile.health</groupId>
-        <artifactId>microprofile-health-api</artifactId>
-        <version>${version.microprofile-health}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.eclipse.microprofile.metrics</groupId>
-        <artifactId>microprofile-metrics-api</artifactId>
-        <version>${version.microprofile-metrics}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.eclipse.microprofile.jwt</groupId>
-        <artifactId>microprofile-jwt-auth-api</artifactId>
-        <version>${version.microprofile-jwt-auth}</version>
-      </dependency>
-
-      <!-- SmallRye -->
-      <dependency>
-        <groupId>io.smallrye</groupId>
-        <artifactId>smallrye-health</artifactId>
-        <version>${version.smallrye.health}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.smallrye</groupId>
-        <artifactId>smallrye-metrics</artifactId>
-        <version>${version.smallrye.metrics}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.smallrye</groupId>
-        <artifactId>smallrye-rest-client</artifactId>
-        <version>${version.smallrye.restclient}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.smallrye</groupId>
-        <artifactId>smallrye-opentracing</artifactId>
-        <version>${version.smallrye.opentracing}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.annotation.versioning</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
         <groupId>io.smallrye</groupId>
         <artifactId>smallrye-fault-tolerance</artifactId>
         <version>${version.smallrye-fault-tolerance}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.annotation.versioning</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
-      <!-- The following are not used, they are here to make PME align proper versions-->
+      <dependency>
+        <groupId>org.eclipse.microprofile.health</groupId>
+        <artifactId>microprofile-health-api</artifactId>
+        <version>${version.microprofile-health}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.annotation.versioning</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>io.smallrye</groupId>
+        <artifactId>smallrye-health</artifactId>
+        <version>${version.smallrye.health}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.annotation.versioning</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.eclipse.microprofile.health</groupId>
+            <artifactId>microprofile-health-api</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.eclipse.microprofile.metrics</groupId>
+        <artifactId>microprofile-metrics-api</artifactId>
+        <version>${version.microprofile-metrics}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.annotation.versioning</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>io.smallrye</groupId>
+        <artifactId>smallrye-metrics</artifactId>
+        <version>${version.smallrye.metrics}</version>
+        <exclusions>
+           <exclusion>
+              <groupId>org.osgi</groupId>
+              <artifactId>org.osgi.annotation.versioning</artifactId>
+           </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>io.smallrye</groupId>
+        <artifactId>smallrye-rest-client</artifactId>
+        <version>${version.smallrye.restclient}</version>
+        <exclusions>
+           <exclusion>
+              <groupId>org.osgi</groupId>
+              <artifactId>org.osgi.annotation.versioning</artifactId>
+           </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.eclipse.microprofile.opentracing</groupId>
+        <artifactId>microprofile-opentracing-api</artifactId>
+        <version>${version.microprofile-opentracing}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.annotation.versioning</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>io.smallrye</groupId>
+        <artifactId>smallrye-opentracing</artifactId>
+        <version>${version.smallrye.opentracing}</version>
+        <exclusions>
+           <exclusion>
+              <groupId>org.osgi</groupId>
+              <artifactId>org.osgi.annotation.versioning</artifactId>
+           </exclusion>
+           <exclusion>
+              <groupId>org.eclipse.microprofile.opentracing</groupId>
+              <artifactId>microprofile-opentracing-api</artifactId>
+           </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.eclipse.microprofile.jwt</groupId>
+        <artifactId>microprofile-jwt-auth-api</artifactId>
+        <version>${version.microprofile-jwt-auth}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.annotation.versioning</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>io.smallrye</groupId>
+        <artifactId>smallrye-jwt</artifactId>
+        <version>${version.smallrye.jwt}</version>
+        <exclusions>
+           <exclusion>
+              <groupId>org.osgi</groupId>
+              <artifactId>org.osgi.annotation.versioning</artifactId>
+           </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>io.smallrye</groupId>
+        <artifactId>smallrye-open-api</artifactId>
+        <version>${version.smallrye.open-api}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.jboss</groupId>
+            <artifactId>jandex</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+          </exclusion>
+          <exclusion>
+              <groupId>org.osgi</groupId>
+              <artifactId>org.osgi.annotation.versioning</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <!-- The following are not used, they are here for dependency alignment -->
       <dependency>
         <groupId>com.squareup.okhttp3</groupId>
         <artifactId>okhttp</artifactId>
@@ -466,6 +610,35 @@
         <artifactId>okio</artifactId>
         <version>${version.com.squareup.okio}</version>
       </dependency>
+
+      <dependency>
+        <groupId>org.jboss.xnio</groupId>
+        <artifactId>xnio-nio</artifactId>
+        <version>${version.xnio}</version>
+      </dependency>
+
+      <dependency>
+       <groupId>org.jboss.xnio</groupId>
+       <artifactId>xnio-api</artifactId>
+       <version>${version.xnio}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.wildfly.client</groupId>
+        <artifactId>wildfly-client-config</artifactId>
+        <version>${version.wildfly-client-config}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.wildfly.common</groupId>
+        <artifactId>wildfly-common</artifactId>
+        <version>${version.wildfly-common}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${version.org.slf4j}</version>
+      </dependency>
       <dependency>
           <groupId>org.apache.thrift</groupId>
           <artifactId>libthrift</artifactId>
@@ -475,6 +648,82 @@
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
         <version>${version.jaeger.gson}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish</groupId>
+        <artifactId>javax.json</artifactId>
+        <version>${version.org.glassfish.javax.json}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-codec</groupId>
+        <artifactId>commons-codec</artifactId>
+        <version>${version.commons-codec}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.james</groupId>
+        <artifactId>apache-mime4j</artifactId>
+        <version>${version.apache-mime4j}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpcore</artifactId>
+        <version>${version.httpcore}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>${version.httpclient}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>commons-logging</groupId>
+        <artifactId>commons-logging</artifactId>
+        <version>${version.commons-logging}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>${version.commons-io}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>net.jcip</groupId>
+        <artifactId>jcip-annotations</artifactId>
+        <version>${version.jcip-annotations}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.openjdk-orb</groupId>
+        <artifactId>openjdk-orb</artifactId>
+        <version>${version.openjdk-orb}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml</groupId>
+        <artifactId>classmate</artifactId>
+        <version>${version.classmate}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.opentracing.contrib</groupId>
+        <artifactId>opentracing-concurrent</artifactId>
+        <version>${version.opentracing.concurrent}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>javax.enterprise.concurrent</groupId>
+        <artifactId>javax.enterprise.concurrent-api</artifactId>
+        <version>${version.javax.enterprise.concurrent-api}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>javax.activation</groupId>
+        <artifactId>activation</artifactId>
+        <version>${version.javax.activation}</version>
       </dependency>
       <!-- end of unused dependencies -->
 

--- a/fractions/jaeger/pom.xml
+++ b/fractions/jaeger/pom.xml
@@ -67,6 +67,17 @@
     <dependency>
       <groupId>io.thorntail</groupId>
       <artifactId>opentracing-tracerresolver</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.opentracing</groupId>
+          <artifactId>opentracing-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-api</artifactId>
+      <version>${version.opentracing}</version>
     </dependency>
 
     <dependency>
@@ -78,6 +89,32 @@
       <groupId>io.jaegertracing</groupId>
       <artifactId>jaeger-thrift</artifactId>
       <version>${version.jaeger}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.squareup.okio</groupId>
+          <artifactId>okio</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okio</groupId>
+      <artifactId>okio</artifactId>
     </dependency>
     <dependency>
       <groupId>org.wildfly.core</groupId>

--- a/fractions/javaee/jaxrs-multipart/pom.xml
+++ b/fractions/javaee/jaxrs-multipart/pom.xml
@@ -52,6 +52,16 @@
     <dependency>
       <groupId>com.sun.mail</groupId>
       <artifactId>javax.mail</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.activation</groupId>
+          <artifactId>activation</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
@@ -61,7 +71,63 @@
           <groupId>com.sun.xml.bind</groupId>
           <artifactId>jaxb-impl</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-codec</groupId>
+          <artifactId>commons-codec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>net.jcip</groupId>
+          <artifactId>jcip-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.james</groupId>
+          <artifactId>apache-mime4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>net.jcip</groupId>
+      <artifactId>jcip-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.james</groupId>
+      <artifactId>apache-mime4j</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
     </dependency>
 
     <dependency>

--- a/fractions/javaee/jaxrs/pom.xml
+++ b/fractions/javaee/jaxrs/pom.xml
@@ -101,6 +101,16 @@
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
       <artifactId>jackson-jaxrs-json-provider</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
 
     <!-- Meta SPI -->

--- a/fractions/javaee/transactions/pom.xml
+++ b/fractions/javaee/transactions/pom.xml
@@ -114,6 +114,16 @@
     <dependency>
       <groupId>org.jboss.narayana.jts</groupId>
       <artifactId>narayana-jts-idlj</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.openjdk-orb</groupId>
+          <artifactId>openjdk-orb</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.openjdk-orb</groupId>
+      <artifactId>openjdk-orb</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/fractions/javaee/undertow/pom.xml
+++ b/fractions/javaee/undertow/pom.xml
@@ -125,6 +125,42 @@
     <dependency>
       <groupId>io.undertow</groupId>
       <artifactId>undertow-servlet</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.xnio</groupId>
+          <artifactId>xnio-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jboss.xnio</groupId>
+          <artifactId>xnio-nio</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.xnio</groupId>
+      <artifactId>xnio-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.wildfly.client</groupId>
+          <artifactId>wildfly-client-config</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.wildfly.common</groupId>
+          <artifactId>wildfly-common</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.client</groupId>
+      <artifactId>wildfly-client-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.common</groupId>
+      <artifactId>wildfly-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.xnio</groupId>
+      <artifactId>xnio-nio</artifactId>
     </dependency>
 
     <!-- Meta SPI -->

--- a/fractions/keycloak/pom.xml
+++ b/fractions/keycloak/pom.xml
@@ -75,6 +75,40 @@
     <dependency>
       <groupId>org.keycloak</groupId>
       <artifactId>keycloak-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk15on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcpkix-jdk15on</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk15on</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
     </dependency>
 
     <dependency>

--- a/fractions/microprofile/microprofile-config/pom.xml
+++ b/fractions/microprofile/microprofile-config/pom.xml
@@ -24,6 +24,8 @@
     <properties>
         <swarm.fraction.stability>stable</swarm.fraction.stability>
         <swarm.fraction.tags>Eclipse MicroProfile,MicroServices,Config</swarm.fraction.tags>
+
+        <version.javax.annotation-api>1.2</version.javax.annotation-api>
     </properties>
 
     <build>
@@ -79,6 +81,17 @@
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-config</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>${version.javax.annotation-api}</version>
         </dependency>
         <!-- CDI fraction is required to be able to inject Config -->
         <dependency>

--- a/fractions/microprofile/microprofile-fault-tolerance/pom.xml
+++ b/fractions/microprofile/microprofile-fault-tolerance/pom.xml
@@ -83,6 +83,25 @@
     <dependency>
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-fault-tolerance</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.enterprise.concurrent</groupId>
+          <artifactId>javax.enterprise.concurrent-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jboss.logging</groupId>
+          <artifactId>jboss-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.enterprise.concurrent</groupId>
+      <artifactId>javax.enterprise.concurrent-api</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
        <groupId>org.jboss.weld</groupId>

--- a/fractions/microprofile/microprofile-health/pom.xml
+++ b/fractions/microprofile/microprofile-health/pom.xml
@@ -64,6 +64,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.eclipse.microprofile.health</groupId>
+      <artifactId>microprofile-health-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.thorntail</groupId>
       <artifactId>management</artifactId>
     </dependency>

--- a/fractions/microprofile/microprofile-jwt/pom.xml
+++ b/fractions/microprofile/microprofile-jwt/pom.xml
@@ -95,12 +95,35 @@
     <dependency>
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-jwt</artifactId>
-      <version>${version.smallrye.jwt}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>javax</groupId>
+          <artifactId>javaee-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.microprofile.config</groupId>
+          <artifactId>microprofile-config-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.microprofile.config</groupId>
+      <artifactId>microprofile-config-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.bitbucket.b_c</groupId>
       <artifactId>jose4j</artifactId>
       <version>${version.jose4j}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
       <groupId>io.thorntail</groupId>
@@ -161,4 +184,3 @@
     </dependency>
   </dependencies>
 </project>
-

--- a/fractions/microprofile/microprofile-openapi/pom.xml
+++ b/fractions/microprofile/microprofile-openapi/pom.xml
@@ -25,9 +25,7 @@
     <swarm.fraction.stability>stable</swarm.fraction.stability>
     <swarm.fraction.tags>MicroProfile,OpenAPI,JaxRs,Web</swarm.fraction.tags>
 
-    <!-- Dependencies -->
     <version.com.fasterxml.jackson.dataformat>2.9.2</version.com.fasterxml.jackson.dataformat>
-    <version.io.smallrye.smallrye-open-api>1.0.1</version.io.smallrye.smallrye-open-api>
   </properties>
 
   <build>
@@ -68,7 +66,6 @@
     <dependency>
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-open-api</artifactId>
-      <version>${version.io.smallrye.smallrye-open-api}</version>
       <exclusions>
         <exclusion>
           <groupId>org.jboss</groupId>
@@ -78,7 +75,69 @@
           <groupId>org.jboss.shrinkwrap</groupId>
           <artifactId>shrinkwrap-api</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.dataformat</groupId>
+          <artifactId>jackson-dataformat-yaml</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.microprofile.openapi</groupId>
+          <artifactId>microprofile-openapi-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+      <version>${version.com.fasterxml.jackson.dataformat}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.yaml</groupId>
+          <artifactId>snakeyaml</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.microprofile.openapi</groupId>
+      <artifactId>microprofile-openapi-api</artifactId>
+      <version>${version.microprofile-openapi}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.osgi</groupId>
+          <artifactId>org.osgi.annotation.versioning</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
     </dependency>
 
     <!-- Provided APIs -->

--- a/fractions/microprofile/microprofile-openapi/src/main/resources/modules/io/smallrye/smallrye-open-api/main/module.xml
+++ b/fractions/microprofile/microprofile-openapi/src/main/resources/modules/io/smallrye/smallrye-open-api/main/module.xml
@@ -15,7 +15,7 @@
   -->
 <module xmlns="urn:jboss:module:1.3" name="io.smallrye.smallrye-open-api">
    <resources>
-      <artifact name="io.smallrye:smallrye-open-api:${version.io.smallrye.smallrye-open-api}"/>
+      <artifact name="io.smallrye:smallrye-open-api:${version.smallrye.open-api}"/>
    </resources>
    <dependencies>
       <module name="javax.enterprise.api"/>

--- a/fractions/microprofile/microprofile-opentracing/pom.xml
+++ b/fractions/microprofile/microprofile-opentracing/pom.xml
@@ -68,23 +68,49 @@
     <dependency>
       <groupId>org.eclipse.microprofile.opentracing</groupId>
       <artifactId>microprofile-opentracing-api</artifactId>
-      <version>${version.microprofile-opentracing}</version>
     </dependency>
+
     <dependency>
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-opentracing</artifactId>
-      <version>${version.smallrye.opentracing}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.opentracing</groupId>
+          <artifactId>opentracing-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-api</artifactId>
+      <version>${version.opentracing}</version>
     </dependency>
 
     <dependency>
       <groupId>io.opentracing.contrib</groupId>
       <artifactId>opentracing-web-servlet-filter</artifactId>
       <version>${version.opentracing.servlet}</version>
+      <exclusions>
+         <exclusion>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-concurrent</artifactId>
+         </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-concurrent</artifactId>
     </dependency>
     <dependency>
       <groupId>io.opentracing.contrib</groupId>
       <artifactId>opentracing-jaxrs2</artifactId>
       <version>${version.opentracing.jaxrs}</version>
+      <exclusions>
+           <exclusion>
+              <groupId>org.eclipse.microprofile.opentracing</groupId>
+              <artifactId>microprofile-opentracing-api</artifactId>
+           </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/fractions/microprofile/microprofile-restclient/pom.xml
+++ b/fractions/microprofile/microprofile-restclient/pom.xml
@@ -52,6 +52,26 @@
     <dependency>
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-rest-client</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.resteasy</groupId>
+          <artifactId>resteasy-client</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-client</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
     </dependency>
 
     <dependency>

--- a/fractions/netflix/archaius/pom.xml
+++ b/fractions/netflix/archaius/pom.xml
@@ -74,18 +74,48 @@
           <groupId>com.google.code.findbugs</groupId>
           <artifactId>annotations</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
-
     <dependency>
       <groupId>commons-configuration</groupId>
       <artifactId>commons-configuration</artifactId>
       <scope>provided</scope>
     </dependency>
-
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
 
     <dependency>

--- a/fractions/netflix/hystrix/pom.xml
+++ b/fractions/netflix/hystrix/pom.xml
@@ -85,10 +85,50 @@
     <dependency>
       <groupId>com.netflix.hystrix</groupId>
       <artifactId>hystrix-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.netflix.hystrix</groupId>
       <artifactId>hystrix-metrics-event-stream</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.module</groupId>
+          <artifactId>jackson-module-afterburner</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.hdrhistogram</groupId>

--- a/fractions/netflix/pom.xml
+++ b/fractions/netflix/pom.xml
@@ -30,12 +30,11 @@
     <version.rxjava>1.3.0</version.rxjava>
     <version.rxnetty>0.4.9</version.rxnetty>
     <version.netty>4.0.26.Final</version.netty>
-    <version.guava>14.0.1</version.guava>
+    <version.guava>16.0.1</version.guava>
     <version.servo>0.9.2</version.servo>
 
     <version.commons-configuration>1.10</version.commons-configuration>
     <version.findbugs>2.0.3</version.findbugs>
-
   </properties>
 
   <dependencyManagement>
@@ -105,8 +104,19 @@
       </dependency>
 
       <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>${version.guava}</version>
+      </dependency>
+
+      <dependency>
         <groupId>com.netflix.hystrix</groupId>
         <artifactId>hystrix-core</artifactId>
+        <version>${version.hystrix}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.netflix.hystrix</groupId>
+        <artifactId>hystrix-serialization</artifactId>
         <version>${version.hystrix}</version>
       </dependency>
       <dependency>
@@ -156,6 +166,7 @@
         <artifactId>rxnetty-servo</artifactId>
         <version>${version.rxnetty}</version>
       </dependency>
+
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-buffer</artifactId>

--- a/fractions/opentracing-tracerresolver/pom.xml
+++ b/fractions/opentracing-tracerresolver/pom.xml
@@ -65,6 +65,12 @@
       <groupId>io.opentracing.contrib</groupId>
       <artifactId>opentracing-tracerresolver</artifactId>
       <version>${version.opentracing.tracerresolver}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.opentracing</groupId>
+          <artifactId>opentracing-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>javax</groupId>

--- a/fractions/wildfly/hibernate-validator/pom.xml
+++ b/fractions/wildfly/hibernate-validator/pom.xml
@@ -51,7 +51,18 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-validator</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml</groupId>
+          <artifactId>classmate</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml</groupId>
+      <artifactId>classmate</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.jboss.spec.javax.el</groupId>
       <artifactId>jboss-el-api_3.0_spec</artifactId>


### PR DESCRIPTION
Motivation
----------
During the `2.2.0.Final-redhat-00021` product release, we did
a lot of dependency alignment changes. We should bring them
(or a subset of them) back upstream, to make subsequent product
releases easier.

Modifications
-------------
Port dependency alignment changes from product to upstream.

Result
------
No behavioral changes, but hopefully easier product release
next time.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
