### PR TITLE
THORN-2205: the "swarm.*" system properties no longer work

### DIFF
--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/WildFlySwarmContainer.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/WildFlySwarmContainer.java
@@ -31,6 +31,7 @@ import org.jboss.shrinkwrap.descriptor.api.Descriptor;
 import org.wildfly.swarm.arquillian.StartupTimeout;
 import org.wildfly.swarm.arquillian.daemon.container.DaemonContainerConfigurationBase;
 import org.wildfly.swarm.arquillian.daemon.container.DaemonDeployableContainerBase;
+import org.wildfly.swarm.bootstrap.util.BootstrapUtil;
 
 /**
  * @author Bob McWhirter
@@ -65,6 +66,8 @@ public class WildFlySwarmContainer extends DaemonDeployableContainerBase<DaemonC
 
     @Override
     public synchronized ProtocolMetaData deploy(Archive<?> archive) throws DeploymentException {
+        BootstrapUtil.convertSwarmSystemPropertiesToThorntail();
+
         StartupTimeout startupTimeout = this.testClass.getAnnotation(StartupTimeout.class);
         if (startupTimeout != null) {
             setTimeout(startupTimeout.value());

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/Main.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/Main.java
@@ -34,6 +34,7 @@ import org.wildfly.swarm.bootstrap.env.ApplicationEnvironment;
 import org.wildfly.swarm.bootstrap.modules.BootModuleLoader;
 import org.wildfly.swarm.bootstrap.performance.Performance;
 import org.wildfly.swarm.bootstrap.util.BootstrapProperties;
+import org.wildfly.swarm.bootstrap.util.BootstrapUtil;
 
 /**
  * @author Bob McWhirter
@@ -55,6 +56,7 @@ public class Main {
     public static void main(String... args) throws Throwable {
         try {
             Performance.start();
+            BootstrapUtil.convertSwarmSystemPropertiesToThorntail();
             //TODO Move property key to -spi
             System.setProperty(BootstrapProperties.IS_UBERJAR, Boolean.TRUE.toString());
 

--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/util/BootstrapUtil.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/util/BootstrapUtil.java
@@ -65,4 +65,14 @@ public class BootstrapUtil {
         }
     }
 
+    public static void convertSwarmSystemPropertiesToThorntail() {
+        for (String systemProperty : System.getProperties().stringPropertyNames()) {
+            if (systemProperty.startsWith("swarm.")) {
+                String corresponding = systemProperty.replaceFirst("^swarm\\.", "thorntail.");
+                if (System.getProperty(corresponding) == null) {
+                    System.setProperty(corresponding, System.getProperty(systemProperty));
+                }
+            }
+        }
+    }
 }

--- a/core/container/src/main/java/org/wildfly/swarm/Swarm.java
+++ b/core/container/src/main/java/org/wildfly/swarm/Swarm.java
@@ -76,6 +76,7 @@ import org.wildfly.swarm.bootstrap.logging.BootstrapLogger;
 import org.wildfly.swarm.bootstrap.modules.BootModuleLoader;
 import org.wildfly.swarm.bootstrap.performance.Performance;
 import org.wildfly.swarm.bootstrap.util.BootstrapProperties;
+import org.wildfly.swarm.bootstrap.util.BootstrapUtil;
 import org.wildfly.swarm.cli.CommandLine;
 import org.wildfly.swarm.container.DeploymentException;
 import org.wildfly.swarm.container.config.ClassLoaderConfigLocator;
@@ -211,6 +212,8 @@ public class Swarm {
         if (debugBootstrap) {
             Module.setModuleLogger(new StreamModuleLogger(System.err));
         }
+
+        BootstrapUtil.convertSwarmSystemPropertiesToThorntail();
 
         setArgs(args);
         this.debugBootstrap = debugBootstrap;


### PR DESCRIPTION
Motivation
----------
In https://github.com/thorntail/thorntail/pull/1141, all the
configuration properties were renamed from `swarm.*` to
`thorntail.*`. Compatibility is provided for the configuration
system (YAML files and system properties that tie into it), but
not for system properties accessed directly (`System.getProperty()`).

Modifications
-------------
Add a piece of code near the beginning of the main Swarm lifecycle
and also near the beginning of the the Arquillian container lifecycle
that converts all `swarm.*` system properties to `thorntail.*`. Rest
of the code can remain agnostic of the compatibility concern and just
use `thorntail.*`.

Result
------
The old `swarm.*` system properties continue to work.
There's one exception: the Maven plugin. The way Maven injects
properties into the plugins make is impossible to do a similarly
localized change; the change would have to touch all places
that previously used `swarm` and now use `thorntail`.

- [ ] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [ ] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
