### PR TITLE
THORN-914 - Configure Flyway before migration using system properties

### DIFF
--- a/fractions/flyway/src/main/java/org/wildfly/swarm/flyway/deployment/FlywayMigrationServletContextListener.java
+++ b/fractions/flyway/src/main/java/org/wildfly/swarm/flyway/deployment/FlywayMigrationServletContextListener.java
@@ -17,6 +17,7 @@ package org.wildfly.swarm.flyway.deployment;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import javax.enterprise.inject.Vetoed;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -25,6 +26,7 @@ import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 import javax.servlet.annotation.WebListener;
 import javax.sql.DataSource;
+
 import org.flywaydb.core.Flyway;
 
 /**
@@ -64,6 +66,8 @@ public class FlywayMigrationServletContextListener implements ServletContextList
             String password = sc.getInitParameter(FLYWAY_JDBC_PASSWORD);
             flyway.setDataSource(url, user, password);
         }
+        // Configure with flyway.* system properties
+        flyway.configure(System.getProperties());
         flyway.migrate();
     }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----

This change allows to use the standard properties for Flyway, e.g. `flyway.locations` to add additional locations for the migration scripts (which would resolve THORN-914).