### PR TITLE
THORN-2241: fix build so that all artifacts are properly built and SNAPSHOTs don't have to be downloaded when generating BOMs

### DIFF
--- a/fractions/camel/components/pom.xml
+++ b/fractions/camel/components/pom.xml
@@ -47,6 +47,43 @@
           </exclusion>
         </exclusions>
       </dependency>
+
+      <dependency>
+        <groupId>org.wildfly.core</groupId>
+        <artifactId>wildfly-core-feature-pack</artifactId>
+        <scope>provided</scope>
+        <type>zip</type>
+        <exclusions>
+          <exclusion>
+            <groupId>*</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-servlet-feature-pack</artifactId>
+        <scope>provided</scope>
+        <type>zip</type>
+        <exclusions>
+          <exclusion>
+            <groupId>*</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-feature-pack</artifactId>
+        <scope>provided</scope>
+        <type>zip</type>
+        <exclusions>
+          <exclusion>
+            <groupId>*</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
     </dependencies>
 
     <modules>

--- a/fractions/camel/components/reactive-streams/module.conf
+++ b/fractions/camel/components/reactive-streams/module.conf
@@ -1,2 +1,2 @@
-org.apache.camel.component.reactive-streams
+org.apache.camel.component.reactive.streams
 org.wildfly.swarm.camel.core

--- a/fractions/camel/components/rest-swagger/module.conf
+++ b/fractions/camel/components/rest-swagger/module.conf
@@ -1,2 +1,2 @@
-org.apache.camel.component.rest-swagger
+org.apache.camel.component.rest.swagger
 org.wildfly.swarm.camel.core

--- a/fractions/camel/components/spring-batch/module.conf
+++ b/fractions/camel/components/spring-batch/module.conf
@@ -1,2 +1,2 @@
-org.apache.camel.component.spring-batch
+org.apache.camel.component.spring.batch
 org.wildfly.swarm.camel.core

--- a/fractions/camel/components/spring-integration/module.conf
+++ b/fractions/camel/components/spring-integration/module.conf
@@ -1,2 +1,2 @@
-org.apache.camel.component.spring-integration
+org.apache.camel.component.spring.integration
 org.wildfly.swarm.camel.core

--- a/fractions/camel/components/spring-ldap/module.conf
+++ b/fractions/camel/components/spring-ldap/module.conf
@@ -1,2 +1,2 @@
-org.apache.camel.component.spring-ldap
+org.apache.camel.component.spring.ldap
 org.wildfly.swarm.camel.core

--- a/fractions/camel/components/spring-redis/module.conf
+++ b/fractions/camel/components/spring-redis/module.conf
@@ -1,2 +1,2 @@
-org.apache.camel.component.spring-redis
+org.apache.camel.component.spring.redis
 org.wildfly.swarm.camel.core

--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,16 @@
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>
         </plugin>
+        <plugin>
+          <artifactId>maven-source-plugin</artifactId>
+          <configuration>
+            <!--
+              - otherwise source JARs wouldn't be created for modules that don't have real sources,
+              - such as Camel components or hollow JARs
+              -->
+            <forceCreation>true</forceCreation>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
Motivation
----------
Some artifacts (Camel components) don't get built properly,
because of missing feature pack ZIP dependencies. Some artifacts
(Camel components and hollow JARs) that are built properly don't
generate source JARs, because they don't have actual sources.

Both these problems cause the BOM generation process to download
`SNAPSHOT`s of these artifacts from external locations. That is wrong
and also causes huge slowdowns. It's also pretty easy to fix.

Modifications
-------------
Added all 3 WildFly feature packs as dependencies to all Camel
components (via the parent POM).

Fixed erroneous module names in `module.conf` files in Camel
components.

Configured the Maven source plugin to force source JAR generation.

Result
------
Build is now correct and also much faster.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
