### PR TITLE
THORN-2262: close the stream of lines on reading Runner cache

### DIFF
--- a/thorntail-runner/src/main/java/org/wildfly/swarm/runner/cache/ArtifactResolutionCache.java
+++ b/thorntail-runner/src/main/java/org/wildfly/swarm/runner/cache/ArtifactResolutionCache.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.wildfly.swarm.runner.cache.RunnerCacheConstants.CACHE_STORAGE_DIR;
 
@@ -53,8 +54,8 @@ public class ArtifactResolutionCache {
         if (!cache.toFile().exists()) {
             System.out.println("No preexisting artifact resolution cache found. The first execution may take some time.");
         } else {
-            try {
-                Files.lines(cache).forEach(this::addToCache);
+            try (Stream<String> lines = Files.lines(cache)) {
+                lines.forEach(this::addToCache);
             } catch (IOException e) {
                 e.printStackTrace();
                 System.out.println("Error reading resolution cache file, caching will be disabled.");


### PR DESCRIPTION
Motivation
----------
Thorntail Runner was failing to overwrite previously existing caches
on Windows. It turned out the problem was in the stream of lines
of the cache file not closed after reading.

Modifications
-------------
Stream of lines that is used to read the cache file is now closed after reading.

Result
------
Caches are overwritten properly on Windows

Tested on Windows 10 with IntelliJ IDEA Community Edition

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
