### PR TITLE
THORN-2264: Runner: pass classpath in env variable

### DIFF
--- a/thorntail-runner/src/main/java/org/wildfly/swarm/runner/Runner.java
+++ b/thorntail-runner/src/main/java/org/wildfly/swarm/runner/Runner.java
@@ -27,6 +27,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -125,9 +126,13 @@ public class Runner {
                 .map(URL::getFile)
                 .collect(Collectors.joining(File.pathSeparator));
 
-        List<String> command = buildCommand(fatJar, classpath);
+        List<String> command = buildCommand(fatJar);
 
-        Process fatJarBuilder = new ProcessBuilder(command)
+        ProcessBuilder processBuilder = new ProcessBuilder(command);
+
+        processBuilder.environment().put("CLASSPATH", classpath);
+
+        Process fatJarBuilder = processBuilder
                 .inheritIO()
                 .start();
 
@@ -140,15 +145,10 @@ public class Runner {
 
     /*
     builds a command like:
-    /my/path/to/java -cp all:elements:of:classpath -Dall -Dsystem=properties JarBuilderClassName pathToTargetJar
+    /my/path/to/java -Dall -Dsystem=properties JarBuilderClassName pathToTargetJar
      */
-    private static List<String> buildCommand(File fatJar, String classpath) {
-        List<String> command = new ArrayList<>(
-                asList(
-                        javaCommand(),
-                        "-cp",
-                        classpath)
-        );
+    private static List<String> buildCommand(File fatJar) {
+        List<String> command = new ArrayList<>(Collections.singleton(javaCommand()));
 
         command.addAll(properties());
         command.addAll(asList(


### PR DESCRIPTION
Motivation
----------
On Windows, Thorntail Runner was failing with a project having many dependencies.
The cause was the fact that classpath was passed to FatJarBuilder
with -cp in the command.

Modifications
-------------
The classpath is passed as an environment variable now

Result
------
The Runner no longer fails on a big project
Tested in IntelliJ IDEA and Eclipse on Windows 10

- [X] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [X] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
