### PR TITLE
THORN-2293: Arquillian tests require the bootstrap module added as a compile time dependency

### DIFF
--- a/tools/src/main/java/org/wildfly/swarm/tools/DependencyManager.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/DependencyManager.java
@@ -70,7 +70,7 @@ public class DependencyManager implements ResolvedDependencies {
 
     @Override
     public ArtifactSpec findWildFlySwarmBootstrapJar() {
-        return findArtifact(FractionDescriptor.THORNTAIL_GROUP_ID, WILDFLY_SWARM_BOOTSTRAP_ARTIFACT_ID, null, JAR, null, false);
+        return findArtifact(FractionDescriptor.THORNTAIL_GROUP_ID, WILDFLY_SWARM_BOOTSTRAP_ARTIFACT_ID, null, JAR, null, true);
     }
 
     @Override


### PR DESCRIPTION
Motivation
----------
The "findWildFlySwarmBootstrapJar" method in org.wildfly.swarm.tools.DependencyManager searches for the bootstrap jar in the "COMPILE" dependencies only.

When running Arquillian based test cases, it is not necessary that every project has an explicit "compile-time" dependency on the bootstrap module.

E.g.,
In a multi-module project, I might have modules that generate stand-alone libraries, but are still being tested using the Thorntail integration.

Modifications
-------------
Changed the DependencyManager to look for bootstrap jar in test dependencies as well.

Result
------
Defining the Arquillian dependency as a test scope is sufficient to get the test cases running.

- [x] Have you followed the guidelines in our [Contributing](http://wildfly-swarm.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
