### PR TITLE
THORN-2276: Thorntail looking for file.ejb when it should be file.jar…

### DIFF
--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelper.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelper.java
@@ -22,7 +22,9 @@ import org.apache.maven.model.DependencyManagement;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.ArtifactProperties;
 import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.artifact.DefaultArtifactType;
 import org.eclipse.aether.collection.CollectRequest;
 import org.eclipse.aether.collection.CollectResult;
 import org.eclipse.aether.graph.DefaultDependencyNode;
@@ -91,7 +93,7 @@ public class MavenArtifactResolvingHelper implements ArtifactResolvingHelper {
     public ArtifactSpec resolve(ArtifactSpec spec) {
         if (spec.file == null) {
             final DefaultArtifact artifact = new DefaultArtifact(spec.groupId(), spec.artifactId(), spec.classifier(),
-                                                                 spec.type(), spec.version());
+                    typeToExtension(spec.type()), spec.version(), new DefaultArtifactType(spec.type()));
 
             final LocalArtifactResult localResult = this.session.getLocalRepositoryManager()
                     .find(this.session, new LocalArtifactRequest(artifact, this.remoteRepositories, null));
@@ -134,8 +136,10 @@ public class MavenArtifactResolvingHelper implements ArtifactResolvingHelper {
                             DefaultArtifact artifact = new DefaultArtifact(
                                     mavenDep.getGroupId(),
                                     mavenDep.getArtifactId(),
-                                    mavenDep.getType(),
-                                    mavenDep.getVersion()
+                                    mavenDep.getClassifier(),
+                                    typeToExtension(mavenDep.getType()),
+                                    mavenDep.getVersion(),
+                                    new DefaultArtifactType(mavenDep.getType())
                             );
                             return new Dependency(artifact, mavenDep.getScope());
                         })
@@ -146,11 +150,12 @@ public class MavenArtifactResolvingHelper implements ArtifactResolvingHelper {
 
             specs.forEach(spec -> request
                     .addDependency(new Dependency(new DefaultArtifact(spec.groupId(),
-                                                                      spec.artifactId(),
-                                                                      spec.classifier(),
-                                                                      spec.type(),
-                                                                      spec.version()),
-                                                  "compile")));
+                            spec.artifactId(),
+                            spec.classifier(),
+                            typeToExtension(spec.type()),
+                            spec.version(),
+                            new DefaultArtifactType(spec.type())),
+                            "compile")));
 
             RepositorySystemSession tempSession
                     = new RepositorySystemSessionWrapper(this.session, defaultExcludes
@@ -163,11 +168,12 @@ public class MavenArtifactResolvingHelper implements ArtifactResolvingHelper {
             nodes = new ArrayList<>();
             for (ArtifactSpec spec : specs) {
                 Dependency dependency = new Dependency(new DefaultArtifact(spec.groupId(),
-                                                                           spec.artifactId(),
-                                                                           spec.classifier(),
-                                                                           spec.type(),
-                                                                           spec.version()),
-                                                       "compile");
+                        spec.artifactId(),
+                        spec.classifier(),
+                        typeToExtension(spec.type()),
+                        spec.version(),
+                        new DefaultArtifactType(spec.type())),
+                        "compile");
                 DefaultDependencyNode node = new DefaultDependencyNode(dependency);
                 nodes.add(node);
             }
@@ -184,16 +190,29 @@ public class MavenArtifactResolvingHelper implements ArtifactResolvingHelper {
                 .map(node -> {
                     final Artifact artifact = node.getArtifact();
                     return new ArtifactSpec(node.getDependency().getScope(),
-                                            artifact.getGroupId(),
-                                            artifact.getArtifactId(),
-                                            artifact.getVersion(),
-                                            artifact.getExtension(),
-                                            artifact.getClassifier(),
-                                            null);
+                            artifact.getGroupId(),
+                            artifact.getArtifactId(),
+                            artifact.getVersion(),
+                            artifact.getProperty(ArtifactProperties.TYPE, null),
+                            artifact.getClassifier(),
+                            null);
                 })
                 .map(this::resolve)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
+    }
+
+    private String typeToExtension(String type) {
+        switch (type) {
+            case "pom":
+            case "jar":
+            case "war":
+            case "ear":
+            case "rar":
+                return type;
+            default:
+                return "jar";
+        }
     }
 
     /**

--- a/plugins/maven/src/test/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelperTest.java
+++ b/plugins/maven/src/test/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelperTest.java
@@ -15,32 +15,60 @@
  */
 package org.wildfly.swarm.plugin.maven;
 
+import java.io.File;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
 import org.apache.maven.artifact.repository.MavenArtifactRepository;
 import org.apache.maven.artifact.repository.layout.DefaultRepositoryLayout;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.collection.CollectResult;
+import org.eclipse.aether.graph.DefaultDependencyNode;
+import org.eclipse.aether.impl.ArtifactResolver;
+import org.eclipse.aether.repository.LocalArtifactRequest;
+import org.eclipse.aether.repository.LocalArtifactResult;
+import org.eclipse.aether.repository.LocalRepositoryManager;
 import org.eclipse.aether.repository.MirrorSelector;
 import org.eclipse.aether.repository.ProxySelector;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.repository.RepositoryPolicy;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.wildfly.swarm.tools.ArtifactSpec;
 
 public class MavenArtifactResolvingHelperTest {
 
-    @Test
-    // SWARM-1173: swarm-plugin trying to download SNAPSHOTs from Maven Central
-    public void propagateRepositoryPolicies() {
-        RepositorySystemSession sessionMock = Mockito.mock(RepositorySystemSession.class);
+    private RepositorySystemSession sessionMock;
+    private LocalRepositoryManager localRepositoryManager;
+    private ArtifactResolver resolver;
+    private RepositorySystem system;
+
+    public MavenArtifactResolvingHelperTest() {
+        sessionMock = Mockito.mock(RepositorySystemSession.class);
         MirrorSelector mirrorSelectorMock = Mockito.mock(MirrorSelector.class);
         Mockito.when(sessionMock.getMirrorSelector()).thenReturn(mirrorSelectorMock);
         ProxySelector proxySelectorMock = Mockito.mock(ProxySelector.class);
         Mockito.when(sessionMock.getProxySelector()).thenReturn(proxySelectorMock);
+        localRepositoryManager = Mockito.mock(LocalRepositoryManager.class);
+        Mockito.when(sessionMock.getLocalRepositoryManager()).thenReturn(localRepositoryManager);
+        resolver = Mockito.mock(ArtifactResolver.class);
+        system = Mockito.mock(RepositorySystem.class);
 
+    }
+
+    @Test
+    // SWARM-1173: swarm-plugin trying to download SNAPSHOTs from Maven Central
+    public void propagateRepositoryPolicies() {
         MavenArtifactResolvingHelper artifactResolverHelper = new MavenArtifactResolvingHelper(null, null, sessionMock, null);
         ArtifactRepositoryPolicy testSnapshotPolicy = new ArtifactRepositoryPolicy(false, "hourly", "warn");
         ArtifactRepositoryPolicy testReleasesPolicy = new ArtifactRepositoryPolicy(true, "never", "warn");
@@ -63,6 +91,89 @@ public class MavenArtifactResolvingHelperTest {
                                               releasesPolicy.getChecksumPolicy().equals(testReleasesPolicy.getChecksumPolicy());
                                   })
         );
+    }
+
+    /**
+     * Artifact extensions (suffixes) should be converted from artifact types according to this table:
+     *
+     * https://maven.apache.org/ref/3.6.0/maven-core/artifact-handlers.html
+     */
+    @Test
+    public void testArtifactExtensions() throws Exception {
+        // prepare mocks - always find an artifact in local repo
+        Mockito.when(localRepositoryManager.find(Mockito.any(), Mockito.any(LocalArtifactRequest.class)))
+                .thenReturn(new LocalArtifactResult(new LocalArtifactRequest())
+                        .setAvailable(true).setFile(new File("test.jar")));
+
+
+        MavenArtifactResolvingHelper artifactResolverHelper =
+                new MavenArtifactResolvingHelper(resolver, system, sessionMock, null);
+        // try to resolve artifacts with various packagings
+        List<ArtifactSpec> artifacts = Arrays.asList(createSpec("ejb"), createSpec("pom"), createSpec("javadoc"));
+        Set<ArtifactSpec> result = artifactResolverHelper.resolveAll(artifacts, false, false);
+
+
+        Assert.assertEquals(3, result.size());
+        ArgumentCaptor<LocalArtifactRequest> captor = ArgumentCaptor.forClass(LocalArtifactRequest.class);
+        Mockito.verify(localRepositoryManager, Mockito.times(3)).find(Mockito.any(), captor.capture());
+        // verify artifact extensions
+        Assert.assertEquals("jar", captor.getAllValues().get(0).getArtifact().getExtension()); // packaging ejb
+        Assert.assertEquals("pom", captor.getAllValues().get(1).getArtifact().getExtension()); // packaging pom
+        Assert.assertEquals("jar", captor.getAllValues().get(2).getArtifact().getExtension()); // packaging javadoc
+    }
+
+    /**
+     * @see #testArtifactExtensions()
+     */
+    @Test
+    public void testManagedDependenciesExtensions() throws Exception {
+        // prepare mocks
+        // always find an artifact in local repo
+        Mockito.when(localRepositoryManager.find(Mockito.any(), Mockito.any(LocalArtifactRequest.class)))
+                .thenReturn(new LocalArtifactResult(new LocalArtifactRequest())
+                        .setAvailable(true).setFile(new File("test.jar")));
+        // return non-null when system.collectDependencies() is called
+        CollectResult collectResult = new CollectResult(new CollectRequest());
+        collectResult.setRoot(new DefaultDependencyNode((Artifact) null));
+        Mockito.when(system.collectDependencies(Mockito.any(), Mockito.any(CollectRequest.class)))
+                .thenReturn(collectResult);
+
+
+        DependencyManagement dependencyManagement = new DependencyManagement();
+        dependencyManagement.addDependency(createDependency("ejb-client"));
+        dependencyManagement.addDependency(createDependency("javadoc"));
+        dependencyManagement.addDependency(createDependency("pom"));
+
+        MavenArtifactResolvingHelper artifactResolverHelper =
+                new MavenArtifactResolvingHelper(resolver, system, sessionMock, dependencyManagement);
+        // try to resolve artifacts with various packagings
+        List<ArtifactSpec> artifacts = Arrays.asList(createSpec("ejb"), createSpec("pom"), createSpec("javadoc"));
+        artifactResolverHelper.resolveAll(artifacts, true, false);
+
+
+        ArgumentCaptor<CollectRequest> captor = ArgumentCaptor.forClass(CollectRequest.class);
+        Mockito.verify(system).collectDependencies(Mockito.any(), captor.capture());
+        // verify managed dependencies extensions
+        Assert.assertEquals("jar", captor.getValue().getManagedDependencies().get(0).getArtifact().getExtension()); // type ejb-client
+        Assert.assertEquals("jar", captor.getValue().getManagedDependencies().get(1).getArtifact().getExtension()); // type javadoc
+        Assert.assertEquals("pom", captor.getValue().getManagedDependencies().get(2).getArtifact().getExtension()); // type pom
+        // verify artifact extensions
+        Assert.assertEquals("jar", captor.getValue().getDependencies().get(0).getArtifact().getExtension()); // packaging ejb
+        Assert.assertEquals("pom", captor.getValue().getDependencies().get(1).getArtifact().getExtension()); // packaging pom
+        Assert.assertEquals("jar", captor.getValue().getDependencies().get(2).getArtifact().getExtension()); // packaging javadoc
+    }
+
+    private ArtifactSpec createSpec(String packaging) {
+        return new ArtifactSpec("compile", "io.thorntail", "test", "1.0", packaging, "", new File("test.jar"));
+    }
+
+    private Dependency createDependency(String type) {
+        Dependency dependency = new Dependency();
+        dependency.setGroupId("io.thorntail");
+        dependency.setArtifactId("test");
+        dependency.setVersion("1.0");
+        dependency.setType(type);
+        return dependency;
     }
 
 }


### PR DESCRIPTION
… for type ejb

Motivation
----------
Thorntail presumes that dependency type == dependency extension, which is not always correct. E.g. extension for dependency of type "ejb" is "jar".

Modifications
-------------
Correct extension is inferred from dependency type according to table at

https://maven.apache.org/ref/3.6.0/maven-core/artifact-handlers.html

Result
------
Dependencies of type jar are handled correctly during build (before ArtifactNotFoundException was thrown).

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
