### PR TITLE
THORN-2229 AbstractMethodError when building using Maven 3.6.0

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -45,7 +45,7 @@
     <version.jandex>2.0.5.Final</version.jandex>
     <!-- Align dependency versions with those present in WildFly parent -->
     <!-- Doing this explicitly since there is no easy way to import project properties from a pom file -->
-    <version.org.eclipse.aether>1.1.0</version.org.eclipse.aether>
+    <version.org.apache.maven.resolver>1.3.1</version.org.apache.maven.resolver>
     <version.com.fasterxml.jackson>2.9.5</version.com.fasterxml.jackson>
 
     <version.org.ow2.asm>6.2.1</version.org.ow2.asm>
@@ -102,7 +102,7 @@
     <version.jaeger.apache.httpcore>4.2.4</version.jaeger.apache.httpcore>
     <version.jaeger.gson>2.8.2</version.jaeger.gson>
 
-    <version.maven.aether>3.2.5</version.maven.aether>
+    <version.maven.resolver.provider>3.6.0</version.maven.resolver.provider>
 
     <version.resteasy>3.6.1.Final</version.resteasy>
     <version.org.glassfish.javax.json>1.1.2</version.org.glassfish.javax.json>
@@ -195,13 +195,13 @@
     -->
       <dependency>
         <groupId>org.apache.maven</groupId>
-        <artifactId>maven-aether-provider</artifactId>
-        <version>${version.maven.aether}</version>
+        <artifactId>maven-resolver-provider</artifactId>
+        <version>${version.maven.resolver.provider}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-settings-builder</artifactId>
-        <version>${version.maven.aether}</version>
+        <version>${version.maven.resolver.provider}</version>
       </dependency>
 
       <dependency>
@@ -256,39 +256,39 @@
       </dependency>
 
       <dependency>
-        <groupId>org.eclipse.aether</groupId>
-        <artifactId>aether-api</artifactId>
-        <version>${version.org.eclipse.aether}</version>
+        <groupId>org.apache.maven.resolver</groupId>
+        <artifactId>maven-resolver-api</artifactId>
+        <version>${version.org.apache.maven.resolver}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.aether</groupId>
-        <artifactId>aether-spi</artifactId>
-        <version>${version.org.eclipse.aether}</version>
+        <groupId>org.apache.maven.resolver</groupId>
+        <artifactId>maven-resolver-spi</artifactId>
+        <version>${version.org.apache.maven.resolver}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.aether</groupId>
-        <artifactId>aether-util</artifactId>
-        <version>${version.org.eclipse.aether}</version>
+        <groupId>org.apache.maven.resolver</groupId>
+        <artifactId>maven-resolver-util</artifactId>
+        <version>${version.org.apache.maven.resolver}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.aether</groupId>
-        <artifactId>aether-impl</artifactId>
-        <version>${version.org.eclipse.aether}</version>
+        <groupId>org.apache.maven.resolver</groupId>
+        <artifactId>maven-resolver-impl</artifactId>
+        <version>${version.org.apache.maven.resolver}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.aether</groupId>
-        <artifactId>aether-connector-basic</artifactId>
-        <version>${version.org.eclipse.aether}</version>
+        <groupId>org.apache.maven.resolver</groupId>
+        <artifactId>maven-resolver-connector-basic</artifactId>
+        <version>${version.org.apache.maven.resolver}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.aether</groupId>
-        <artifactId>aether-transport-file</artifactId>
-        <version>${version.org.eclipse.aether}</version>
+        <groupId>org.apache.maven.resolver</groupId>
+        <artifactId>maven-resolver-transport-file</artifactId>
+        <version>${version.org.apache.maven.resolver}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.aether</groupId>
-        <artifactId>aether-transport-http</artifactId>
-        <version>${version.org.eclipse.aether}</version>
+        <groupId>org.apache.maven.resolver</groupId>
+        <artifactId>maven-resolver-transport-http</artifactId>
+        <version>${version.org.apache.maven.resolver}</version>
       </dependency>
 
       <dependency>

--- a/plugins/gradle/gradle-plugin/pom.xml
+++ b/plugins/gradle/gradle-plugin/pom.xml
@@ -81,9 +81,8 @@
       <version>3.0.20</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-util</artifactId>
-      <version>1.0.0.v20140518</version>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-util</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>

--- a/plugins/maven-utils/pom.xml
+++ b/plugins/maven-utils/pom.xml
@@ -26,12 +26,12 @@
       <artifactId>tools</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-util</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-api</artifactId>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-util</artifactId>
     </dependency>
   </dependencies>
 

--- a/plugins/maven-utils/src/main/java/org/wildfly/swarm/maven/utils/RepositorySystemSessionWrapper.java
+++ b/plugins/maven-utils/src/main/java/org/wildfly/swarm/maven/utils/RepositorySystemSessionWrapper.java
@@ -39,6 +39,7 @@ import org.eclipse.aether.repository.WorkspaceReader;
 import org.eclipse.aether.resolution.ArtifactDescriptorPolicy;
 import org.eclipse.aether.resolution.ResolutionErrorPolicy;
 import org.eclipse.aether.transfer.TransferListener;
+import org.eclipse.aether.transform.FileTransformerManager;
 import org.eclipse.aether.util.graph.transformer.ConflictResolver;
 import org.eclipse.aether.util.graph.transformer.JavaScopeDeriver;
 import org.eclipse.aether.util.graph.transformer.JavaScopeSelector;
@@ -192,6 +193,11 @@ public final class RepositorySystemSessionWrapper implements RepositorySystemSes
     @Override
     public RepositoryCache getCache() {
         return delegate.getCache();
+    }
+
+    @Override
+    public FileTransformerManager getFileTransformerManager() {
+        return delegate.getFileTransformerManager();
     }
 
     private RepositorySystemSession delegate;

--- a/plugins/maven/pom.xml
+++ b/plugins/maven/pom.xml
@@ -76,9 +76,8 @@
       <version>3.0.20</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-util</artifactId>
-      <version>1.0.0.v20140518</version>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-util</artifactId>
     </dependency>
     <dependency>
       <groupId>io.thorntail</groupId>

--- a/thorntail-runner/pom.xml
+++ b/thorntail-runner/pom.xml
@@ -27,36 +27,36 @@
       <artifactId>tools</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-util</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-impl</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-connector-basic</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-aether-provider</artifactId>
+      <artifactId>maven-resolver-provider</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-connector-basic</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-transport-file</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-transport-http</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-settings-builder</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-transport-file</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.aether</groupId>
-      <artifactId>aether-transport-http</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Motivation
----------

Thorntail projects fail to build with Maven 3.6.0.

Modifications
-------------

Dependecies on org.eclipse.aether:aether-*:1.1.0 were replaced by org.apache.maven.resolver:maven-resolver-*:1.3.1. Class RepositorySystemSessionWrapper implements missing method getFileTransformerManager().

Result
------

Build works with Maven 3.6.0, 3.5.2 and 3.3.9.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
