### PR TITLE
THORN-2176: Bootstrap duplicates dependencies

### DIFF
--- a/core/bootstrap/pom.xml
+++ b/core/bootstrap/pom.xml
@@ -58,7 +58,6 @@
             <configuration>
               <excludeTransitive>true</excludeTransitive>
               <includeGroupIds>org.jboss.modules,org.yaml</includeGroupIds>
-              <includeScope>compile</includeScope>
               <excludes>**\/MavenArtifactUtil.class,**\/ArtifactCoordinates.class,**\/MavenSettings.class</excludes>
               <outputDirectory>${project.build.directory}/classes</outputDirectory>
             </configuration>
@@ -72,10 +71,12 @@
     <dependency>
       <groupId>org.jboss.modules</groupId>
       <artifactId>jboss-modules</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.logging</groupId>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
JBoss Modules and Snake YAML are compile dependencies to `bootstrap`, but then also shaded into it. This leads to duplicate classes on the classpath and two versions of the classes in the uber jar.

Modifications
-------------
Marked the dependencies as provided scope, so they're only included via shading.

Result
------
Removes duplicate classes on classpath, and JBoss Modules jar is no longer added to m2repo in uber jar.
