### PR TITLE
THORN-2290: Clarify default datasource in docs

### DIFF
--- a/docs/howto/create-a-datasource/configuring-a-datasource-manually.adoc
+++ b/docs/howto/create-a-datasource/configuring-a-datasource-manually.adoc
@@ -1,6 +1,6 @@
 
-[id='configuring-a-datasource_{context}']
-= Configuring a datasource
+[id='configuring-a-datasource_manually_{context}']
+= Configuring a datasource manually
 
 [discrete]
 == Prerequisites

--- a/docs/howto/create-a-datasource/configuring-the-jdbc-driver-manually.adoc
+++ b/docs/howto/create-a-datasource/configuring-the-jdbc-driver-manually.adoc
@@ -28,7 +28,7 @@
 +
 In the `thorntail` -> `datasources` -> `jdbc-drivers` tree, define the driver by
 key, which will be used later for connecting it to the datasource.
-Set the `driver-module-name` to that defined in the `module.xml`.
+Set the `driver-module-name` to that defined in the `module.xml` file.
 +
 [source,yaml]
 ----

--- a/docs/howto/create-a-datasource/configuring-the-jdbc-driver-manually.adoc
+++ b/docs/howto/create-a-datasource/configuring-the-jdbc-driver-manually.adoc
@@ -6,7 +6,7 @@
 == Prerequisites
 
 * A Maven-based application.
-* The `module.xml` file created according to relevant {WildFly} instructions.
+* The `module.xml` file created in `src/main/resources/modules` directory according to relevant {WildFly} instructions.
   This file is necessary to expose the driver through JBoss Modules.
 
 [discrete]
@@ -28,6 +28,7 @@
 +
 In the `thorntail` -> `datasources` -> `jdbc-drivers` tree, define the driver by
 key, which will be used later for connecting it to the datasource.
+Set `driver-module-name` to that defined by the `module.xml` from earlier.
 +
 [source,yaml]
 ----

--- a/docs/howto/create-a-datasource/configuring-the-jdbc-driver-manually.adoc
+++ b/docs/howto/create-a-datasource/configuring-the-jdbc-driver-manually.adoc
@@ -28,7 +28,7 @@
 +
 In the `thorntail` -> `datasources` -> `jdbc-drivers` tree, define the driver by
 key, which will be used later for connecting it to the datasource.
-Set the `driver-module-name` to that defined by the `module.xml` from above.
+Set the `driver-module-name` to that defined in the `module.xml`.
 +
 [source,yaml]
 ----

--- a/docs/howto/create-a-datasource/configuring-the-jdbc-driver-manually.adoc
+++ b/docs/howto/create-a-datasource/configuring-the-jdbc-driver-manually.adoc
@@ -28,7 +28,7 @@
 +
 In the `thorntail` -> `datasources` -> `jdbc-drivers` tree, define the driver by
 key, which will be used later for connecting it to the datasource.
-Set the `driver-module-name` to that defined by the `module.xml` from earlier.
+Set the `driver-module-name` to that defined by the `module.xml` from above.
 +
 [source,yaml]
 ----

--- a/docs/howto/create-a-datasource/configuring-the-jdbc-driver-manually.adoc
+++ b/docs/howto/create-a-datasource/configuring-the-jdbc-driver-manually.adoc
@@ -6,7 +6,7 @@
 == Prerequisites
 
 * A Maven-based application.
-* The `module.xml` file created in `src/main/resources/modules` directory according to relevant {WildFly} instructions.
+* The `module.xml` file created in the `src/main/resources/modules` directory according to relevant {WildFly} instructions.
   This file is necessary to expose the driver through JBoss Modules.
 
 [discrete]
@@ -28,7 +28,7 @@
 +
 In the `thorntail` -> `datasources` -> `jdbc-drivers` tree, define the driver by
 key, which will be used later for connecting it to the datasource.
-Set `driver-module-name` to that defined by the `module.xml` from earlier.
+Set the `driver-module-name` to that defined by the `module.xml` from earlier.
 +
 [source,yaml]
 ----

--- a/docs/howto/create-a-datasource/index.adoc
+++ b/docs/howto/create-a-datasource/index.adoc
@@ -19,7 +19,7 @@ a pool of connections to a particular database using the driver.
 
 == Configuring a JDBC driver
 
-There are two options how to configure JDBC drivers:
+There are the following options how to configure JDBC drivers:
 
 include::auto-detecting-jdbc-drivers.adoc[leveloffset=+2]
 
@@ -27,7 +27,7 @@ include::configuring-the-jdbc-driver-manually.adoc[leveloffset=+2]
 
 == Configuring a Datasource
 
-There are two options for how to configure a datasource:
+There are the following options for how to configure a datasource:
 
 include::using-default-datasource.adoc[leveloffset=+2]
 

--- a/docs/howto/create-a-datasource/index.adoc
+++ b/docs/howto/create-a-datasource/index.adoc
@@ -25,7 +25,13 @@ include::auto-detecting-jdbc-drivers.adoc[leveloffset=+2]
 
 include::configuring-the-jdbc-driver-manually.adoc[leveloffset=+2]
 
-include::configuring-a-datasource.adoc[leveloffset=+1]
+== Configuring a Datasource
+
+There are two options for how to configure a datasource:
+
+include::using-default-datasource.adoc[leveloffset=+2]
+
+include::configuring-a-datasource-manually.adoc[leveloffset=+2]
 
 == Example full project-defaults.yml file
 

--- a/docs/howto/create-a-datasource/using-default-datasource.adoc
+++ b/docs/howto/create-a-datasource/using-default-datasource.adoc
@@ -13,7 +13,9 @@ The presence of a JDBC driver will automatically create a datasource with the na
 [discrete]
 == Procedure
 
-. Edit the `project-defaults.yml` file to customize the datasource name. The configuration is stored under `thorntail`
+. Edit the `project-defaults.yml` file to customize the datasource name.
++
+The configuration is stored under `thorntail`
 -> `ds` -> `name`:
 +
 [source,yaml]

--- a/docs/howto/create-a-datasource/using-default-datasource.adoc
+++ b/docs/howto/create-a-datasource/using-default-datasource.adoc
@@ -2,15 +2,23 @@
 [id='using-default-datasource_{context}']
 = Using the default datasource
 
+The presence of a JDBC driver will automatically create a datasource with the name `ExampleDS`.
+
 [discrete]
 == Prerequisites
 
 * A Maven-based application.
-* A JDBC Driver configured, either auto detected or manually.
+* A JDBC Driver configured manually or auto-detected.
 
 [discrete]
 == Procedure
 
-The presence of a JDBC driver will automatically create a datasource with the name `ExampleDS`.
-
-The property `thorntail.ds.name` can be used to customize the name of the datasource that is automatically created.
+. Edit the `project-defaults.yml` file to customize the datasource name. The configuration is stored under `thorntail`
+-> `ds` -> `name`:
++
+[source,yaml]
+----
+thorntail:
+  ds:
+    name: myDS
+----

--- a/docs/howto/create-a-datasource/using-default-datasource.adoc
+++ b/docs/howto/create-a-datasource/using-default-datasource.adoc
@@ -1,0 +1,16 @@
+
+[id='using-default-datasource_{context}']
+= Using the default datasource
+
+[discrete]
+== Prerequisites
+
+* A Maven-based application.
+* A JDBC Driver configured, either auto detected or manually.
+
+[discrete]
+== Procedure
+
+The presence of a JDBC driver will automatically create a datasource with the name `ExampleDS`.
+
+The property `thorntail.ds.name` can be used to customize the name of the datasource that is automatically created.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
It's unclear from the documentation that a default datasource is created.

Modifications
-------------
Add content specifying that a default datasource is created, what it's called, and how to override its name.

Result
------
No impact to product, improve clarity of docs.
