### PR TITLE
THORN-2285: Thorntail jpa fraction seems to be causing ClassNotFoundE…

### DIFF
--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/MainInvoker.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/MainInvoker.java
@@ -26,12 +26,16 @@ import java.util.List;
 
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleLoadException;
+import org.jboss.modules.ModuleNotFoundException;
+import org.wildfly.swarm.bootstrap.logging.BootstrapLogger;
 import org.wildfly.swarm.bootstrap.modules.BootModuleLoader;
 
 /**
  * @author Bob McWhirter
  */
 public class MainInvoker {
+
+    private static BootstrapLogger LOGGER = BootstrapLogger.logger("org.wildfly.swarm.bootstrap");
 
     private static final String BOOT_MODULE_PROPERTY = "boot.module.loader";
 
@@ -113,6 +117,9 @@ public class MainInvoker {
             ClassLoader cl = module.getClassLoader();
             mainClass = cl.loadClass(mainClassName);
         } catch (ClassNotFoundException | ModuleLoadException e) {
+            if (e instanceof ModuleNotFoundException) {
+                LOGGER.warn("Module not found: " + e.getMessage());
+            }
             ClassLoader cl = ClassLoader.getSystemClassLoader();
             mainClass = cl.loadClass(mainClassName);
         }

--- a/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/ThorntailExtension.java
+++ b/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/ThorntailExtension.java
@@ -261,7 +261,7 @@ public class ThorntailExtension implements ThorntailConfiguration {
     @Override
     public Map<DependencyDescriptor, Set<DependencyDescriptor>> getDependencies() {
         if (dependencyMap == null) {
-            dependencyMap = GradleDependencyResolutionHelper.determineProjectDependencies(project, "runtimeClasspath", false);
+            dependencyMap = GradleDependencyResolutionHelper.determineProjectDependencies(project, "runtimeClasspath", true);
         }
         return dependencyMap;
     }


### PR DESCRIPTION
…xception

Motivation
----------
Gradle plugin doesn't package transitive dependencies deeper than one level.

Modifications
-------------
ThorntailExtension.getDependencies() should return either all transitive
dependencies or none at all. Currently it returns just one level of transitive
dependencies, which confuses BuildTool into thinking that whole dependency tree
has already been resolved, while in fact it has only been resolved partially.

Result
------
Whole dependency tree is resolved straight away by the package task and
injected into the BuildTool#declaredDependencies (same as in maven plugin).

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
