### PR TITLE
THORN-1996: realm-name ignored for web.xml login-config

### DIFF
--- a/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/runtime/HttpSecurityPreparer.java
+++ b/fractions/javaee/undertow/src/main/java/org/wildfly/swarm/undertow/runtime/HttpSecurityPreparer.java
@@ -83,7 +83,7 @@ public class HttpSecurityPreparer implements DeploymentProcessor {
             String authMethod = (String) loginConfig.getOrDefault("auth-method", "NONE");
 
             // Setup login-config
-            webXml.setLoginConfig(authMethod, "ignored");
+            webXml.setLoginConfig(authMethod, (String) loginConfig.getOrDefault("realm-name", "ignored"));
 
             // security domain
             if (loginConfig.containsKey("security-domain")) {


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----

Motivation
----------
If provided in `thorntail.deployment`, the realm-config name for a login-config is always set to "ignored".

Instead we should default it to "ignored" but actually attempt to retrieve a value from YAML.

Modifications
-------------
Modify setting login-config to retrieve a value for `realm-name` key and set to "ignored" if one is not found.

Result
------
Allows a deployment to specify the realm-name for their login-config within YAML.
