### PR TITLE
THORN-2302: MP Metrics: wrong unit scaling in Prometheus output

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -125,7 +125,7 @@
     <version.smallrye.health>1.0.2</version.smallrye.health>
     <version.smallrye.openapi>1.0.3</version.smallrye.openapi>
     <version.smallrye.opentracing>1.2.1</version.smallrye.opentracing>
-    <version.smallrye.metrics>1.1.2</version.smallrye.metrics>
+    <version.smallrye.metrics>1.1.3</version.smallrye.metrics>
     <version.smallrye.restclient>1.1.0</version.smallrye.restclient>
     <version.smallrye.jwt>1.1.0</version.smallrye.jwt>
     <version.smallrye-fault-tolerance>1.1.0</version.smallrye-fault-tolerance>


### PR DESCRIPTION
Motivation
----------
SmallRye Metrics 1.1.2 does wrong unit scaling in Prometheus output
in case of timers. This leads to a semantic difference in the JSON
and Prometheus outputs.

Modifications
-------------
Upgrade to SmallRye Metrics 1.1.3 which has a fix.

Result
------
Metrics Prometheus output is now semantically equivalent
to the JSON output.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
