### PR TITLE
Gradle Plugin: Code Cleanup

### DIFF
--- a/plugins/gradle/gradle-plugin/pom.xml
+++ b/plugins/gradle/gradle-plugin/pom.xml
@@ -41,14 +41,6 @@
   <dependencies>
     <dependency>
       <groupId>io.thorntail</groupId>
-      <artifactId>fraction-metadata</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.thorntail</groupId>
-      <artifactId>spi</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.thorntail</groupId>
       <artifactId>thorntail-gradle-tooling</artifactId>
     </dependency>
     <dependency>
@@ -74,15 +66,6 @@
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy</artifactId>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-utils</artifactId>
-      <version>3.0.20</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-util</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>

--- a/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/GradleDependencyResolutionHelper.java
+++ b/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/GradleDependencyResolutionHelper.java
@@ -241,7 +241,10 @@ public final class GradleDependencyResolutionHelper {
         Set<DependencyDescriptor> dependencies = new HashSet<>();
         while (!stack.empty()) {
             ResolvedDependency rd = stack.pop();
-            rd.getModuleArtifacts().forEach(a -> dependencies.add(asDescriptor(scope, a)));
+            // Skip the parent's artifacts.
+            if (rd != parent) {
+                rd.getModuleArtifacts().forEach(a -> dependencies.add(asDescriptor(scope, a)));
+            }
             rd.getChildren().forEach(d -> {
                 if (!stack.contains(d)) {
                     stack.add(d);
@@ -298,12 +301,13 @@ public final class GradleDependencyResolutionHelper {
         final String NEW_LINE = "\n";
         if (project.getLogger().isEnabled(LogLevel.INFO)) {
             StringBuilder builder = new StringBuilder(100);
+            builder.append("Resolved dependencies:").append(NEW_LINE);
             map.forEach((k, v) -> {
                 builder.append(k).append(NEW_LINE);
                 v.forEach(e -> builder.append("\t").append(e).append(NEW_LINE));
                 builder.append(NEW_LINE);
             });
-            project.getLogger().info("Resolved dependencies:\n" + builder.toString());
+            project.getLogger().info(builder.toString());
         }
     }
 

--- a/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/ThorntailExtension.java
+++ b/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/ThorntailExtension.java
@@ -16,10 +16,7 @@
 package org.wildfly.swarm.plugin.gradle;
 
 import java.io.File;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
@@ -273,34 +270,6 @@ public class ThorntailExtension implements ThorntailConfiguration {
     public Map<DependencyDescriptor, Set<DependencyDescriptor>> getTestDependencies() {
         if (testDependencyMap == null) {
             testDependencyMap = GradleDependencyResolutionHelper.determineProjectDependencies(project, "testRuntimeClasspath", true);
-
-            // The Arquillian adapter uses its own ArtifactResolver which makes things a little challenging.
-            // We need to prune the map for "project" dependencies and make sure they have no dependencies explicitly called out.
-            // This will ensure that there is no transitive resolution being performed on it as "isPresolved" will return true.
-            Set<DependencyDescriptor> addFinally = new HashSet<>();
-            Map<DependencyDescriptor, Set<DependencyDescriptor>> depPrj = new HashMap<>();
-            testDependencyMap.forEach((key, values) -> {
-
-                // Check if any of the elements in the "value" set represent a dependent project-module.
-                // If they do, then move it to the top level.
-                Iterator<DependencyDescriptor> itr = values.iterator();
-                while (itr.hasNext()) {
-                    DependencyDescriptor d = itr.next();
-                    if (GradleDependencyResolutionHelper.isProject(project, d)) {
-                        itr.remove();
-                        addFinally.add(d);
-                    }
-                }
-
-                // Check if the "key" itself represents a dependent project-module.
-                // If it does, then move all the children to top-level.
-                if (GradleDependencyResolutionHelper.isProject(project, key)) {
-                    addFinally.addAll(values);
-                    values.clear();
-                }
-            });
-
-            addFinally.forEach(d -> testDependencyMap.putIfAbsent(d, Collections.emptySet()));
         }
         return testDependencyMap;
     }


### PR DESCRIPTION
Motivation
----------
Code hygiene.

Modifications
-------------
* Clean up the POM dependency list.
* Clean up the test dependency computation logic.

Result
------
Test are working as expected. Verified the builds on all the example projects.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [ ] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

I am observing an unrelated test case failure with the project `testsuite-microprofile-restclient`

> Caused by: java.lang.NoClassDefFoundError: org/eclipse/microprofile/rest/client/ext/AsyncInvocationInterceptorFactory
-----
