### PR TITLE
THORN-2311: conflicting definitions of the org.eclipse.microprofile.restclient module

### DIFF
--- a/module-rewrite.conf
+++ b/module-rewrite.conf
@@ -1,2 +1,5 @@
 module: org.jboss.resteasy.resteasy-jaxrs
   remove-artifact: resteasy-client-microprofile
+  optional: org.eclipse.microprofile.restclient
+module: org.jboss.resteasy.resteasy-cdi
+  optional: org.eclipse.microprofile.restclient


### PR DESCRIPTION
Motivation
----------
A lot of (probably all of) MP RestClient tests started failing
with a classloading error:

```
java.lang.NoClassDefFoundError: org/eclipse/microprofile/rest/client/ext/AsyncInvocationInterceptorFactory
        at io.smallrye.restclient.ProxyInvocationHandler.prepareAsyncInterceptors(ProxyInvocationHandler.java:174)
        at io.smallrye.restclient.ProxyInvocationHandler.invoke(ProxyInvocationHandler.java:100)
        at com.sun.proxy.$Proxy117.hello(Unknown Source)
        at org.wildfly.swarm.microprofile.restclient.proxy.RestClientProxyTest.testGetClient(RestClientProxyTest.java:72)
        ...
Caused by: java.lang.ClassNotFoundException: org.eclipse.microprofile.rest.client.ext.AsyncInvocationInterceptorFactory from [Module "io.smallrye.restclient" version 1.1.0 from BootModuleLoader@1f75a668 for finders [JDK Module Finder, BootstrapClasspathModuleFinder, BootstrapModuleFinder(org.wildfly.swarm.bootstrap), ClasspathModuleFinder, ContainerModuleFinder(swarm.container), ApplicationModuleFinder(thorntail.application), org.wildfly.swarm.bootstrap.modules.DynamicModuleFinder@35399441]]
        at org.jboss.modules.ModuleClassLoader.findClass(ModuleClassLoader.java:255)
        ...
```

This is because the module from which MP RestClient API classes are loaded
is of version 1.0.1. This is yet another case of RESTEasy (which bundles their
own implementation of MP RestClient 1.0) colliding with Thorntail. One problem
of this kind was already solved during the update to WildFly 14. It seems that
wasn't enough.

Modifications
-------------
Using the mechanism of `module-rewrite.conf`,
the `org.eclipse.microprofile.restclient` module is marked as optional in the
definitions of `org.jboss.resteasy.resteasy-jaxrs`
and `org.jboss.resteasy.resteasy-cdi` modules. This solves the problem because
the fraction plugin doesn't add `module.xml` files of optional modules
to fractions. Moreover, we already remove `resteasy-client-microprofile-*.jar`
from the set of artifacts of the `org.jboss.resteasy.resteasy-jaxrs` module,
which is even more invasive change. So this should be safe.

Result
------
There's only one definition of `org.eclipse.microprofile.restclient`.
MP RestClient 1.1 works fine.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
