### PR TITLE
THORN-2313: Gradle plugin: provide tasks to run|start|stop the applic…

### DIFF
--- a/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/PackageTask.java
+++ b/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/PackageTask.java
@@ -213,7 +213,7 @@ public class PackageTask extends DefaultTask {
     }
 
     @OutputFile
-    private File getOutputFile() {
+    File getOutputFile() {
         return BuildTool.getOutputFile(getBaseName() + UBERJAR_SUFFIX + ".jar", getOutputDirectory());
     }
 

--- a/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/StartTask.java
+++ b/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/StartTask.java
@@ -1,0 +1,386 @@
+package org.wildfly.swarm.plugin.gradle;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.gradle.BuildListener;
+import org.gradle.BuildResult;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
+import org.gradle.api.initialization.Settings;
+import org.gradle.api.invocation.Gradle;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.bundling.Jar;
+import org.gradle.api.tasks.bundling.War;
+import org.gradle.initialization.BuildCancellationToken;
+import org.slf4j.helpers.MessageFormatter;
+import org.wildfly.swarm.bootstrap.util.BootstrapProperties;
+import org.wildfly.swarm.fractions.FractionDescriptor;
+import org.wildfly.swarm.fractions.FractionList;
+import org.wildfly.swarm.fractions.FractionUsageAnalyzer;
+import org.wildfly.swarm.tools.ArtifactResolvingHelper;
+import org.wildfly.swarm.tools.ArtifactSpec;
+import org.wildfly.swarm.tools.BuildTool;
+import org.wildfly.swarm.tools.DependencyManager;
+import org.wildfly.swarm.tools.exec.SwarmExecutor;
+import org.wildfly.swarm.tools.exec.SwarmProcess;
+
+public class StartTask extends DefaultTask {
+
+    private static final String EXCLUDE_PREFIX = "!";
+    private static final String INDENTATION_DELIMITER = "\n  ";
+    private static final String DEBUG_PORT_PROPERTY = "thorntail.debug.port";
+    private static final String FAILED_TO_START_MESSAGE = "Thorntail process failed to start: ";
+
+    private ThorntailExtension extension;
+    private boolean waitForProcess = false;
+
+    public StartTask() {
+        extension = getProject().getExtensions().getByType(ThorntailExtension.class);
+    }
+
+    void waitForProcess() {
+        waitForProcess = true;
+    }
+
+    @TaskAction
+    public void startApplication() {
+        final SwarmExecutor executor;
+        if (extension.isUseUberJar()) {
+            executor = uberJarExecutor();
+        } else if (!getProject().getTasks().withType(War.class).isEmpty()) {
+            executor = warExecutor();
+        } else if (!getProject().getTasks().withType(Jar.class).isEmpty()) {
+            executor = jarExecutor();
+        } else {
+            throw new GradleException("Unable to determine type of the project, neither war or jar tasks were found.");
+        }
+
+        executor.withJVMArguments(extension.getJvmArguments());
+        executor.withArguments(extension.getArguments());
+
+        final SwarmProcess process;
+        try {
+
+            File processFile;
+            try {
+                processFile = Files.createTempFile("thorntail-process-file", null).toFile();
+                getLogger().info("Thorntail process file: " + processFile.toPath().toString());
+            } catch (IOException e) {
+                throw new GradleException("Error while creating Thorntail process file");
+            }
+
+            process = executor.withDebug(getDebugPort())
+                    .withProcessFile(processFile)
+                    .withProperties(extension.getProperties())
+                    .withProperties(ThorntailUtils.getPropertiesFromFile(extension.getPropertiesFile()))
+                    .withStdoutFile(extension.getStdoutFile() != null ? getProject().file(extension.getStdoutFile()).toPath() : null)
+                    .withStderrFile(extension.getStderrFile() != null ? getProject().file(extension.getStderrFile()).toPath() : null)
+                    .withEnvironment(extension.getEnvironment())
+                    .withEnvironment(ThorntailUtils.getPropertiesFromFile(extension.getEnvironmentFile()))
+                    .withWorkingDirectory(getProject().getProjectDir().toPath())
+                    .withProperty("remote.maven.repo",
+                            getProject().getRepositories().withType(MavenArtifactRepository.class).stream()
+                                    .map(mavenArtifactRepository -> mavenArtifactRepository.getUrl().toASCIIString())
+                                    .collect(Collectors.joining(",")))
+                    .execute();
+            registerCancellationListeners(process);
+
+            process.awaitReadiness(extension.getStartTimeout(), TimeUnit.SECONDS);
+
+            if (!process.isAlive()) {
+                throw new GradleException(
+                        MessageFormatter.format(FAILED_TO_START_MESSAGE + "process not ready in {} seconds",
+                                extension.getStartTimeout()).getMessage());
+            }
+            if (process.getError() != null) {
+                throw new GradleException(FAILED_TO_START_MESSAGE
+                        + (process.getError() != null ? process.getError().getMessage() : "unknown reason"),
+                        process.getError());
+            }
+
+        } catch (IOException e) {
+            throw new GradleException(FAILED_TO_START_MESSAGE + e.getMessage(), e);
+        } catch (InterruptedException e) {
+            throw new GradleException(FAILED_TO_START_MESSAGE + "interrupted", e);
+        }
+
+        if (waitForProcess) {
+            try {
+                process.waitFor();
+            } catch (InterruptedException e) {
+                try {
+                    process.stop(extension.getStopTimeout(), TimeUnit.SECONDS);
+                } catch (InterruptedException ie) {
+                    // Do nothing
+                }
+            } finally {
+                process.destroyForcibly();
+            }
+        } else {
+            // save the process into a property so it can be stopped by another task later
+            getProject().getExtensions().getExtraProperties().set(PackagePlugin.THORNTAIL_PROCESS_PROPERTY, process);
+        }
+    }
+
+    private SwarmExecutor uberJarExecutor() {
+        getLogger().info("Creating uber-jar Thorntail executor.");
+        return new SwarmExecutor().withExecutableJar(getUberJarArchivePath().toPath());
+    }
+
+    private SwarmExecutor warExecutor() {
+        getLogger().info("Creating WAR Thorntail executor.");
+
+        final String finalName = ThorntailUtils.getArchiveTask(getProject()).getArchiveName();
+
+        final SwarmExecutor executor = new SwarmExecutor()
+                .withModules(getModules())
+                .withProperty(BootstrapProperties.APP_NAME, finalName)
+                .withClassPathEntries(getClassPathEntries(Collections.singletonList(getArchivePath().toPath()), false));
+
+        if (extension.getMainClassName() != null) {
+            getLogger().info("With Thorntail app main class " + extension.getMainClassName());
+            executor.withMainClass(extension.getMainClassName());
+        } else {
+            getLogger().info("With default Thorntail app main class.");
+            executor.withDefaultMainClass();
+        }
+
+        executor.withProperty(BootstrapProperties.APP_PATH, getArchivePath().getPath());
+        return executor;
+    }
+
+    private SwarmExecutor jarExecutor() {
+        getLogger().info("Creating WAR Thorntail executor.");
+
+        final String finalName = ThorntailUtils.getArchiveTask(getProject()).getArchiveName();
+
+        // TODO: application path could possibly contain more classesDirs
+        // TODO: getClassesDir() no longer exists in gradle 4+?, gradle-plugins dep should be upgraded, but current
+        // version is not available as a maven artifact
+//        getProject().getConvention().getPlugin(JavaPluginConvention.class).getSourceSets()
+//                .getByName(SourceSet.MAIN_SOURCE_SET_NAME).getOutput().getClassesDir();
+        final List<Path> sourcePaths = Arrays.asList(getProject().getBuildDir().toPath().resolve("classes/java/main"),
+                getProject().getBuildDir().toPath().resolve("resources/main"));
+        getLogger().info("Source paths: {}", sourcePaths);
+
+        final SwarmExecutor executor = new SwarmExecutor()
+                .withModules(getModules())
+                .withProperty(BootstrapProperties.APP_NAME, finalName)
+                .withClassPathEntries(sourcePaths)
+                .withClassPathEntries(getClassPathEntries(sourcePaths, true));
+
+        if (extension.getMainClassName() != null) {
+            getLogger().info("With Thorntail app main class " + extension.getMainClassName());
+            executor.withMainClass(extension.getMainClassName());
+        } else {
+            getLogger().info("With default Thorntail app main class.");
+            executor.withDefaultMainClass();
+        }
+
+        return executor;
+    }
+
+    private File getArchivePath() {
+        final Jar task = ThorntailUtils.getArchiveTask(getProject());
+        final File archivePath = task.getArchivePath();
+        getLogger().info("Archive path: {}", archivePath.getAbsolutePath());
+        return archivePath;
+    }
+
+    private File getUberJarArchivePath() {
+        final File outputFile = getProject().getTasks().withType(PackageTask.class)
+                .getByName(PackagePlugin.THORNTAIL_PACKAGE_TASK_NAME).getOutputFile();
+        getLogger().info("Thorntail Uber-JAR archive path: {}", outputFile.getAbsolutePath());
+        return outputFile;
+    }
+
+    private List<Path> getModules() {
+        List<Path> modules = extension.getModules().stream().map(File::toPath).collect(Collectors.toList());
+        getLogger().info("With Thorntail modules:\n  {}",
+                modules.stream().map(Path::toString).collect(Collectors.joining(INDENTATION_DELIMITER)));
+        return modules;
+    }
+
+    private List<Path> getClassPathEntries(List<Path> sourcePaths, boolean scanDependencies) {
+        Collection<ArtifactSpec> allDependencies = GradleToolingHelper
+                .toDeclaredDependencies(extension.getDependencies()).getRuntimeExplicitAndTransientDependencies();
+        getLogger().info("Original dependencies including transitive:\n  {}",
+                allDependencies.stream().map(ArtifactSpec::toString).collect(Collectors.joining(INDENTATION_DELIMITER)));
+
+        final List<Path> classpathEntries = allDependencies.stream()
+                .map(artifactSpec -> artifactSpec.file.toPath())
+                .collect(Collectors.toList());
+
+        final boolean hasThorntailDeps = allDependencies.stream()
+                .anyMatch(a -> FractionDescriptor.THORNTAIL_GROUP_ID.equals(a.groupId())
+                        && DependencyManager.WILDFLY_SWARM_BOOTSTRAP_ARTIFACT_ID.equals(a.artifactId()));
+        getLogger().info("Thorntail dependencies detected: {}", hasThorntailDeps);
+
+        // automatic fraction detection
+        if (extension.getFractionDetectionMode() != BuildTool.FractionDetectionMode.never
+                && (extension.getFractionDetectionMode() == BuildTool.FractionDetectionMode.force
+                || !hasThorntailDeps)) {
+            getLogger().info("Detecting fractions.");
+
+            final FractionUsageAnalyzer analyzer = new FractionUsageAnalyzer(FractionList.get());
+            // always scan application source files
+            sourcePaths.forEach(analyzer::source);
+            // scan dependencies if indicated
+            if (scanDependencies) {
+                classpathEntries.forEach(analyzer::source);
+            }
+
+            final Set<FractionDescriptor> detectedFractions;
+            try {
+                detectedFractions = analyzer.detectNeededFractions()
+                        .stream()
+                        // filter out fractions already on classpath
+                        .filter(fd -> !allDependencies.contains(ArtifactSpec.fromFractionDescriptor(fd)))
+                        .collect(Collectors.toSet());
+                getLogger().info("Detected fractions:\n  {}",
+                        detectedFractions.stream().map(FractionDescriptor::gav)
+                                .collect(Collectors.joining(INDENTATION_DELIMITER)));
+            } catch (IOException e) {
+                throw new GradleException("Failed to scan for fractions.", e);
+            }
+
+            // exclude or add further fractions according to user config
+            extension.getFractions().forEach(f -> {
+                if (f.startsWith(EXCLUDE_PREFIX)) {
+                    FractionDescriptor toRemove = FractionDescriptor.fromGav(FractionList.get(), f.substring(1));
+                    getLogger().info("Excluding from detected fractions: {}", toRemove);
+                    detectedFractions.remove(toRemove);
+                } else {
+                    FractionDescriptor toAdd = FractionDescriptor.fromGav(FractionList.get(), f);
+                    getLogger().info("Adding to detected fractions: {}", toAdd);
+                    detectedFractions.add(toAdd);
+                }
+            });
+
+            // combine detected fractions with their dependent fractions
+            final Set<FractionDescriptor> fractionsWithDependencies = new HashSet<>(detectedFractions);
+            fractionsWithDependencies.addAll(detectedFractions.stream()
+                    .flatMap(f -> f.getDependencies().stream())
+                    .collect(Collectors.toSet()));
+
+            getLogger().info("Detected fractions including dependencies:\n  {}",
+                    fractionsWithDependencies.stream()
+                            .map(FractionDescriptor::gav)
+                            .sorted()
+                            .collect(Collectors.joining(INDENTATION_DELIMITER)));
+
+            final Set<ArtifactSpec> fractionsSpecs = fractionsWithDependencies.stream()
+                    .map(ArtifactSpec::fromFractionDescriptor)
+                    .collect(Collectors.toSet());
+
+            // resolve fraction artifacts and include into classpath entries
+            try {
+                List<Path> resolvedPaths = artifactResolvingHelper().resolveAll(fractionsSpecs).stream()
+                        .map(s -> s.file.toPath())
+                        .collect(Collectors.toList());
+                classpathEntries.addAll(resolvedPaths);
+            } catch (Exception e) {
+                throw new GradleException("Failed to resolve fraction dependencies.", e);
+            }
+        }
+
+        getLogger().info("Computed classpath entries:\n  {}",
+                classpathEntries.stream().map(Path::toString).collect(Collectors.joining(INDENTATION_DELIMITER)));
+
+        return classpathEntries;
+    }
+
+    private ArtifactResolvingHelper artifactResolvingHelper() {
+        return new GradleArtifactResolvingHelper(getProject());
+    }
+
+    private void stopProcess(SwarmProcess process) {
+        if (process != null && process.isAlive()) {
+            try {
+                process.stop(extension.getStopTimeout(), TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                // ignore
+            } finally {
+                process.destroyForcibly();
+            }
+        }
+    }
+
+    private void registerCancellationListeners(SwarmProcess process) {
+        // stop the thorntail process when the build is cancelled, e.g. via CTRL+C
+        BuildCancellationToken cancellationToken = getServices().get(BuildCancellationToken.class);
+        cancellationToken.addCallback(new Runnable() {
+            @Override
+            public void run() {
+                getLogger().info("Build cancelled, stopping the Thorntail process.");
+                stopProcess(process);
+                cancellationToken.removeCallback(this);
+            }
+        });
+
+        // stop the process when the build finishes - this is mainly for the case when the build fails and something
+        // prevents the stopTask from stopping the process
+        getProject().getGradle().addBuildListener(new BuildListener() {
+            @Override
+            public void buildStarted(Gradle gradle) {
+            }
+
+            @Override
+            public void settingsEvaluated(Settings settings) {
+            }
+
+            @Override
+            public void projectsLoaded(Gradle gradle) {
+            }
+
+            @Override
+            public void projectsEvaluated(Gradle gradle) {
+            }
+
+            @Override
+            public void buildFinished(BuildResult result) {
+                if (process != null && process.isAlive()) {
+                    getLogger().info("Build finished, but the Thorntail process is still active. Stopping it now.");
+                    stopProcess(process);
+                }
+            }
+        });
+    }
+
+    private Integer getDebugPort() {
+        Integer port = null;
+
+        // project property has the highest priority
+        final Object value = getProject().findProperty(DEBUG_PORT_PROPERTY);
+        if (value != null) {
+            try {
+                port = Integer.parseInt(String.valueOf(value));
+            } catch (NumberFormatException e) {
+                getLogger().error("Invalid number format for debug port: {}", value);
+            }
+        }
+
+        // then goes extension attribute
+        if (port == null) {
+            port = extension.getDebugPort();
+        }
+
+        if (port != null) {
+            getLogger().info("Waiting on debug port {}.", port);
+        }
+
+        return port;
+    }
+}

--- a/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/StopTask.java
+++ b/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/StopTask.java
@@ -1,0 +1,29 @@
+package org.wildfly.swarm.plugin.gradle;
+
+import java.util.concurrent.TimeUnit;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.TaskAction;
+import org.wildfly.swarm.tools.exec.SwarmProcess;
+
+public class StopTask extends DefaultTask {
+
+    @TaskAction
+    public void stopThorntailProcess() {
+        ThorntailExtension extension = getProject().getExtensions().getByType(ThorntailExtension.class);
+
+        SwarmProcess process = (SwarmProcess) getProject().findProperty(PackagePlugin.THORNTAIL_PROCESS_PROPERTY);
+        if (process == null) {
+            getLogger().error("No Thorntail process was found to stop.");
+            return;
+        }
+        try {
+            getLogger().info("Stopping Thorntail process.");
+            process.stop(extension.getStopTimeout(), TimeUnit.SECONDS);
+        } catch (InterruptedException ie) {
+            // Do nothing
+        } finally {
+            process.destroyForcibly();
+        }
+    }
+}

--- a/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/ThorntailExtension.java
+++ b/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/ThorntailExtension.java
@@ -17,6 +17,8 @@ package org.wildfly.swarm.plugin.gradle;
 
 import java.io.File;
 import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
@@ -59,6 +61,26 @@ public class ThorntailExtension implements ThorntailConfiguration {
     private BuildTool.FractionDetectionMode fractionDetectMode = BuildTool.FractionDetectionMode.when_missing;
 
     private boolean hollow = false;
+
+    private Integer debugPort = null;
+
+    private File stdoutFile;
+
+    private File stderrFile;
+
+    private List<String> arguments = new ArrayList<>();
+
+    private List<String> jvmArguments = new ArrayList<>();
+
+    private boolean useUberJar = false;
+
+    private int startTimeout = 120;
+
+    private int stopTimeout = 120;
+
+    private Properties environment = new Properties();
+
+    private File environmentFile;
 
     private Map<DependencyDescriptor, Set<DependencyDescriptor>> dependencyMap;
 
@@ -158,6 +180,86 @@ public class ThorntailExtension implements ThorntailConfiguration {
         this.executableScript = executableScript;
     }
 
+    @Override
+    public Integer getDebugPort() {
+        return debugPort;
+    }
+
+    @Override
+    public void setDebugPort(Integer debugPort) {
+        this.debugPort = debugPort;
+    }
+
+    @Override
+    public File getStdoutFile() {
+        return stdoutFile;
+    }
+
+    @Override
+    public void setStdoutFile(File file) {
+        this.stdoutFile = file;
+    }
+
+    @Override
+    public File getStderrFile() {
+        return stderrFile;
+    }
+
+    @Override
+    public void setStderrFile(File file) {
+        this.stderrFile = file;
+    }
+
+    @Override
+    public List<String> getArguments() {
+        return arguments;
+    }
+
+    @Override
+    public void setArguments(List<String> arguments) {
+        this.arguments = arguments;
+    }
+
+    @Override
+    public List<String> getJvmArguments() {
+        return jvmArguments;
+    }
+
+    @Override
+    public void setJvmArguments(List<String> arguments) {
+        this.jvmArguments = arguments;
+    }
+
+    @Override
+    public boolean isUseUberJar() {
+        return useUberJar;
+    }
+
+    @Override
+    public void setUseUberJar(boolean useUberJar) {
+        this.useUberJar = useUberJar;
+    }
+
+    @Override
+    public int getStartTimeout() {
+        return startTimeout;
+    }
+
+    @Override
+    public void setStartTimeout(int startTimeout) {
+        this.startTimeout = startTimeout;
+    }
+
+    @Override
+    public int getStopTimeout() {
+        return stopTimeout;
+    }
+
+    @Override
+    public void setStopTimeout(int stopTimeout) {
+        this.stopTimeout = stopTimeout;
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -172,6 +274,29 @@ public class ThorntailExtension implements ThorntailConfiguration {
     @Override
     public void setPropertiesFile(final File propertiesFile) {
         this.propertiesFile = propertiesFile;
+    }
+
+    public void environment(Closure<Properties> closure) {
+        ConfigObject config = new ConfigObject();
+        closure.setResolveStrategy(Closure.DELEGATE_ONLY);
+        closure.setDelegate(config);
+        closure.call();
+        config.flatten(this.environment);
+    }
+
+    @Override
+    public Properties getEnvironment() {
+        return environment;
+    }
+
+    @Override
+    public File getEnvironmentFile() {
+        return environmentFile;
+    }
+
+    @Override
+    public void setEnvironmentFile(File environmentFile) {
+        this.environmentFile = environmentFile;
     }
 
     /**

--- a/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/ThorntailUtils.java
+++ b/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/ThorntailUtils.java
@@ -1,0 +1,64 @@
+package org.wildfly.swarm.plugin.gradle;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.plugins.WarPlugin;
+import org.gradle.api.tasks.TaskCollection;
+import org.gradle.api.tasks.bundling.Jar;
+import org.wildfly.swarm.fractions.PropertiesUtil;
+
+public final class ThorntailUtils {
+
+    private static final Logger LOGGER = Logging.getLogger(ThorntailUtils.class);
+
+    private ThorntailUtils() {
+    }
+
+    public static Properties getPropertiesFromFile(File file) {
+        final Properties properties = new Properties();
+
+        if (file != null) {
+            try {
+                properties.putAll(PropertiesUtil.loadProperties(file));
+            } catch (IOException e) {
+                LOGGER.error("Failed to load properties from " + file, e);
+            }
+        }
+        return properties;
+    }
+
+    /**
+     * Returns the most suitable Archive-Task for wrapping in the swarm jar - in the following order:
+     * <p>
+     * 1. Custom-JAR-Task defined in ThorntailExtension 'archiveTask'
+     * 2. WAR-Task
+     * 3. JAR-Task
+     */
+    public static Jar getArchiveTask(Project project) {
+
+        TaskCollection<Jar> existingArchiveTasks = project.getTasks().withType(Jar.class);
+        Jar customArchiveTask = project.getExtensions().getByType(ThorntailExtension.class).getArchiveTask();
+
+        if (customArchiveTask != null) {
+            return existingArchiveTasks.getByName(customArchiveTask.getName());
+
+        } else if (existingArchiveTasks.findByName(WarPlugin.WAR_TASK_NAME) != null) {
+            return existingArchiveTasks.getByName(WarPlugin.WAR_TASK_NAME);
+
+        } else if (existingArchiveTasks.findByName(JavaPlugin.JAR_TASK_NAME) != null) {
+            return existingArchiveTasks.getByName(JavaPlugin.JAR_TASK_NAME);
+        }
+
+        throw new GradleException("Unable to detect Archive-Task: project contains neither 'war' nor 'jar', " +
+                "nor is custom Archive-Task specified in the \"thorntail\" extension.");
+    }
+
+
+}

--- a/plugins/gradle/tooling-api/src/main/java/org/wildfly/swarm/plugin/gradle/ThorntailConfiguration.java
+++ b/plugins/gradle/tooling-api/src/main/java/org/wildfly/swarm/plugin/gradle/ThorntailConfiguration.java
@@ -19,6 +19,7 @@ package org.wildfly.swarm.plugin.gradle;
 import java.io.File;
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -193,6 +194,143 @@ public interface ThorntailConfiguration extends Serializable {
      * @param script the executable file that should be included along with the archive.
      */
     void setExecutableScript(File script);
+
+    /**
+     * @see #setDebugPort(Integer)
+     */
+    Integer getDebugPort();
+
+    /**
+     * When set, Thorntail executor will wait for debugger connection on given port.
+     *
+     * Used by "thorntail-run" and "thorntail-start" tasks.
+     *
+     * @param debugPort debugging port.
+     */
+    void setDebugPort(Integer debugPort);
+
+    /**
+     * @see #setStdoutFile(File)
+     */
+    File getStdoutFile();
+
+    /**
+     * File to log Thorntail executor standard output into.
+     *
+     * Used by "thorntail-run" and "thorntail-start" tasks.
+     *
+     * @param file log file for standard output.
+     */
+    void setStdoutFile(File file);
+
+    /**
+     * @see #setStderrFile(File)
+     */
+    File getStderrFile();
+
+    /**
+     * File to log Thorntail executor error output into.
+     *
+     * Used by "thorntail-run" and "thorntail-start" tasks.
+     *
+     * @param file log file for error output.
+     */
+    void setStderrFile(File file);
+
+    /**
+     * @see #setArguments(List)
+     */
+    List<String> getArguments();
+
+    /**
+     * Arguments to be given to the application main class when executing Thorntail process.
+     *
+     * Used by "thorntail-run" and "thorntail-start" tasks.
+     *
+     * @param arguments arguments for application main class.
+     */
+    void setArguments(List<String> arguments);
+
+    /**
+     * @see #setJvmArguments(List)
+     */
+    List<String> getJvmArguments();
+
+    /**
+     * JVM arguments ti be used when executing Thorntail process.
+     *
+     * Used by "thorntail-run" and "thorntail-start" tasks.
+     *
+     * @param arguments JVM arguments for Thorntail process.
+     */
+    void setJvmArguments(List<String> arguments);
+
+    /**
+     * @see #setUseUberJar(boolean)
+     */
+    boolean isUseUberJar();
+
+    /**
+     * Instead of adding compiled project classes and project dependencies on the classpath, the Thorntail executor will
+     * directly execute the generated Uber-JAR.
+     *
+     * It is the responsibility of a user to ensure that the Uber-JAR exists and is up-to-date by running
+     * "thorntail-package" task as necessary.
+     *
+     * Used by "thorntail-run" and "thorntail-start" tasks.
+     *
+     * @param useUberJar if true execute an Uber-JAR, if false compute and set the classpath.
+     */
+    void setUseUberJar(boolean useUberJar);
+
+    /**
+     * @see #setStartTimeout(int)
+     */
+    int getStartTimeout();
+
+    /**
+     * Sets a timeout for the Thorntail application process to start.
+     *
+     * Used by "thorntail-run" and "thorntail-start" tasks.
+     *
+     * @param startTimeout timeout in seconds.
+     */
+    void setStartTimeout(int startTimeout);
+
+    /**
+     * @see #setStopTimeout(int)
+     */
+    int getStopTimeout();
+
+    /**
+     * Sets a timeout for the Thorntail application process to stop, before it's forcibly destroyed.
+     *
+     * Used by "thorntail-run" and "thorntail-stop" tasks.
+     *
+     * @param stopTimeout timeout in seconds.
+     */
+    void setStopTimeout(int stopTimeout);
+
+    /**
+     * Environment variables that will be set for the Thorntail process.
+     *
+     * Used by "thorntail-run" and "thorntail-start" tasks.
+     *
+     * @return environment variables.
+     */
+    Properties getEnvironment();
+
+    /**
+     * @see #setEnvironmentFile(File)
+     */
+    File getEnvironmentFile();
+
+    /**
+     * Property file containing environment variables to be given to the Thorntail process.
+     *
+     * @param environmentFile property file with environment variables.
+     */
+    void setEnvironmentFile(File environmentFile);
 
     /**
      * Get the version of the plugin configured for the Gradle project. This method is used to determine the version when not

--- a/tools/src/main/java/org/wildfly/swarm/tools/exec/SwarmProcess.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/exec/SwarmProcess.java
@@ -105,17 +105,6 @@ public class SwarmProcess {
 
         if (this.processFile != null) {
             this.processFile.delete();
-            long timeoutMillis = timeUnit.toMillis(timeout);
-            long initialTimeMillis = System.currentTimeMillis();
-            while (true) {
-                long currentTimeMillis = System.currentTimeMillis();
-                if (!process.isAlive() || (currentTimeMillis - initialTimeMillis) > timeoutMillis) {
-                    break;
-                }
-            }
-        }
-        if (!this.process.isAlive()) {
-            return process.exitValue();
         }
         this.process.destroy();
         if (!this.process.waitFor(timeout, timeUnit)) {


### PR DESCRIPTION
…ation

Motivation
----------
The ability to run Thorntail app directly from gradle would (1.) simplify running
functional tests in gradle projects and (2.) improve user experience.

Modifications
-------------
* Tasks "thorntail-[run|start|stop]" were added to the gradle plugin.
* Configuration properties relevant for running the app were added to
  ThorntailExtension of the gradle plugin.

Result
------
It is now possible to run the Thorntail application via "thorntail-run" gradle
task. The "thorntail-start" gradle task can be used to start the application
before integration tests are executed. User should arrange for the
"thorntail-stop" task to be run after integration tests to terminate the
application process. If the stop task is not invoked, the application process
will be terminated at the end of the build.

- [ ] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [ ] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
