### PR TITLE
THORN-2324: add toggle for filtering WEB-INF/lib

### DIFF
--- a/docs/modules/ref_thorntail-maven-plugin-configuration-options.adoc
+++ b/docs/modules/ref_thorntail-maven-plugin-configuration-options.adoc
@@ -66,6 +66,24 @@ A `.properties` file with environment variables to use when executing the applic
 |`multistart`, `run`, `start`
 |===
 
+filterWebInfLib::
+If true, the plugin will remove artifacts from the project WAR's `WEB-INF/lib` directory that are provided by the Thorntail runtime.
+Otherwise, the contents of `WEB-INF/lib` will remain untouched.
++
+[cols="1,2a"]
+|===
+|Property
+|`thorntail.filterWebInfLib`
+
+|Default
+|true
+
+|Used by
+|`package`
+|===
+
+NOTE: This option should generally not be necessary and is provided as a workaround in case the Thorntail plugin removes a dependency required by the application. When false, it is the developer's responsibility to ensure that the `WEB-INF/lib` directory does not contain Thorntail artifacts that would comprimise the functionality of the application. One way to do that is to avoid expressing dependencies on fractions and rely on xref:auto-detecting-fractions_{context}[auto-detection] and/or explicitly listing them with the *fractions* option detailed below.
+
 fractionDetectMode::
 +
 --

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/PackageMojo.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/PackageMojo.java
@@ -58,8 +58,8 @@ public class PackageMojo extends AbstractSwarmMojo {
     @Parameter(alias = "bundleDependencies", defaultValue = "true", property = "thorntail.bundleDependencies")
     protected boolean bundleDependencies;
 
-    @Parameter(alias = "filterWebinfLib", defaultValue = "true", property = "thorntail.filterWebinfLib")
-    protected boolean filterWebinfLib;
+    @Parameter(alias = "filterWebInfLib", defaultValue = "true", property = "thorntail.filterWebInfLib")
+    protected boolean filterWebInfLib;
 
     /**
      * Make a fully executable jar for *nix machines by prepending a launch script to the jar.
@@ -141,7 +141,7 @@ public class PackageMojo extends AbstractSwarmMojo {
                 .properties(this.properties)
                 .mainClass(this.mainClass)
                 .bundleDependencies(this.bundleDependencies)
-                .filterWebinfLib(this.filterWebinfLib)
+                .filterWebInfLib(this.filterWebInfLib)
                 .executable(executable)
                 .executableScript(executableScript)
                 .fractionDetectionMode(fractionDetectMode)

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/PackageMojo.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/PackageMojo.java
@@ -58,6 +58,9 @@ public class PackageMojo extends AbstractSwarmMojo {
     @Parameter(alias = "bundleDependencies", defaultValue = "true", property = "thorntail.bundleDependencies")
     protected boolean bundleDependencies;
 
+    @Parameter(alias = "filterWebinfLib", defaultValue = "true", property = "thorntail.filterWebinfLib")
+    protected boolean filterWebinfLib;
+
     /**
      * Make a fully executable jar for *nix machines by prepending a launch script to the jar.
      */
@@ -138,6 +141,7 @@ public class PackageMojo extends AbstractSwarmMojo {
                 .properties(this.properties)
                 .mainClass(this.mainClass)
                 .bundleDependencies(this.bundleDependencies)
+                .filterWebinfLib(this.filterWebinfLib)
                 .executable(executable)
                 .executableScript(executableScript)
                 .fractionDetectionMode(fractionDetectMode)

--- a/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
@@ -108,6 +108,11 @@ public class BuildTool {
         return this;
     }
 
+    public BuildTool filterWebinfLib(boolean filterWebinfLib) {
+        this.filterWebinfLib = filterWebinfLib;
+        return this;
+    }
+
     public BuildTool projectArtifact(String groupId, String artifactId, String version, String packaging, File file) {
         projectArtifact(groupId, artifactId, version, packaging, file, null);
 
@@ -208,7 +213,7 @@ public class BuildTool {
             original.as(ZipImporter.class).importFrom(inputStream);
         }
 
-        WebInfLibFilteringArchive repackaged = new WebInfLibFilteringArchive(original, this.dependencyManager);
+        Archive repackaged = this.filterWebinfLib ? new WebInfLibFilteringArchive(original, this.dependencyManager) : original;
         repackaged.as(ZipExporter.class).exportTo(file, true);
         this.log.info("Repackaged .war: " + file);
     }
@@ -315,7 +320,7 @@ public class BuildTool {
         if (this.hollow) {
             return;
         }
-        this.archive.add(new WebInfLibFilteringArchiveAsset(this.projectAsset, this.dependencyManager));
+        this.archive.add(this.filterWebinfLib ? new WebInfLibFilteringArchiveAsset(this.projectAsset, this.dependencyManager) : this.projectAsset);
     }
 
     private void detectFractions() throws Exception {
@@ -593,6 +598,8 @@ public class BuildTool {
     private String testClass;
 
     private boolean bundleDependencies = true;
+
+    private boolean filterWebinfLib = true;
 
     private boolean executable;
 

--- a/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
@@ -108,8 +108,8 @@ public class BuildTool {
         return this;
     }
 
-    public BuildTool filterWebinfLib(boolean filterWebinfLib) {
-        this.filterWebinfLib = filterWebinfLib;
+    public BuildTool filterWebInfLib(boolean filterWebInfLib) {
+        this.filterWebInfLib = filterWebInfLib;
         return this;
     }
 
@@ -213,7 +213,7 @@ public class BuildTool {
             original.as(ZipImporter.class).importFrom(inputStream);
         }
 
-        Archive repackaged = this.filterWebinfLib ? new WebInfLibFilteringArchive(original, this.dependencyManager) : original;
+        Archive repackaged = this.filterWebInfLib ? new WebInfLibFilteringArchive(original, this.dependencyManager) : original;
         repackaged.as(ZipExporter.class).exportTo(file, true);
         this.log.info("Repackaged .war: " + file);
     }
@@ -320,7 +320,7 @@ public class BuildTool {
         if (this.hollow) {
             return;
         }
-        this.archive.add(this.filterWebinfLib ? new WebInfLibFilteringArchiveAsset(this.projectAsset, this.dependencyManager) : this.projectAsset);
+        this.archive.add(this.filterWebInfLib ? new WebInfLibFilteringArchiveAsset(this.projectAsset, this.dependencyManager) : this.projectAsset);
     }
 
     private void detectFractions() throws Exception {
@@ -599,7 +599,7 @@ public class BuildTool {
 
     private boolean bundleDependencies = true;
 
-    private boolean filterWebinfLib = true;
+    private boolean filterWebInfLib = true;
 
     private boolean executable;
 


### PR DESCRIPTION
Motivation
----------
Provides the ability to deactivate the default filtering of JARs from
WEB-INF/lib when repacking WARs. This avoids situations where the
developer knows that no filtering is required but the plugin removes
required dependencies in error.

Modifications
-------------
A boolean property is added to the build tool and package mojo
controlling whether or not to filter WEB-INF/lib. The property defaults
to true in order to preserve existing behavior by default.

Result
------
Developers wishing to do so can set filterWebinfLib to false in their
poms to disabled fitlering in order to mitigated any issues caused by
the plugin. It will be up to the developer to ensure that any JARs in
WEB-INF/lib belong there.
