### PR TITLE
THORN-2319: Fraction 'full' does not contain JSON-B and EE Security f…

### DIFF
--- a/fractions/javaee/full/pom.xml
+++ b/fractions/javaee/full/pom.xml
@@ -93,6 +93,21 @@
     </dependency>
 
     <dependency>
+      <groupId>io.thorntail</groupId>
+      <artifactId>jsonb</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.thorntail</groupId>
+      <artifactId>jaxrs-jsonb</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.thorntail</groupId>
+      <artifactId>ee-security</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.wildfly.core</groupId>
       <artifactId>wildfly-core-feature-pack</artifactId>
       <type>zip</type>


### PR DESCRIPTION
…ractions

Motivation
----------
Fraction 'full' should contain all java ee related APIs. Above mentioned are missing.

Modifications
-------------
Added jsonb, jaxrs-jsonb and ee-security dependencies to full.

Result
------
Jsonb and security capabilities are available with 'full' fraction dependency.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
