### PR TITLE
THORN-2327: JSF fraction doesn't transitively bring in the JSF API

### DIFF
--- a/fractions/javaee/jsf/pom.xml
+++ b/fractions/javaee/jsf/pom.xml
@@ -52,6 +52,12 @@
       <artifactId>undertow</artifactId>
     </dependency>
 
+    <!-- Provided APIs -->
+    <dependency>
+      <groupId>org.jboss.spec.javax.faces</groupId>
+      <artifactId>jboss-jsf-api_2.3_spec</artifactId>
+    </dependency>
+
     <!-- Meta SPI -->
     <dependency>
       <groupId>io.thorntail</groupId>

--- a/testsuite/testsuite-jsf/src/main/java/org/wildfly/swarm/jsf/test/Action.java
+++ b/testsuite/testsuite-jsf/src/main/java/org/wildfly/swarm/jsf/test/Action.java
@@ -1,0 +1,12 @@
+package org.wildfly.swarm.jsf.test;
+
+import javax.enterprise.inject.Model;
+import javax.faces.application.FacesMessage;
+import javax.faces.context.FacesContext;
+
+@Model
+public class Action {
+    public void perform() {
+        FacesContext.getCurrentInstance().addMessage(null, new FacesMessage("Action message"));
+    }
+}

--- a/testsuite/testsuite-jsf/src/main/webapp/index.xhtml
+++ b/testsuite/testsuite-jsf/src/main/webapp/index.xhtml
@@ -1,7 +1,12 @@
 <?xml version='1.0' encoding='UTF-8' ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
       xmlns:h="http://xmlns.jcp.org/jsf/html">
+
+<f:metadata>
+    <f:viewAction action="${action.perform()}"/>
+</f:metadata>
 
 <h:head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
@@ -9,6 +14,8 @@
 </h:head>
 
 <h:body>
+    <h:messages/>
+
     <h:outputText value="#{hello.hello()}"/>
     <h:outputText value="#{helloBean.message}"/>
     <h:outputText value="#{libraryHelloBean.message}"/>

--- a/testsuite/testsuite-jsf/src/test/java/org/wildfly/swarm/jsf/test/JsfIT.java
+++ b/testsuite/testsuite-jsf/src/test/java/org/wildfly/swarm/jsf/test/JsfIT.java
@@ -35,6 +35,7 @@ public class JsfIT {
     @Test
     public void jsf() throws IOException, InterruptedException {
         String result = Request.Get("http://localhost:8080/index.jsf").execute().returnContent().asString();
+        assertThat(result).contains("Action message");
         assertThat(result).contains("Hello from JSF");
         assertThat(result).contains("Message from faces-config.xml bean");
         assertThat(result).contains("Message from custom-library.faces-config.xml bean");


### PR DESCRIPTION
Motivation
----------
Depending on `io.thorntail:jsf` isn't enough to bring in the JSF API,
which can be demonstrated by using some `javax.faces.*` classes.

Modifications
-------------
Add the JBoss JSF API as a dependency of `io.thorntail:jsf`.

Result
------
Depending on the JSF fraction now brings in the JSF API.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
