### PR TITLE
THORN-2335: Invalid META-INF/services record in microprofile-restclie…

### DIFF
--- a/fractions/microprofile/microprofile-restclient/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
+++ b/fractions/microprofile/microprofile-restclient/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
@@ -1,1 +1,0 @@
-org.wildfly.swarm.microprofile.restclient.deployment.RestClientExtension


### PR DESCRIPTION
…nt fraction

Motivation
----------
Service file META-INF/services/javax.enterprise.inject.spi.Extension in MP rest
client fraction contains record:

org.wildfly.swarm.microprofile.restclient.deployment.RestClientExtension

This file doesn't exist anymore.

Modifications
-------------
The file META-INF/services/javax.enterprise.inject.spi.Extension was removed.

Result
------
No functional changes.