### PR TITLE
THORN-2322: Thorntail Maven Plugin Strips Required Dependencies from …

### DIFF
--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/DependencyTree.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/env/DependencyTree.java
@@ -16,15 +16,16 @@
 package org.wildfly.swarm.bootstrap.env;
 
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Each direct dependency (parent) keeps a bucket of transient dependencies (children)
  * so we can infer the origin (parent) for each transient dependency.
+ *
+ * Insertion order of dependencies is preserved.
  *
  * @author Heiko Braun
  * @author Ken Finnigan
@@ -38,7 +39,7 @@ public class DependencyTree<T> {
      * @param parent
      */
     public void add(T parent, T child) {
-        final Set<T> children = depTree.computeIfAbsent(parent, p -> new HashSet<>());
+        final Set<T> children = depTree.computeIfAbsent(parent, p -> new LinkedHashSet<>());
         if (!child.equals(parent)) {
             children.add(child);
         }
@@ -50,15 +51,11 @@ public class DependencyTree<T> {
      * @param parent
      */
     public void add(T parent) {
-        depTree.computeIfAbsent(parent, p -> new HashSet<>());
+        depTree.computeIfAbsent(parent, p -> new LinkedHashSet<>());
     }
 
     public Collection<T> getDirectDeps() {
-        return depTree
-                .keySet()
-                .stream()
-                .sorted(this::comparator)
-                .collect(Collectors.toList());
+        return depTree.keySet();
     }
 
     /**
@@ -71,10 +68,6 @@ public class DependencyTree<T> {
         return depTree.containsKey(parent);
     }
 
-    protected int comparator(T first, T second) {
-        return 0;
-    }
-
     public Collection<T> getTransientDeps(T parent) {
         Set<T> deps = depTree.get(parent);
         if (null == deps) {
@@ -83,6 +76,6 @@ public class DependencyTree<T> {
         return deps;
     }
 
-    private Map<T, Set<T>> depTree = new HashMap<>();
+    private Map<T, Set<T>> depTree = new LinkedHashMap<>();
 
 }

--- a/core/bootstrap/src/test/java/org/wildfly/swarm/bootstrap/env/DependencyTreeTest.java
+++ b/core/bootstrap/src/test/java/org/wildfly/swarm/bootstrap/env/DependencyTreeTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2015-2019 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.bootstrap.env;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+import org.jboss.modules.maven.ArtifactCoordinates;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DependencyTreeTest {
+
+    private DependencyTree<ArtifactCoordinates> tree = new DependencyTree<>();
+
+    @Test
+    public void testDirectDepsOrder() {
+        tree.add(ArtifactCoordinates.fromString("g:a:2.0"));
+        tree.add(ArtifactCoordinates.fromString("g:a:1.0"));
+        tree.add(ArtifactCoordinates.fromString("g:a:3.0"));
+        tree.add(ArtifactCoordinates.fromString("g:a:4.0"));
+        tree.add(ArtifactCoordinates.fromString("g:a:5.0"));
+        tree.add(ArtifactCoordinates.fromString("g:a:6.0"));
+        tree.add(ArtifactCoordinates.fromString("g:a:7.0"));
+        tree.add(ArtifactCoordinates.fromString("g:a:1.5"));
+
+        Collection<ArtifactCoordinates> directDeps = tree.getDirectDeps();
+        Iterator<ArtifactCoordinates> iterator = directDeps.iterator();
+
+        Assert.assertEquals("2.0", iterator.next().getVersion());
+        Assert.assertEquals("1.0", iterator.next().getVersion());
+        Assert.assertEquals("3.0", iterator.next().getVersion());
+        Assert.assertEquals("4.0", iterator.next().getVersion());
+        Assert.assertEquals("5.0", iterator.next().getVersion());
+        Assert.assertEquals("6.0", iterator.next().getVersion());
+        Assert.assertEquals("7.0", iterator.next().getVersion());
+        Assert.assertEquals("1.5", iterator.next().getVersion());
+    }
+
+    @Test
+    public void testTransitiveDepsOrder() {
+        ArtifactCoordinates parent = ArtifactCoordinates.fromString("g:a:v");
+        tree.add(parent, ArtifactCoordinates.fromString("g:a:2.0"));
+        tree.add(parent, ArtifactCoordinates.fromString("g:a:1.0"));
+        tree.add(parent, ArtifactCoordinates.fromString("g:a:3.0"));
+        tree.add(parent, ArtifactCoordinates.fromString("g:a:4.0"));
+        tree.add(parent, ArtifactCoordinates.fromString("g:a:5.0"));
+        tree.add(parent, ArtifactCoordinates.fromString("g:a:6.0"));
+        tree.add(parent, ArtifactCoordinates.fromString("g:a:7.0"));
+        tree.add(parent, ArtifactCoordinates.fromString("g:a:1.5"));
+
+        Collection<ArtifactCoordinates> transientDeps = tree.getTransientDeps(parent);
+        Iterator<ArtifactCoordinates> iterator = transientDeps.iterator();
+
+        Assert.assertEquals("2.0", iterator.next().getVersion());
+        Assert.assertEquals("1.0", iterator.next().getVersion());
+        Assert.assertEquals("3.0", iterator.next().getVersion());
+        Assert.assertEquals("4.0", iterator.next().getVersion());
+        Assert.assertEquals("5.0", iterator.next().getVersion());
+        Assert.assertEquals("6.0", iterator.next().getVersion());
+        Assert.assertEquals("7.0", iterator.next().getVersion());
+        Assert.assertEquals("1.5", iterator.next().getVersion());
+    }
+}

--- a/tools/src/test/java/org/wildfly/swarm/tools/DeclaredDependenciesTest.java
+++ b/tools/src/test/java/org/wildfly/swarm/tools/DeclaredDependenciesTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2015-2019 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.tools;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.stream.Stream;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DeclaredDependenciesTest {
+
+    private static final String COMPILE = "compile";
+    private static final String PROVIDED = "provided";
+    private static final String TEST = "test";
+
+    private DeclaredDependencies declaredDependencies = new DeclaredDependencies();
+
+    @Test
+    public void testUnsolvedDirect() {
+        dependencyStream().forEach(declaredDependencies::add);
+
+        Collection<ArtifactSpec> directDependencies = declaredDependencies.getDirectDependencies(true, false);
+        Iterator<ArtifactSpec> iterator = directDependencies.iterator();
+
+        assertOrder(iterator);
+    }
+
+    private ArtifactSpec createSpec(String gav, String scope) {
+        String[] parts = gav.split(":");
+        return new ArtifactSpec(scope, parts[0], parts[1], parts[2], "jar", null, null);
+    }
+
+    private Stream<ArtifactSpec> dependencyStream() {
+        ArrayList<ArtifactSpec> list = new ArrayList<>();
+        list.add(createSpec("g:a:1.0", COMPILE));
+        list.add(createSpec("g:a:3.0", PROVIDED));
+        list.add(createSpec("g:a:2.0", TEST));
+        list.add(createSpec("g:a:5.0", TEST));
+        list.add(createSpec("g:a:4.0", PROVIDED));
+        list.add(createSpec("g:a:6.0", TEST));
+        list.add(createSpec("g:a:7.0", COMPILE));
+        list.add(createSpec("g:a:8.0", TEST));
+        return list.stream();
+    }
+
+    private void assertOrder(Iterator<ArtifactSpec> iterator) {
+        // compile and provided scopes first
+        Assert.assertEquals("1.0", iterator.next().version());
+        Assert.assertEquals("3.0", iterator.next().version());
+        Assert.assertEquals("4.0", iterator.next().version());
+        Assert.assertEquals("7.0", iterator.next().version());
+        // test scope second
+        Assert.assertEquals("2.0", iterator.next().version());
+        Assert.assertEquals("5.0", iterator.next().version());
+        Assert.assertEquals("6.0", iterator.next().version());
+        Assert.assertEquals("8.0", iterator.next().version());
+    }
+}


### PR DESCRIPTION
…WEB-INF/lib

Motivation
----------
DeclaredDependencies#getDirectDeps() doesn't maintain the order of direct
dependencies as they were specified in the POM. Those direct dependencies are
then going to be passed for resolution in a random order, which may lead to
different transitive dependencies versions being resolved (compared to what
Maven originally resolved). Later, those wrong dependencies versions break
dependency analysis during repackaging.

Modifications
-------------
DeclaredDependencies#getDirectDeps() returns dependencies ordered so that
compile and provided deps come before the rest, however inside those two groups
the original insertion order is maintained.

Result
------
Valid dependencies are no longer removed.

- [ ] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [ ] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
