### PR TITLE
THORN-2350: upgrade to fraction plugin 94

### DIFF
--- a/boms/src/main/resources/generated-project-template.xml
+++ b/boms/src/main/resources/generated-project-template.xml
@@ -36,14 +36,6 @@
 
   <dependencies>
     FRACTIONS_FROM_BOM
-
-    <dependency>
-      <groupId>io.thorntail</groupId>
-      <artifactId>fraction-metadata</artifactId>
-      <version>SWARM_VERSION</version>
-      <scope>provided</scope>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -22,7 +22,7 @@
   <description>Build Parent to bring in required dependencies</description>
 
   <properties>
-    <version.thorntail.fraction.plugin>93</version.thorntail.fraction.plugin>
+    <version.thorntail.fraction.plugin>94</version.thorntail.fraction.plugin>
 
     <version.thorntail-jdk-specific>1</version.thorntail-jdk-specific>
 


### PR DESCRIPTION
Motivation
----------
Fraction plugin version 94 fixes THORN-2349.

Modifications
-------------
Upgrades to fraction plugin version 94.

In addition to that, this also fixes the template of an artificial
Maven project used for generating an offline Maven repo. It used
to hardcode a dependency on `io.thorntail:fraction-metadata`, but
this dependency is always present in the Thorntail BOM and so is
always added when adding all artifacts from the BOM.

Result
------
Generating offline Maven repository works fine again.

- [ ] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [ ] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
