### PR TITLE
THORN-2340: update OpenShift REST Client Java to 7.0.0

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -67,14 +67,9 @@
 
     <version.com.orbitz.consul>1.2.1</version.com.orbitz.consul>
 
-    <!-- TODO update to 7.0.0.Final when released -->
-    <version.openshift.client>6.1.2.Final</version.openshift.client>
-    <!-- TODO update to whatever OpenShift Java Rest Client uses when updated to 7.0.0.Final; currently it's 3.11.0 -->
+    <version.openshift.client>7.0.0.Final</version.openshift.client>
     <version.com.squareup.okhttp>3.9.0</version.com.squareup.okhttp>
-    <!-- TODO remove the okhttp-openshift stuff when updating OpenShift Java Rest Client to 7.0.0.Final -->
-    <!-- THORN-2165 Align okhttp and okhttp-ws for topology-openshift as there is API dependency and okhttp-ws has older version -->
-    <version.com.squareup.okhttp-openshift>3.4.2</version.com.squareup.okhttp-openshift>
-    <version.com.squareup.okio>1.9.0</version.com.squareup.okio>
+    <version.com.squareup.okio>1.13.0</version.com.squareup.okio>
 
     <version.vertx>3.3.3</version.vertx>
 
@@ -418,6 +413,26 @@
         <groupId>com.openshift</groupId>
         <artifactId>openshift-restclient-java</artifactId>
         <version>${version.openshift.client}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp</artifactId>
+        <version>${version.com.squareup.okhttp}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.squareup.okio</groupId>
+        <artifactId>okio</artifactId>
+        <version>${version.com.squareup.okio}</version>
       </dependency>
 
       <!-- MicroProfile -->
@@ -541,21 +556,6 @@
       </dependency>
 
       <!-- The following are not used, they are here to make PME align proper versions-->
-      <dependency>
-        <groupId>com.squareup.okhttp3</groupId>
-        <artifactId>okhttp</artifactId>
-        <version>${version.com.squareup.okhttp}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.squareup.okhttp3</groupId>
-        <artifactId>okhttp-ws</artifactId>
-        <version>${version.com.squareup.okhttp-openshift}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.squareup.okio</groupId>
-        <artifactId>okio</artifactId>
-        <version>${version.com.squareup.okio}</version>
-      </dependency>
       <dependency>
           <groupId>org.apache.thrift</groupId>
           <artifactId>libthrift</artifactId>

--- a/fractions/topology-openshift/src/main/resources/modules/com/squareup/okhttp3/main/module.xml
+++ b/fractions/topology-openshift/src/main/resources/modules/com/squareup/okhttp3/main/module.xml
@@ -1,7 +1,6 @@
 <module xmlns="urn:jboss:module:1.3" name="com.squareup.okhttp3">
   <resources>
-    <artifact name="com.squareup.okhttp3:okhttp:${version.com.squareup.okhttp-openshift}"/>
-    <artifact name="com.squareup.okhttp3:okhttp-ws:${version.com.squareup.okhttp-openshift}"/>
+    <artifact name="com.squareup.okhttp3:okhttp:${version.com.squareup.okhttp}"/>
   </resources>
 
   <dependencies>


### PR DESCRIPTION
Motivation
----------
OpenShift REST Client Java 7.0.0.Final has been released,
which depends on OkHttp 3.11.0. This means we can unify
our OkHttp versions once again, after having to split
in THORN-2165.

Modifications
-------------
OpenShift REST Client Java was updated to 7.0.0.Final.

The OkHttp library is kept on 3.9.0 to ease dependency
alignment for product.

The Okio library was updated to 1.13.0 because that's
what OkHttp 3.9.0 uses.

Result
------
Single version of OkHttp across all fractions.
No behavioral difference.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
