### PR TITLE
THORN-2352: Making it much simpler to configure microprofile-jwt

### DIFF
--- a/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/runtime/MPJWTLoginModuleCustomizer.java
+++ b/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/runtime/MPJWTLoginModuleCustomizer.java
@@ -67,7 +67,8 @@ public class MPJWTLoginModuleCustomizer implements Customizer {
      * Realm name
      */
     @Configurable("thorntail.microprofile.jwtauth.realm")
-    @AttributeDocumentation("Realm name")
+    @AttributeDocumentation("If set, a security domain with this name that supports MicroProfile JWT is automatically created"
+                             + "in the security subsystem. The realmName parameter of the @LoginConfig annotation must be set to the same value.")
     private Defaultable<String> jwtRealm = string("");
 
     /**

--- a/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/runtime/MPJWTLoginModuleCustomizer.java
+++ b/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/runtime/MPJWTLoginModuleCustomizer.java
@@ -44,7 +44,7 @@ public class MPJWTLoginModuleCustomizer implements Customizer {
             security.securityDomain(jwtRealm.get(), (domain) -> {
                 domain.jaspiAuthentication((auth) -> {
                     auth.loginModuleStack("roles-lm-stack", (stack) -> {
-                        stack.loginModule("rm", (module) -> {
+                        stack.loginModule("0", (module) -> {
                             module.code("org.wildfly.swarm.microprofile.jwtauth.deployment.auth.jaas.JWTLoginModule");
                             module.flag(Flag.REQUIRED);
                             if (!rolesPropertiesFile.get().isEmpty()) {
@@ -66,14 +66,14 @@ public class MPJWTLoginModuleCustomizer implements Customizer {
     /**
      * Realm name
      */
-    @Configurable("thorntail.microprofile.jwt.realm")
+    @Configurable("thorntail.microprofile.jwtauth.realm")
     @AttributeDocumentation("Realm name")
     private Defaultable<String> jwtRealm = string("");
 
     /**
      * Roles properties file path
      */
-    @Configurable("thorntail.microprofile.jwt.roles.file")
+    @Configurable("thorntail.microprofile.jwtauth.roles.file")
     @AttributeDocumentation("Roles properties file path")
     private Defaultable<String> rolesPropertiesFile = string("");
 }

--- a/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/runtime/MPJWTLoginModuleCustomizer.java
+++ b/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/runtime/MPJWTLoginModuleCustomizer.java
@@ -67,8 +67,8 @@ public class MPJWTLoginModuleCustomizer implements Customizer {
      * Realm name
      */
     @Configurable("thorntail.microprofile.jwtauth.realm")
-    @AttributeDocumentation("If set, a security domain with this name that supports MicroProfile JWT is automatically created"
-                             + "in the security subsystem. The realmName parameter of the @LoginConfig annotation must be set to the same value.")
+    @AttributeDocumentation("If set, a security domain with this name that supports MicroProfile JWT is automatically created in the security subsystem."
+                            + " The realmName parameter of the @LoginConfig annotation must be set to the same value.")
     private Defaultable<String> jwtRealm = string("");
 
     /**

--- a/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/runtime/MPJWTLoginModuleCustomizer.java
+++ b/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/runtime/MPJWTLoginModuleCustomizer.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.jwtauth.runtime;
+
+import static org.wildfly.swarm.spi.api.Defaultable.string;
+
+import java.io.IOException;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.jboss.modules.ModuleLoadException;
+import org.wildfly.swarm.config.runtime.AttributeDocumentation;
+import org.wildfly.swarm.config.security.Flag;
+import org.wildfly.swarm.security.SecurityFraction;
+import org.wildfly.swarm.spi.api.Customizer;
+import org.wildfly.swarm.spi.api.Defaultable;
+import org.wildfly.swarm.spi.api.annotations.Configurable;
+import org.wildfly.swarm.spi.runtime.annotations.Post;
+
+@Post
+@ApplicationScoped
+public class MPJWTLoginModuleCustomizer implements Customizer {
+
+    @Inject
+    SecurityFraction security;
+
+    @Override
+    public void customize() throws ModuleLoadException, IOException {
+        if (!jwtRealm.get().isEmpty() && security.subresources().securityDomain(jwtRealm.get()) == null) {
+            security.securityDomain(jwtRealm.get(), (domain) -> {
+                domain.jaspiAuthentication((auth) -> {
+                    auth.loginModuleStack("roles-lm-stack", (stack) -> {
+                        stack.loginModule("rm", (module) -> {
+                            module.code("org.wildfly.swarm.microprofile.jwtauth.deployment.auth.jaas.JWTLoginModule");
+                            module.flag(Flag.REQUIRED);
+                            if (!rolesPropertiesFile.get().isEmpty()) {
+                                module.moduleOption("rolesProperties", rolesPropertiesFile.get());
+                            }
+                        });
+                    });
+                    auth.authModule("http", (module) -> {
+                        module.code("org.wildfly.extension.undertow.security.jaspi.modules.HTTPSchemeServerAuthModule");
+                        module.module("org.wildfly.extension.undertow");
+                        module.flag(Flag.REQUIRED);
+                        module.loginModuleStackRef("roles-lm-stack");
+                    });
+                });
+            });
+        }
+    }
+
+    /**
+     * Realm name
+     */
+    @Configurable("thorntail.microprofile.jwt.realm")
+    @AttributeDocumentation("Realm name")
+    private Defaultable<String> jwtRealm = string("");
+
+    /**
+     * Roles properties file path
+     */
+    @Configurable("thorntail.microprofile.jwt.roles.file")
+    @AttributeDocumentation("Roles properties file path")
+    private Defaultable<String> rolesPropertiesFile = string("");
+}

--- a/testsuite/testsuite-microprofile-jwt/src/test/java/org/wildfly/swarm/microprofile/jwtauth/roles/RolesAllowedSimpleConfigEmptyPropsTest.java
+++ b/testsuite/testsuite-microprofile-jwt/src/test/java/org/wildfly/swarm/microprofile/jwtauth/roles/RolesAllowedSimpleConfigEmptyPropsTest.java
@@ -1,0 +1,31 @@
+/*
+ *   Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package org.wildfly.swarm.microprofile.jwtauth.roles;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.Archive;
+
+public class RolesAllowedSimpleConfigEmptyPropsTest extends AbstractRolesAllowedTest {
+
+    @Deployment
+    public static Archive<?> createDeployment() throws Exception {
+        return initDeployment().addAsResource("project-simple-config-empty-roles.yml", "project-defaults.yml")
+                               .addAsResource("emptyRoles.properties");
+    }
+    
+
+}

--- a/testsuite/testsuite-microprofile-jwt/src/test/java/org/wildfly/swarm/microprofile/jwtauth/roles/RolesAllowedSimpleConfigNoPropsTest.java
+++ b/testsuite/testsuite-microprofile-jwt/src/test/java/org/wildfly/swarm/microprofile/jwtauth/roles/RolesAllowedSimpleConfigNoPropsTest.java
@@ -1,0 +1,30 @@
+/*
+ *   Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package org.wildfly.swarm.microprofile.jwtauth.roles;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.Archive;
+
+public class RolesAllowedSimpleConfigNoPropsTest extends AbstractRolesAllowedTest {
+
+    @Deployment
+    public static Archive<?> createDeployment() throws Exception {
+        return initDeployment().addAsResource("project-simple-config-no-roles.yml", "project-defaults.yml");
+    }
+    
+
+}

--- a/testsuite/testsuite-microprofile-jwt/src/test/resources/project-simple-config-empty-roles.yml
+++ b/testsuite/testsuite-microprofile-jwt/src/test/resources/project-simple-config-empty-roles.yml
@@ -1,6 +1,6 @@
-thorntail:
+swarm:
   microprofile:
-    jwt:
+    jwtauth:
       realm: testSuiteRealm
       roles:
         file: emptyRoles.properties

--- a/testsuite/testsuite-microprofile-jwt/src/test/resources/project-simple-config-empty-roles.yml
+++ b/testsuite/testsuite-microprofile-jwt/src/test/resources/project-simple-config-empty-roles.yml
@@ -1,0 +1,8 @@
+thorntail:
+  microprofile:
+    jwt:
+      realm: testSuiteRealm
+      roles:
+        file: emptyRoles.properties
+      token:
+        issuedBy: "http://testsuite-jwt-issuer.io"

--- a/testsuite/testsuite-microprofile-jwt/src/test/resources/project-simple-config-no-roles.yml
+++ b/testsuite/testsuite-microprofile-jwt/src/test/resources/project-simple-config-no-roles.yml
@@ -1,6 +1,6 @@
 thorntail:
   microprofile:
-    jwt:
+    jwtauth:
       realm: testSuiteRealm
       token:
         issuedBy: "http://testsuite-jwt-issuer.io"

--- a/testsuite/testsuite-microprofile-jwt/src/test/resources/project-simple-config-no-roles.yml
+++ b/testsuite/testsuite-microprofile-jwt/src/test/resources/project-simple-config-no-roles.yml
@@ -1,0 +1,6 @@
+thorntail:
+  microprofile:
+    jwt:
+      realm: testSuiteRealm
+      token:
+        issuedBy: "http://testsuite-jwt-issuer.io"


### PR DESCRIPTION
Motivation
----------
Microprofile-jwt login module configuration is complex, would be good to let users type just a couple of YAML lines instead  

Modifications
-------------
MPJWTLoginModuleCustomizer is introduced. It supports two new properties, `thorntail.microprofile.jwtauth.realm` to let users customize the name of the security domain and `thorntail.microprofile.jwtauth.roles.file` to let users customize the location of the roles properties file. `thorntail.microprofile.jwtauth.roles.map` to inline the roles mapping in the YAML can be supported next

Result
------
Significantly simpler microprofile-jwt configuration is possible, with the current configuration format still being supported