### PR TITLE
THORN-2360: fix MySQL JDBC driver autodetection

### DIFF
--- a/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/DriverInfo.java
+++ b/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/DriverInfo.java
@@ -229,6 +229,10 @@ public abstract class DriverInfo {
         return System.getProperty("os.name").toLowerCase().contains("win");
     }
 
+    protected boolean isClassPresent(String clazz) {
+        return findLocationOfClass(clazz) != null;
+    }
+
     public boolean isInstalled() {
         return this.installed;
     }

--- a/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/drivers/MySQLDriverInfo.java
+++ b/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/drivers/MySQLDriverInfo.java
@@ -41,7 +41,13 @@ public class MySQLDriverInfo extends DriverInfo {
 
     @Override
     protected void configureDriver(JDBCDriver driver) {
-        driver.driverXaDatasourceClassName("com.mysql.jdbc.jdbc2.optional.MysqlXADataSource");
+        if (isClassPresent("com.mysql.cj.jdbc.MysqlXADataSource")) {
+            // MySQL Connector/J 8.0
+            driver.driverXaDatasourceClassName("com.mysql.cj.jdbc.MysqlXADataSource");
+        } else {
+            // MySQL Connector/J 5.1
+            driver.driverXaDatasourceClassName("com.mysql.jdbc.jdbc2.optional.MysqlXADataSource");
+        }
     }
 
     @Override


### PR DESCRIPTION
Motivation
----------
The XA datasource class in the MySQL JDBC driver has changed
between versions 5.1 and 8.0. We currently always set
the XA datasource class for version 5.1, which doesn't work
when version 8.0 is present.

Modifications
-------------
Set the correct XA datasource class of the MySQL JDBC driver
based on presence of the 8.0 class. If the 8.0 class is present,
it will be used, otherwise the 5.1 class will be set.

Result
------
MySQL JDBC driver autodetection works fine with MySQL JDBC driver
versions 5.1 and 8.0.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
