### PR TITLE
THORN-2364: wrong "thorntail.batch" prefix in the Batch fraction docs, should be "thorntail.batch-jberet"

### DIFF
--- a/fractions/javaee/batch-jberet/src/main/java/org/wildfly/swarm/batch/jberet/BatchFraction.java
+++ b/fractions/javaee/batch-jberet/src/main/java/org/wildfly/swarm/batch/jberet/BatchFraction.java
@@ -26,6 +26,7 @@ import org.wildfly.swarm.config.batch.jberet.JDBCJobRepository;
 import org.wildfly.swarm.config.batch.jberet.ThreadPool;
 import org.wildfly.swarm.datasources.DatasourcesFraction;
 import org.wildfly.swarm.spi.api.Fraction;
+import org.wildfly.swarm.spi.api.annotations.Configurable;
 import org.wildfly.swarm.spi.api.annotations.MarshalDMR;
 import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
 
@@ -36,6 +37,7 @@ import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
  */
 @WildFlyExtension(module = "org.wildfly.extension.batch.jberet")
 @MarshalDMR
+@Configurable("thorntail.batch-jberet")
 public class BatchFraction extends BatchJBeret<BatchFraction> implements Fraction<BatchFraction> {
     public static final String DEFAULT_JOB_REPOSITORY_NAME = "in-memory";
 


### PR DESCRIPTION
Motivation
----------
Our docs say that the Batch fraction is configured using
`thorntail.batch.*` properties. That, however, is wrong.
The correct prefix is `thorntail.batch-jberet.*`.

Modifications
-------------
Add the `@Configurable` annotation on the fraction class.

Result
------
Correct docs for the Batch fraction.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
