### PR TITLE
THORN-2366: documentation still tells users to define "xa-datasource-name" for datasources

### DIFF
--- a/docs/howto/create-a-datasource/src/main/resources/project-defaults.yml
+++ b/docs/howto/create-a-datasource/src/main/resources/project-defaults.yml
@@ -13,8 +13,7 @@ thorntail:
     jdbc-drivers:
       # tag::driver[]
       myh2:
-        driver-class-name: org.h2.Driver
-        xa-datasource-name: org.h2.jdbcx.JdbcDataSource
         driver-module-name: com.h2database.h2
+        driver-xa-datasource-class-name: org.h2.jdbcx.JdbcDataSource
       # end::driver[]
 # end::all[]

--- a/docs/howto/test-in-container/src/main/resources/project-defaults.yml
+++ b/docs/howto/test-in-container/src/main/resources/project-defaults.yml
@@ -8,6 +8,5 @@ thorntail:
         password: sa
     jdbc-drivers:
       myh2:
-        driver-class-name: org.h2.Driver
-        xa-datasource-name: org.h2.jdbcx.JdbcDataSource
         driver-module-name: com.h2database.h2
+        driver-xa-datasource-class-name: org.h2.jdbcx.JdbcDataSource

--- a/docs/howto/use-a-bom/src/main/resources/project-defaults.yml
+++ b/docs/howto/use-a-bom/src/main/resources/project-defaults.yml
@@ -12,7 +12,6 @@ thorntail:
     jdbc-drivers:
       ### [driver]
       myh2:
-        driver-class-name: org.h2.Driver
-        xa-datasource-name: org.h2.jdbcx.JdbcDataSource
         driver-module-name: com.h2database.h2
+        driver-xa-datasource-class-name: org.h2.jdbcx.JdbcDataSource
       ### [driver]

--- a/testsuite/testsuite-datasources-config/src/main/resources/project-stages.yml
+++ b/testsuite/testsuite-datasources-config/src/main/resources/project-stages.yml
@@ -9,6 +9,5 @@ swarm:
         password: sa
     jdbc-drivers:
       myh2:
-        driver-class-name: org.h2.Driver
-        xa-datasource-name: org.h2.jdbcx.JdbcDataSource
         driver-module-name: com.h2database.h2
+        driver-xa-datasource-class-name: org.h2.jdbcx.JdbcDataSource


### PR DESCRIPTION
Motivation
----------
As we found in the past in THORN-1215, the WildFly's `datasources`
subsystem management model has a usability issue (WFLY-8718) in that
it has two similarly named attributes `xa-datasource-class` and
`driver-xa-datasource-class-name`. The first one is useless, but
our documentation still says on several places that users should
define it. We need to fix the docs to refer to the second attribute
instead.

Modifications
-------------
Replaced all references to `xa-datasource-class`
by `driver-xa-datasource-class-name`.

Result
------
Documentation for defining a JDBC driver is finally correct.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
