### PR TITLE
THORN-2367: some documentation parts still use the "swarm.*" prefix instead of "thorntail.*"

### DIFF
--- a/docs/howto/enabling-logging/index.adoc
+++ b/docs/howto/enabling-logging/index.adoc
@@ -30,6 +30,6 @@ Verify it contains the following coordinates. If it does not, add them.
 $ mvn thorntail:run -Dthorntail.logging=FINE
 ----
 
-See the link:https://wildfly-swarm.github.io/wildfly-swarm-javadocs/{version}/apidocs/org/wildfly/swarm/config/logging/Level.html[`org.wildfly.swarm.config.logging.Level`] class for the list of available levels.
+See the link:https://thorntail.github.io/javadocs/{version}/apidocs/org/wildfly/swarm/config/logging/Level.html[`org.wildfly.swarm.config.logging.Level`] class for the list of available levels.
 --
 

--- a/docs/modules/ref_commonly-used-system-properties.adoc
+++ b/docs/modules/ref_commonly-used-system-properties.adoc
@@ -5,7 +5,7 @@
 This is a non-exhaustive list of system properties you are likely to use in your application:
 
 .General system properties
-swarm.bind.address:: The interface to bind servers
+thorntail.bind.address:: The interface to bind servers
 +
 [cols="1,2a"]
 |===
@@ -13,7 +13,7 @@ swarm.bind.address:: The interface to bind servers
 |0.0.0.0
 |===
 
-swarm.port.offset:: The global port adjustment
+thorntail.port.offset:: The global port adjustment
 +
 [cols="1,2a"]
 |===
@@ -21,7 +21,7 @@ swarm.port.offset:: The global port adjustment
 |0
 |===
 
-swarm.context.path:: The context path for the deployed application
+thorntail.context.path:: The context path for the deployed application
 +
 [cols="1,2a"]
 |===
@@ -29,7 +29,7 @@ swarm.context.path:: The context path for the deployed application
 |/
 |===
 
-swarm.http.port:: The port for the HTTP server
+thorntail.http.port:: The port for the HTTP server
 +
 [cols="1,2a"]
 |===
@@ -37,7 +37,7 @@ swarm.http.port:: The port for the HTTP server
 |8080
 |===
 
-swarm.https.port:: The port for the HTTPS server
+thorntail.https.port:: The port for the HTTPS server
 +
 [cols="1,2a"]
 |===
@@ -45,10 +45,10 @@ swarm.https.port:: The port for the HTTPS server
 |8483
 |===
 
-swarm.debug.port:: If provided, the swarm process will pause for debugging on the given port.
+thorntail.debug.port:: If provided, the Thorntail process will pause for debugging on the given port.
 +
 --
-This option is only available when running an Arquillian test or starting the application using the `mvn wildfly-swarm:run` command, not when executing a JAR file.
+This option is only available when running an Arquillian test or starting the application using the `mvn thorntail:run` command, not when executing a JAR file.
 The JAR file execution requires normal Java debug agent parameters.
 
 [cols="1,2a"]
@@ -58,10 +58,11 @@ The JAR file execution requires normal Java debug agent parameters.
 |===
 --
 
-With the H2, MySQL, and Postgres database fractions,  use the following properties to configure the datasource:
-
 .Datasource-related system properties
-swarm.ds.name:: The name of the datasource
+
+With JDBC driver autodetection, use the following properties to configure the datasource:
+
+thorntail.ds.name:: The name of the datasource
 +
 [cols="1,2a"]
 |===
@@ -69,7 +70,7 @@ swarm.ds.name:: The name of the datasource
 |ExampleDS
 |===
 
-swarm.ds.username:: The user name to access the database
+thorntail.ds.username:: The user name to access the database
 +
 [cols="1,2a"]
 |===
@@ -77,7 +78,7 @@ swarm.ds.username:: The user name to access the database
 |_driver-specific_
 |===
 
-swarm.ds.password:: The password to access the database
+thorntail.ds.password:: The password to access the database
 +
 [cols="1,2a"]
 |===
@@ -85,7 +86,7 @@ swarm.ds.password:: The password to access the database
 |_driver-specific_
 |===
 
-swarm.ds.connection.url:: The JDBC Connection URL
+thorntail.ds.connection.url:: The JDBC connection URL
 +
 [cols="1,2a"]
 |===

--- a/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/DatasourceAndDriverCustomizer.java
+++ b/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/DatasourceAndDriverCustomizer.java
@@ -65,11 +65,11 @@ public class DatasourceAndDriverCustomizer implements Customizer {
     @Configurable("thorntail.ds.username")
     private String datasourceUserName;
 
-    @AttributeDocumentation("Defatul datasource connection password")
+    @AttributeDocumentation("Default datasource connection password")
     @Configurable("thorntail.ds.password")
     private String datasourcePassword;
 
-    @AttributeDocumentation("Defatul datasource JDBC driver name")
+    @AttributeDocumentation("Default datasource JDBC driver name")
     @Configurable("thorntail.jdbc.driver")
     private String driverName;
 

--- a/fractions/wildfly/logging/README.adoc
+++ b/fractions/wildfly/logging/README.adoc
@@ -4,4 +4,4 @@ Provides facilities to configure logging categories, levels and handlers.
 
 When specifying log-levels through properties, since
 they include dots, they should be placed between
-square brackets, such as `swarm.logging.loggers.[com.mycorp.logger].level`.
+square brackets, such as `thorntail.logging.loggers.[com.mycorp.logger].level`.


### PR DESCRIPTION
Motivation
----------
Some parts of the documentation still use the old `swarm.*` prefix,
even though WildFly Swarm was renamed to Thorntail a long time ago.

Modifications
-------------
Changed occurences of `swarm.*` to `thorntail.*`.
Fixed a couple of other typos along the way.

Result
------
More up to date documentation. No behavioral changes.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
