### PR TITLE
THORN-2373: wrong "thorntail.web-services" prefix in the Web Services fraction docs, should be "thorntail.webservices"

### DIFF
--- a/fractions/javaee/webservices/src/main/java/org/wildfly/swarm/webservices/WebServicesFraction.java
+++ b/fractions/javaee/webservices/src/main/java/org/wildfly/swarm/webservices/WebServicesFraction.java
@@ -18,11 +18,13 @@ package org.wildfly.swarm.webservices;
 import org.wildfly.swarm.config.Webservices;
 import org.wildfly.swarm.config.webservices.EndpointConfig;
 import org.wildfly.swarm.spi.api.Fraction;
+import org.wildfly.swarm.spi.api.annotations.Configurable;
 import org.wildfly.swarm.spi.api.annotations.MarshalDMR;
 import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
 
 @WildFlyExtension(module = "org.jboss.as.webservices")
 @MarshalDMR
+@Configurable("thorntail.webservices")
 public class WebServicesFraction extends Webservices<WebServicesFraction> implements Fraction<WebServicesFraction> {
 
     public static WebServicesFraction createDefaultFraction() {


### PR DESCRIPTION
Motivation
----------
Our docs say that the Web Services fraction is configured using
`thorntail.web-services.*` properties. That, however, is wrong.
The correct prefix is `thorntail.webservices.*`.

Modifications
-------------
Add the `@Configurable` annotation on the fraction class.

Result
------
Correct docs for the Web Services fraction.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
