### PR TITLE
[ENTSWM-618] add MP RestClient dependency to MP OpenTracing

### DIFF
--- a/fractions/microprofile/microprofile-opentracing/pom.xml
+++ b/fractions/microprofile/microprofile-opentracing/pom.xml
@@ -61,6 +61,10 @@
       <groupId>io.thorntail</groupId>
       <artifactId>microprofile-config</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.thorntail</groupId>
+      <artifactId>microprofile-restclient</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.jboss.resteasy</groupId>


### PR DESCRIPTION
Our implementation of MP OpenTracing integrates with MP RestClient,
so the `microprofile-opentracing` fraction includes a `module.xml`
for the RestClient module. This should not be loaded from WildFly;
instead, it should come from the `microprofile-restclient` fraction.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [ ] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
