### PR TITLE
Remove Fabric8 Maven profile to be on the same lines as launcher docs

### DIFF
--- a/docs/howto/writing-an-application-from-scratch/src/main/resources/pom-product.xml
+++ b/docs/howto/writing-an-application-from-scratch/src/main/resources/pom-product.xml
@@ -74,25 +74,4 @@
     </pluginRepository>
   </pluginRepositories>
 
-  <profiles>
-    <profile>
-      <id>openshift</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>io.fabric8</groupId>
-            <artifactId>fabric8-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>resource</goal>
-                  <goal>build</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/docs/howto/writing-an-application-from-scratch/src/main/resources/pom.xml
+++ b/docs/howto/writing-an-application-from-scratch/src/main/resources/pom.xml
@@ -57,25 +57,4 @@
     </plugins>
   </build>
 
-  <profiles>
-    <profile>
-      <id>openshift</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>io.fabric8</groupId>
-            <artifactId>fabric8-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>resource</goal>
-                  <goal>build</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>


### PR DESCRIPTION
This PR is for compliance with work in launcher repository where fabric8 profile is decoupled from basic application development. Instead, instructions to add the profile are provided in the topic "Preparing runtime application for OpenShift deployment".

Reference to changes in launcher documentation:
https://github.com/fabric8-launcher/launcher-documentation/pull/1264