### PR TITLE
THORN-2398: fix DB2 JDBC driver autodetection

### DIFF
--- a/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/drivers/DB2DriverInfo.java
+++ b/fractions/javaee/datasources/src/main/java/org/wildfly/swarm/datasources/runtime/drivers/DB2DriverInfo.java
@@ -46,7 +46,7 @@ public class DB2DriverInfo extends DriverInfo {
 
     @Override
     protected void configureDriver(JDBCDriver driver) {
-        driver.driverXaDatasourceClassName("com.ibm.db2.jdbc.DB2XADataSource");
+        driver.driverXaDatasourceClassName("com.ibm.db2.jcc.DB2XADataSource");
     }
 
     @Override


### PR DESCRIPTION
Motivation
----------
The DB2 JDBC driver autodetection code sets a wrong XA datasource
class name. It currently uses `com.ibm.db2.jdbc.DB2XADataSource`,
but the correct value is `com.ibm.db2.jcc.DB2XADataSource`.
I verified that by looking into multiple versions of the DB2 JDBC 4.0
driver JAR (`db2jcc4.jar` of versions 4.15.146, 4.16.53, 4.22.29 and
4.25.1301).

Modifications
-------------
Use correct DB2 XA datasource class name.

Result
------
JDBC driver autodetection works for DB2.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
