### PR TITLE
THORN-2401: wrong fraction names in reference documentation of NoSQL fractions

### DIFF
--- a/fractions/nosql/cassandra/src/main/java/org/wildfly/swarm/cassandra/CassandraFraction.java
+++ b/fractions/nosql/cassandra/src/main/java/org/wildfly/swarm/cassandra/CassandraFraction.java
@@ -17,6 +17,7 @@ package org.wildfly.swarm.cassandra;
 
 import org.wildfly.swarm.config.Cassandradriver;
 import org.wildfly.swarm.spi.api.Fraction;
+import org.wildfly.swarm.spi.api.annotations.Configurable;
 import org.wildfly.swarm.spi.api.annotations.MarshalDMR;
 import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
 
@@ -26,6 +27,7 @@ import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
 
 @WildFlyExtension(module = "org.wildfly.extension.nosql.cassandra")
 @MarshalDMR
+@Configurable("thorntail.cassandradriver")
 public class CassandraFraction extends Cassandradriver<CassandraFraction> implements Fraction<CassandraFraction> {
     public static CassandraFraction createDefaultFraction() {
         return new CassandraFraction().applyDefaults();

--- a/fractions/nosql/mongodb/src/main/java/org/wildfly/swarm/mongodb/MongoDBFraction.java
+++ b/fractions/nosql/mongodb/src/main/java/org/wildfly/swarm/mongodb/MongoDBFraction.java
@@ -17,6 +17,7 @@ package org.wildfly.swarm.mongodb;
 
 import org.wildfly.swarm.config.Mongodb;
 import org.wildfly.swarm.spi.api.Fraction;
+import org.wildfly.swarm.spi.api.annotations.Configurable;
 import org.wildfly.swarm.spi.api.annotations.MarshalDMR;
 import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
 
@@ -26,6 +27,7 @@ import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
 
 @WildFlyExtension(module = "org.wildfly.extension.nosql.mongodb")
 @MarshalDMR
+@Configurable("thorntail.mongodb")
 public class MongoDBFraction extends Mongodb<MongoDBFraction> implements Fraction<MongoDBFraction> {
     public static MongoDBFraction createDefaultFraction() {
         return new MongoDBFraction().applyDefaults();

--- a/fractions/nosql/neo4j/src/main/java/org/wildfly/swarm/neo4j/Neo4jFraction.java
+++ b/fractions/nosql/neo4j/src/main/java/org/wildfly/swarm/neo4j/Neo4jFraction.java
@@ -17,6 +17,7 @@ package org.wildfly.swarm.neo4j;
 
 import org.wildfly.swarm.config.Neo4jdriver;
 import org.wildfly.swarm.spi.api.Fraction;
+import org.wildfly.swarm.spi.api.annotations.Configurable;
 import org.wildfly.swarm.spi.api.annotations.MarshalDMR;
 import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
 
@@ -26,6 +27,7 @@ import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
 
 @WildFlyExtension(module = "org.wildfly.extension.nosql.neo4j")
 @MarshalDMR
+@Configurable("thorntail.neo4jdriver")
 public class Neo4jFraction extends Neo4jdriver<Neo4jFraction> implements Fraction<Neo4jFraction> {
     public static Neo4jFraction createDefaultFraction() {
         return new Neo4jFraction().applyDefaults();

--- a/fractions/nosql/orientdb/src/main/java/org/wildfly/swarm/orientdb/OrientDBFraction.java
+++ b/fractions/nosql/orientdb/src/main/java/org/wildfly/swarm/orientdb/OrientDBFraction.java
@@ -17,6 +17,7 @@ package org.wildfly.swarm.orientdb;
 
 import org.wildfly.swarm.config.Orientdb;
 import org.wildfly.swarm.spi.api.Fraction;
+import org.wildfly.swarm.spi.api.annotations.Configurable;
 import org.wildfly.swarm.spi.api.annotations.MarshalDMR;
 import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
 
@@ -26,6 +27,7 @@ import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
 
 @WildFlyExtension(module = "org.wildfly.extension.nosql.orientdb")
 @MarshalDMR
+@Configurable("thorntail.orientdb")
 public class OrientDBFraction extends Orientdb<OrientDBFraction> implements Fraction<OrientDBFraction> {
     public static OrientDBFraction createDefaultFraction() {
         return new OrientDBFraction().applyDefaults();


### PR DESCRIPTION
Motivation
----------
The generated reference documentation of fractions contains
wrong names of NoSQL fractions.

Modifications
-------------
Add the `@Configurable` annotation to fraction classes
of NoSQL fractions to explicitly provide the correct name.

Result
------
No behavioral changes, just more correct docs.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
