### PR TITLE
THORN-2396: investigate why some fractions don't have module.conf

### DIFF
--- a/arquillian/resolver/pom.xml
+++ b/arquillian/resolver/pom.xml
@@ -17,8 +17,8 @@
   <groupId>io.thorntail</groupId>
   <artifactId>arquillian-resolver</artifactId>
 
-  <name> Arquillian Resolver</name>
-  <description> Arquillian Resolver</description>
+  <name>Arquillian Resolver</name>
+  <description>Arquillian Resolver</description>
 
   <packaging>jar</packaging>
 

--- a/arquillian/test/pom.xml
+++ b/arquillian/test/pom.xml
@@ -16,8 +16,8 @@
 
   <artifactId>arquillian-test</artifactId>
 
-  <name> Arquillian Test</name>
-  <description> Arquillian Test</description>
+  <name>Arquillian Test</name>
+  <description>Arquillian Test</description>
 
   <packaging>jar</packaging>
 

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -88,10 +88,10 @@
     <!-- OpenTracing related versions -->
     <version.opentracing.tracerresolver>0.1.5</version.opentracing.tracerresolver>
     <version.opentracing.servlet>0.2.0</version.opentracing.servlet>
-    <version.jaeger>0.30.6</version.jaeger>
     <version.opentracing.concurrent>0.2.0</version.opentracing.concurrent>
     <version.opentracing.jaxrs>0.4.1</version.opentracing.jaxrs>
     <version.opentracing.interceptors>0.0.4</version.opentracing.interceptors>
+    <version.jaeger>0.30.6</version.jaeger>
     <version.jaeger.apache.thrift>0.11.0</version.jaeger.apache.thrift>
     <version.jaeger.apache.httpclient>4.2.5</version.jaeger.apache.httpclient>
     <version.jaeger.commons.logging>1.1.1</version.jaeger.commons.logging>

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -59,7 +59,7 @@ include::assemblies/assembly_configuring-a-thorntail-application.adoc[leveloffse
 include::assemblies/assembly_prebuilt-servers.adoc[leveloffset=+2]
 include::modules/ref_network-configuration.adoc[leveloffset=+2]
 include::modules/ref_the-usage-txt-file.adoc[leveloffset=+2]
-include::modules/ref_additional_resources.adoc[leveloffset=+2]
+include::modules/ref_additional-resources.adoc[leveloffset=+2]
 
 ## Fractions
 

--- a/fractions/javaee/full/no.module.conf
+++ b/fractions/javaee/full/no.module.conf
@@ -1,0 +1,2 @@
+# This fraction doesn't need module.conf, because it is not a real fraction.
+# It just aggregates fractions on Maven level.

--- a/fractions/javaee/jaxrs-cdi/no.module.conf
+++ b/fractions/javaee/jaxrs-cdi/no.module.conf
@@ -1,0 +1,2 @@
+# This fraction doesn't need module.conf, because it is not a full fraction.
+# It only extends the `jaxrs` fraction.

--- a/fractions/javaee/jaxrs-jaxb/no.module.conf
+++ b/fractions/javaee/jaxrs-jaxb/no.module.conf
@@ -1,0 +1,2 @@
+# This fraction doesn't need module.conf, because it is not a full fraction.
+# It only extends the `jaxrs` fraction.

--- a/fractions/javaee/jaxrs-jsonb/module.conf
+++ b/fractions/javaee/jaxrs-jsonb/module.conf
@@ -1,1 +1,0 @@
-org.jboss.resteasy.resteasy-json-binding-provider

--- a/fractions/javaee/jaxrs-jsonb/no.module.conf
+++ b/fractions/javaee/jaxrs-jsonb/no.module.conf
@@ -1,0 +1,2 @@
+# This fraction doesn't need module.conf, because it is not a full fraction.
+# It only extends the `jaxrs` fraction.

--- a/fractions/javaee/jaxrs-jsonb/src/main/resources/modules/org/wildfly/swarm/jaxrs/jsonb/main/module.xml
+++ b/fractions/javaee/jaxrs-jsonb/src/main/resources/modules/org/wildfly/swarm/jaxrs/jsonb/main/module.xml
@@ -1,0 +1,5 @@
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.swarm.jaxrs.jsonb">
+  <dependencies>
+    <module name="org.jboss.resteasy.resteasy-json-binding-provider"/>
+  </dependencies>
+</module>

--- a/fractions/javaee/jaxrs-jsonp/no.module.conf
+++ b/fractions/javaee/jaxrs-jsonp/no.module.conf
@@ -1,0 +1,2 @@
+# This fraction doesn't need module.conf, because it is not a full fraction.
+# It only extends the `jaxrs` fraction.

--- a/fractions/javaee/jaxrs-multipart/no.module.conf
+++ b/fractions/javaee/jaxrs-multipart/no.module.conf
@@ -1,0 +1,2 @@
+# This fraction doesn't need module.conf, because it is not a full fraction.
+# It only extends the `jaxrs` fraction.

--- a/fractions/javaee/jaxrs-validator/no.module.conf
+++ b/fractions/javaee/jaxrs-validator/no.module.conf
@@ -1,0 +1,2 @@
+# This fraction doesn't need module.conf, because it is not a full fraction.
+# It only extends the `jaxrs` fraction.

--- a/fractions/javaee/web/no.module.conf
+++ b/fractions/javaee/web/no.module.conf
@@ -1,0 +1,2 @@
+# This fraction doesn't need module.conf, because it is not a real fraction.
+# It just aggregates fractions on Maven level.

--- a/fractions/microprofile/microprofile/no.module.conf
+++ b/fractions/microprofile/microprofile/no.module.conf
@@ -1,0 +1,2 @@
+# This fraction doesn't need module.conf, because it is not a real fraction.
+# It just aggregates fractions on Maven level.

--- a/fractions/netflix/guava/no.module.conf
+++ b/fractions/netflix/guava/no.module.conf
@@ -1,0 +1,2 @@
+# This fraction doesn't need module.conf, because it is not a real fraction.
+# It just provides module.xml files.

--- a/fractions/netflix/guava/pom.xml
+++ b/fractions/netflix/guava/pom.xml
@@ -17,8 +17,8 @@
   <groupId>io.thorntail</groupId>
   <artifactId>netflix-guava</artifactId>
 
-  <name> Guava</name>
-  <description> Guava</description>
+  <name>Guava</name>
+  <description>Guava</description>
 
   <packaging>jar</packaging>
 

--- a/fractions/netflix/no.module.conf
+++ b/fractions/netflix/no.module.conf
@@ -1,0 +1,2 @@
+# This fraction doesn't need module.conf, because it is just a Maven parent module.
+# Actually this Maven module should probably be removed and all submodules should be managed directly in root /pom.xml.

--- a/fractions/netflix/ribbon-secured-client/pom.xml
+++ b/fractions/netflix/ribbon-secured-client/pom.xml
@@ -17,7 +17,7 @@
   <groupId>io.thorntail</groupId>
   <artifactId>ribbon-secured-client</artifactId>
 
-  <name> Ribbon Secured Client</name>
+  <name>Ribbon Secured Client</name>
   <description>Ribbon Secured Client</description>
 
   <packaging>jar</packaging>

--- a/fractions/netflix/rxjava/no.module.conf
+++ b/fractions/netflix/rxjava/no.module.conf
@@ -1,0 +1,2 @@
+# This fraction doesn't need module.conf, because it is not a real fraction.
+# It just provides module.xml files.

--- a/fractions/netflix/rxjava/pom.xml
+++ b/fractions/netflix/rxjava/pom.xml
@@ -17,8 +17,8 @@
   <groupId>io.thorntail</groupId>
   <artifactId>netflix-rxjava</artifactId>
 
-  <name> RX-Java</name>
-  <description> RX-Java</description>
+  <name>RX-Java</name>
+  <description>RX-Java</description>
 
   <packaging>jar</packaging>
 

--- a/fractions/netflix/rxnetty/no.module.conf
+++ b/fractions/netflix/rxnetty/no.module.conf
@@ -1,0 +1,2 @@
+# This fraction doesn't need module.conf, because it is not a real fraction.
+# It just provides module.xml files.

--- a/fractions/netflix/rxnetty/pom.xml
+++ b/fractions/netflix/rxnetty/pom.xml
@@ -17,8 +17,8 @@
   <groupId>io.thorntail</groupId>
   <artifactId>netflix-rxnetty</artifactId>
 
-  <name> RX-Netty</name>
-  <description> RX-Netty</description>
+  <name>RX-Netty</name>
+  <description>RX-Netty</description>
 
   <packaging>jar</packaging>
 

--- a/fractions/netflix/servo/no.module.conf
+++ b/fractions/netflix/servo/no.module.conf
@@ -1,0 +1,2 @@
+# This fraction doesn't need module.conf, because it is not a real fraction.
+# It just provides module.xml files.

--- a/fractions/netflix/servo/pom.xml
+++ b/fractions/netflix/servo/pom.xml
@@ -17,8 +17,8 @@
   <groupId>io.thorntail</groupId>
   <artifactId>servo</artifactId>
 
-  <name> Servo</name>
-  <description> Servo</description>
+  <name>Servo</name>
+  <description>Servo</description>
 
   <packaging>jar</packaging>
 

--- a/fractions/wildfly/hibernate-search/no.module.conf
+++ b/fractions/wildfly/hibernate-search/no.module.conf
@@ -1,0 +1,2 @@
+# This fraction doesn't need module.conf, because it is not a full fraction.
+# It only extends the `jpa` fraction.

--- a/fractions/wildfly/hibernate-validator/no.module.conf
+++ b/fractions/wildfly/hibernate-validator/no.module.conf
@@ -1,0 +1,2 @@
+# This fraction doesn't need module.conf, because it is not a full fraction.
+# It only extends the `bean-validation` fraction.


### PR DESCRIPTION
Motivation
----------
Some fractions provide a `module.xml` directly
in `src/main/resources/modules`, which can be wrong and might need
replacing by `module.conf`.

Modifications
-------------
Unified the approach taken for `jaxrs-*` fractions: they shouldn't
use `module.conf`, because they are not really full fractions,
they just extend the `jaxrs` fraction.

All directories under `fractions` that don't have `module.conf`
now have `no.module.conf` file with a short explanation.

Also few unrelated typos are fixed in this commit.

Result
------
No behavioral change.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
