### PR TITLE
THORN-2402: update to latest SmallRye Fault Tolerance with OpenTracing propagation

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -125,7 +125,7 @@
     <version.smallrye.metrics>1.1.3</version.smallrye.metrics>
     <version.smallrye.restclient>1.2.2</version.smallrye.restclient>
     <version.smallrye.jwt>1.1.3</version.smallrye.jwt>
-    <version.smallrye-fault-tolerance>2.0.2</version.smallrye-fault-tolerance>
+    <version.smallrye-fault-tolerance>2.0.4</version.smallrye-fault-tolerance>
 
   </properties>
 

--- a/fractions/microprofile/microprofile-fault-tolerance/src/main/resources/modules/io/smallrye/faulttolerance/main/module.xml
+++ b/fractions/microprofile/microprofile-fault-tolerance/src/main/resources/modules/io/smallrye/faulttolerance/main/module.xml
@@ -35,5 +35,6 @@
       <module name="org.jboss.weld.core" export="true"/>
       <module name="org.jboss.weld.spi" export="true"/>
       <module name="io.reactivex.rxjava"/>
+      <module name="io.opentracing.tracer" optional="true"/>
    </dependencies>
 </module>


### PR DESCRIPTION
Motivation
----------
Latest SmallRye Fault Tolerance integrates with OpenTracing.
This is a good feature, but needs slightly more work than
just updating SmallRye Fault Tolerance version number.

Modifications
-------------
Update to latest SmallRye Fault Tolerance.
The SmallRye Fault Tolerance module now has optional dependency
on the `io.opentracing.tracer` module, which contains the core
OpenTracing classes. If the user depends on one of the OpenTracing
fractions, this module will be present and the integration
will be enabled.

Result
------
Fault Tolerance will integrate will OpenTracing.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
