### PR TITLE
THORN-2400: Update keycloak-microprofile-jwt to support the adapter YAML config

### DIFF
--- a/fractions/keycloak-microprofile-jwt/src/main/java/org/wildfly/swarm/keycloak/mpjwt/runtime/KeycloakMicroprofileJwtArchivePreparer.java
+++ b/fractions/keycloak-microprofile-jwt/src/main/java/org/wildfly/swarm/keycloak/mpjwt/runtime/KeycloakMicroprofileJwtArchivePreparer.java
@@ -19,7 +19,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Method;
-import java.util.Enumeration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -71,21 +70,21 @@ public class KeycloakMicroprofileJwtArchivePreparer implements DeploymentProcess
 
         Map<String, String> kcAdapterSystemProps = new LinkedHashMap<>();
         Properties systemProps = System.getProperties();
-        for (Enumeration<Object> en = systemProps.keys(); en.hasMoreElements();) {
-            String key = en.nextElement().toString();
+        for (Map.Entry<Object, Object> entry : systemProps.entrySet()) {
+            String key = entry.getKey().toString();
             if (key.startsWith(thorntailPrefix)) {
                 kcAdapterSystemProps.put(key.substring(thorntailPrefix.length()),
-                                         systemProps.getProperty(key));
+                                         entry.getValue().toString());
             } else if (key.startsWith(swarmPrefix)) {
                 kcAdapterSystemProps.put(key.substring(swarmPrefix.length()),
-                                         systemProps.getProperty(key));
+                                         entry.getValue().toString());
             }
         }
         InputStream is = null;
         if (!kcAdapterSystemProps.isEmpty()) {
             // Simple JSON builder tailored for the keycloak.json format
             // which can contain simple string or boolean or integer values only
-            // with the only exception being a 'credentials' single entry map 
+            // with the only exception being a 'credentials' single entry map
             StringBuilder sb = new StringBuilder();
             sb.append("{");
             for (Map.Entry<String, String> entry : kcAdapterSystemProps.entrySet()) {

--- a/fractions/keycloak-microprofile-jwt/src/main/java/org/wildfly/swarm/keycloak/mpjwt/runtime/KeycloakMicroprofileJwtArchivePreparer.java
+++ b/fractions/keycloak-microprofile-jwt/src/main/java/org/wildfly/swarm/keycloak/mpjwt/runtime/KeycloakMicroprofileJwtArchivePreparer.java
@@ -91,23 +91,21 @@ public class KeycloakMicroprofileJwtArchivePreparer implements DeploymentProcess
                 JsonGenerator jg = new JsonFactory().createGenerator(out, JsonEncoding.UTF8);
                 jg.writeStartObject();
                 for (Map.Entry<String, String> entry : kcAdapterSystemProps.entrySet()) {
-                    String key = entry.getKey();
-                    boolean credentials = entry.getKey().equals(credentialsSecretProperty);
-                    if (credentials) {
-                        key = "secret";
+                    if (entry.getKey().equals(credentialsSecretProperty)) {
                         jg.writeFieldName("credentials");
                         jg.writeStartObject();
-                    }
-                    jg.writeFieldName(key);
-                    if (isBoolean(entry.getValue())) {
-                        jg.writeBoolean(Boolean.valueOf(entry.getValue()));
-                    } else if (!credentials && isSimpleNumber(entry.getValue())) {
-                        jg.writeNumber(Integer.valueOf(entry.getValue()));
-                    } else {
+                        jg.writeFieldName("secret");
                         jg.writeString(entry.getValue());
-                    }
-                    if (credentials) {
                         jg.writeEndObject();
+                    } else {
+                        jg.writeFieldName(entry.getKey());
+                        if (isBoolean(entry.getValue())) {
+                            jg.writeBoolean(Boolean.valueOf(entry.getValue()));
+                        } else if (isSimpleNumber(entry.getValue())) {
+                            jg.writeNumber(Long.valueOf(entry.getValue()));
+                        } else {
+                            jg.writeString(entry.getValue());
+                        }
                     }
                 }
                 jg.writeEndObject();

--- a/testsuite/testsuite-keycloak-mpjwt/src/test/java/org/wildfly/swarm/keycloak/KeycloakMicroprofileJwtWithoutJsonTest.java
+++ b/testsuite/testsuite-keycloak-mpjwt/src/test/java/org/wildfly/swarm/keycloak/KeycloakMicroprofileJwtWithoutJsonTest.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.keycloak;
+
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Form;
+import javax.ws.rs.core.HttpHeaders;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.jaxrs.JAXRSArchive;
+import org.wildfly.swarm.microprofile.jwtauth.keycloak.SecuredApplication;
+import org.wildfly.swarm.microprofile.jwtauth.keycloak.SecuredResource;
+
+@RunWith(Arquillian.class)
+public class KeycloakMicroprofileJwtWithoutJsonTest {
+
+    @Deployment
+    public static Archive<?> createDeployment() {
+        JAXRSArchive deployment = ShrinkWrap.create(JAXRSArchive.class, "test.war");
+        deployment.addClass(SecuredApplication.class);
+        deployment.addClass(SecuredResource.class);
+        deployment.addAsResource("project-no-keycloak-json.yml", "project-defaults.yml");
+        return deployment;
+    }
+
+    @Test
+    @RunAsClient
+    public void testResourceIsSecured() {
+        String authResponse = ClientBuilder.newClient()
+                .target("http://localhost:8080/auth/realms/thorntail-cmd-client/protocol/openid-connect/token")
+                .request()
+                .post(Entity.form(new Form()
+                        .param("grant_type", "password")
+                        .param("client_id", "thorntail-cmd-client-example")
+                        .param("username", "user1")
+                        .param("password", "password1")
+                ), String.class);
+        String accessToken = getAccessTokenFromResponse(authResponse);
+
+        String serviceResponse = ClientBuilder.newClient()
+                .target("http://localhost:8080/mpjwt/secured")
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .get(String.class);
+        Assert.assertEquals("Hi user1, this resource is secured", serviceResponse);
+    }
+
+    private String getAccessTokenFromResponse(String response) {
+        String tokenStart = response.substring("{\"access_token\":\"".length());
+        return tokenStart.substring(0, tokenStart.indexOf("\""));
+    }
+}

--- a/testsuite/testsuite-keycloak-mpjwt/src/test/resources/project-no-keycloak-json.yml
+++ b/testsuite/testsuite-keycloak-mpjwt/src/test/resources/project-no-keycloak-json.yml
@@ -7,7 +7,7 @@ keycloak:
     provider: singleFile
     action: import
     file: ${project.build.testOutputDirectory}/thorntail-keycloak-example-realm.json
-swarm:
+thorntail:
   keycloak:
     secure-deployments:
       test.war:

--- a/testsuite/testsuite-keycloak-mpjwt/src/test/resources/project-no-keycloak-json.yml
+++ b/testsuite/testsuite-keycloak-mpjwt/src/test/resources/project-no-keycloak-json.yml
@@ -1,0 +1,23 @@
+# keycloak-server fraction requires keycloak.migration.* system properties to initialize itself
+# for the purpose of this test. These migration properties are set as YAML properties but
+# Thorntail automatically creates system properties out of them.
+  
+keycloak:
+  migration:
+    provider: singleFile
+    action: import
+    file: ${project.build.testOutputDirectory}/thorntail-keycloak-example-realm.json
+swarm:
+  keycloak:
+    secure-deployments:
+      test.war:
+        auth-server-url: "http://localhost:8080/auth"
+        realm: thorntail-cmd-client
+        resource: thorntail-keycloak-example
+        bearer-only: true
+        ssl-required: external
+  microprofile:
+    jwtauth:
+      realm: testSuiteRealm
+      token:
+        issuedBy: "http://localhost:8080/auth/realms/thorntail-keycloak-example"


### PR DESCRIPTION
Motivation
----------
A user would like to access KC tokens via MP-JWT API while configuring the adapter in YAML

Modifications
-------------
The archive preparer for `keycloak-micropfile-jwt` has been updated to introspect the equivalent system properties and converting them to keycloak.json with the help of the basic JSON builder. IMHO there is no need (yet) to have some generic JSON builder support for this issue though if really needed it can be provided in due time 

Result
------
`keycloak-micropfile-jwt` fraction can now have the KC adapter configured with `keycloak.json` and the equivalent YAML properties