### PR TITLE
THORN-2410: update Jaeger client to 0.34.0

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -91,12 +91,8 @@
     <version.opentracing.concurrent>0.2.0</version.opentracing.concurrent>
     <version.opentracing.jaxrs>0.4.1</version.opentracing.jaxrs>
     <version.opentracing.interceptors>0.0.4</version.opentracing.interceptors>
-    <version.jaeger>0.30.6</version.jaeger>
-    <version.jaeger.apache.thrift>0.11.0</version.jaeger.apache.thrift>
-    <version.jaeger.apache.httpclient>4.2.5</version.jaeger.apache.httpclient>
-    <version.jaeger.commons.logging>1.1.1</version.jaeger.commons.logging>
-    <version.jaeger.commons.codec>1.6</version.jaeger.commons.codec>
-    <version.jaeger.apache.httpcore>4.2.4</version.jaeger.apache.httpcore>
+    <version.jaeger>0.34.0</version.jaeger>
+    <version.jaeger.apache.thrift>0.12.0</version.jaeger.apache.thrift>
     <version.jaeger.gson>2.8.2</version.jaeger.gson>
 
     <version.maven.resolver.provider>3.6.0</version.maven.resolver.provider>


### PR DESCRIPTION
Motivation
----------
Jaeger changed format of trace IDs and our current version
of Jaeger client (0.30.6) is no longer compatible with latest
development. We need to update to 0.34.0, which is still
compatible with OpenTracing 0.31.0, but uses the latest
trace ID format.

Modifications
-------------
Update to Jaeger client 0.34.0 and related dependencies.
Also remove useless Maven properties.

Result
------
Trace propagation now works with latest Jaeger.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] [v2] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] [v4] Have you created a [GitHub Issue](https://github.com/thorntail/thorntail/issues) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
