### PR TITLE
THORN-2417: the MP RestClient part of MP OpenTracing TCK isn't executed with Thorntail

### DIFF
--- a/testsuite/microprofile-tcks/opentracing/pom.xml
+++ b/testsuite/microprofile-tcks/opentracing/pom.xml
@@ -58,6 +58,11 @@
       <version>${version.microprofile-opentracing}</version>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.microprofile.opentracing</groupId>
+      <artifactId>microprofile-opentracing-tck-rest-client</artifactId>
+      <version>${version.microprofile-opentracing}</version>
+    </dependency>
+    <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <version>6.9.9</version>


### PR DESCRIPTION
Motivation
----------
We need to run the entire MP OpenTracing TCK, because
our implementations of MP RestClient and MP OpenTracing
are supposed to be integrated.

Modifications
-------------
Add a dependency on the `microprofile-opentracing-tck-rest-client`
artifact, which has the tests for MP OpenTracing + MP RestClient.

Result
------
No behavioral change. More test coverage.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
