### PR TITLE
THORN-1616: add the "ejb-mdb" fraction

### DIFF
--- a/fractions/javaee/ejb-mdb/README.adoc
+++ b/fractions/javaee/ejb-mdb/README.adoc
@@ -1,0 +1,50 @@
+= EJB MDB
+
+Provides support for Message Driven Beans.
+
+For this to work, you need to deploy a resource adapter for an external messaging server.
+The name of this resource adapter must be configured in the `ejb3` subsystem.
+If the resource adapter's connection factory is bound to a different JNDI name than `java:jboss/DefaultJMSConnectionFactory`, the JNDI name must be configured in the `ee` subsystem.
+For example:
+
+```yaml
+thorntail:
+  # deploy AMQP resource adapter
+  deployment:
+    org.amqphub.jca:resource-adapter.rar:
+  # configure the resource adapter
+  resource-adapters:
+    resource-adapters:
+      # the resource adapter is called `default`
+      default:
+        archive: resource-adapter.rar
+        transaction-support: NoTransaction
+        connection-definitions:
+          default:
+            # the connection factory is bound to JNDI name `java:global/jms/default`
+            jndi-name: java:global/jms/default
+            class-name: org.jboss.resource.adapter.jms.JmsManagedConnectionFactory
+            config-properties:
+              ConnectionFactory:
+                value: factory1
+              UserName:
+                value: username
+              Password:
+                value: password
+              JndiParameters:
+                value: "java.naming.factory.initial=org.apache.qpid.jms.jndi.JmsInitialContextFactory;connectionFactory.factory1=amqp://${env.MESSAGING_SERVICE_HOST:localhost}:${env.MESSAGING_SERVICE_PORT:5672}"
+  # configure the `ejb3` and `ee` subsystems
+  ejb3:
+    default-resource-adapter-name: default
+  ee:
+    annotation-property-replacement: true
+    default-bindings-service:
+      jms-connection-factory: java:global/jms/default
+```
+
+ifndef::product[]
+== The `messaging` fraction
+
+This fraction provides a minimum subset of the `messaging` fraction, enough to use message driven beans.
+If you use the `messaging` fraction, don't use this fraction.
+endif::product[]

--- a/fractions/javaee/ejb-mdb/module.conf
+++ b/fractions/javaee/ejb-mdb/module.conf
@@ -1,0 +1,2 @@
+javax.jms.api export=true
+org.wildfly.extension.messaging-activemq

--- a/fractions/javaee/ejb-mdb/pom.xml
+++ b/fractions/javaee/ejb-mdb/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.thorntail</groupId>
+    <artifactId>build-parent</artifactId>
+    <version>2.4.1.Final-SNAPSHOT</version>
+    <relativePath>../../../build-parent/pom.xml</relativePath>
+  </parent>
+
+  <groupId>io.thorntail</groupId>
+  <artifactId>ejb-mdb</artifactId>
+
+  <name>EJB MDB</name>
+  <description>Message Driven Beans</description>
+
+  <packaging>jar</packaging>
+
+  <properties>
+    <swarm.fraction.stability>stable</swarm.fraction.stability>
+    <swarm.fraction.tags>JavaEE,Integration</swarm.fraction.tags>
+  </properties>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.thorntail</groupId>
+      <artifactId>container</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.thorntail</groupId>
+      <artifactId>logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.thorntail</groupId>
+      <artifactId>ejb</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.thorntail</groupId>
+      <artifactId>resource-adapters</artifactId>
+    </dependency>
+
+    <!-- Provided APIs -->
+    <dependency>
+      <groupId>org.jboss.spec.javax.jms</groupId>
+      <artifactId>jboss-jms-api_2.0_spec</artifactId>
+    </dependency>
+
+    <!-- Meta SPI -->
+    <dependency>
+      <groupId>io.thorntail</groupId>
+      <artifactId>meta-spi</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.wildfly.core</groupId>
+      <artifactId>wildfly-core-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-servlet-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/fractions/javaee/ejb-mdb/src/main/java/org/wildfly/swarm/ejb/mdb/EjbMdbFraction.java
+++ b/fractions/javaee/ejb-mdb/src/main/java/org/wildfly/swarm/ejb/mdb/EjbMdbFraction.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2019 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.ejb.mdb;
+
+import org.wildfly.swarm.spi.api.Fraction;
+import org.wildfly.swarm.spi.api.annotations.DeploymentModule;
+import org.wildfly.swarm.spi.api.annotations.MarshalDMR;
+import org.wildfly.swarm.spi.api.annotations.WildFlyExtension;
+
+@WildFlyExtension(module = "org.wildfly.extension.messaging-activemq")
+@MarshalDMR
+@DeploymentModule(name = "javax.jms.api")
+public class EjbMdbFraction extends MessagingSubsystemStub implements Fraction<EjbMdbFraction> {
+    // this class, together with MessagingSubsystemStub, only exists to install
+    // an empty and unconfigurable `messaging-activemq` subsystem, which contains
+    // some pieces necessary for using MDBs (e.g. injection of JMS classes)
+}

--- a/fractions/javaee/ejb-mdb/src/main/java/org/wildfly/swarm/ejb/mdb/MessagingSubsystemStub.java
+++ b/fractions/javaee/ejb-mdb/src/main/java/org/wildfly/swarm/ejb/mdb/MessagingSubsystemStub.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2019 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.ejb.mdb;
+
+import org.wildfly.swarm.config.runtime.Address;
+import org.wildfly.swarm.config.runtime.Implicit;
+import org.wildfly.swarm.config.runtime.Keyed;
+import org.wildfly.swarm.config.runtime.ResourceType;
+
+@Address("/subsystem=messaging-activemq")
+@ResourceType("subsystem")
+@Implicit
+public class MessagingSubsystemStub implements Keyed {
+    @Override
+    public String getKey() {
+        return "messaging-activemq";
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -423,6 +423,12 @@
 
       <dependency>
         <groupId>io.thorntail</groupId>
+        <artifactId>ejb-mdb</artifactId>
+        <version>2.4.1.Final-SNAPSHOT</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.thorntail</groupId>
         <artifactId>ejb-remote</artifactId>
         <version>2.4.1.Final-SNAPSHOT</version>
       </dependency>
@@ -959,6 +965,7 @@
     <module>fractions/javaee/ee</module>
     <module>fractions/javaee/ee-security</module>
     <module>fractions/javaee/ejb</module>
+    <module>fractions/javaee/ejb-mdb</module>
 
     <module>fractions/javaee/jaxrs</module>
     <module>fractions/javaee/jaxrs-cdi</module>


### PR DESCRIPTION
Motivation
----------
There is no need to include the entire `messaging` fraction
if the application only produces or consumes messages
to/from an external messaging server.

Modifications
-------------
Added a new fraction called `ejb-mdb`, which contains a minimum
subset of `messaging` enough to use MDBs. It expects a resource
adapter to be deployed by the user.

Result
------
Users can now use MDBs connected to external messaging server
without using the entire `messaging` fraction.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
