### PR TITLE
THORN-2419: using config useUberJar with value false doesn't work

### DIFF
--- a/docs/modules/ref_thorntail-maven-plugin-configuration-options.adoc
+++ b/docs/modules/ref_thorntail-maven-plugin-configuration-options.adoc
@@ -299,6 +299,3 @@ This JAR is not created automatically, so make sure you execute the `package` go
 |Used by
 |`run`, `start`
 |===
-+
-NOTE: Before version 2.3.0.Final, this property was called `wildfly-swarm.useUberJar`, and only setting it to `true` enabled this behavior: `-Dwildfly-swarm.useUberJar=true`.
-You can continue using the old name in later releases, but consider using the new variant, which no longer requires you to set a value: `-Dthorntail.useUberJar`.

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/StartMojo.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/StartMojo.java
@@ -64,11 +64,8 @@ public class StartMojo extends AbstractSwarmMojo {
     @Parameter(alias = "stderrFile", property = "thorntail.stderr")
     public File stderrFile;
 
-    @Parameter(defaultValue = "${wildfly-swarm.useUberJar}")
-    public boolean oldUseUberJar;
-
     @Parameter(alias = "useUberJar", property = "thorntail.useUberJar")
-    public String useUberJar;
+    public boolean useUberJar;
 
     @Parameter(alias = "debug", property = SwarmProperties.DEBUG_PORT)
     public Integer debugPort;
@@ -93,7 +90,7 @@ public class StartMojo extends AbstractSwarmMojo {
 
         final SwarmExecutor executor;
 
-        if (useUberjar()) {
+        if (useUberJar) {
             executor = uberJarExecutor();
         } else if (this.project.getPackaging().equals(WAR)) {
             executor = warExecutor();
@@ -380,9 +377,4 @@ public class StartMojo extends AbstractSwarmMojo {
                 .map(m -> Paths.get(this.project.getBuild().getOutputDirectory(), m))
                 .collect(Collectors.toList());
     }
-
-    private boolean useUberjar() {
-        return useUberJar != null ? true : oldUseUberJar;
-    }
-
 }


### PR DESCRIPTION
Motivation
----------
The Maven plugin's `start` and `run` goals used to accept
a `<useUberJar>` config property, which could be overridden
using `-Dwildfly-swarm.useUberJar`. Later, we added the option
to override it with `-Dthorntail.useUberJar`, but tried to
preserve the option of using `-Dwildfly-swarm.useUberJar`.
We made a mistake and the `<useUberJar>` config property
no longer works properly.

Modifications
-------------
Remove the old `-Dwildfly-swarm.useUberJar` option and get back
to simple injection of a `boolean` variable, with the usual
Maven behavior.

Result
------
XML configuration now works properly again.

Using `-Dthorntail.useUberJar` option still works fine.

Breaking change: using `-Dwildfly-swarm.useUberJar` no longer works.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
