### PR TITLE
THORN-2435: OpenAPI: query parameter "format" value

### DIFF
--- a/fractions/microprofile/microprofile-openapi/src/main/java/org/wildfly/swarm/microprofile/openapi/runtime/OpenApiHttpHandler.java
+++ b/fractions/microprofile/microprofile-openapi/src/main/java/org/wildfly/swarm/microprofile/openapi/runtime/OpenApiHttpHandler.java
@@ -84,8 +84,9 @@ public class OpenApiHttpHandler implements HttpHandler {
         Format format = Format.YAML;
 
         // Check Accept, then query parameter "format" for JSON; else use YAML.
-        if ((accept != null && accept.contains(Format.JSON.getMimeType())) ||
-                (formatParam != null && Format.JSON.getMimeType().equalsIgnoreCase(formatParam))) {
+        if ((accept != null && accept.contains(Format.JSON.getMimeType()))
+                || Format.JSON.name().equalsIgnoreCase(formatParam)
+                || Format.JSON.getMimeType().equalsIgnoreCase(formatParam)) {
             format = Format.JSON;
         }
 

--- a/testsuite/testsuite-microprofile-openapi/src/test/java/org/wildfly/swarm/microprofile/openapi/OpenApiTest.java
+++ b/testsuite/testsuite-microprofile-openapi/src/test/java/org/wildfly/swarm/microprofile/openapi/OpenApiTest.java
@@ -16,7 +16,9 @@
 
 package org.wildfly.swarm.microprofile.openapi;
 
+import org.apache.http.HttpResponse;
 import org.apache.http.client.fluent.Request;
+import org.apache.http.util.EntityUtils;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
@@ -32,8 +34,75 @@ public class OpenApiTest {
     @Test
     @RunAsClient
     public void testOpenApi() throws Exception {
-        String content = Request.Get("http://localhost:8080/openapi").execute().returnContent().asString();
+        HttpResponse response = Request.Get("http://localhost:8080/openapi").execute().returnResponse();
+        assertTrue(response.getFirstHeader("Content-Type").getValue().contains("application/yaml"));
+        String content = EntityUtils.toString(response.getEntity());
         assertNotNull(content);
         assertTrue(content.contains("/api/foo/hello"));
+    }
+
+    @Test
+    @RunAsClient
+    public void acceptYaml() throws Exception {
+        HttpResponse response = Request.Get("http://localhost:8080/openapi")
+                .addHeader("Accept", "application/yaml")
+                .execute()
+                .returnResponse();
+        assertTrue(response.getFirstHeader("Content-Type").getValue().contains("application/yaml"));
+    }
+
+    @Test
+    @RunAsClient
+    public void acceptJson() throws Exception {
+        HttpResponse response = Request.Get("http://localhost:8080/openapi")
+                .addHeader("Accept", "application/json")
+                .execute()
+                .returnResponse();
+        assertTrue(response.getFirstHeader("Content-Type").getValue().contains("application/json"));
+    }
+
+    @Test
+    @RunAsClient
+    public void acceptNonsense() throws Exception {
+        HttpResponse response = Request.Get("http://localhost:8080/openapi")
+                .addHeader("Accept", "foo/bar")
+                .execute()
+                .returnResponse();
+        assertTrue(response.getFirstHeader("Content-Type").getValue().contains("application/yaml"));
+    }
+
+    @Test
+    @RunAsClient
+    public void formatYaml() throws Exception {
+        HttpResponse response = Request.Get("http://localhost:8080/openapi?format=YAML").execute().returnResponse();
+        assertTrue(response.getFirstHeader("Content-Type").getValue().contains("application/yaml"));
+    }
+
+    @Test
+    @RunAsClient
+    public void formatJson() throws Exception {
+        HttpResponse response = Request.Get("http://localhost:8080/openapi?format=JSON").execute().returnResponse();
+        assertTrue(response.getFirstHeader("Content-Type").getValue().contains("application/json"));
+    }
+
+    @Test
+    @RunAsClient
+    public void formatJsonLowercase() throws Exception {
+        HttpResponse response = Request.Get("http://localhost:8080/openapi?format=json").execute().returnResponse();
+        assertTrue(response.getFirstHeader("Content-Type").getValue().contains("application/json"));
+    }
+
+    @Test
+    @RunAsClient
+    public void formatJsonLegacy() throws Exception {
+        HttpResponse response = Request.Get("http://localhost:8080/openapi?format=application/json").execute().returnResponse();
+        assertTrue(response.getFirstHeader("Content-Type").getValue().contains("application/json"));
+    }
+
+    @Test
+    @RunAsClient
+    public void formatNonsense() throws Exception {
+        HttpResponse response = Request.Get("http://localhost:8080/openapi?format=foo-bar").execute().returnResponse();
+        assertTrue(response.getFirstHeader("Content-Type").getValue().contains("application/yaml"));
     }
 }


### PR DESCRIPTION
Motivation
----------
The MicroProfile OpenAPI specification clearly states that the optional
query string parameter `format` can have 2 values: `YAML` and `JSON`.
Our current implementation defaults to YAML and checks the `format`
parameter (and the `Accept` header) if it should switch to JSON.

However, it doesn't check the `format` parameter correctly. Instead
of checking for `JSON`, it checks for `application/json`.

Modifications
-------------
Check the `format` parameter for `JSON` value as well. The check
is case insensitive.

Result
------
More conformant to the specification. No breaking change,
as the original behavior is retained.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
