### PR TITLE
THORN-2414: topology-openshift fraction doesn't work on OpenShift 4.1

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -68,7 +68,7 @@
 
     <version.com.orbitz.consul>1.2.1</version.com.orbitz.consul>
 
-    <version.openshift.client>7.0.0.Final</version.openshift.client>
+    <version.openshift.client>8.0.0.Final</version.openshift.client>
     <version.com.squareup.okhttp>3.9.0</version.com.squareup.okhttp>
     <version.com.squareup.okio>1.13.0</version.com.squareup.okio>
 


### PR DESCRIPTION
Motivation
----------
The `topology-openshift` fraction doesn't work on OpenShift 4.1, because
the OpenShift RestClient Java throws an exception:

```
ERROR [stderr] (main) Caused by: org.jboss.msc.service.StartException in service "swarm.topology.openshift".service-watcher: Failed to start service
ERROR [stderr] (main) Caused by: com.openshift.restclient.OpenShiftException: Exception trying to fetch null response code: 0
ERROR [stderr] (main) Caused by: com.openshift.restclient.NotFoundException:
```

The OpenShift RestClient Java version 7 doesn't support OpenShift 4.
Version 8 does.

Modifications
-------------
Update to latest version 8.0.0.Final of OpenShift RestClient Java.

Result
------
The `topology-openshift` fraction now works with OpenShift 4.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
