### PR TITLE
THORN-2430: Upgrade Jackson dependency to 2.9.9

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -49,7 +49,7 @@
     <!-- Align dependency versions with those present in WildFly parent -->
     <!-- Doing this explicitly since there is no easy way to import project properties from a pom file -->
     <version.org.apache.maven.resolver>1.3.1</version.org.apache.maven.resolver>
-    <version.com.fasterxml.jackson>2.9.5</version.com.fasterxml.jackson>
+    <version.com.fasterxml.jackson>2.9.9</version.com.fasterxml.jackson>
 
     <version.org.ow2.asm>7.0</version.org.ow2.asm>
 


### PR DESCRIPTION
Motivation
----------
Our Jackson version is very old.

Modifications
-------------
Upgrade Jackson to latest version.

One notable thing: WildFly 15.0.1.Final, on which Thorntail
is currently based, uses the same old Jackson version.
But we already configure the global `module-rewrite.conf`
to override all Jackson modules to our selected version,
so the old version shouldn't appear anywhere.

Result
------
More up to date Jackson.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
