### PR TITLE
[THORN-2433] Making configuring @LoginConfig realmName optional

### DIFF
--- a/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/MicroProfileJWTAuthFraction.java
+++ b/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/MicroProfileJWTAuthFraction.java
@@ -68,7 +68,7 @@ public class MicroProfileJWTAuthFraction implements Fraction<MicroProfileJWTAuth
     @Configurable("thorntail.microprofile.jwt.realm")
     @Configurable("thorntail.microprofile.jwtauth.realm")
     @AttributeDocumentation("If set, a security domain with this name that supports MicroProfile JWT is automatically created in the security subsystem."
-                            + " The realmName parameter of the @LoginConfig annotation must be set to the same value.")
+                            + " If the @LoginConfig realName property is configured then it must have the same value.")
     private Defaultable<String> jwtRealm = string("");
 
     /**

--- a/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/MicroProfileJWTAuthFraction.java
+++ b/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/MicroProfileJWTAuthFraction.java
@@ -67,8 +67,8 @@ public class MicroProfileJWTAuthFraction implements Fraction<MicroProfileJWTAuth
      */
     @Configurable("thorntail.microprofile.jwt.realm")
     @Configurable("thorntail.microprofile.jwtauth.realm")
-    @AttributeDocumentation("Defines the security domain which should be used for MicroProfile JWT. This property will be ignored if the security domain with this name already exists. "
-                            + "If this option is set then the realmName property of the @LoginConfig annotation does not have to be configured but if it is then it must have the same value as this option")
+    @AttributeDocumentation("Defines the security domain which should be used for MicroProfile JWT. If no security domain with this name exists, one will be created using sensible defaults. "
+                            + " If this option is set, then the realmName property of the @LoginConfig annotation does not have to be configured; but if it is, then it must have the same value as this option.")
     private Defaultable<String> jwtRealm = string("");
 
     /**

--- a/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/MicroProfileJWTAuthFraction.java
+++ b/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/MicroProfileJWTAuthFraction.java
@@ -67,7 +67,7 @@ public class MicroProfileJWTAuthFraction implements Fraction<MicroProfileJWTAuth
      */
     @Configurable("thorntail.microprofile.jwt.realm")
     @Configurable("thorntail.microprofile.jwtauth.realm")
-    @AttributeDocumentation("Defines the security domain which should be used for MicroProfile JWT but be ignored if the security domain with this name already exists. "
+    @AttributeDocumentation("Defines the security domain which should be used for MicroProfile JWT. This property will be ignored if the security domain with this name already exists. "
                             + "If this option is set then the realmName property of the @LoginConfig annotation does not have to be configured but if it is then it must have the same value as this option")
     private Defaultable<String> jwtRealm = string("");
 

--- a/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/MicroProfileJWTAuthFraction.java
+++ b/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/MicroProfileJWTAuthFraction.java
@@ -67,8 +67,8 @@ public class MicroProfileJWTAuthFraction implements Fraction<MicroProfileJWTAuth
      */
     @Configurable("thorntail.microprofile.jwt.realm")
     @Configurable("thorntail.microprofile.jwtauth.realm")
-    @AttributeDocumentation("If set, a security domain with this name that supports MicroProfile JWT is automatically created in the security subsystem."
-                            + " If the @LoginConfig realName property is configured then it must have the same value.")
+    @AttributeDocumentation("Defines the security domain which should be used for MicroProfile JWT but be ignored if the security domain with this name already exists. "
+                            + "If this option is set then the realmName property of the @LoginConfig annotation does not have to be configured but if it is then it must have the same value as this option")
     private Defaultable<String> jwtRealm = string("");
 
     /**

--- a/testsuite/testsuite-microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/SimpleLoginConfigApplication.java
+++ b/testsuite/testsuite-microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/SimpleLoginConfigApplication.java
@@ -1,0 +1,14 @@
+package org.wildfly.swarm.microprofile.jwtauth;
+
+import org.eclipse.microprofile.auth.LoginConfig;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationScoped
+@ApplicationPath("/mpjwt")
+@LoginConfig(authMethod = "MP-JWT")
+public class SimpleLoginConfigApplication extends Application {
+    // intentionally left empty
+}

--- a/testsuite/testsuite-microprofile-jwt/src/test/java/org/wildfly/swarm/microprofile/jwtauth/SimpleLoginConfigTest.java
+++ b/testsuite/testsuite-microprofile-jwt/src/test/java/org/wildfly/swarm/microprofile/jwtauth/SimpleLoginConfigTest.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.jwtauth;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.wildfly.swarm.microprofile.jwtauth.utils.TokenUtils.createToken;
+
+import org.apache.http.client.fluent.Request;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.ClassLoaderAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.microprofile.jwtauth.utils.TokenUtils;
+import org.wildfly.swarm.undertow.WARArchive;
+
+@RunWith(Arquillian.class)
+public class SimpleLoginConfigTest {
+    @Deployment
+    public static Archive<?> createDeployment() {
+        return initDeployment().addAsResource("project-simple-login-config.yml", "project-defaults.yml");
+    }
+
+    protected static WARArchive initDeployment() {
+        WARArchive deployment = ShrinkWrap.create(WARArchive.class);
+        deployment.addClass(ApplicationScopedSubjectExposingResource.class);
+        deployment.addClass(SimpleLoginConfigApplication.class);
+        deployment.addAsManifestResource(new ClassLoaderAsset("keys/public-key.pem"), "/MP-JWT-SIGNER");
+        return deployment;
+    }
+
+
+    @RunAsClient
+    @Test
+    public void subjectShouldBeRequestSpecific() throws Exception {
+        String response = Request.Get("http://localhost:8080/mpjwt/subject/secured")
+                .setHeader("Authorization", "Bearer " + createToken(TokenUtils.SUBJECT, "MappedRole"))
+                .execute().returnContent().asString();
+        assertThat(response).isEqualTo(TokenUtils.SUBJECT);
+
+        response = Request.Get("http://localhost:8080/mpjwt/subject/secured")
+                .setHeader("Authorization", "Bearer " + createToken(TokenUtils.SUBJECT2, "MappedRole"))
+                .execute().returnContent().asString();
+        assertThat(response).isEqualTo(TokenUtils.SUBJECT2);
+    }
+}

--- a/testsuite/testsuite-microprofile-jwt/src/test/resources/project-simple-login-config.yml
+++ b/testsuite/testsuite-microprofile-jwt/src/test/resources/project-simple-login-config.yml
@@ -1,0 +1,6 @@
+thorntail:
+  microprofile:
+    jwt:
+      realm: testSuiteRealm
+      token:
+        issued-by: "http://testsuite-jwt-issuer.io"


### PR DESCRIPTION
Motivation
----------
Let users to avoid having to specify the MP JWT realm in the `LoginConfig` annotation if a `thorntail.microprofile.jwt.realm` property is set

Modifications
-------------
`MPJWTAuthExtensionArchivePreparer` has been updated to use the `thorntail.microprofile.jwt.realm` value if `LoginConfig``s `realmName` is empty/null. Also the error is logged if both values are not empty and non equal 

Result
------
No need for users to type the realm name twice in the code and the configuartion
