### PR TITLE
[THORN-2436] Let users disable MP JWT and make LoginConfig optional if the jwt realm is configured

### DIFF
--- a/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/MicroProfileJWTAuthFraction.java
+++ b/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/MicroProfileJWTAuthFraction.java
@@ -84,7 +84,7 @@ public class MicroProfileJWTAuthFraction implements Fraction<MicroProfileJWTAuth
     @Configurable("thorntail.microprofile.jwt.realm")
     @Configurable("thorntail.microprofile.jwtauth.realm")
     @AttributeDocumentation("Defines the security domain which should be used for MicroProfile JWT. If no security domain with this name exists, one will be created using sensible defaults. "
-                            + " If this option is set, then the realmName property of the @LoginConfig annotation does not have to be configured; but if it is, then it must have the same value as this option.")
+                            + " If this option is set, then the @LoginConfig annotation is not needed but if it is available then its realmName property, if set, must have the same value as this option.")
     private Defaultable<String> jwtRealm = string("");
 
     /**
@@ -103,8 +103,7 @@ public class MicroProfileJWTAuthFraction implements Fraction<MicroProfileJWTAuth
     @AttributeDocumentation("Roles properties map")
     private Map<String, String> rolesPropertiesMap;
 
-    @AttributeDocumentation("If both this and 'thorntail.microprofile.jwt.realm' properties are enabled then the @LoginConfig annotation does not have to be present."
-                            + "If this option is disabled then the MP JWT authentication mechanism will not be activated")
+    @AttributeDocumentation("Set this to false to disable the MP JWT authentication mechanism. Defaults to true.")
     @Configurable("thorntail.microprofile.jwt.enabled")
     private Defaultable<Boolean> jwtEnabled = bool(true);
 

--- a/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/MicroProfileJWTAuthFraction.java
+++ b/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/MicroProfileJWTAuthFraction.java
@@ -84,7 +84,7 @@ public class MicroProfileJWTAuthFraction implements Fraction<MicroProfileJWTAuth
     @Configurable("thorntail.microprofile.jwt.realm")
     @Configurable("thorntail.microprofile.jwtauth.realm")
     @AttributeDocumentation("Defines the security domain which should be used for MicroProfile JWT. If no security domain with this name exists, one will be created using sensible defaults. "
-                            + " If this option is set, then the @LoginConfig annotation is not needed but if it is available then its realmName property, if set, must have the same value as this option.")
+                            + " If this option is set, then the @LoginConfig annotation is not needed but if it is present then its realmName property, if set, must have the same value as this option.")
     private Defaultable<String> jwtRealm = string("");
 
     /**

--- a/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/MicroProfileJWTAuthFraction.java
+++ b/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/MicroProfileJWTAuthFraction.java
@@ -103,6 +103,19 @@ public class MicroProfileJWTAuthFraction implements Fraction<MicroProfileJWTAuth
     @AttributeDocumentation("Roles properties map")
     private Map<String, String> rolesPropertiesMap;
 
+    @AttributeDocumentation("If both this and 'thorntail.microprofile.jwt.realm' properties are enabled then the @LoginConfig annotation does not have to be present."
+                            + "If this option is disabled then the MP JWT authentication mechanism will not be activated")
+    @Configurable("thorntail.microprofile.jwt.enabled")
+    private Defaultable<Boolean> jwtEnabled = bool(true);
+
+    public Defaultable<Boolean> isJwtEnabled() {
+        return jwtEnabled;
+    }
+
+    public void setJwtEnabled(boolean enabled) {
+        this.jwtEnabled = bool(enabled);
+    }
+
     public Defaultable<String> getTokenIssuer() {
         return tokenIssuer;
     }

--- a/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/runtime/MPJWTAuthExtensionArchivePreparer.java
+++ b/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/runtime/MPJWTAuthExtensionArchivePreparer.java
@@ -103,10 +103,13 @@ public class MPJWTAuthExtensionArchivePreparer implements DeploymentProcessor {
             }
         }
 
-        if (!loginConfigMpJwtAvailable && !fraction.getJwtRealm().get().isEmpty()) {
-            selectSecurityDomain(war, fraction.getJwtRealm().get());
+        if (!loginConfigMpJwtAvailable) {
+            if (!fraction.getJwtRealm().get().isEmpty()) {
+                selectSecurityDomain(war, fraction.getJwtRealm().get());
+            } else {
+                return;
+            }
         }
-
         // Handle the verification configuration on the fraction
         if (fraction.getTokenIssuer().isPresent()) {
             log.debugf("Issuer: %s", fraction.getTokenIssuer().get());

--- a/testsuite/testsuite-microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/ApplicationWithoutLoginConfig.java
+++ b/testsuite/testsuite-microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/ApplicationWithoutLoginConfig.java
@@ -1,0 +1,11 @@
+package org.wildfly.swarm.microprofile.jwtauth;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationScoped
+@ApplicationPath("/mpjwt")
+public class ApplicationWithoutLoginConfig extends Application {
+    // intentionally left empty
+}

--- a/testsuite/testsuite-microprofile-jwt/src/test/java/org/wildfly/swarm/microprofile/jwtauth/AppWithNoLoginConfigAndConfiguredJwtRealmTest.java
+++ b/testsuite/testsuite-microprofile-jwt/src/test/java/org/wildfly/swarm/microprofile/jwtauth/AppWithNoLoginConfigAndConfiguredJwtRealmTest.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.jwtauth;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.wildfly.swarm.microprofile.jwtauth.utils.TokenUtils.createToken;
+
+import org.apache.http.client.fluent.Content;
+import org.apache.http.client.fluent.Request;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.ClassLoaderAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.undertow.WARArchive;
+
+@RunWith(Arquillian.class)
+public class AppWithNoLoginConfigAndConfiguredJwtRealmTest {
+    @Deployment
+    public static Archive<?> createDeployment() {
+        return initDeployment().addAsResource("project-empty-roles.yml", "project-defaults.yml");
+    }
+
+    protected static WARArchive initDeployment() {
+        WARArchive deployment = ShrinkWrap.create(WARArchive.class);
+        deployment.addClass(ApplicationScopedSubjectExposingResource.class);
+        deployment.addClass(ApplicationWithoutLoginConfig.class);
+        deployment.addAsManifestResource(new ClassLoaderAsset("keys/public-key.pem"), "/MP-JWT-SIGNER");
+        return deployment;
+    }
+
+    @RunAsClient
+    @Test
+    public void tokenIsNotProcessed() throws Exception {
+        Content content = Request.Get("http://localhost:8080/mpjwt/subject/secured")
+                .setHeader("Authorization", "Bearer " + createToken("MappedRole"))
+                .execute().returnContent();
+        assertThat(content).isNull();
+    }
+}

--- a/testsuite/testsuite-microprofile-jwt/src/test/java/org/wildfly/swarm/microprofile/jwtauth/AppWithNoLoginConfigWithConfiguredJwtRealmTest.java
+++ b/testsuite/testsuite-microprofile-jwt/src/test/java/org/wildfly/swarm/microprofile/jwtauth/AppWithNoLoginConfigWithConfiguredJwtRealmTest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.jwtauth;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.wildfly.swarm.microprofile.jwtauth.utils.TokenUtils.createToken;
+
+import org.apache.http.client.fluent.Content;
+import org.apache.http.client.fluent.Request;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.ClassLoaderAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.microprofile.jwtauth.utils.TokenUtils;
+import org.wildfly.swarm.undertow.WARArchive;
+
+@RunWith(Arquillian.class)
+public class AppWithNoLoginConfigWithConfiguredJwtRealmTest {
+    @Deployment
+    public static Archive<?> createDeployment() {
+        return initDeployment().addAsResource("project-simple-login-config.yml", "project-defaults.yml");
+    }
+
+    protected static WARArchive initDeployment() {
+        WARArchive deployment = ShrinkWrap.create(WARArchive.class);
+        deployment.addClass(ApplicationScopedSubjectExposingResource.class);
+        deployment.addClass(ApplicationWithoutLoginConfig.class);
+        deployment.addAsManifestResource(new ClassLoaderAsset("keys/public-key.pem"), "/MP-JWT-SIGNER");
+        return deployment;
+    }
+
+    @RunAsClient
+    @Test
+    public void subjectShouldNotLeakToNonSecuredRequest() throws Exception {
+        // project-no-roles-props.yml restricts the number of worker threads to 1,
+        // that is, all requests are processed by the same single thread
+
+        String response = Request.Get("http://localhost:8080/mpjwt/subject/secured")
+                .setHeader("Authorization", "Bearer " + createToken("MappedRole"))
+                .execute().returnContent().asString();
+        assertThat(response).isEqualTo(TokenUtils.SUBJECT);
+
+        Content content = Request.Get("http://localhost:8080/mpjwt/subject/unsecured")
+                .execute().returnContent();
+        assertThat(content).isNull();
+    }
+    
+    @RunAsClient
+    @Test
+    public void subjectShouldBeRequestSpecific() throws Exception {
+        String response = Request.Get("http://localhost:8080/mpjwt/subject/secured")
+                .setHeader("Authorization", "Bearer " + createToken(TokenUtils.SUBJECT, "MappedRole"))
+                .execute().returnContent().asString();
+        assertThat(response).isEqualTo(TokenUtils.SUBJECT);
+
+        response = Request.Get("http://localhost:8080/mpjwt/subject/secured")
+                .setHeader("Authorization", "Bearer " + createToken(TokenUtils.SUBJECT2, "MappedRole"))
+                .execute().returnContent().asString();
+        assertThat(response).isEqualTo(TokenUtils.SUBJECT2);
+    }
+}

--- a/testsuite/testsuite-microprofile-jwt/src/test/java/org/wildfly/swarm/microprofile/jwtauth/MpJwtDisabledTest.java
+++ b/testsuite/testsuite-microprofile-jwt/src/test/java/org/wildfly/swarm/microprofile/jwtauth/MpJwtDisabledTest.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.swarm.microprofile.jwtauth;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.wildfly.swarm.microprofile.jwtauth.utils.TokenUtils.createToken;
+
+import org.apache.http.client.fluent.Content;
+import org.apache.http.client.fluent.Request;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.ClassLoaderAsset;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.swarm.microprofile.jwtauth.roles.TestApplication;
+import org.wildfly.swarm.undertow.WARArchive;
+
+@RunWith(Arquillian.class)
+public class MpJwtDisabledTest {
+    @Deployment
+    public static Archive<?> createDeployment() {
+        return initDeployment().addAsResource("project-jwt-disabled.yml", "project-defaults.yml");
+    }
+
+    protected static WARArchive initDeployment() {
+        WARArchive deployment = ShrinkWrap.create(WARArchive.class);
+        deployment.addClass(ApplicationScopedSubjectExposingResource.class);
+        deployment.addClass(TestApplication.class);
+        deployment.addAsManifestResource(new ClassLoaderAsset("keys/public-key.pem"), "/MP-JWT-SIGNER");
+        return deployment;
+    }
+
+    @RunAsClient
+    @Test
+    public void tokenIsNotProcessed() throws Exception {
+        Content content = Request.Get("http://localhost:8080/mpjwt/subject/secured")
+                .setHeader("Authorization", "Bearer " + createToken("MappedRole"))
+                .execute().returnContent();
+        assertThat(content).isNull();
+    }
+}

--- a/testsuite/testsuite-microprofile-jwt/src/test/resources/project-jwt-disabled.yml
+++ b/testsuite/testsuite-microprofile-jwt/src/test/resources/project-jwt-disabled.yml
@@ -1,0 +1,7 @@
+thorntail:
+  microprofile:
+    jwt:
+      enabled: false
+      realm: testSuiteRealm
+      token:
+        issued-by: "http://testsuite-jwt-issuer.io"


### PR DESCRIPTION
Motivation
----------
Do not require users to add @LoginConfig if the  `thorntail.microprofile.jwt.realm` property is set.
Also add the ability to disable MP JWT similarly to Quarkus.

Modifications
-------------
`thorntail.microprofile.jwt.enabled` property. The security domain selection is skipped if the feature is disabled or if no @LoginConfig with the authentication method `MP-JWT` is found and no `thorntail.microprofile.jwt.realm` is set

Result
------
JAX-RS `Application` will not have to be tied to to the MP JWT API