### PR TITLE
Upgraded EclipseLink version to the latest available.

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -64,7 +64,7 @@
     <version.geolatte>1.4.0</version.geolatte>
     <version.vividsolutions-jts>1.13</version.vividsolutions-jts>
 
-    <version.eclipse.link>2.7.3</version.eclipse.link>
+    <version.eclipse.link>2.7.4</version.eclipse.link>
 
     <version.com.orbitz.consul>1.2.1</version.com.orbitz.consul>
 


### PR DESCRIPTION
Motivation
----------
The EclipseLink library is outdated.

Modifications
-------------
Updated the EclipseLink version in build-parent pom.

Result
------
Thorntail will now have the latest EclipseLink version available - 2.7.4.