### PR TITLE
THORN-2399: move all version-related Maven properties to the root POM

### DIFF
--- a/arquillian/adapter/pom.xml
+++ b/arquillian/adapter/pom.xml
@@ -104,18 +104,6 @@
       <artifactId>junit</artifactId>
       <scope>compile</scope>
     </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.10.19</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-core</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
 
   </dependencies>
 

--- a/arquillian/daemon/pom.xml
+++ b/arquillian/daemon/pom.xml
@@ -22,13 +22,6 @@
 
   <packaging>jar</packaging>
 
-<!--
-  <properties>
-    <swarm.fraction.cdi>false</swarm.fraction.cdi>
-    <swarm.fraction.bootstrap>org.wildfly.swarm.arquillian.daemon</swarm.fraction.bootstrap>
-  </properties>
--->
-
   <build>
     <resources>
       <resource>

--- a/boms/bom-all/pom.xml
+++ b/boms/bom-all/pom.xml
@@ -83,7 +83,7 @@
       <extension>
         <groupId>org.apache.maven.wagon</groupId>
         <artifactId>wagon-webdav-jackrabbit</artifactId>
-        <version>2.10</version>
+        <version>${version.wagon-webdav-jackrabbit}</version>
       </extension>
     </extensions>
   </build>

--- a/boms/bom-certified/pom.xml
+++ b/boms/bom-certified/pom.xml
@@ -59,7 +59,7 @@
       <extension>
         <groupId>org.apache.maven.wagon</groupId>
         <artifactId>wagon-webdav-jackrabbit</artifactId>
-        <version>2.10</version>
+        <version>${version.wagon-webdav-jackrabbit}</version>
       </extension>
     </extensions>
   </build>

--- a/boms/bom-deprecated/pom.xml
+++ b/boms/bom-deprecated/pom.xml
@@ -62,7 +62,7 @@
       <extension>
         <groupId>org.apache.maven.wagon</groupId>
         <artifactId>wagon-webdav-jackrabbit</artifactId>
-        <version>2.10</version>
+        <version>${version.wagon-webdav-jackrabbit}</version>
       </extension>
     </extensions>
   </build>

--- a/boms/bom-experimental/pom.xml
+++ b/boms/bom-experimental/pom.xml
@@ -62,7 +62,7 @@
       <extension>
         <groupId>org.apache.maven.wagon</groupId>
         <artifactId>wagon-webdav-jackrabbit</artifactId>
-        <version>2.10</version>
+        <version>${version.wagon-webdav-jackrabbit}</version>
       </extension>
     </extensions>
   </build>

--- a/boms/bom-frozen/pom.xml
+++ b/boms/bom-frozen/pom.xml
@@ -62,7 +62,7 @@
       <extension>
         <groupId>org.apache.maven.wagon</groupId>
         <artifactId>wagon-webdav-jackrabbit</artifactId>
-        <version>2.10</version>
+        <version>${version.wagon-webdav-jackrabbit}</version>
       </extension>
     </extensions>
   </build>

--- a/boms/bom-locked/pom.xml
+++ b/boms/bom-locked/pom.xml
@@ -62,7 +62,7 @@
       <extension>
         <groupId>org.apache.maven.wagon</groupId>
         <artifactId>wagon-webdav-jackrabbit</artifactId>
-        <version>2.10</version>
+        <version>${version.wagon-webdav-jackrabbit}</version>
       </extension>
     </extensions>
   </build>

--- a/boms/bom-stable/pom.xml
+++ b/boms/bom-stable/pom.xml
@@ -62,7 +62,7 @@
       <extension>
         <groupId>org.apache.maven.wagon</groupId>
         <artifactId>wagon-webdav-jackrabbit</artifactId>
-        <version>2.10</version>
+        <version>${version.wagon-webdav-jackrabbit}</version>
       </extension>
     </extensions>
   </build>

--- a/boms/bom-unstable/pom.xml
+++ b/boms/bom-unstable/pom.xml
@@ -62,7 +62,7 @@
       <extension>
         <groupId>org.apache.maven.wagon</groupId>
         <artifactId>wagon-webdav-jackrabbit</artifactId>
-        <version>2.10</version>
+        <version>${version.wagon-webdav-jackrabbit}</version>
       </extension>
     </extensions>
   </build>

--- a/boms/bom/pom.xml
+++ b/boms/bom/pom.xml
@@ -62,7 +62,7 @@
       <extension>
         <groupId>org.apache.maven.wagon</groupId>
         <artifactId>wagon-webdav-jackrabbit</artifactId>
-        <version>2.10</version>
+        <version>${version.wagon-webdav-jackrabbit}</version>
       </extension>
     </extensions>
   </build>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -21,110 +21,6 @@
   <name>Thorntail Build Parent</name>
   <description>Build Parent to bring in required dependencies</description>
 
-  <properties>
-    <version.thorntail.fraction.plugin>97</version.thorntail.fraction.plugin>
-
-    <version.thorntail-jdk-specific>1</version.thorntail-jdk-specific>
-
-    <version.org.snakeyaml>1.18</version.org.snakeyaml>
-
-    <version.wildfly.config-api>1.7.0</version.wildfly.config-api>
-
-    <version.keycloak.config-api>1.7.0</version.keycloak.config-api>
-    <version.keycloak>4.8.3.Final</version.keycloak>
-
-    <version.mongo.config-api>1.7.0</version.mongo.config-api>
-    <version.cassandra.config-api>1.7.0</version.cassandra.config-api>
-    <version.neo4j.config-api>1.7.0</version.neo4j.config-api>
-    <version.orientdb.config-api>1.7.0</version.orientdb.config-api>
-    <version.wildfly.nosql.feature-pack>1.0.2.Final</version.wildfly.nosql.feature-pack>
-
-    <version.jboss-modules>1.8.7.Final</version.jboss-modules>
-    <version.wildfly>15.0.1.Final</version.wildfly>
-    <version.org.wildfly.core>7.0.0.Final</version.org.wildfly.core>
-    <version.jboss-logmanager-ext>1.0.0.Alpha5</version.jboss-logmanager-ext>
-    <!-- Weld SE version must be aligned with the version used in WildFly -->
-    <version.weld-se>3.0.5.Final</version.weld-se>
-    <version.jandex>2.0.5.Final</version.jandex>
-    <!-- Align dependency versions with those present in WildFly parent -->
-    <!-- Doing this explicitly since there is no easy way to import project properties from a pom file -->
-    <version.org.apache.maven.resolver>1.3.1</version.org.apache.maven.resolver>
-    <version.com.fasterxml.jackson>2.9.9</version.com.fasterxml.jackson>
-
-    <version.org.ow2.asm>7.0</version.org.ow2.asm>
-
-    <version.jolokia>1.3.4</version.jolokia>
-    <version.io.swagger>1.5.21</version.io.swagger>
-    <version.org.webjars.swagger-ui>3.2.2</version.org.webjars.swagger-ui>
-    <version.swagger.reflections>0.9.10</version.swagger.reflections>
-    <version.swagger.slf4j>1.6.3</version.swagger.slf4j>
-    <version.swagger.commons.lang>3.2.1</version.swagger.commons.lang>
-
-    <version.hibernate-spatial>5.3.7.Final</version.hibernate-spatial>
-    <version.geolatte>1.4.0</version.geolatte>
-    <version.vividsolutions-jts>1.13</version.vividsolutions-jts>
-
-    <version.eclipse.link>2.7.4</version.eclipse.link>
-
-    <version.com.orbitz.consul>1.2.1</version.com.orbitz.consul>
-
-    <version.openshift.client>8.0.0.Final</version.openshift.client>
-    <version.com.squareup.okhttp>3.9.0</version.com.squareup.okhttp>
-    <version.com.squareup.okio>1.13.0</version.com.squareup.okio>
-
-    <version.vertx>3.3.3</version.vertx>
-
-    <version.org.kie>6.4.0.Final</version.org.kie>
-
-    <version.flyway>4.2.0</version.flyway>
-
-    <version.gradle>3.1</version.gradle>
-    <version.gradle.plugins>1.12</version.gradle.plugins>
-    <version.groovy>2.4.3</version.groovy>
-
-    <version.brave>3.14.1</version.brave>
-    <version.zipkin.reporter>0.6.1</version.zipkin.reporter>
-    <version.zipkin>1.13.1</version.zipkin>
-
-    <!-- OpenTracing related versions -->
-    <version.opentracing.tracerresolver>0.1.5</version.opentracing.tracerresolver>
-    <version.opentracing.servlet>0.2.0</version.opentracing.servlet>
-    <version.opentracing.concurrent>0.2.0</version.opentracing.concurrent>
-    <version.opentracing.jaxrs>0.4.1</version.opentracing.jaxrs>
-    <version.opentracing.interceptors>0.0.4</version.opentracing.interceptors>
-    <version.jaeger>0.34.0</version.jaeger>
-    <version.jaeger.apache.thrift>0.12.0</version.jaeger.apache.thrift>
-    <version.jaeger.gson>2.8.2</version.jaeger.gson>
-
-    <version.maven.resolver.provider>3.6.0</version.maven.resolver.provider>
-
-    <version.resteasy>3.8.0.Final</version.resteasy>
-    <version.org.glassfish.javax.json>1.1.2</version.org.glassfish.javax.json>
-
-    <!-- MicroProfile APIs -->
-    <version.microprofile-config>1.3</version.microprofile-config>
-    <version.microprofile-health>2.0.1</version.microprofile-health>
-    <version.microprofile-fault-tolerance>2.0.1</version.microprofile-fault-tolerance>
-    <version.microprofile-jwt-auth>1.1.1</version.microprofile-jwt-auth>
-    <version.microprofile-metrics>2.0.1</version.microprofile-metrics>
-    <version.microprofile.restclient>1.3.2</version.microprofile.restclient>
-    <version.microprofile-openapi>1.1.2</version.microprofile-openapi>
-    <version.microprofile-opentracing>1.3.1</version.microprofile-opentracing>
-
-    <!-- MP Config WildFly subsystem -->
-    <version.microprofile-config-wildfly>1.7.1</version.microprofile-config-wildfly>
-
-    <!-- SmallRye versions -->
-    <version.smallrye.config-1.3>1.0.0</version.smallrye.config-1.3>
-    <version.smallrye.health-2.0>1.0.1</version.smallrye.health-2.0>
-    <version.smallrye.openapi-1.1>1.0.1</version.smallrye.openapi-1.1>
-    <version.smallrye.opentracing-1.3>1.0.0</version.smallrye.opentracing-1.3>
-    <version.smallrye.metrics-2.0>1.1.0</version.smallrye.metrics-2.0>
-    <version.smallrye.jwt-1.1>2.0.0</version.smallrye.jwt-1.1>
-    <version.smallrye.fault-tolerance-2.0>1.0.1</version.smallrye.fault-tolerance-2.0>
-
-  </properties>
-
   <build>
     <plugins>
       <plugin>
@@ -188,19 +84,16 @@
         <version>${version.thorntail-jdk-specific}</version>
       </dependency>
 
-      <!--
-        org.wildfly:wildfly-parent transitively brings in 3.2.1, which breaks ShrinkWrap's resolver.
-        Must override with 3.2.5
-    -->
+      <!-- org.wildfly:wildfly-parent transitively brings in an older version -->
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-resolver-provider</artifactId>
-        <version>${version.maven.resolver.provider}</version>
+        <version>${version.org.apache.maven}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-settings-builder</artifactId>
-        <version>${version.maven.resolver.provider}</version>
+        <version>${version.org.apache.maven}</version>
       </dependency>
 
       <dependency>
@@ -354,7 +247,7 @@
       <dependency>
         <groupId>net.sf.jopt-simple</groupId>
         <artifactId>jopt-simple</artifactId>
-        <version>4.9</version>
+        <version>${version.jopt-simple}</version>
       </dependency>
 
       <!-- Needed by bootstrap -->
@@ -571,7 +464,7 @@
       <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
-        <version>${version.jaeger.gson}</version>
+        <version>${version.gson}</version>
       </dependency>
       <!-- end of unused dependencies -->
 

--- a/core/container/pom.xml
+++ b/core/container/pom.xml
@@ -39,7 +39,7 @@
          <plugin>
             <groupId>io.reformanda.semper</groupId>
             <artifactId>dependencyversion-maven-plugin</artifactId>
-            <version>1.0.1</version>
+            <version>${version.dependencyversion-maven-plugin}</version>
             <executions>
                <execution>
                   <id>set-versions</id>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -73,7 +73,7 @@
       <plugin>
         <groupId>org.asciidoctor</groupId>
         <artifactId>asciidoctor-maven-plugin</artifactId>
-        <version>1.5.7.1</version>
+        <version>${version.asciidoctor-maven-plugin}</version>
         <inherited>false</inherited>
         <dependencies>
           <dependency>

--- a/fractions/asciidoctorj/pom.xml
+++ b/fractions/asciidoctorj/pom.xml
@@ -36,7 +36,6 @@
     <properties>
         <swarm.fraction.stability>experimental</swarm.fraction.stability>
         <swarm.fraction.tags>Documentation</swarm.fraction.tags>
-        <version.asciidoctorj>1.5.5</version.asciidoctorj>
     </properties>
 
     <build>

--- a/fractions/cdi-extensions/cdi-config/pom.xml
+++ b/fractions/cdi-extensions/cdi-config/pom.xml
@@ -99,7 +99,7 @@
       <plugin>
         <groupId>org.jboss.jandex</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
-        <version>1.0.4</version>
+        <version>${version.jandex-maven-plugin}</version>
         <executions>
           <execution>
             <id>make-index</id>

--- a/fractions/cdi-extensions/cdi-jaxrsapi/pom.xml
+++ b/fractions/cdi-extensions/cdi-jaxrsapi/pom.xml
@@ -118,7 +118,7 @@
       <plugin>
         <groupId>org.jboss.jandex</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
-        <version>1.0.4</version>
+        <version>${version.jandex-maven-plugin}</version>
         <executions>
           <execution>
             <id>make-index</id>

--- a/fractions/fluentd/pom.xml
+++ b/fractions/fluentd/pom.xml
@@ -25,7 +25,6 @@
   <properties>
     <swarm.fraction.stability>experimental</swarm.fraction.stability>
     <swarm.fraction.tags>Logging, Openshift</swarm.fraction.tags>
-    <fluentd.version>0.3.2</fluentd.version>
   </properties>
 
   <build>
@@ -69,7 +68,7 @@
     <dependency>
       <groupId>org.fluentd</groupId>
       <artifactId>fluent-logger</artifactId>
-      <version>${fluentd.version}</version>
+      <version>${version.fluentd}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/fractions/jaeger/src/main/resources/modules/com/google/code/gson/jaeger/module.xml
+++ b/fractions/jaeger/src/main/resources/modules/com/google/code/gson/jaeger/module.xml
@@ -1,6 +1,6 @@
 <module xmlns="urn:jboss:module:1.3" name="com.google.code.gson" slot="jaeger">
   <resources>
-    <artifact name="com.google.code.gson:gson:${version.jaeger.gson}"/>
+    <artifact name="com.google.code.gson:gson:${version.gson}"/>
   </resources>
 
   <dependencies>

--- a/fractions/javaee/jpa-spatial/pom.xml
+++ b/fractions/javaee/jpa-spatial/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>com.vividsolutions</groupId>
       <artifactId>jts</artifactId>
-      <version>1.13</version>
+      <version>${version.vividsolutions-jts}</version>
     </dependency>
   </dependencies>
 

--- a/fractions/javaee/mvc/pom.xml
+++ b/fractions/javaee/mvc/pom.xml
@@ -26,8 +26,6 @@
   <properties>
     <swarm.fraction.stability>experimental</swarm.fraction.stability>
     <swarm.fraction.tags>JavaEE,Web</swarm.fraction.tags>
-    <version.ozark>1.0.0-m04</version.ozark>
-    <version.mvc>1.0-pfd</version.mvc>
   </properties>
 
   <build>

--- a/fractions/jose/pom.xml
+++ b/fractions/jose/pom.xml
@@ -25,7 +25,6 @@
   <properties>
     <swarm.fraction.stability>experimental</swarm.fraction.stability>
     <swarm.fraction.tags>Signing,Encryption</swarm.fraction.tags>
-    <version.cxf>3.2.5</version.cxf>
   </properties>
 
   <dependencies>

--- a/fractions/microprofile/microprofile-jwt/pom.xml
+++ b/fractions/microprofile/microprofile-jwt/pom.xml
@@ -24,7 +24,6 @@
   <properties>
     <swarm.fraction.stability>stable</swarm.fraction.stability>
     <swarm.fraction.tags>Eclipse MicroProfile,JWT,Security,Web</swarm.fraction.tags>
-    <version.jose4j>0.6.0</version.jose4j>
   </properties>
 
   <build>
@@ -112,7 +111,7 @@
     <dependency>
       <groupId>javax</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>8.0</version>
+      <version>${version.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/fractions/microprofile/microprofile-openapi/pom.xml
+++ b/fractions/microprofile/microprofile-openapi/pom.xml
@@ -80,7 +80,7 @@
     <dependency>
       <groupId>javax</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>8.0</version>
+      <version>${version.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
 
@@ -125,7 +125,7 @@
     <dependency>
       <groupId>org.skyscreamer</groupId>
       <artifactId>jsonassert</artifactId>
-      <version>1.5.0</version>
+      <version>${version.org.skyscreamer.jsonassert}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -143,7 +143,7 @@
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
-      <version>1.2</version>
+      <version>${version.commons-logging}</version>
       <scope>test</scope>
     </dependency>
 

--- a/fractions/netflix/hystrix/pom.xml
+++ b/fractions/netflix/hystrix/pom.xml
@@ -25,7 +25,6 @@
   <properties>
     <swarm.fraction.stability>stable</swarm.fraction.stability>
     <swarm.fraction.tags>Fault Tolerance,Netflix OSS</swarm.fraction.tags>
-    <version.hdrHistogram>2.1.9</version.hdrHistogram>
   </properties>
 
   <build>

--- a/fractions/netflix/pom.xml
+++ b/fractions/netflix/pom.xml
@@ -22,22 +22,6 @@
 
   <packaging>pom</packaging>
 
-  <properties>
-    <version.netflix.commons>0.1.1</version.netflix.commons>
-    <version.archaius>0.6.6</version.archaius>
-    <version.ribbon>2.1.0</version.ribbon>
-    <version.hystrix>1.5.12</version.hystrix>
-    <version.rxjava>1.3.0</version.rxjava>
-    <version.rxnetty>0.4.9</version.rxnetty>
-    <version.netty>4.0.26.Final</version.netty>
-    <version.guava>14.0.1</version.guava>
-    <version.servo>0.9.2</version.servo>
-
-    <version.commons-configuration>1.10</version.commons-configuration>
-    <version.findbugs>2.0.3</version.findbugs>
-
-  </properties>
-
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/fractions/opentracing-tracerresolver/pom.xml
+++ b/fractions/opentracing-tracerresolver/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>javax</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>8.0</version>
+      <version>${version.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/fractions/zipkin-jaxrs/pom.xml
+++ b/fractions/zipkin-jaxrs/pom.xml
@@ -92,19 +92,19 @@
     <dependency>
       <groupId>io.zipkin.brave</groupId>
       <artifactId>brave-jaxrs2</artifactId>
-      <version>${version.brave}</version>
+      <version>${version.zipkin.brave}</version>
     </dependency>
 
     <dependency>
       <groupId>io.zipkin.brave</groupId>
       <artifactId>brave-http</artifactId>
-      <version>${version.brave}</version>
+      <version>${version.zipkin.brave}</version>
     </dependency>
 
     <dependency>
       <groupId>io.zipkin.brave</groupId>
       <artifactId>brave-core</artifactId>
-      <version>${version.brave}</version>
+      <version>${version.zipkin.brave}</version>
     </dependency>
 
     <dependency>

--- a/fractions/zipkin-jaxrs/src/main/resources/modules/io/zipkin/brave/main/module.xml
+++ b/fractions/zipkin-jaxrs/src/main/resources/modules/io/zipkin/brave/main/module.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module xmlns="urn:jboss:module:1.3" name="io.zipkin.brave">
   <resources>
-    <artifact name="io.zipkin.brave:brave-jaxrs2:${version.brave}"/>
-    <artifact name="io.zipkin.brave:brave-http:${version.brave}"/>
-    <artifact name="io.zipkin.brave:brave-core:${version.brave}"/>
+    <artifact name="io.zipkin.brave:brave-jaxrs2:${version.zipkin.brave}"/>
+    <artifact name="io.zipkin.brave:brave-http:${version.zipkin.brave}"/>
+    <artifact name="io.zipkin.brave:brave-core:${version.zipkin.brave}"/>
     <artifact name="io.zipkin.reporter:zipkin-reporter:${version.zipkin.reporter}"/>
     <artifact name="io.zipkin.reporter:zipkin-sender-urlconnection:${version.zipkin.reporter}"/>
     <artifact name="io.zipkin.java:zipkin:${version.zipkin}"/>

--- a/meta/fraction-metadata/pom.xml
+++ b/meta/fraction-metadata/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>com.eclipsesource.minimal-json</groupId>
       <artifactId>minimal-json</artifactId>
-      <version>0.9.4</version>
+      <version>${version.minimal-json}</version>
     </dependency>
 
     <dependency>

--- a/plugins/maven/pom.xml
+++ b/plugins/maven/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.0.20</version>
+      <version>${version.plexus-utils}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>org.jooq</groupId>
       <artifactId>joox-java-6</artifactId>
-      <version>1.6.0</version>
+      <version>${version.joox}</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,32 +29,192 @@
   </scm>
 
   <properties>
+    <!-- ===== code quality ===== -->
+    <version.checkstyle>7.4</version.checkstyle>
+    <version.findbugs>2.0.3</version.findbugs>
     <version.wildfly.swarm.checkstyle>3</version.wildfly.swarm.checkstyle>
 
-    <version.certified-community>2.0.0.Final</version.certified-community>
+    <!-- ===== Thorntail and Config APIs ===== -->
+    <version.certified-community>2.4.0.Final</version.certified-community>
     <version.wildfly.swarm>${project.version}</version.wildfly.swarm>
 
-    <version.org.arquillian>1.1.15.Final</version.org.arquillian>
+    <version.thorntail.fraction.plugin>97</version.thorntail.fraction.plugin>
+    <version.thorntail-jdk-specific>1</version.thorntail-jdk-specific>
+
+    <version.wildfly.config-api>1.7.0</version.wildfly.config-api>
+    <version.keycloak.config-api>1.7.0</version.keycloak.config-api>
+    <version.cassandra.config-api>1.7.0</version.cassandra.config-api>
+    <version.mongo.config-api>1.7.0</version.mongo.config-api>
+    <version.neo4j.config-api>1.7.0</version.neo4j.config-api>
+    <version.orientdb.config-api>1.7.0</version.orientdb.config-api>
+
+    <!-- ===== WildFly and components that need to be aligned with it or carefully overridden ===== -->
+    <version.org.wildfly.core>7.0.0.Final</version.org.wildfly.core>
+    <version.wildfly>15.0.1.Final</version.wildfly>
+
+    <version.javaee-api>8.0</version.javaee-api>
+
+    <version.com.fasterxml.jackson>2.9.9</version.com.fasterxml.jackson>
+    <version.com.squareup.okhttp>3.9.0</version.com.squareup.okhttp>
+    <version.com.squareup.okio>1.13.0</version.com.squareup.okio>
+    <version.cxf>3.2.5-jbossorg-1</version.cxf>
+    <version.elytron>1.7.0.Final</version.elytron>
+    <version.gson>2.8.2</version.gson> <!-- also needs to be aligned with Jaeger -->
+    <version.jandex>2.0.5.Final</version.jandex>
+    <version.jandex-maven-plugin>1.0.4</version.jandex-maven-plugin>
+    <version.jboss-logmanager-ext>1.0.0.Alpha5</version.jboss-logmanager-ext>
+    <version.jboss-modules>1.8.7.Final</version.jboss-modules>
+    <version.org.apache.maven>3.6.0</version.org.apache.maven>
+    <version.org.apache.maven.resolver>1.3.1</version.org.apache.maven.resolver>
+    <version.org.ow2.asm>7.0</version.org.ow2.asm>
+    <version.remoting-jmx>3.0.0.Final</version.remoting-jmx>
+    <version.resteasy>3.8.0.Final</version.resteasy>
+    <version.slf4j>1.7.22.jbossorg-1</version.slf4j>
+    <version.weld-se>3.0.5.Final</version.weld-se>
+
+    <!-- ===== Keycloak ===== -->
+    <version.keycloak>4.8.3.Final</version.keycloak>
+
+    <!-- ===== MicroProfile and SmallRye ===== -->
+    <version.microprofile-config>1.3</version.microprofile-config>
+    <version.microprofile-health>2.0.1</version.microprofile-health>
+    <version.microprofile-fault-tolerance>2.0.1</version.microprofile-fault-tolerance>
+    <version.microprofile-jwt-auth>1.1.1</version.microprofile-jwt-auth>
+    <version.microprofile-metrics>2.0.1</version.microprofile-metrics>
+    <version.microprofile.restclient>1.3.2</version.microprofile.restclient>
+    <version.microprofile-openapi>1.1.2</version.microprofile-openapi>
+    <version.microprofile-opentracing>1.3.1</version.microprofile-opentracing>
+
+    <!-- MP Config WildFly subsystem -->
+    <version.microprofile-config-wildfly>1.7.1</version.microprofile-config-wildfly>
+
+    <version.smallrye.config-1.3>1.0.0</version.smallrye.config-1.3>
+    <version.smallrye.health-2.0>1.0.1</version.smallrye.health-2.0>
+    <version.smallrye.openapi-1.1>1.0.1</version.smallrye.openapi-1.1>
+    <version.smallrye.opentracing-1.3>1.0.0</version.smallrye.opentracing-1.3>
+    <version.smallrye.metrics-2.0>1.1.0</version.smallrye.metrics-2.0>
+    <version.smallrye.jwt-1.1>2.0.0</version.smallrye.jwt-1.1>
+    <version.smallrye.fault-tolerance-2.0>1.0.1</version.smallrye.fault-tolerance-2.0>
+
+    <!-- ===== other ===== -->
+    <!-- ShrinkWrap -->
     <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>
     <version.org.jboss.shrinkwrap.descriptors>2.0.0</version.org.jboss.shrinkwrap.descriptors>
-    <version.fest-assert>1.4</version.fest-assert>
-    <version.junit>4.12</version.junit>
-    <version.mockito>2.2.28</version.mockito>
+    <version.org.jboss.shrinkwrap.resolver>2.2.4</version.org.jboss.shrinkwrap.resolver>
 
-    <!-- OpenTracing related versions. Needed at this level because it's used by testsuite -->
+    <!-- tracing -->
     <version.opentracing>0.31.0</version.opentracing>
+    <version.opentracing.concurrent>0.2.0</version.opentracing.concurrent>
+    <version.opentracing.interceptors>0.0.4</version.opentracing.interceptors>
+    <version.opentracing.jaxrs>0.4.1</version.opentracing.jaxrs>
+    <version.opentracing.servlet>0.2.0</version.opentracing.servlet>
+    <version.opentracing.tracerresolver>0.1.5</version.opentracing.tracerresolver>
+    <version.jaeger>0.34.0</version.jaeger>
+    <version.jaeger.apache.thrift>0.12.0</version.jaeger.apache.thrift>
+    <version.zipkin>1.13.1</version.zipkin>
+    <version.zipkin.brave>3.14.1</version.zipkin.brave>
+    <version.zipkin.reporter>0.6.1</version.zipkin.reporter>
 
-    <!-- NoSQL related versions.  Needed at this level because it's used by testsuite -->
-    <version.mongodb.driver>3.2.2</version.mongodb.driver>
+    <!-- Swagger -->
+    <version.io.swagger>1.5.21</version.io.swagger>
+    <version.org.webjars.swagger-ui>3.2.2</version.org.webjars.swagger-ui>
+    <version.swagger.reflections>0.9.10</version.swagger.reflections>
+    <version.swagger.commons.lang>3.2.1</version.swagger.commons.lang>
+
+    <!-- Hibernate spatial -->
+    <version.geolatte>1.4.0</version.geolatte>
+    <version.hibernate-spatial>5.3.7.Final</version.hibernate-spatial>
+    <version.vividsolutions-jts>1.13</version.vividsolutions-jts>
+
+    <!-- NoSQL -->
     <version.cassandra.driver>3.0.0</version.cassandra.driver>
-    <version.neo4j.driver>1.2.1</version.neo4j.driver>
-    <version.com.orientechnologies>2.2.9</version.com.orientechnologies>
     <version.com.googlecode.concurrentlinkedhashmap>1.4.1</version.com.googlecode.concurrentlinkedhashmap>
+    <version.com.orientechnologies>2.2.9</version.com.orientechnologies>
     <version.com.tinkerpop.blueprints>2.6.0</version.com.tinkerpop.blueprints>
+    <version.mongodb.driver>3.2.2</version.mongodb.driver>
+    <version.neo4j.driver>1.2.1</version.neo4j.driver>
+    <version.wildfly.nosql.feature-pack>1.0.2.Final</version.wildfly.nosql.feature-pack>
 
+    <!-- Netflix OSS -->
+    <version.netflix.commons>0.1.1</version.netflix.commons>
+    <version.archaius>0.6.6</version.archaius>
+    <version.ribbon>2.1.0</version.ribbon>
+    <version.hystrix>1.5.12</version.hystrix>
+    <version.rxjava>1.3.0</version.rxjava>
+    <version.rxnetty>0.4.9</version.rxnetty>
+    <version.netty>4.0.26.Final</version.netty>
+    <version.guava>14.0.1</version.guava>
+    <version.servo>0.9.2</version.servo>
+    <version.hdrHistogram>2.1.9</version.hdrHistogram>
+
+    <!-- Apache Commons -->
+    <version.commons-configuration>1.10</version.commons-configuration>
+    <version.commons-io>2.4</version.commons-io>
+    <version.commons-logging>1.2</version.commons-logging>
+
+    <!-- Gradle -->
+    <version.gradle>3.1</version.gradle>
+    <version.gradle.plugins>1.12</version.gradle.plugins>
+    <version.groovy>2.4.3</version.groovy>
+
+    <!-- MVC -->
+    <version.mvc>1.0-pfd</version.mvc>
+    <version.ozark>1.0.0-m04</version.ozark>
+
+    <!-- unsorted -->
+    <version.asciidoctorj>1.5.5</version.asciidoctorj>
+    <version.com.orbitz.consul>1.2.1</version.com.orbitz.consul>
+    <version.eclipse.link>2.7.4</version.eclipse.link>
+    <version.fluentd>0.3.2</version.fluentd>
+    <version.flyway>4.2.0</version.flyway>
+    <version.jersey>1.19.1</version.jersey>
+    <version.joda-time>2.7</version.joda-time>
+    <version.jolokia>1.3.4</version.jolokia>
+    <version.joox>1.6.0</version.joox>
+    <version.jopt-simple>4.9</version.jopt-simple>
+    <version.jose4j>0.6.0</version.jose4j>
+    <version.minimal-json>0.9.4</version.minimal-json>
+    <version.openshift.client>8.0.0.Final</version.openshift.client>
+    <version.org.glassfish.javax.json>1.1.2</version.org.glassfish.javax.json>
+    <version.org.kie>6.4.0.Final</version.org.kie>
+    <version.org.snakeyaml>1.18</version.org.snakeyaml>
+    <version.plexus-utils>3.0.20</version.plexus-utils>
+    <version.vertx>3.3.3</version.vertx>
+    <version.xadisk>1.2.2</version.xadisk>
+    <version.zip4j>1.3.2</version.zip4j>
+
+    <!-- testing -->
+    <version.ajp-client>1.0</version.ajp-client>
+    <version.fest-assert>1.4</version.fest-assert>
+    <version.hamcrest>1.3</version.hamcrest>
+    <version.junit>4.12</version.junit>
+    <version.maven-verifier>1.6</version.maven-verifier>
+    <version.mockito>2.2.28</version.mockito>
+    <version.org.arquillian>1.1.15.Final</version.org.arquillian>
+    <version.org.arquillian.drone>2.0.1.Final</version.org.arquillian.drone>
+    <version.org.arquillian.graphene>2.1.0.Final</version.org.arquillian.graphene>
+    <!-- When upgrading testng, make sure to use swarm version of arquillian -->
+    <version.org.arquillian.testng>1.1.13.Final</version.org.arquillian.testng>
+    <version.org.arquillian.warp-rest>1.0.0.Alpha4</version.org.arquillian.warp-rest>
+    <version.org.skyscreamer.jsonassert>1.5.0</version.org.skyscreamer.jsonassert>
+    <!-- Do not upgrade until https://issues.jboss.org/browse/ARQ-2144 is fixed -->
+    <version.testng>6.9.9</version.testng>
+    <version.wiremock>2.10.1</version.wiremock>
+    <version.xmlunit>2.6.0</version.xmlunit>
+
+    <version.h2>1.4.187</version.h2>
+    <version.mysql>5.1.39</version.mysql>
+    <version.postgresql>9.4.1208</version.postgresql>
+
+    <version.httpclient>4.5.9</version.httpclient>
+    <version.fluent-hc>4.5.9</version.fluent-hc>
+
+    <version.org.jboss.cdi.tck>1.2.10.Final</version.org.jboss.cdi.tck>
+
+    <!-- Maven plugins and extensions -->
     <version.jruby>9.2.5.0</version.jruby>
-
     <version.jruby-maven-plugin>1.1.6</version.jruby-maven-plugin>
+    <version.asciidoctor-maven-plugin>1.5.7.1</version.asciidoctor-maven-plugin>
     <version.maven-plugin-plugin>3.5</version.maven-plugin-plugin>
     <version.maven-shade-plugin>2.4.1</version.maven-shade-plugin>
     <version.build-helper-maven-plugin>1.9.1</version.build-helper-maven-plugin>
@@ -63,8 +223,9 @@
     <version.xml-maven-plugin>1.0.1</version.xml-maven-plugin>
     <version.license-maven-plugin>1.13</version.license-maven-plugin>
     <version.wildfly-licenses-plugin>1.0.1</version.wildfly-licenses-plugin>
-
-    <version.checkstyle>7.4</version.checkstyle>
+    <version.dependencyversion-maven-plugin>1.0.1</version.dependencyversion-maven-plugin>
+    <version.wagon-webdav-jackrabbit>2.10</version.wagon-webdav-jackrabbit>
+    <version.wiremock-maven-plugin>4.1.0</version.wiremock-maven-plugin>
 
     <maven.min.version>3.2.1</maven.min.version>
 

--- a/testsuite/microprofile-tcks/opentracing/pom.xml
+++ b/testsuite/microprofile-tcks/opentracing/pom.xml
@@ -36,7 +36,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.2</version>
     </dependency>
 
     <!-- TCK uses MockTracer configured by the container -->
@@ -65,7 +64,7 @@
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <version>6.9.9</version>
+      <version>${version.testng}</version>
       <scope>test</scope>
     </dependency>
 
@@ -87,30 +86,26 @@
     <dependency>
       <groupId>org.codehaus.jackson</groupId>
       <artifactId>jackson-jaxrs</artifactId>
-      <version>1.9.13</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.jackson</groupId>
       <artifactId>jackson-xc</artifactId>
-      <version>1.9.13</version>
     </dependency>
 
     <dependency>
       <groupId>org.jboss.shrinkwrap.resolver</groupId>
       <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-      <version>2.2.4</version>
+      <version>${version.org.jboss.shrinkwrap.resolver}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>javax.enterprise</groupId>
       <artifactId>cdi-api</artifactId>
-      <version>2.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-      <version>2.1</version>
+      <groupId>org.jboss.spec.javax.ws.rs</groupId>
+      <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/testsuite/microprofile-tcks/pom.xml
+++ b/testsuite/microprofile-tcks/pom.xml
@@ -36,14 +36,6 @@
     <packaging>pom</packaging>
 
     <properties>
-        <!-- Do not upgrade until https://issues.jboss.org/browse/ARQ-2144 is fixed -->
-        <version.testng>6.9.9</version.testng>
-        <!-- When upgrading testng, make sure to use swarm version of arquillian -->
-        <version.arquillian.testng>1.1.13.Final</version.arquillian.testng>
-        
-        <!-- commons-logging (needed by httpclient) is for some reason exluded -->
-        <version.commons-logging>1.2</version.commons-logging>
-        <version.hamcrest>1.3</version.hamcrest>
     </properties>
 
     <modules>
@@ -113,7 +105,7 @@
          <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>
-            <version>${version.arquillian.testng}</version>
+            <version>${version.org.arquillian.testng}</version>
             <scope>test</scope>
          </dependency>
 

--- a/testsuite/microprofile-tcks/restclient/pom.xml
+++ b/testsuite/microprofile-tcks/restclient/pom.xml
@@ -92,14 +92,13 @@
       <dependency>
          <groupId>org.slf4j</groupId>
          <artifactId>slf4j-jdk14</artifactId>
-         <version>1.7.25</version>
+         <version>${version.slf4j}</version>
          <scope>test</scope>
       </dependency>
 
       <dependency>
          <groupId>javax.json</groupId>
          <artifactId>javax.json-api</artifactId>
-         <version>1.0</version>
          <scope>test</scope>
       </dependency>
 
@@ -114,14 +113,13 @@
       <dependency>
          <groupId>org.glassfish</groupId>
          <artifactId>javax.json</artifactId>
-         <version>1.0.4</version>
          <scope>test</scope>
       </dependency>
 
       <dependency>
          <groupId>com.github.tomakehurst</groupId>
          <artifactId>wiremock</artifactId>
-         <version>2.10.1</version>
+         <version>${version.wiremock}</version>
          <scope>test</scope>
          <exclusions>
             <exclusion>
@@ -138,7 +136,7 @@
          <plugin>
             <groupId>uk.co.automatictester</groupId>
             <artifactId>wiremock-maven-plugin</artifactId>
-            <version>4.1.0</version>
+            <version>${version.wiremock-maven-plugin}</version>
             <executions>
                <execution>
                   <phase>generate-test-sources</phase>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -24,21 +24,6 @@
 
   <properties>
     <browser>phantomjs</browser>
-
-    <version.org.jboss.arquillian.drone>2.0.1.Final</version.org.jboss.arquillian.drone>
-    <version.org.arquillian.graphene>2.1.0.Final</version.org.arquillian.graphene>
-
-    <version.h2>1.4.187</version.h2>
-    <version.keycloak>4.8.3.Final</version.keycloak>
-    <version.mysql>5.1.39</version.mysql>
-    <version.postgresql>9.4.1208</version.postgresql>
-
-    <version.resteasy>3.8.0.Final</version.resteasy>
-    <version.remoting>3.0.0.Final</version.remoting>
-    <version.wildfly-controller>7.0.0.Final</version.wildfly-controller>
-    <version.jackson>2.9.5</version.jackson>
-    <httpclient.version>4.5</httpclient.version>
-    <fluent-hc.version>4.5</fluent-hc.version>
   </properties>
 
   <build>
@@ -113,7 +98,7 @@
       <dependency>
         <groupId>org.jboss.arquillian.extension</groupId>
         <artifactId>arquillian-drone-bom</artifactId>
-        <version>${version.org.jboss.arquillian.drone}</version>
+        <version>${version.org.arquillian.drone}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -121,12 +106,12 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>${httpclient.version}</version>
+        <version>${version.httpclient}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>fluent-hc</artifactId>
-        <version>${fluent-hc.version}</version>
+        <version>${version.fluent-hc}</version>
       </dependency>
 
       <dependency>
@@ -138,19 +123,19 @@
       <dependency>
         <groupId>org.jboss.remotingjmx</groupId>
         <artifactId>remoting-jmx</artifactId>
-        <version>${version.remoting}</version>
+        <version>${version.remoting-jmx}</version>
       </dependency>
 
       <dependency>
         <groupId>org.wildfly.core</groupId>
         <artifactId>wildfly-controller-client</artifactId>
-        <version>${version.wildfly-controller}</version>
+        <version>${version.org.wildfly.core}</version>
       </dependency>
 
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${version.jackson}</version>
+        <version>${version.com.fasterxml.jackson}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/testsuite/testsuite-ajp/pom.xml
+++ b/testsuite/testsuite-ajp/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>ajp-client</artifactId>
-      <version>1.0</version>
+      <version>${version.ajp-client}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/testsuite/testsuite-buildtool/multi-module/api/pom.xml
+++ b/testsuite/testsuite-buildtool/multi-module/api/pom.xml
@@ -36,19 +36,19 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.6.2</version>
+      <version>${version.gson}</version>
     </dependency>
 
     <!-- http://mvnrepository.com/artifact/com.sun.jersey/jersey-client -->
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-client</artifactId>
-      <version>1.19.1</version>
+      <version>${version.jersey}</version>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-json</artifactId>
-      <version>1.19.1</version>
+      <version>${version.jersey}</version>
     </dependency>
 
   </dependencies>

--- a/testsuite/testsuite-buildtool/multi-module/pom.xml
+++ b/testsuite/testsuite-buildtool/multi-module/pom.xml
@@ -27,7 +27,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.5.1</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
@@ -41,7 +40,7 @@
       <dependency>
         <groupId>org.jboss.arquillian.extension</groupId>
         <artifactId>arquillian-rest-warp-bom</artifactId>
-        <version>1.0.0.Alpha4</version>
+        <version>${version.org.arquillian.warp-rest}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -55,15 +54,15 @@
 
   <dependencies>
 
-    <!-- Java EE 7 dependency -->
+    <!-- Java EE dependency -->
     <dependency>
       <groupId>javax</groupId>
       <artifactId>javaee-api</artifactId>
-      <version>8.0</version>
+      <version>${version.javaee-api}</version>
       <scope>provided</scope>
     </dependency>
 
-    <!-- Wildfly Swarm Fractions -->
+    <!-- Fractions -->
     <dependency>
       <groupId>io.thorntail</groupId>
       <artifactId>cdi</artifactId>

--- a/testsuite/testsuite-buildtool/multi-module/view/pom.xml
+++ b/testsuite/testsuite-buildtool/multi-module/view/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.4</version>
+      <version>${version.commons-io}</version>
     </dependency>
   </dependencies>
 

--- a/testsuite/testsuite-cdi/pom.xml
+++ b/testsuite/testsuite-cdi/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
        <groupId>org.jboss.cdi.tck</groupId>
        <artifactId>cdi-tck-ext-lib</artifactId>
-       <version>1.2.10.Final</version>
+       <version>${version.org.jboss.cdi.tck}</version>
        <exclusions>
           <exclusion>
              <groupId>javax.enterprise</groupId>

--- a/testsuite/testsuite-datasources-config/pom.xml
+++ b/testsuite/testsuite-datasources-config/pom.xml
@@ -21,10 +21,6 @@
 
   <packaging>jar</packaging>
 
-  <properties>
-    <version.h2>1.4.187</version.h2>
-  </properties>
-
   <build>
     <resources>
       <resource>

--- a/testsuite/testsuite-datasources/pom.xml
+++ b/testsuite/testsuite-datasources/pom.xml
@@ -21,10 +21,6 @@
 
   <packaging>jar</packaging>
 
-  <properties>
-    <version.h2>1.4.187</version.h2>
-  </properties>
-
   <build>
     <resources>
       <resource>

--- a/testsuite/testsuite-jaxrs/pom.xml
+++ b/testsuite/testsuite-jaxrs/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
-      <version>2.7</version>
+      <version>${version.joda-time}</version>
     </dependency>
 
     <dependency>

--- a/testsuite/testsuite-jose-jose4j/pom.xml
+++ b/testsuite/testsuite-jose-jose4j/pom.xml
@@ -21,10 +21,6 @@
 
   <packaging>jar</packaging>
   
-  <properties>
-    <version.jose4j>0.6.3</version.jose4j>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>io.thorntail</groupId>

--- a/testsuite/testsuite-management/pom.xml
+++ b/testsuite/testsuite-management/pom.xml
@@ -44,23 +44,9 @@
     <dependency>
       <groupId>org.wildfly.security</groupId>
       <artifactId>wildfly-elytron</artifactId>
-      <version>1.1.6.Final</version>
+      <version>${version.elytron}</version>
       <scope>test</scope>
     </dependency>
-<!--
-    <dependency>
-      <groupId>org.jboss.xnio</groupId>
-      <artifactId>xnio-api</artifactId>
-      <version>3.5.4.Final</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.xnio</groupId>
-      <artifactId>xnio-nio</artifactId>
-      <version>3.5.4.Final</version>
-      <scope>test</scope>
-    </dependency>
--->
   </dependencies>
 
 </project>

--- a/testsuite/testsuite-maven-plugin-migration/pom.xml
+++ b/testsuite/testsuite-maven-plugin-migration/pom.xml
@@ -25,13 +25,13 @@
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-verifier</artifactId>
-      <version>1.6</version>
+      <version>${version.maven-verifier}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.xmlunit</groupId>
       <artifactId>xmlunit-core</artifactId>
-      <version>2.6.0</version>
+      <version>${version.xmlunit}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/testsuite/testsuite-maven-plugin/pom.xml
+++ b/testsuite/testsuite-maven-plugin/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-verifier</artifactId>
-      <version>1.6</version>
+      <version>${version.maven-verifier}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/testsuite/testsuite-orientdb/pom.xml
+++ b/testsuite/testsuite-orientdb/pom.xml
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>commons-configuration</groupId>
             <artifactId>commons-configuration</artifactId>
-            <version>1.6</version>
+            <version>${version.commons-configuration}</version>
         </dependency>
 
     </dependencies>

--- a/testsuite/testsuite-resource-adapters/pom.xml
+++ b/testsuite/testsuite-resource-adapters/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>net.java.xadisk</groupId>
       <artifactId>xadisk</artifactId>
-      <version>1.2.2</version>
+      <version>${version.xadisk}</version>
       <type>rar</type>
       <scope>test</scope>
     </dependency>
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>net.java.xadisk</groupId>
       <artifactId>xadisk</artifactId>
-      <version>1.2.2</version>
+      <version>${version.xadisk}</version>
       <type>jar</type>
       <scope>test</scope>
     </dependency>

--- a/testsuite/testsuite-zipkin-jaxrs/pom.xml
+++ b/testsuite/testsuite-zipkin-jaxrs/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
-      <version>2.7</version>
+      <version>${version.joda-time}</version>
     </dependency>
 
     <dependency>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>net.lingala.zip4j</groupId>
       <artifactId>zip4j</artifactId>
-      <version>1.3.2</version>
+      <version>${version.zip4j}</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Motivation
----------
Currently, versions of components are scattered through various POMs,
most of them are in `/pom.xml`, `/build-parent/pom.xml` and
`/testsuite/pom.xml`. This is hard to navigate, and can be radically
simplified by just moving all of them to the root POM.

Modifications
-------------
Moved all version properties to the root POM. Nothing but Maven properties
moves; specifically `<dependencyManagement>` doesn't not change.

Result
------
All component versions are specified on a single place. No behavioral change.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
