### PR TITLE
THORN-2443: update to RESTEasy 3.8.1

### DIFF
--- a/module-rewrite.conf
+++ b/module-rewrite.conf
@@ -5,7 +5,7 @@ module: org.jboss.resteasy.resteasy-jaxrs
 module: org.jboss.resteasy.resteasy-cdi
   # RESTEasy includes MP RestClient implementation, but we don't want that in plain JAX-RS
   optional: org.eclipse.microprofile.restclient
-  # update to RESTEasy 3.8.0; can be removed when updated to WildFly 17+
+  # update to RESTEasy 3.8.x; can be removed when updated to WildFly 17+
   include: javax.annotation.api
 module: asm.asm
   force-artifact-version: org.ow2.asm:asm:*=${version.org.ow2.asm}
@@ -22,7 +22,7 @@ module: ALL:ALL
   force-artifact-version: com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:*=${version.com.fasterxml.jackson}
   force-artifact-version: com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:*=${version.com.fasterxml.jackson}
   force-artifact-version: com.fasterxml.jackson.module:jackson-module-jaxb-annotations:*=${version.com.fasterxml.jackson}
-  # update to RESTEasy 3.8.0; can be removed when updated to WildFly 17+
+  # update to RESTEasy 3.8.x; can be removed when updated to WildFly 17+
   replace-artifact: org.jboss.resteasy:resteasy-validator-provider-11:* > org.jboss.resteasy:resteasy-validator-provider:${version.resteasy}
   force-artifact-version: org.jboss.resteasy:jose-jwt:*=${version.resteasy}
   force-artifact-version: org.jboss.resteasy:resteasy-atom-provider:*=${version.resteasy}

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <version.org.apache.maven.resolver>1.3.1</version.org.apache.maven.resolver>
     <version.org.ow2.asm>7.0</version.org.ow2.asm>
     <version.remoting-jmx>3.0.0.Final</version.remoting-jmx>
-    <version.resteasy>3.8.0.Final</version.resteasy>
+    <version.resteasy>3.8.1.Final</version.resteasy>
     <version.slf4j>1.7.22.jbossorg-1</version.slf4j>
     <version.weld-se>3.0.5.Final</version.weld-se>
 


### PR DESCRIPTION
Motivation
----------
This is to align RESTEasy with MP RestClient and future
WildFly release. We use MP RestClient 1.3.3, and RESTEasy 3.8.1
has just updated to this version. We also want to be as close
as possible to which RESTEasy version WildFly 18 will have.
(Can't be 100% sure, but it already has RESTEasy 3.8.1.)

Modifications
-------------
Update to RESTEasy 3.8.1.

Result
------
Better RESTEasy alignment with MP RestClient and WildFly.
No behavioral changes.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
