### PR TITLE
[THORN-2444] Update to smallrye-jwt-1.1-2.0.1

### DIFF
--- a/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/runtime/MPJWTAuthExtensionArchivePreparer.java
+++ b/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/runtime/MPJWTAuthExtensionArchivePreparer.java
@@ -17,7 +17,6 @@
  */
 package org.wildfly.swarm.microprofile.jwtauth.runtime;
 
-import java.io.File;
 import java.util.Collection;
 import java.util.Map;
 
@@ -31,7 +30,6 @@ import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.asset.FileAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.wildfly.swarm.jaxrs.JAXRSArchive;
 import org.wildfly.swarm.microprofile.jwtauth.MicroProfileJWTAuthFraction;
@@ -123,11 +121,7 @@ public class MPJWTAuthExtensionArchivePreparer implements DeploymentProcessor {
                 log.warn("Using 'thorntail.microprofile.jwt.token.signer-pub-key' for the 'file:' or 'classpath:' key "
                         + "assets is deprecated, use the 'thorntail.microprofile.jwt.token.signer-pub-key-location' "
                         + "property instead");
-                if (publicKey.startsWith("file:")) {
-                    addFileKeyAsset(war, publicKey);
-                } else if (publicKey.startsWith("classpath:")) {
-                    war.addAsManifestResource(new StringAsset(publicKey), "MP-JWT-SIGNER-KEY-LOCATION");
-                }
+                war.addAsManifestResource(new StringAsset(publicKey), "MP-JWT-SIGNER-KEY-LOCATION");
             } else {
                 war.addAsManifestResource(new StringAsset(publicKey), "MP-JWT-SIGNER");
             }
@@ -137,9 +131,6 @@ public class MPJWTAuthExtensionArchivePreparer implements DeploymentProcessor {
             if (fraction.getPublicKey() != null) {
                 log.warn("'thorntail.microprofile.jwt.token.signer-pub-key' property has already been set,"
                         + " 'thorntail.microprofile.jwt.token.signer-pub-key-location' property will be ignored");
-            } else if (fraction.getPublicKeyLocation().startsWith("file:")) {
-                // smallrye-jwt-1.1 does not support the file key assets yet
-                addFileKeyAsset(war, fraction.getPublicKeyLocation());
             } else {
                 log.debugf("PublicKey location: %s", fraction.getPublicKeyLocation());
                 war.addAsManifestResource(new StringAsset(fraction.getPublicKeyLocation()), "MP-JWT-SIGNER-KEY-LOCATION");
@@ -194,12 +185,6 @@ public class MPJWTAuthExtensionArchivePreparer implements DeploymentProcessor {
         if (fraction.getRolesPropertiesMap() != null) {
             createRolePropertiesFileFromMap();
         }
-    }
-
-    // This function will be removed after the upgrade to the next version of smallrye-jwt-1.1 which supports the file key assets
-    private void addFileKeyAsset(WARArchive war, String publicKeyLocation) {
-        File fileRef = new File(publicKeyLocation.substring(5, publicKeyLocation.length()));
-        war.addAsManifestResource(new FileAsset(fileRef), "MP-JWT-SIGNER");
     }
 
     private void selectSecurityDomain(WARArchive war, String realm) {

--- a/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/runtime/MPJWTAuthExtensionArchivePreparer.java
+++ b/fractions/microprofile/microprofile-jwt/src/main/java/org/wildfly/swarm/microprofile/jwtauth/runtime/MPJWTAuthExtensionArchivePreparer.java
@@ -17,6 +17,7 @@
  */
 package org.wildfly.swarm.microprofile.jwtauth.runtime;
 
+import java.io.File;
 import java.util.Collection;
 import java.util.Map;
 
@@ -30,6 +31,7 @@ import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.FileAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.wildfly.swarm.jaxrs.JAXRSArchive;
 import org.wildfly.swarm.microprofile.jwtauth.MicroProfileJWTAuthFraction;
@@ -121,7 +123,11 @@ public class MPJWTAuthExtensionArchivePreparer implements DeploymentProcessor {
                 log.warn("Using 'thorntail.microprofile.jwt.token.signer-pub-key' for the 'file:' or 'classpath:' key "
                         + "assets is deprecated, use the 'thorntail.microprofile.jwt.token.signer-pub-key-location' "
                         + "property instead");
-                war.addAsManifestResource(new StringAsset(publicKey), "MP-JWT-SIGNER-KEY-LOCATION");
+                if (publicKey.startsWith("file:")) {
+                    addFileKeyAsset(war, publicKey);
+                } else if (publicKey.startsWith("classpath:")) {
+                    war.addAsManifestResource(new StringAsset(publicKey), "MP-JWT-SIGNER-KEY-LOCATION");
+                }
             } else {
                 war.addAsManifestResource(new StringAsset(publicKey), "MP-JWT-SIGNER");
             }
@@ -131,6 +137,9 @@ public class MPJWTAuthExtensionArchivePreparer implements DeploymentProcessor {
             if (fraction.getPublicKey() != null) {
                 log.warn("'thorntail.microprofile.jwt.token.signer-pub-key' property has already been set,"
                         + " 'thorntail.microprofile.jwt.token.signer-pub-key-location' property will be ignored");
+            } else if (fraction.getPublicKeyLocation().startsWith("file:")) {
+                // smallrye-jwt-1.1 does not support the file key assets yet
+                addFileKeyAsset(war, fraction.getPublicKeyLocation());
             } else {
                 log.debugf("PublicKey location: %s", fraction.getPublicKeyLocation());
                 war.addAsManifestResource(new StringAsset(fraction.getPublicKeyLocation()), "MP-JWT-SIGNER-KEY-LOCATION");
@@ -185,6 +194,12 @@ public class MPJWTAuthExtensionArchivePreparer implements DeploymentProcessor {
         if (fraction.getRolesPropertiesMap() != null) {
             createRolePropertiesFileFromMap();
         }
+    }
+
+    // This function will be removed after the upgrade to the next version of smallrye-jwt-1.1 which supports the file key assets
+    private void addFileKeyAsset(WARArchive war, String publicKeyLocation) {
+        File fileRef = new File(publicKeyLocation.substring(5, publicKeyLocation.length()));
+        war.addAsManifestResource(new FileAsset(fileRef), "MP-JWT-SIGNER");
     }
 
     private void selectSecurityDomain(WARArchive war, String realm) {

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <version.smallrye.openapi-1.1>1.0.2</version.smallrye.openapi-1.1>
     <version.smallrye.opentracing-1.3>1.0.0</version.smallrye.opentracing-1.3>
     <version.smallrye.metrics-2.0>1.1.0</version.smallrye.metrics-2.0>
-    <version.smallrye.jwt-1.1>2.0.0</version.smallrye.jwt-1.1>
+    <version.smallrye.jwt-1.1>2.0.1</version.smallrye.jwt-1.1>
     <version.smallrye.fault-tolerance-2.0>1.0.1</version.smallrye.fault-tolerance-2.0>
 
     <!-- ===== other ===== -->


### PR DESCRIPTION
Motivation
----------
Update to SmallRye JWT 1.1-2.0.1 which supports file based key assets, avoids NPE for claims whose values may contain `null`, as well as does a correct mapping from a `scope` to `groups` claim when required. 

Modifications
-------------
Updated `smallrye-jwt-1.1` to `2.0.1`. Didn't remove the code for loading
file-based key assets, because the SmallRye JWT code fails on Windows.

Result
------
Better support for 3rd party non KC tokens in MP JWT.