### PR TITLE
THORN-2445: old groupId org.wildfly.swarm.cli

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -14,7 +14,7 @@
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 
-  <groupId>org.wildfly.swarm.cli</groupId>
+  <groupId>io.thorntail.cli</groupId>
   <artifactId>cli</artifactId>
 
   <name>JBoss CLI</name>


### PR DESCRIPTION
Motivation
----------
During the 2.5.0.Final release, I found that we still have
one artifact with old `groupId` of `org.wildfly.swarm.cli`.
It's been like that since 2.0.0.Final, but we should fix it anyway.

Modifications
-------------
Changed `groupId` from `org.wildfly.swarm.cli` to `io.thorntail.cli`.

Result
------
Everything Thorntail will be deployed under `io.thorntail`.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
