### PR TITLE
THORN-2026: Swagger fraction should create swagger.yaml file

### DIFF
--- a/fractions/swagger/src/main/resources/modules/com/fasterxml/jackson/swagger/module.xml
+++ b/fractions/swagger/src/main/resources/modules/com/fasterxml/jackson/swagger/module.xml
@@ -4,6 +4,7 @@
     <artifact name="com.fasterxml.jackson.datatype:jackson-datatype-guava:${version.com.fasterxml.jackson}"/>
     <artifact name="com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${version.com.fasterxml.jackson}"/>
     <artifact name="com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${version.com.fasterxml.jackson}"/>
+    <artifact name="org.yaml:snakeyaml:${version.org.snakeyaml}" />
   </resources>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -117,8 +117,8 @@
     <version.zipkin.reporter>0.6.1</version.zipkin.reporter>
 
     <!-- Swagger -->
-    <version.io.swagger>1.5.21</version.io.swagger>
-    <version.org.webjars.swagger-ui>3.2.2</version.org.webjars.swagger-ui>
+    <version.io.swagger>1.5.22</version.io.swagger>
+    <version.org.webjars.swagger-ui>3.23.0</version.org.webjars.swagger-ui>
     <version.swagger.reflections>0.9.10</version.swagger.reflections>
     <version.swagger.commons.lang>3.2.1</version.swagger.commons.lang>
 

--- a/testsuite/testsuite-swagger/pom.xml
+++ b/testsuite/testsuite-swagger/pom.xml
@@ -36,6 +36,11 @@
       <artifactId>arquillian-junit-container</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>fluent-hc</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/testsuite/testsuite-swagger/src/test/java/com/mycorp/SwaggerArquillianTest.java
+++ b/testsuite/testsuite-swagger/src/test/java/com/mycorp/SwaggerArquillianTest.java
@@ -15,10 +15,7 @@
  */
 package com.mycorp;
 
-import java.net.URL;
-import java.nio.charset.Charset;
-
-import org.apache.commons.io.IOUtils;
+import org.apache.http.client.fluent.Request;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
@@ -37,8 +34,11 @@ public class SwaggerArquillianTest {
     @RunAsClient
     @Test
     public void testEndpoints() throws Exception {
-        String content = IOUtils.toString(new URL("http://127.0.0.1:8080/swagger.json"), Charset.forName("UTF-8"));
-        assertThat(content).contains("\"tags\":[{\"name\":\"theapp\"}]");
+        String content = Request.Get("http://127.0.0.1:8080/swagger.json").execute().returnContent().asString();
+        assertThat(content).contains("\"tags\":[{\"name\":\"theapp\"}]").contains("\"summary\":\"Say howdy\"");
+
+        content = Request.Get("http://127.0.0.1:8080/swagger.yaml").execute().returnContent().asString();
+        assertThat(content).contains("name: \"theapp\"").contains("summary: \"Say howdy\"");
     }
 
 }


### PR DESCRIPTION
Motivation
----------
The `swagger.yaml` endpoint exposed by the `swagger` fraction
doesn't work correctly.

Modifications
-------------
Add SnakeYAML to the `com.fasterxml.jackson:swagger` module.
Also update Swagger and Swagger UI to latest versions.

Result
------
The `swagger.yaml` endpoint works correctly.
Using latest Swagger now.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
