### PR TITLE
THORN-2449: some OpenTracing libraries need to be updated

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,10 +105,10 @@
 
     <!-- tracing -->
     <version.opentracing>0.31.0</version.opentracing>
-    <version.opentracing.concurrent>0.2.0</version.opentracing.concurrent>
+    <version.opentracing.concurrent>0.2.1</version.opentracing.concurrent>
     <version.opentracing.interceptors>0.0.4</version.opentracing.interceptors>
     <version.opentracing.jaxrs>0.4.1</version.opentracing.jaxrs>
-    <version.opentracing.servlet>0.2.0</version.opentracing.servlet>
+    <version.opentracing.servlet>0.2.3</version.opentracing.servlet>
     <version.opentracing.tracerresolver>0.1.5</version.opentracing.tracerresolver>
     <version.jaeger>0.34.0</version.jaeger>
     <version.jaeger.apache.thrift>0.12.0</version.jaeger.apache.thrift>


### PR DESCRIPTION
Motivation
----------
Per https://github.com/wildfly/wildfly/pull/12440, the correct
versions of OpenTracing components currently are:

- `io.opentracing`: 0.31.0
- `io.opentracing.concurrent`: 0.2.1
- `io.opentracing.interceptors`: 0.0.4
- `io.opentracing.jaxrs`: 0.4.1
- `io.opentracing.servlet`: 0.2.3
- `io.opentracing.tracerresolver`: 0.1.5
- `io.jaegertracing`: 0.34.0

This means we need to update `io.opentracing.concurrent`
and `io.opentracing.servlet`.

Modifications
-------------
Update `io.opentracing.concurrent` and `io.opentracing.servlet`.

Result
------
Bugfixes in OpenTracing components. Alignment with WildFly.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
