### PR TITLE
THORN-2450: update jose4j to 0.6.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
     <version.jolokia>1.3.4</version.jolokia>
     <version.joox>1.6.0</version.joox>
     <version.jopt-simple>4.9</version.jopt-simple>
-    <version.jose4j>0.6.0</version.jose4j>
+    <version.jose4j>0.6.5</version.jose4j>
     <version.minimal-json>0.9.4</version.minimal-json>
     <version.openshift.client>8.0.0.Final</version.openshift.client>
     <version.org.glassfish.javax.json>1.1.2</version.org.glassfish.javax.json>


### PR DESCRIPTION
Motivation
----------
Thorntail product uses jose4j 0.6.5, but we're still
on 0.6.0 in community. We should align.

Modifications
-------------
Update jose4j to 0.6.5.

Result
------
Bugfixes in the jose4j component.
Better alignment with product.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
