### PR TITLE
THORN-2452: remove outdated parts of default logging.properties

### DIFF
--- a/fractions/wildfly/logging/src/main/resources/logging.properties
+++ b/fractions/wildfly/logging/src/main/resources/logging.properties
@@ -4,7 +4,7 @@
 #
 
 # Additional loggers to configure (the root logger is always configured)
-loggers=org.wildfly.swarm,com.arjuna,jacorb,org.jboss.as.config,org.apache.tomcat.util.modeler,sun.rmi,jacorb.config
+loggers=org.wildfly.swarm,com.arjuna,org.jboss.as.config,sun.rmi
 
 logger.level=INFO
 logger.handlers=CONSOLE
@@ -15,20 +15,11 @@ logger.com.arjuna.useParentHandlers=true
 logger.org.wildfly.swarm.level=${thorntail.logging:INFO}
 logger.org.wildfly.swarm.useParentHandlers=true
 
-logger.jacorb.level=WARN
-logger.jacorb.useParentHandlers=true
-
 logger.org.jboss.as.config.level=INFO
 logger.org.jboss.as.config.useParentHandlers=true
 
-logger.org.apache.tomcat.util.modeler.level=WARN
-logger.org.apache.tomcat.util.modeler.useParentHandlers=true
-
 logger.sun.rmi.level=WARN
 logger.sun.rmi.useParentHandlers=true
-
-logger.jacorb.config.level=ERROR
-logger.jacorb.config.useParentHandlers=true
 
 handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
 handler.CONSOLE.level=INFO


### PR DESCRIPTION
Motivation
----------
The `logging` fraction provides default `logging.properties` file
which configures logging before the `logging` subsystem kicks in.
This file contains some outdated sections, back from times when
WildFly used JacORB and Tomcat. Those should be removed.

Modifications
-------------
Removed outdated parts of default `logging.properties`.

Result
------
No behavioral difference.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
