### PR TITLE
THORN-2460: thorntail.classpath system property can be used also for …

### DIFF
--- a/docs/assemblies/assembly_configuring-a-thorntail-application.adoc
+++ b/docs/assemblies/assembly_configuring-a-thorntail-application.adoc
@@ -21,7 +21,7 @@ include::../modules/proc_setting-system-properties-using-the-maven-plugin.adoc[l
 
 include::../modules/proc_setting-system-properties-using-the-command-line.adoc[leveloffset=+2]
 
-include::../modules/proc_specifying-jdbc-drivers-for-hollow-jars.adoc[leveloffset=+2]
+include::../modules/proc_specifying-external-jdbc-drivers.adoc[leveloffset=+2]
 
 [id='configuring-a-thorntail-application-using-environment-variables_{context}']
 == Environment Variables

--- a/docs/modules/proc_specifying-external-jdbc-drivers.adoc
+++ b/docs/modules/proc_specifying-external-jdbc-drivers.adoc
@@ -2,7 +2,7 @@
 [id='specifying-external-jdbc-drivers_{context}']
 = Specifying external JDBC drivers
 
-When executing an application (either as a hollow JAR or as an uberjar), you can specify a JDBC Driver JAR using the `thorntail.classpath` property.
+When executing an application (either as a hollow JAR or as an uberjar), you can specify a JDBC driver JAR using the `thorntail.classpath` system property.
 This way, you do not need to package the driver in the application.
 
 The `thorntail.classpath` property accepts one or more paths to JAR files separated by `;` (a semicolon).

--- a/docs/modules/proc_specifying-external-jdbc-drivers.adoc
+++ b/docs/modules/proc_specifying-external-jdbc-drivers.adoc
@@ -1,9 +1,9 @@
 
-[id='specifying-jdbc-drivers-for-hollow-jars_{context}']
-= Specifying JDBC drivers for hollow JARs
+[id='specifying-external-jdbc-drivers_{context}']
+= Specifying external JDBC drivers
 
-When executing a hollow JAR, you can specify a JDBC Driver JAR using the `thorntail.classpath` property.
-This way, you do not need to package the driver in the hollow JAR.
+When executing an application (either as a hollow JAR or as an uberjar), you can specify a JDBC Driver JAR using the `thorntail.classpath` property.
+This way, you do not need to package the driver in the application.
 
 The `thorntail.classpath` property accepts one or more paths to JAR files separated by `;` (a semicolon).
 The specified JAR files are added to the classpath of the application.


### PR DESCRIPTION
…uberjars

Motivation
----------
Documentation is not very clear about using external JDBC drivers.
It suggests that the thorntail.classpath property can be used only
with hollow JARs, which is not true. Improve wording so it is clear
that it can be used for both hollow JARs and uberjars.

Modifications
-------------
Reworded and renamed the section about specifying JDBC drivers
via the thorntail.classpath system property.

Result
------
Better user experience when reading the documentation.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
@Ladicek this is the promised documentation PR about the usage of `thorntail.classpath` system property. Should you have any suggestions about better wording, just let me know.