### PR TITLE
Support for BOM style dependencies in the Gradle plugins

### DIFF
--- a/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/GradleDependencyResolutionHelper.java
+++ b/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/GradleDependencyResolutionHelper.java
@@ -211,6 +211,9 @@ public final class GradleDependencyResolutionHelper {
                 // Should never happen.
                 throw new IllegalStateException("Gradle dependency resolution logic is broken. Unable to get scope for dependency: " + lookup);
             }
+            if ("import".equals(scope) || resolvedDep.getModuleArtifacts().isEmpty()) {
+                return;
+            }
             DependencyDescriptor key = asDescriptor(scope, resolvedDep);
             Set<DependencyDescriptor> value;
             if (resolveChildrenTransitively) {
@@ -218,6 +221,7 @@ public final class GradleDependencyResolutionHelper {
             } else {
                 value = resolvedDep.getChildren()
                         .stream()
+                        .filter(rd -> !rd.getModuleArtifacts().isEmpty())
                         .map(rd -> asDescriptor(scope, rd))
                         .collect(Collectors.toSet());
             }
@@ -407,6 +411,9 @@ public final class GradleDependencyResolutionHelper {
         final String TEST = "test";
         final String PROVIDED = "provided";
         final String RUNTIME = "runtime";
+
+        REMAPPED_SCOPES.put("platform-runtime", "import");
+        REMAPPED_SCOPES.put("enforced-platform-runtime", "import");
 
         REMAPPED_SCOPES.put("compile", COMPILE);
         REMAPPED_SCOPES.put("api", COMPILE);


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
@TomasHofman @Ladicek 

I have been playing around with consuming the Gradle's version of [BOM definitions](https://docs.gradle.org/current/userguide/java_platform_plugin.html) (a.k.a. `java-platform`) and I noticed that the plugin always returns the bom parent as having the artifact type as `jar` and then that fails during dependency resolution.

Since in the Gradle plugin, all the dependencies have been resolved, we can skip any dependency that does not have a resolved artifact.

This assumes that developers can not create a Gradle project that has no outputs but has dependencies, in which case the work around would be to just include those dependencies directly. If we know of additional use cases, we can always factor them in at that point.