### PR TITLE
THORN-2473 Allow system properties with = in the value

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/cli/CommandLine.java
+++ b/core/container/src/main/java/org/wildfly/swarm/cli/CommandLine.java
@@ -95,7 +95,7 @@ public class CommandLine {
             .withDescription("Set a system property")
             .withDefault(Properties::new)
             .then((cmd, opt, value) -> {
-                String[] nameValue = value.split("=");
+                String[] nameValue = value.split("=", 2);
                 Properties props = cmd.get(opt);
                 String propName = nameValue[0];
                 String propValue = "true";


### PR DESCRIPTION
This fixes the system property parsing, so that values containing = are supported

- [ ] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [X] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [X] Have you built the project locally prior to submission with `mvn clean install`?

-----
