### PR TITLE
Gradle: Align the Gradle version during Arquillian dependency resolution

### DIFF
--- a/arquillian/gradle-adapter/pom.xml
+++ b/arquillian/gradle-adapter/pom.xml
@@ -45,6 +45,7 @@
     <dependency>
       <groupId>org.gradle</groupId>
       <artifactId>gradle-tooling-api</artifactId>
+      <scope>provided</scope>
     </dependency>
 
   </dependencies>

--- a/arquillian/gradle-adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/gradle/GradleDependencyAdapter.java
+++ b/arquillian/gradle-adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/gradle/GradleDependencyAdapter.java
@@ -62,6 +62,10 @@ public class GradleDependencyAdapter {
 
             File projectDir = rootPath.toFile();
             GradleConnector connector = GradleConnector.newConnector().forProjectDirectory(projectDir);
+            String gradleVersion = System.getenv(GradleToolingHelper.THORNTAIL_ARQUILLIAN_GRADLE_VERSION);
+            if (gradleVersion != null) {
+                connector.useGradleVersion(gradleVersion);
+            }
             ProjectConnection connection = connector.connect();
             try {
                 // 1. Attempt to fetch the dependencies via the Thorntail model.

--- a/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/PackagePlugin.java
+++ b/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/PackagePlugin.java
@@ -59,7 +59,7 @@ public class PackagePlugin extends AbstractThorntailPlugin {
     public void apply(Project project) {
         super.apply(project);
         PluginManager pluginManager = project.getPluginManager();
-        if (pluginManager.hasPlugin(ThorntailArquillianPlugin.PLUGIN_ID)) {
+        if (!pluginManager.hasPlugin(ThorntailArquillianPlugin.PLUGIN_ID)) {
             pluginManager.apply(ThorntailArquillianPlugin.class);
         }
         project.afterEvaluate(__ -> {

--- a/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/ThorntailArquillianPlugin.java
+++ b/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/ThorntailArquillianPlugin.java
@@ -44,6 +44,8 @@ public class ThorntailArquillianPlugin extends AbstractThorntailPlugin {
 
     private static final String BUILD_SCRIPT_FRAGMENT = "META-INF/thorntail-scripts/configure-tasks.groovy";
 
+    private boolean projectConfigured = false;
+
     /**
      * Constructs a new instance of {@code PackagePlugin}, which is initialized with the Gradle tooling model builder registry.
      *
@@ -57,6 +59,12 @@ public class ThorntailArquillianPlugin extends AbstractThorntailPlugin {
 
     @Override
     public void apply(Project project) {
+        if (projectConfigured) {
+            // Nothing to do.
+            return;
+        }
+        projectConfigured = true;
+
         super.apply(project);
 
         //noinspection Convert2Lambda

--- a/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/ThorntailArquillianPlugin.java
+++ b/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/ThorntailArquillianPlugin.java
@@ -16,11 +16,23 @@
 
 package org.wildfly.swarm.plugin.gradle;
 
-import javax.inject.Inject;
-
+import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry;
+
+import javax.inject.Inject;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * Gradle plugin for enabling Arquillian tests based on Thorntail. This is useful in cases where a Gradle project doesn't
@@ -29,6 +41,8 @@ import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry;
 public class ThorntailArquillianPlugin extends AbstractThorntailPlugin {
 
     public static final String PLUGIN_ID = "thorntail-arquillian";
+
+    private static final String BUILD_SCRIPT_FRAGMENT = "META-INF/thorntail-scripts/configure-tasks.groovy";
 
     /**
      * Constructs a new instance of {@code PackagePlugin}, which is initialized with the Gradle tooling model builder registry.
@@ -44,11 +58,65 @@ public class ThorntailArquillianPlugin extends AbstractThorntailPlugin {
     @Override
     public void apply(Project project) {
         super.apply(project);
-        // Add the Gradle tooling dependency if it is missing.
-        Configuration testRuntimeConfig = project.getConfigurations().findByName("testRuntimeClasspath");
-        if (testRuntimeConfig != null) {
-            project.getDependencies().add("testRuntimeClasspath",
-                                          "org.gradle:gradle-tooling-api:" + project.getGradle().getGradleVersion());
+
+        //noinspection Convert2Lambda
+        project.afterEvaluate(new Action<Project>() {
+            @Override
+            public void execute(Project __) {
+                final String CONFIGURATION = "testRuntimeClasspath";
+                // Add the Gradle tooling dependency if it is missing.
+                String gav = "org.gradle:gradle-tooling-api:" + project.getGradle().getGradleVersion();
+                Configuration config = project.getConfigurations().findByName("testRuntimeClasspath");
+                if (config != null) {
+                    DependencyHandler handler = project.getDependencies();
+                    handler.add(config.getName(), handler.create(gav));
+                } else {
+                    System.err.println("Unable to add Gradle Tooling APIs to the " + CONFIGURATION +
+                            ". Thorntail Arquillian integration might not work.");
+                }
+
+                URL resource = ThorntailArquillianPlugin.class.getClassLoader().getResource(BUILD_SCRIPT_FRAGMENT);
+                if (resource != null) {
+                    try {
+                        File scriptFile = new File(project.getBuildDir(), "thorntail-arquillian-script.gradle");
+                        if (!scriptFile.exists()) {
+                            scriptFile.createNewFile();
+                            String[] lines = readString(resource.openStream()).split("\n");
+                            Files.write(scriptFile.toPath(), Arrays.asList(lines));
+                        }
+                        Map<String, Object> map = Collections.singletonMap("from", scriptFile.getAbsolutePath());
+                        project.apply(map);
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                } else {
+                    System.err.println("Thorntail Arquillian:: Unable to locate resource: " + BUILD_SCRIPT_FRAGMENT);
+                }
+            }
+        });
+    }
+
+    /**
+     * Read the given stream in to a String. This method will close the stream as well.
+     *
+     * @param stream the input stream.
+     * @return the string built out of the data available in the given stream.
+     */
+    private static String readString(InputStream stream) throws IOException {
+        if (stream == null) {
+            return null;
+        }
+        try {
+            ByteArrayOutputStream result = new ByteArrayOutputStream();
+            byte[] buffer = new byte[1024];
+            int length;
+            while ((length = stream.read(buffer)) != -1) {
+                result.write(buffer, 0, length);
+            }
+            return result.toString(StandardCharsets.UTF_8.name());
+        } finally {
+            stream.close();
         }
     }
+
 }

--- a/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/ThorntailArquillianPlugin.java
+++ b/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/ThorntailArquillianPlugin.java
@@ -78,6 +78,9 @@ public class ThorntailArquillianPlugin extends AbstractThorntailPlugin {
                 URL resource = ThorntailArquillianPlugin.class.getClassLoader().getResource(BUILD_SCRIPT_FRAGMENT);
                 if (resource != null) {
                     try {
+                        if (!project.getBuildDir().exists()) {
+                            project.getBuildDir().mkdirs();
+                        }
                         File scriptFile = new File(project.getBuildDir(), "thorntail-arquillian-script.gradle");
                         if (!scriptFile.exists()) {
                             scriptFile.createNewFile();

--- a/plugins/gradle/gradle-plugin/src/main/resources/META-INF/thorntail-scripts/configure-tasks.groovy
+++ b/plugins/gradle/gradle-plugin/src/main/resources/META-INF/thorntail-scripts/configure-tasks.groovy
@@ -1,0 +1,29 @@
+import org.gradle.api.tasks.testing.Test
+
+/*
+ * Copyright 2018 Red Hat, Inc, and individual contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+// Given our current integration model, we end up in a scenario where we are unable to perform all integrations from
+// Java layer as that would mean that we now need to have a dependency on a newer version of the Gradle plugin.
+// For such scenarios, we can make use of the concept of applying a Gradle build snippet to the project directly.
+// The only catch is that we need to be very careful when going via this approach. Once we figure out a better way
+// on integrating directly via Java API calls, we will no longer need this approach.
+
+project.tasks.withType(Test).each { task ->
+    // Specify the current Gradle version as an environment variable to all the test tasks. This variable will be used
+    // by the Arquillian adapter when invoking the tooling API.
+    task.environment('THORNTAIL_ARQUILLIAN_GRADLE_VERSION', gradle.gradleVersion)
+}

--- a/plugins/gradle/tooling-api/src/main/java/org/wildfly/swarm/plugin/gradle/GradleToolingHelper.java
+++ b/plugins/gradle/tooling-api/src/main/java/org/wildfly/swarm/plugin/gradle/GradleToolingHelper.java
@@ -27,6 +27,17 @@ import org.wildfly.swarm.tools.DeclaredDependencies;
  */
 public final class GradleToolingHelper {
 
+    /**
+     * The System environment that will passed from the plugin to testing tasks which will contain the Gradle version
+     * being used for the current test execution. This environment variable is setup in order to facilitate the testing
+     * of the project against a newer version of Gradle instead of having to upgrade the Gradle wrapper.properties file.
+     * <p>
+     * Also, useful when the project root folder does not contain the Gradle wrapper properties, as is the case with the
+     * Thorntail Gradle examples. Since we cannot anticipate all possible scenarios, it is advisable to use the same
+     * version of Gradle that started this build.
+     */
+    public static final String THORNTAIL_ARQUILLIAN_GRADLE_VERSION = "THORNTAIL_ARQUILLIAN_GRADLE_VERSION";
+
     private GradleToolingHelper() {
     }
 


### PR DESCRIPTION
Previously, the Gradle Arquillian integration would always spin up a Gradle 3.1 daemon. This was becuase we were pulling in the Gradle jar (version 3.1) as a dependency. This has a performance implication on the CI equation as each build would download Gradle 3.1 for testing.

With this commit, I am making the following changes,

1. Mark all Gradle dependencies as provided.
2. Include the required dependencies (from the Gradle platform) dynamically as part of the plugin configurations.
3. Introduce a path forward for adding Gradle specific changes without having to rely on bumping the Gradle library versions.

-----

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
