### PR TITLE
Avoid replacing the original war file if no filtering is required

### DIFF
--- a/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
@@ -218,7 +218,7 @@ public class BuildTool {
             original.as(ZipImporter.class).importFrom(inputStream);
         }
 
-        Archive repackaged = this.filterWebInfLib ? new WebInfLibFilteringArchive(original, this.dependencyManager) : original;
+        Archive repackaged = new WebInfLibFilteringArchive(original, this.dependencyManager);
         repackaged.as(ZipExporter.class).exportTo(file, true);
         this.log.info("Repackaged .war: " + file);
     }

--- a/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/BuildTool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -204,6 +204,10 @@ public class BuildTool {
 
 
     public void repackageWar(File file) throws IOException {
+        if (!filterWebInfLib) {
+            return;
+        }
+
         this.log.info("Repackaging .war: " + file);
 
         Path backupPath = get(file);


### PR DESCRIPTION
The current implementation will always replace the built war file irrespective of whether the `filterWebInfLib` flag has been set or not. By doing an early check we can speed up the execution time for projects that build large war files.

Additionally, this would also help the Gradle plugin leverage task avoidance which is currently not happening. By replacing the war file (with the same content), Gradle believes that the file has changed and thus re-executes the war task, which will re-execute the thorntail-package task. With this change, the Gradle plugin will be able to avoid repackaging and speed up development.

-----
- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
