### PR TITLE
THORN-2498: undertow brings in jboss-annotations-api_1.2_spec

### DIFF
--- a/fractions/javaee/undertow/pom.xml
+++ b/fractions/javaee/undertow/pom.xml
@@ -125,6 +125,16 @@
     <dependency>
       <groupId>io.undertow</groupId>
       <artifactId>undertow-servlet</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.annotation</groupId>
+          <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.annotation</groupId>
+      <artifactId>jboss-annotations-api_1.3_spec</artifactId>
     </dependency>
 
     <!-- Meta SPI -->


### PR DESCRIPTION
Motivation
----------
The `undertow` fraction transitively brings in
`org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec`,
even though we should provide `jboss-annotations-api_1.3_spec`
everywhere.

Modifications
-------------
Add a dependency exclusion on the old version of Common Annotations
to the `undertow` fraction, and an explicit dependency on the new
version of Common Annotations.

Result
------
`undertow` fraction now brings in `jboss-annotations-api_1.3_spec`.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
