### PR TITLE
Bump checkstyle to 8.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
   <properties>
     <!-- ===== code quality ===== -->
-    <version.checkstyle>7.4</version.checkstyle>
+    <version.checkstyle>8.18</version.checkstyle>
     <version.findbugs>2.0.3</version.findbugs>
     <version.wildfly.swarm.checkstyle>3</version.wildfly.swarm.checkstyle>
 


### PR DESCRIPTION
Checkstyle prior to 8.18 loads external DTDs by default, which can potentially lead to denial of service attacks or the leaking of confidential information.
CVE-2019-9658: https://nvd.nist.gov/vuln/detail/CVE-2019-9658

See https://github.com/thorntail/thorntail/network/alert/pom.xml/com.puppycrawl.tools:checkstyle/open


- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----