### PR TITLE
THORN-2492: Maven plugin ignores exclusions when creating wildfly-swarm-manifest.yaml

### DIFF
--- a/plugins/gradle/tooling-api/src/main/java/org/wildfly/swarm/plugin/gradle/GradleToolingHelper.java
+++ b/plugins/gradle/tooling-api/src/main/java/org/wildfly/swarm/plugin/gradle/GradleToolingHelper.java
@@ -48,10 +48,11 @@ public final class GradleToolingHelper {
         DeclaredDependencies dependencies = new DeclaredDependencies();
         depMap.forEach((directDep, resolvedDeps) -> {
             ArtifactSpec parent = toArtifactSpec(directDep);
-            dependencies.addResolved(parent);
+            dependencies.add(parent);
             if (resolvedDeps != null) {
-                resolvedDeps.forEach(d -> dependencies.addResolved(parent, toArtifactSpec(d)));
+                resolvedDeps.forEach(d -> dependencies.add(parent, toArtifactSpec(d)));
             }
+            dependencies.markComplete(parent);
         });
         return dependencies;
     }

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/PackageMojo.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/PackageMojo.java
@@ -192,6 +192,7 @@ public class PackageMojo extends AbstractSwarmMojo {
                     declaredDependencies.add(directDep, transientDep);
                 }
             }
+            declaredDependencies.markComplete(directDep);
         }
 
         tool.declaredDependencies(declaredDependencies);

--- a/tools/src/main/java/org/wildfly/swarm/tools/DeclaredDependencies.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/DeclaredDependencies.java
@@ -261,9 +261,27 @@ public class DeclaredDependencies extends DependencyTree<ArtifactSpec> {
         return reordered;
     }
 
+    /**
+     * Marks given {@code directDep} as "complete", which means that this instance of {@code DeclaredDependencies}
+     * already has information about all transitive dependencies brought in by the {@code directDep}. Calling this
+     * method only makes sense if the caller has access to the complete dependency tree.
+     */
+    public void markComplete(ArtifactSpec directDep) {
+        if (completeTransitiveDependencies == null) {
+            completeTransitiveDependencies = new HashSet<>();
+        }
+        completeTransitiveDependencies.add(directDep);
+    }
+
+    public boolean isComplete(ArtifactSpec directDep) {
+        return completeTransitiveDependencies != null && completeTransitiveDependencies.contains(directDep);
+    }
+
     private static final Set<String> PRIORITIZED_SCOPES = Stream.of("compile", "provided").collect(Collectors.toSet());
 
     private final DependencyTree<ArtifactSpec> presolvedDependencies = new DependencyTree<>();
 
     private Set<ArtifactSpec> allTransient;
+
+    private Set<ArtifactSpec> completeTransitiveDependencies;
 }

--- a/tools/src/test/java/org/wildfly/swarm/tools/DeclaredDependenciesTest.java
+++ b/tools/src/test/java/org/wildfly/swarm/tools/DeclaredDependenciesTest.java
@@ -35,7 +35,7 @@ public class DeclaredDependenciesTest {
     public void testUnsolvedDirect() {
         dependencyStream().forEach(declaredDependencies::add);
 
-        Collection<ArtifactSpec> directDependencies = declaredDependencies.getDirectDependencies(true, false);
+        Collection<ArtifactSpec> directDependencies = declaredDependencies.getDirectDependencies();
         Iterator<ArtifactSpec> iterator = directDependencies.iterator();
 
         assertOrder(iterator);


### PR DESCRIPTION
Motivation
----------
When the `pom.xml` declares an exclusion for a library, this exclusion
is not taken into account when the `wildfly-swarm-manifest.yaml` file
is created. This can cause library conflicts at runtime.

Example:
The SLF4J logging framework supports different underlying logging systems,
e.g. Log4j or Logback; however, only one of the corresponding binding JAR
files is allowed to be present at runtime.

When a Thorntail project uses the SLF4J logging framework, declares
a direct dependency on one of the bindings, and declares a dependency
on a 3rd party library (e.g. ZooKeeper) which itself declares a dependency
on another binding, this will lead to multiple bindings being present
at runtime. The 3rd party library should normally not declare that dependency,
but if it does, the only solution is to add an exclusion; however, this is
ignored when the `wildfly-swarm-manifest.yaml` file is created, so the SLF4J
system complains at runtime about duplicate bindings.

Modifications
-------------
When the uberjar is being built by the Maven plugin, we can access
the entire dependency tree exactly how Maven sees it. Therefore, we don't
have to figure out the transitive dependencies ourselves, which has a nice
benefit: dependency exclusions are taken into account.

Result
------
Only affects how the Maven plugin builds the uberjar. Other code paths
that build an uberjar are not affected, which unfortunately means
there might be behavioral differences between e.g. Maven plugin
and Arquillian.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
