### PR TITLE
THORN-2500: improve wording around custom main deprecation

### DIFF
--- a/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/PackageTask.java
+++ b/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/PackageTask.java
@@ -178,9 +178,9 @@ public class PackageTask extends DefaultTask {
         if (mainClassName != null && !mainClassName.equals("")) {
             getLogger().warn(
                     "\n------\n" +
-                            "Custom main() usage is intended to be deprecated in a future release and is no longer supported, \n" +
-                            "please refer to http://docs.thorntail.io for YAML configuration that replaces it." +
-                            "\n------"
+                    "Custom main() usage is deprecated and is no longer supported.\n" +
+                    "Please refer to https://docs.thorntail.io for YAML configuration that replaces it." +
+                    "\n------"
             );
         }
 

--- a/plugins/gradle/tooling-api/src/main/java/org/wildfly/swarm/plugin/gradle/ThorntailConfiguration.java
+++ b/plugins/gradle/tooling-api/src/main/java/org/wildfly/swarm/plugin/gradle/ThorntailConfiguration.java
@@ -133,8 +133,8 @@ public interface ThorntailConfiguration extends Serializable {
      * Get the main class name that will be invoked when executing the Thorntail application.
      *
      * @return the main class name that will be invoked when executing the Thorntail application.
-     * @deprecated Custom main() usage is intended to be deprecated in a future release and is no longer supported, please refer
-     * to http://docs.wildfly-swarm.io for YAML configuration that replaces it.
+     * @deprecated Custom main() usage is deprecated and is no longer supported. Please refer
+     * to https://docs.thorntail.io for YAML configuration that replaces it.
      */
     @Deprecated
     String getMainClassName();
@@ -143,8 +143,8 @@ public interface ThorntailConfiguration extends Serializable {
      * Set the main class name that will be invoked when executing the Thorntail application.
      *
      * @param className the main class name that will be invoked when executing the Thorntail application.
-     * @deprecated Custom main() usage is intended to be deprecated in a future release and is no longer supported, please refer
-     * to http://docs.wildfly-swarm.io for YAML configuration that replaces it.
+     * @deprecated Custom main() usage is deprecated and is no longer supported. Please refer
+     * to https://docs.thorntail.io for YAML configuration that replaces it.
      */
     @Deprecated
     void setMainClassName(String className);

--- a/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/AbstractSwarmMojo.java
+++ b/plugins/maven/src/main/java/org/wildfly/swarm/plugin/maven/AbstractSwarmMojo.java
@@ -135,8 +135,8 @@ public abstract class AbstractSwarmMojo extends AbstractMojo {
         if (mainClass != null && !mainClass.equals("")) {
             getLog().warn(
                     "\n------\n" +
-                    "Custom main() usage is intended to be deprecated in a future release and is no longer supported, \n" +
-                            "please refer to http://docs.thorntail.io for YAML configuration that replaces it." +
+                    "Custom main() usage is deprecated and is no longer supported.\n" +
+                    "Please refer to https://docs.thorntail.io for YAML configuration that replaces it." +
                     "\n------"
             );
         }


### PR DESCRIPTION
Motivation
----------
The wording around custom `main` deprecation is somewhat evasive:

```
------
Custom main() usage is intended to be deprecated in a future release and is no longer supported,
please refer to http://docs.thorntail.io for YAML configuration that replaces it.
------
```

IMHO, we should make clear that custom `main` is already deprecated. Something like:

```
------
Custom main() usage is deprecated and is no longer supported.
Please refer to http://docs.thorntail.io for YAML configuration that replaces it.
------
```

Modifications
-------------
Updated the custom `main` message per above.

Result
------
More clear message around custom `main` deprecation.
No behavioral change.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
