### PR TITLE
THORN-2503: update the test for the Thorntail Maven plugin

### DIFF
--- a/testsuite/testsuite-maven-plugin/src/test/java/org/wildfly/swarm/maven/plugin/MavenPluginTest.java
+++ b/testsuite/testsuite-maven-plugin/src/test/java/org/wildfly/swarm/maven/plugin/MavenPluginTest.java
@@ -89,28 +89,30 @@ public class MavenPluginTest {
                     new TestingProject(Packaging.WAR, Dependencies.FRACTIONS, Autodetection.FORCE,
                                        new IncludedTechnology[]{IncludedTechnology.SERVLET, IncludedTechnology.JAX_RS},
                                        AdditionalDependency.NON_JAVA_EE, AdditionalFraction.NONE),
-                    // SWARM-870
-/*
                     new TestingProject(Packaging.WAR, Dependencies.JAVA_EE_APIS, Autodetection.FORCE,
                                        new IncludedTechnology[]{IncludedTechnology.SERVLET},
                                        AdditionalDependency.NON_JAVA_EE, AdditionalFraction.ALREADY_PRESENT),
-*/
-                    // SWARM-814
                     new TestingProject(Packaging.WAR, Dependencies.JAVA_EE_APIS, Autodetection.WHEN_MISSING,
                                        new IncludedTechnology[]{IncludedTechnology.SERVLET, IncludedTechnology.EJB},
-                                       AdditionalDependency.NONE, AdditionalFraction.NONE)
-                    // SWARM-970
+                                       AdditionalDependency.NONE, AdditionalFraction.NONE),
+                    new TestingProject(Packaging.WAR, Dependencies.FRACTIONS, Autodetection.NEVER,
+                                       new IncludedTechnology[]{IncludedTechnology.SERVLET, IncludedTechnology.JAX_RS},
+                                       AdditionalDependency.NON_JAVA_EE, AdditionalFraction.NOT_YET_PRESENT),
+                    // THORN-2502
 /*
+                    new TestingProject(Packaging.WAR, Dependencies.JAVA_EE_APIS, Autodetection.WHEN_MISSING,
+                                       new IncludedTechnology[]{IncludedTechnology.SERVLET, IncludedTechnology.JAX_RS},
+                                       AdditionalDependency.USING_JAVA_EE, AdditionalFraction.NONE),
+*/
                     new TestingProject(Packaging.WAR, Dependencies.FRACTIONS, Autodetection.FORCE,
                                        new IncludedTechnology[]{IncludedTechnology.SERVLET, IncludedTechnology.EJB},
                                        AdditionalDependency.NONE, AdditionalFraction.NONE),
-*/
-                    // SWARM-869
-/*
-                    new TestingProject(Packaging.JAR_WITH_MAIN, Dependencies.FRACTIONS, Autodetection.WHEN_MISSING,
+                    new TestingProject(Packaging.JAR, Dependencies.FRACTIONS, Autodetection.WHEN_MISSING,
                                        new IncludedTechnology[]{IncludedTechnology.SERVLET, IncludedTechnology.JAX_RS},
                                        AdditionalDependency.USING_JAVA_EE, AdditionalFraction.NOT_YET_PRESENT),
-*/
+                    new TestingProject(Packaging.JAR, Dependencies.JAVA_EE_APIS, Autodetection.FORCE,
+                                       new IncludedTechnology[]{IncludedTechnology.SERVLET, IncludedTechnology.JAX_RS},
+                                       AdditionalDependency.NONE, AdditionalFraction.ALREADY_PRESENT)
             );
         }
 
@@ -120,12 +122,8 @@ public class MavenPluginTest {
                 for (Autodetection autodetection : Autodetection.values()) {
                     for (AdditionalDependency additionalDependency : AdditionalDependency.values()) {
                         for (AdditionalFraction additionalFraction : AdditionalFraction.values()) {
-                            // a lot of these fail because of SWARM-869
-                            if (autodetection == Autodetection.WHEN_MISSING && additionalFraction != AdditionalFraction.NONE) {
-                                continue;
-                            }
-                            // a lot of these fail because of SWARM-870
-                            if (autodetection != Autodetection.NEVER && additionalFraction == AdditionalFraction.ALREADY_PRESENT) {
+                            // a lot of these fail because of THORN-2502
+                            if (additionalDependency == AdditionalDependency.USING_JAVA_EE) {
                                 continue;
                             }
 
@@ -139,11 +137,6 @@ public class MavenPluginTest {
                                     new IncludedTechnology[]{IncludedTechnology.SERVLET, IncludedTechnology.JAX_RS},
                                     additionalDependency, additionalFraction
                             ));
-
-                            // a lot of these fail because of SWARM-970
-                            if (dependencies == Dependencies.FRACTIONS && autodetection == Autodetection.FORCE) {
-                                continue;
-                            }
                             testingProjects.add(new TestingProject(
                                     packaging, dependencies, autodetection,
                                     new IncludedTechnology[]{IncludedTechnology.SERVLET, IncludedTechnology.EJB},
@@ -220,11 +213,6 @@ public class MavenPluginTest {
         String goal = "package";
         if (testingProject.canRunTests()) {
             goal = "verify";
-
-            // a lot of these fail because of SWARM-873
-            if (testingProject.additionalDependency == AdditionalDependency.USING_JAVA_EE) {
-                goal = "package";
-            }
         }
 
         try {

--- a/testsuite/testsuite-maven-plugin/src/test/java/org/wildfly/swarm/maven/plugin/Packaging.java
+++ b/testsuite/testsuite-maven-plugin/src/test/java/org/wildfly/swarm/maven/plugin/Packaging.java
@@ -16,8 +16,9 @@
 package org.wildfly.swarm.maven.plugin;
 
 /**
- * How should the testing project be packaged. This isn't exactly the same as Maven project packaging,
- * because it distinguishes between cases with and without custom {@code main} method.
+ * How should the testing project be packaged. This is essentially equivalent to Maven project packaging.
+ * (If we tested custom {@code main} methods, we'd have a separate value for with and without custom {@code main},
+ * and so this wouldn't be the same as Maven packaging. Custom {@code main} methods, however, are no longer supported.)
  */
 public enum Packaging {
     WAR("war"),

--- a/testsuite/testsuite-maven-plugin/src/test/resources/testing-project/pom.xml
+++ b/testsuite/testsuite-maven-plugin/src/test/resources/testing-project/pom.xml
@@ -21,7 +21,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
-    <version.org.wildfly.swarm><!--PLACEHOLDER:swarm-version--></version.org.wildfly.swarm>
+    <version.io.thorntail><!--PLACEHOLDER:thorntail-version--></version.io.thorntail>
   </properties>
 
   <dependencyManagement>
@@ -29,7 +29,7 @@
       <dependency>
         <groupId>io.thorntail</groupId>
         <artifactId>bom</artifactId>
-        <version>${version.org.wildfly.swarm}</version>
+        <version>${version.io.thorntail}</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -74,7 +74,7 @@
       <plugin>
         <groupId>io.thorntail</groupId>
         <artifactId>thorntail-maven-plugin</artifactId>
-        <version>${version.org.wildfly.swarm}</version>
+        <version>${version.io.thorntail}</version>
         <configuration>
           <!--PLACEHOLDER:configuration-->
         </configuration>


### PR DESCRIPTION
Motivation
----------
The Thorntail Maven plugin test needs a few updates:

- some test variants are still commented out, even though the issues
  have been fixed
- still using the word "swarm" on some places
- still manually including the `undertow` fraction for the JAR packaging
  (it was needed for testing custom `main`, but we no longer test it)
- still expecting the `undertow` fraction to be present with the JAR
  packaging (related to previous point)
- still running tests with the JAR packaging (they used to pass because
  the `undertow` fraction was present and therefore HTTP endpoints were
  exposed, see the previous points)

Modifications
-------------
Updated the Thorntail Maven plugin tests per above.

Result
------
Better Maven plugin test coverage. No behavioral changes.

- [ ] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
