### PR TITLE
THORN-2508: jaxrs-jsonb fraction doesn't bring in jaxrs-jsonp

### DIFF
--- a/fractions/javaee/jaxrs-jsonb/pom.xml
+++ b/fractions/javaee/jaxrs-jsonb/pom.xml
@@ -36,7 +36,7 @@
     <!-- Fraction Dependencies -->
     <dependency>
       <groupId>io.thorntail</groupId>
-      <artifactId>jaxrs</artifactId>
+      <artifactId>jaxrs-jsonp</artifactId>
     </dependency>
     <dependency>
       <groupId>io.thorntail</groupId>


### PR DESCRIPTION
Motivation
----------
The `jsonb` fraction brings in the `jsonp` fraction transitively.
It isn't the case for the `jaxrs-jsonb` fraction -- it currently
doesn't bring in `jaxrs-jsonp`. I believe it should, because when
working with JSON-B, you very often also need JSON-P.

Modifications
-------------
Added a dependency on `jaxrs-jsonp` to the `jaxrs-jsonb` fraction.

Result
------
Made the work with JSON-B in JAX-RS a little easier.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
