### PR TITLE
Gradle Plugin: Usability and dependency resolution improvements

### DIFF
--- a/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/GradleArtifactResolvingHelper.java
+++ b/plugins/gradle/gradle-plugin/src/main/java/org/wildfly/swarm/plugin/gradle/GradleArtifactResolvingHelper.java
@@ -25,6 +25,8 @@ import org.wildfly.swarm.tools.ArtifactResolvingHelper;
 import org.wildfly.swarm.tools.ArtifactSpec;
 
 /**
+ * An implementation of the {@link ArtifactResolvingHelper} for Gradle based builds.
+ *
  * @author Bob McWhirter
  */
 public class GradleArtifactResolvingHelper implements ArtifactResolvingHelper {

--- a/plugins/gradle/gradle-plugin/src/main/resources/META-INF/thorntail-scripts/configure-tasks.groovy
+++ b/plugins/gradle/gradle-plugin/src/main/resources/META-INF/thorntail-scripts/configure-tasks.groovy
@@ -1,5 +1,3 @@
-import org.gradle.api.tasks.testing.Test
-
 /*
  * Copyright 2018 Red Hat, Inc, and individual contributors.
  *
@@ -15,6 +13,8 @@ import org.gradle.api.tasks.testing.Test
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
+import org.gradle.api.tasks.testing.Test
 
 // Given our current integration model, we end up in a scenario where we are unable to perform all integrations from
 // Java layer as that would mean that we now need to have a dependency on a newer version of the Gradle plugin.

--- a/tools/src/main/java/org/wildfly/swarm/tools/DeclaredDependencies.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/DeclaredDependencies.java
@@ -103,7 +103,7 @@ public class DeclaredDependencies extends DependencyTree<ArtifactSpec> {
      */
     public boolean isPresolved() {
         // Check if the tool has added unsolved dependencies to this instance that need further resolution.
-        boolean unsolvedDependenciesExist = getDirectDeps().stream().anyMatch(d -> !getTransientDeps(d).isEmpty());
+        boolean unsolvedDependenciesExist = getDirectDeps().stream().anyMatch(d -> !isComplete(d));
         return !unsolvedDependenciesExist;
     }
 


### PR DESCRIPTION
Usability Improvements
----------------------
The Gradle plugin now automatically associated some of the required libraries with the projects:

* runtimeOnly          "io.thorntail:bootstrap:THORNTAIL_PLUGIN_VERSION"
* testImplementation   "io.thorntail:arquillian:THORNTAIL_PLUGIN_VERSION"
* testRuntimeClasspath "io.thorntail:gradle-arquillian-adapter:THORNTAIL_PLUGIN_VERSION"
* testRuntimeClasspath "org.gradle:gradle-tooling-api:GRADLE_VERSION"

This simplifies the structure within the Gradle build scripts.

Dependency Resolution Improvements
----------------------------------
Thorntail fractions are now returned as top level dependencies (instead of being nested deep within the dependency tree). This ensures a more reliable & predictable packaging of the artifacts.

Other Fixes
-----------
*  DeclaredDependencies - Updated the logic for `isPresolved` to make use of the `isComplete` method.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
