### PR TITLE
Gradle Plugin: Optimize lookup for module dependencies in DependencyManager

### DIFF
--- a/tools/src/main/java/org/wildfly/swarm/tools/DependencyManager.java
+++ b/tools/src/main/java/org/wildfly/swarm/tools/DependencyManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015-2017 Red Hat, Inc, and individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -210,6 +211,9 @@ public class DependencyManager implements ResolvedDependencies {
         this.dependencies.addAll(
                 resolver.resolveAllArtifactsNonTransitively(remainder)
         );
+
+        // populate the dependency map for faster lookups
+        this.dependencies.forEach(s -> dependencyMap.put(s.mavenGav(), s));
     }
 
     private void filterOutRunnerDependencies(ArtifactSpec runnerJar, Collection<ArtifactSpec> explicitDependencies) {
@@ -233,7 +237,17 @@ public class DependencyManager implements ResolvedDependencies {
 
     private void analyzeModuleDependencies(ModuleAnalyzer analyzer) {
         List<ArtifactSpec> thorntailDependencies = analyzer.getDependencies();
-        this.moduleDependencies.addAll(thorntailDependencies);
+
+        // ModuleAnalyzer looks for dependencies in a predefined location and assumes that the folder conforms to the
+        // Maven repository layout. If it doesn't find the dependency in that location, then the ModuleAnalyzer will
+        // return an ArtifactSpec object that does not contain the file location. But when using the Gradle plugin, it
+        // is highly possible that the dependency was already retrieved and stored in the Gradle dependency cache.
+
+        this.moduleDependencies.addAll(
+                thorntailDependencies.stream()
+                        .map(s -> s.file != null ? s : dependencyMap.getOrDefault(s.mavenGav(), s))
+                        .collect(Collectors.toList())
+        );
     }
 
     private void analyzeFractionManifests() {
@@ -453,6 +467,8 @@ public class DependencyManager implements ResolvedDependencies {
     private final List<FractionManifest> fractionManifests = new ArrayList<>();
 
     private final Set<ArtifactSpec> dependencies = new HashSet<>();
+
+    private final Map<String, ArtifactSpec> dependencyMap = new HashMap<>();
 
     private final Set<ArtifactSpec> removableDependencies = new HashSet<>();
 


### PR DESCRIPTION
The ModuleAnalyzer class looks for dependencies in a predefined location and assumes that the folder conforms
to the Maven repository layout. If it doesn't find the dependency in that location, then the ModuleAnalyzer will
return an ArtifactSpec object that does not contain the file location. But when using the Gradle plugin, it
is highly possible that the dependency was already retrieved and stored in the Gradle dependency cache.

In this commit, I am performing an additional check to handle such scenarios.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [ ] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [x] Have you built the project locally prior to submission with `mvn clean install`?

-----
