### PR TITLE
THORN-2526: add option to only repackage WAR inside the uberjar and leave the WAR file untouched

### DIFF
--- a/docs/modules/ref_thorntail-maven-plugin-configuration-options.adoc
+++ b/docs/modules/ref_thorntail-maven-plugin-configuration-options.adoc
@@ -67,7 +67,8 @@ A `.properties` file with environment variables to use when executing the applic
 |===
 
 filterWebInfLib::
-If true, the plugin removes artifacts that are provided by the Thorntail runtime from the `WEB-INF/lib` directory of the project WAR file.
+If `true`, the plugin removes artifacts that are provided by the Thorntail runtime from the `WEB-INF/lib` directory of the project WAR file.
+If `uberjar-only`, this transformation is only done on the WAR file that is put into the uberjar, and the standalone WAR file remains untouched.
 Otherwise, the contents of `WEB-INF/lib` remain untouched.
 +
 [cols="1,2a"]


### PR DESCRIPTION
Motivation
----------
When `<packaging>` is `war`, we filter the `WEB-INF/lib` directory
of the WAR file by default. We do it on two places -- in the WAR
which is inside the uberjar, and in the standalone WAR file.

This is inconvenient when we want to build the uberjar, but also keep
using the WAR file e.g. for deploying to WildFly. In such scenario,
we want to modify the WAR which is inside the uberjar, but keep
the standalone WAR file untouched.

Modifications
-------------
This could be achieved by adding another option, e.g. `repackageWar`,
but the combination of `repackageWar` and `filterWebInfLib` would be
confusing. So this commit adds a 3rd value to `filterWebInfLib`:
`uberjar-only`. With this value, the standalone WAR file is left
untouched, only the WAR inside the uberjar is modified.

Result
------
No behavioral difference by default.
Added the ability to only modify the WAR inside the uberjar,
but not modify the standalone WAR file.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
