### PR TITLE
THORN-2529: can't express "null" value in environment variables

### DIFF
--- a/core/container/src/main/java/org/wildfly/swarm/container/config/EnvironmentConfigNodeFactory.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/EnvironmentConfigNodeFactory.java
@@ -56,6 +56,9 @@ public class EnvironmentConfigNodeFactory {
             String after = normalizeName(name);
             if (after.startsWith("swarm.") || after.startsWith("thorntail.")) {
                 String value = input.get(name);
+                if (NullPlaceholder.VALUE.equals(value)) {
+                    value = null;
+                }
                 ConfigKey key = ConfigKey.parse(after);
                 config.recursiveChild(key, value);
             }

--- a/core/container/src/main/java/org/wildfly/swarm/container/config/NullPlaceholder.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/NullPlaceholder.java
@@ -1,0 +1,9 @@
+package org.wildfly.swarm.container.config;
+
+final class NullPlaceholder {
+    static final String VALUE = "<<null>>";
+
+    private NullPlaceholder() {
+        // avoid instantiation
+    }
+}

--- a/core/container/src/main/java/org/wildfly/swarm/container/config/PropertiesConfigNodeFactory.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/config/PropertiesConfigNodeFactory.java
@@ -54,6 +54,9 @@ public class PropertiesConfigNodeFactory {
         while (names.hasMoreElements()) {
             String propName = names.nextElement().toString();
             String propValue = input.getProperty(propName);
+            if (NullPlaceholder.VALUE.equals(propValue)) {
+                propValue = null;
+            }
 
             ConfigKey key = ConfigKey.parse(propName);
 


### PR DESCRIPTION
Motivation
----------
When overriding configuration using environment variables (and system
properties), it is not possible to express the `null` value. This is
sometimes required, e.g. to set the various `*-relative-to`
management attributes (where `null` means that the corresponding path
attribute is absolute path).

We should invent a placeholder value, such as `<<null>>`, which
would be translated to `null` when present.

Modifications
-------------
The code that reads environment variables and properties (system
properties included) now recognizes the `<<null>>` placeholder
string and translates that to actual `null` value.

Result
------
Able to express `null` in environment variables and system properties.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
