### PR TITLE
THORN-2530: udpate ShrinkWrap Resolver

### DIFF
--- a/boms/src/main/resources/bom-template.xml
+++ b/boms/src/main/resources/bom-template.xml
@@ -49,6 +49,7 @@
   <properties>
     <version.shrinkwrap>${version.org.jboss.shrinkwrap}</version.shrinkwrap>
     <version.shrinkwrap-descriptors>${version.org.jboss.shrinkwrap.descriptors}</version.shrinkwrap-descriptors>
+    <version.shrinkwrap-resolver>${version.org.jboss.shrinkwrap.resolver}</version.shrinkwrap-resolver>
     <version.thorntail>${project.version}</version.thorntail>
     <version.wildfly-config-api-runtime>${version.wildfly.config-api}</version.wildfly-config-api-runtime>
   </properties>
@@ -83,6 +84,13 @@
         <version>${version.shrinkwrap-descriptors}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.shrinkwrap.resolver</groupId>
+        <artifactId>shrinkwrap-resolver-bom</artifactId>
+        <version>${version.shrinkwrap-resolver}</version>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
       #{dependencies}
     </dependencies>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -51,6 +51,14 @@
       </dependency>
 
       <dependency>
+        <groupId>org.jboss.shrinkwrap.resolver</groupId>
+        <artifactId>shrinkwrap-resolver-bom</artifactId>
+        <version>${version.org.jboss.shrinkwrap.resolver}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+
+      <dependency>
         <groupId>org.jboss.arquillian</groupId>
         <artifactId>arquillian-bom</artifactId>
         <version>${version.org.arquillian}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,8 @@
     <version.jboss-modules>1.9.1.Final</version.jboss-modules>
     <version.jcip-annotations>1.0</version.jcip-annotations>
     <version.openjdk-orb>8.1.4.Final</version.openjdk-orb>
-    <version.org.apache.maven>3.6.0</version.org.apache.maven>
-    <version.org.apache.maven.resolver>1.3.1</version.org.apache.maven.resolver>
+    <version.org.apache.maven>3.6.0</version.org.apache.maven> <!-- cf. ShrinkWrap Resolver -->
+    <version.org.apache.maven.resolver>1.3.1</version.org.apache.maven.resolver> <!-- cf. ShrinkWrap Resolver -->
     <version.org.glassfish.jakarta.json>1.1.6</version.org.glassfish.jakarta.json>
     <version.org.ow2.asm>7.1</version.org.ow2.asm>
     <version.remoting-jmx>3.0.3.Final</version.remoting-jmx>
@@ -113,7 +113,7 @@
     <!-- ShrinkWrap -->
     <version.org.jboss.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap>
     <version.org.jboss.shrinkwrap.descriptors>2.0.0</version.org.jboss.shrinkwrap.descriptors>
-    <version.org.jboss.shrinkwrap.resolver>2.2.4</version.org.jboss.shrinkwrap.resolver>
+    <version.org.jboss.shrinkwrap.resolver>2.2.7</version.org.jboss.shrinkwrap.resolver>
 
     <!-- tracing -->
     <version.opentracing>0.31.0</version.opentracing>
@@ -415,6 +415,13 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.jboss.shrinkwrap.resolver</groupId>
+        <artifactId>shrinkwrap-resolver-bom</artifactId>
+        <version>${version.org.jboss.shrinkwrap.resolver}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
       <dependency>
         <groupId>org.jboss.arquillian</groupId>
         <artifactId>arquillian-bom</artifactId>


### PR DESCRIPTION
Motivation
----------
Maven Central no longer supports plain HTTP access,
which the old version of ShrinkWrap Resolver uses.
We need to use access Maven Central over HTTPS,
for which we need a new version of ShrinkWrap Resolver.

Modifications
-------------
Updated ShrinkWrap Resolver.

Result
------
No behavioral difference.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
