### PR TITLE
THORN-2531: Null value for thorntail.public.url.base

### DIFF
--- a/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/AnnotationBasedMain.java
+++ b/arquillian/adapter/src/main/java/org/wildfly/swarm/arquillian/adapter/AnnotationBasedMain.java
@@ -27,7 +27,7 @@ import org.wildfly.swarm.arquillian.CreateSwarm;
  * @uathor Ken Finnigan
  */
 public class AnnotationBasedMain {
-    public static final String ANNOTATED_CLASS_NAME = "swarm.arquillian.createswarm.class";
+    public static final String ANNOTATED_CLASS_NAME = "thorntail.arquillian.createswarm.class";
 
     protected AnnotationBasedMain() {
     }

--- a/arquillian/resolver/src/main/java/org/wildfly/swarm/arquillian/resolver/ShrinkwrapArtifactResolvingHelper.java
+++ b/arquillian/resolver/src/main/java/org/wildfly/swarm/arquillian/resolver/ShrinkwrapArtifactResolvingHelper.java
@@ -89,7 +89,7 @@ public class ShrinkwrapArtifactResolvingHelper implements ArtifactResolvingHelpe
             gradleTools.setChecksumPolicy(MavenChecksumPolicy.CHECKSUM_POLICY_IGNORE);
             gradleTools.setUpdatePolicy(MavenUpdatePolicy.UPDATE_POLICY_NEVER);
 
-            Boolean offline = Boolean.valueOf(System.getProperty("swarm.resolver.offline", "false"));
+            Boolean offline = Boolean.valueOf(System.getProperty("thorntail.resolver.offline", "false"));
             final ConfigurableMavenResolverSystem resolver = Maven.configureResolver()
                     .withMavenCentralRepo(true)
                     .withRemoteRepo(jbossPublic)

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/usage/NetworkVariableSupplier.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/usage/NetworkVariableSupplier.java
@@ -23,7 +23,7 @@ public class NetworkVariableSupplier implements UsageVariableSupplier {
         }
 
         String[] parts = name.split("\\.");
-        if (parts.length > 0 && parts[0].equals("swarm")) {
+        if (parts.length > 0 && parts[0].equals("thorntail")) {
             if (parts.length == 3) {
                 for (Interface each : this.interfaces) {
                     if (parts[1].equals(each.getName())) {


### PR DESCRIPTION
Motivation
----------
In the previous version of Swarm (e.g. 2018.1.0), we could use
the key `swarm.public.url.base` in the file `usage.txt` in order
to display the host of our application when it has been deployed.

Since THORN-2185, we can use `thorntail.public.url.base`, but
it's not working, it always returns `null`.

The bug has been introduced in `NetworkVariableSupplier#valueOf`:

```java
if (name.equals("thorntail.public.url.base")) {
    return "http://" + valueOf("thorntail.public.host") + ":" + valueOf("thorntail.http.port") + "/";
}

String[] parts = name.split("\\.");
if (parts.length > 0 && parts[0].equals("swarm")) {
    ...
}
```

Modifications
-------------
Updated some code paths that still expected system properties
prefixed with `swarm.*` to correctly read `thorntail.*`.

Result
------
Using `thorntail.public.url.base` should work now.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
