### PR TITLE
Use of thorntail.runner.webapp-location generates a invalid WAR

### DIFF
--- a/thorntail-runner/src/main/java/org/wildfly/swarm/runner/WarBuilder.java
+++ b/thorntail-runner/src/main/java/org/wildfly/swarm/runner/WarBuilder.java
@@ -148,7 +148,9 @@ public class WarBuilder {
                 String projectDir = System.getProperty("thorntail.runner.webapp-location");
                 if (projectDir != null) {
                     projectDir = Paths.get(projectDir).toFile().getAbsolutePath();
-                    if (file.getAbsolutePath().contains("WEB-INF" + File.separator + "classes")) { // Ignore classes.
+                    if (file.getAbsolutePath().contains("WEB-INF" + File.separator + "classes") || // Ignore classes.
+                            file.getAbsolutePath().contains("WEB-INF" + File.separator + "lib") // Ignore JARs.
+                    ) {
                         return;
                     }
                 } else {

--- a/thorntail-runner/src/main/java/org/wildfly/swarm/runner/WarBuilder.java
+++ b/thorntail-runner/src/main/java/org/wildfly/swarm/runner/WarBuilder.java
@@ -145,8 +145,15 @@ public class WarBuilder {
         File file = path.toFile();
         if (file.isFile()) {
             try {
-                String projectDir = Paths.get("src", "main", "webapp").toFile().getAbsolutePath();
-
+                String projectDir = System.getProperty("thorntail.runner.webapp-location");
+                if (projectDir != null) {
+                    projectDir = Paths.get(projectDir).toFile().getAbsolutePath();
+                    if (file.getAbsolutePath().contains("WEB-INF" + File.separator + "classes")) { // Ignore classes.
+                        return;
+                    }
+                } else {
+                    projectDir = Paths.get("src", "main", "webapp").toFile().getAbsolutePath();
+                }
                 String fileName = file.getAbsolutePath().replace(projectDir, "");
                 writeFileToZip(output, file, fileName);
             } catch (IOException e) {


### PR DESCRIPTION
Jira issue: THORN-2538

Our company is using thorntail for all new microservice projects and we found that using thorntail.runner.webapp-location property an invalid WAR is generated.

For productivity reasons, we run the thorntail runner pointing to the target directory. This is very useful when the application has customizations performed at post-packaging time. For example:

* Maven overlays;
* Custom Anttasks or scripts.

With this fix, we were able to run the thorntail-runner by taking advantage of the hot-swap of classes and JSPs at run time in the IDE with all the complete post-packaging steps that a Maven project in any IDE already supports.

We hope you enjoy the patch with the fix.

Long live Thorntail!