### PR TITLE
THORN-2545: the "microprofile" fraction doesn't bring in "jaxrs-jsonb"

### DIFF
--- a/fractions/microprofile/microprofile/pom.xml
+++ b/fractions/microprofile/microprofile/pom.xml
@@ -87,6 +87,11 @@
       <groupId>io.thorntail</groupId>
       <artifactId>microprofile-restclient</artifactId>
     </dependency>
+    <!-- Fractions introduced by MicroProfile 2.0 -->
+    <dependency>
+      <groupId>io.thorntail</groupId>
+      <artifactId>jaxrs-jsonb</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.wildfly.core</groupId>


### PR DESCRIPTION
Motivation
----------
The `microprofile` fraction is supposed to bring in
all of MicroProfile. Since MicroProfile 2.0, that includes
JSONB. Therefore, the `microprofile` fraction should
transitively bring in `jaxrs-jsonb`, but it doesn't.
(It does bring `jaxrs-jsonp`.)

Modifications
-------------
Added a dependency on `jaxrs-jsonb` to the `microprofile` fraction.

Result
------
More complete `microprofile` fraction.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
