### PR TITLE
[THORN-2577] Runner fails with ClassNotFoundError because commons-logging is missing

### DIFF
--- a/thorntail-runner/pom.xml
+++ b/thorntail-runner/pom.xml
@@ -86,7 +86,6 @@
     <dependency>
       <groupId>org.jboss.logging</groupId>
       <artifactId>commons-logging-jboss-logging</artifactId>
-      <scope>test</scope>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
