### PR TITLE
THORN-2585: WildFly OpenSSL doesn't work

### DIFF
--- a/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/util/TempFileManager.java
+++ b/core/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/util/TempFileManager.java
@@ -67,9 +67,11 @@ public class TempFileManager {
         return tmp;
     }
 
+    /**
+     * Creates a new file on the file system, in the temp dir location, and returns its path.
+     */
     public File newTempFile(String base, String ext) throws IOException {
         File tmp = File.createTempFile(WFSWARM_TMP_PREFIX + base, ext, this.tmpDir);
-        tmp.delete();
         register(tmp);
         return tmp;
     }

--- a/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
+++ b/core/container/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
@@ -147,6 +147,11 @@ public class RuntimeServer implements Server {
         File configurationFile;
         try {
             configurationFile = TempFileManager.INSTANCE.newTempFile("thorntail-config-", ".xml");
+            // subsequent code (namely, BootstrapPersister.load) relies on the file not existing!
+            // this is not safe (someone can create the file in the short time span between this call
+            // and the BootstrapPersister.load call), but it's not a regression, this unsafety
+            // was always present (TempFileManager.newTempFile used to delete the file)
+            configurationFile.delete();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/module-rewrite.conf
+++ b/module-rewrite.conf
@@ -8,6 +8,8 @@ module: org.jboss.resteasy.resteasy-cdi
 module: asm.asm
   force-artifact-version: org.ow2.asm:asm:*=${version.org.ow2.asm}
   force-artifact-version: org.ow2.asm:asm-util:*=${version.org.ow2.asm}
+module: org.wildfly.openssl
+  replace-artifact: org.wildfly.openssl:wildfly-openssl-java:* > org.wildfly.openssl:wildfly-openssl:${version.wildfly-openssl}
 module: ALL:ALL
   # make sure we only have a single version of Apache HTTP client
   force-artifact-version: org.apache.httpcomponents:httpclient:*=${version.httpclient}

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
     <version.weld-se>3.1.2.Final</version.weld-se>
     <version.wildfly-client-config>1.0.1.Final</version.wildfly-client-config>
     <version.wildfly-common>1.5.1.Final</version.wildfly-common>
+    <version.wildfly-openssl>1.0.11.Final</version.wildfly-openssl>
     <version.xnio>3.7.3.Final</version.xnio>
 
     <!-- ===== Keycloak ===== -->


### PR DESCRIPTION
Motivation
----------
When WildFly OpenSSL is enabled, Thorntail applications fail to boot.
This is because we don't include the `libwfssl` native libraries.

Modifications
-------------
Instead of `org.wildfly.openssl:wildfly-openssl-java`, which is
just plain Java code (and the native libraries must be provided
separately), we now use `org.wildfly.openssl:wildfly-openssl`,
which is the same Java code + the compiled native libraries.

In addition to that, this commit also fixes how the Arquillian
adapter stops the running application. It first tries to delete
the process file, but that could never possibly have worked,
because the process file is created using `TempFileManager`,
which used to always delete the temporary file before handing
back its path. Almost all users of `TempFileManager` are ready
to deal with newly created temp files existing, so this commit
changes the code to _not_ delete the file. The one caller
expecting the temp file to not exist was updated to delete it
explicitly.

Result
------
WildFly OpenSSL works as intended.
Stopping the running application by deleting the process file
also works as intended.

- [x] Have you followed the guidelines in our [Contributing](https://thorntail.io/community/contributing/) document?
- [x] Have you created a [JIRA](https://issues.jboss.org/browse/THORN) and used it in the commit message?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/thorntail/thorntail/pulls) for the same issue?
- [ ] Have you built the project locally prior to submission with `mvn clean install`?

-----
